### PR TITLE
Inspector fixup

### DIFF
--- a/bins/revme/src/debugger/ctrl/ctrl.rs
+++ b/bins/revme/src/debugger/ctrl/ctrl.rs
@@ -218,7 +218,19 @@ impl<DB: Database> Inspector<DB> for Controller {
         (Return::Continue, Gas::new(0), Bytes::new())
     }
 
-    fn call_end(&mut self) {
+    fn call_end(
+        &mut self,
+        _data: &mut EVMData<'_, DB>,
+        _call: H160,
+        _context: &revm::CallContext,
+        _transfer: &revm::Transfer,
+        _input: &Bytes,
+        _gas_limit: u64,
+        _remaining_gas: u64,
+        _ret: Return,
+        _out: &Bytes,
+        _is_static: bool,
+    ) {
         if let StateMachine::StepOut = self.state_machine {
             self.state_machine = StateMachine::TriggerStep
         }
@@ -236,7 +248,19 @@ impl<DB: Database> Inspector<DB> for Controller {
         (Return::Continue, None, Gas::new(0), Bytes::new())
     }
 
-    fn create_end(&mut self) {
+    fn create_end(
+        &mut self,
+        _data: &mut EVMData<'_, DB>,
+        _caller: H160,
+        _scheme: &revm::CreateScheme,
+        _value: U256,
+        _init_code: &Bytes,
+        _ret: Return,
+        _address: Option<H160>,
+        _gas_limit: u64,
+        _remaining_gas: u64,
+        _out: &Bytes,
+    ) {
         if let StateMachine::StepOut = self.state_machine {
             self.state_machine = StateMachine::TriggerStep
         }

--- a/bins/revme/src/statetest/trace.rs
+++ b/bins/revme/src/statetest/trace.rs
@@ -121,7 +121,20 @@ impl<DB: Database> Inspector<DB> for CustomPrintTracer {
         (Return::Continue, Gas::new(0), Bytes::new())
     }
 
-    fn call_end(&mut self) {}
+    fn call_end(
+        &mut self,
+        _data: &mut EVMData<'_, DB>,
+        _call: H160,
+        _context: &revm::CallContext,
+        _transfer: &revm::Transfer,
+        _input: &Bytes,
+        _gas_limit: u64,
+        _remaining_gas: u64,
+        _ret: Return,
+        _out: &Bytes,
+        _is_static: bool,
+    ) {
+    }
 
     fn create(
         &mut self,
@@ -143,7 +156,20 @@ impl<DB: Database> Inspector<DB> for CustomPrintTracer {
         (Return::Continue, None, Gas::new(0), Bytes::new())
     }
 
-    fn create_end(&mut self) {}
+    fn create_end(
+        &mut self,
+        _data: &mut EVMData<'_, DB>,
+        _caller: H160,
+        _scheme: &revm::CreateScheme,
+        _value: U256,
+        _init_code: &Bytes,
+        _ret: Return,
+        _address: Option<H160>,
+        _gas_limit: u64,
+        _remaining_gas: u64,
+        _out: &Bytes,
+    ) {
+    }
 
     fn selfdestruct(&mut self) {
         //, address: H160, target: H160) {

--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -52,8 +52,19 @@ pub trait Inspector<DB: Database> {
         is_static: bool,
     ) -> (Return, Gas, Bytes);
 
-    //TODO add all field
-    fn call_end(&mut self);
+    fn call_end(
+        &mut self,
+        data: &mut EVMData<'_, DB>,
+        call: H160,
+        context: &CallContext,
+        transfer: &Transfer,
+        input: &Bytes,
+        gas_limit: u64,
+        remaining_gas: u64,
+        ret: Return,
+        out: &Bytes,
+        is_static: bool,
+    );
 
     fn create(
         &mut self,
@@ -62,11 +73,22 @@ pub trait Inspector<DB: Database> {
         scheme: &CreateScheme,
         value: U256,
         init_code: &Bytes,
-        gas: u64,
+        gas_limit: u64,
     ) -> (Return, Option<H160>, Gas, Bytes);
 
-    //TODO add all field
-    fn create_end(&mut self);
+    fn create_end(
+        &mut self,
+        data: &mut EVMData<'_, DB>,
+        caller: H160,
+        scheme: &CreateScheme,
+        value: U256,
+        init_code: &Bytes,
+        ret: Return,
+        address: Option<H160>,
+        gas_limit: u64,
+        remaining_gas: u64,
+        out: &Bytes,
+    );
 
     fn selfdestruct(&mut self);
 
@@ -130,7 +152,20 @@ impl<DB: Database> Inspector<DB> for NoOpInspector {
         (Return::Continue, Gas::new(0), Bytes::new())
     }
 
-    fn call_end(&mut self) {}
+    fn call_end(
+        &mut self,
+        _data: &mut EVMData<'_, DB>,
+        _call: H160,
+        _context: &CallContext,
+        _transfer: &Transfer,
+        _input: &Bytes,
+        _gas_limit: u64,
+        _remaining_gas: u64,
+        _ret: Return,
+        _out: &Bytes,
+        _is_static: bool,
+    ) {
+    }
 
     fn create(
         &mut self,
@@ -139,12 +174,25 @@ impl<DB: Database> Inspector<DB> for NoOpInspector {
         _scheme: &CreateScheme,
         _value: U256,
         _init_code: &Bytes,
-        _gas: u64,
+        _gas_limit: u64,
     ) -> (Return, Option<H160>, Gas, Bytes) {
         (Return::Continue, None, Gas::new(0), Bytes::new())
     }
 
-    fn create_end(&mut self) {}
+    fn create_end(
+        &mut self,
+        _data: &mut EVMData<'_, DB>,
+        _caller: H160,
+        _scheme: &CreateScheme,
+        _value: U256,
+        _init_code: &Bytes,
+        _ret: Return,
+        _address: Option<H160>,
+        _gas_limit: u64,
+        _remaining_gas: u64,
+        _out: &Bytes,
+    ) {
+    }
 
     fn selfdestruct(&mut self) {}
 }

--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -52,6 +52,7 @@ pub trait Inspector<DB: Database> {
         is_static: bool,
     ) -> (Return, Gas, Bytes);
 
+    #[allow(clippy::too_many_arguments)]
     fn call_end(
         &mut self,
         data: &mut EVMData<'_, DB>,
@@ -76,6 +77,7 @@ pub trait Inspector<DB: Database> {
         gas_limit: u64,
     ) -> (Return, Option<H160>, Gas, Bytes);
 
+    #[allow(clippy::too_many_arguments)]
     fn create_end(
         &mut self,
         data: &mut EVMData<'_, DB>,


### PR DESCRIPTION
An attempt at fixing #45 

- Adds parameters to `create_end` and `call_end`
- Calls `create_end` and `call_end` in the correct places

Putting this in draft to get comments - is this the right direction and/or does this break anything?

Closes #45 