### PR TITLE
Remove all `unsafe` code

### DIFF
--- a/bins/revme/src/debugger/ctrl/ctrl.rs
+++ b/bins/revme/src/debugger/ctrl/ctrl.rs
@@ -135,7 +135,7 @@ impl<DB: Database> Inspector<DB> for Controller {
                         let opcode = machine
                             .contract
                             .code
-                            .get(machine.program_counter())
+                            .get(machine.program_counter)
                             .cloned()
                             .unwrap();
                         let gas_spend = machine.gas().spend();
@@ -144,7 +144,7 @@ impl<DB: Database> Inspector<DB> for Controller {
                             "call_depth:{} PC:{} Opcode: {:#x} {:?} gas(spend,remaining):({},{})\n\
                             Stack:{}",
                             machine.call_depth,
-                            machine.program_counter(),
+                            machine.program_counter,
                             opcode,
                             OPCODE_JUMPMAP[opcode as usize].unwrap_or("Invalid"),
                             gas_spend,
@@ -153,20 +153,14 @@ impl<DB: Database> Inspector<DB> for Controller {
                         );
                     }
                     CtrlPrint::Opcode => {
-                        let opcode = *machine
-                            .contract
-                            .code
-                            .get(machine.program_counter())
-                            .unwrap();
+                        let opcode = *machine.contract.code.get(machine.program_counter).unwrap();
                         println!(
                             "PC:{} OpCode: {:#x} {:?}",
-                            machine.program_counter(),
-                            opcode,
-                            OPCODE_JUMPMAP[opcode as usize]
+                            machine.program_counter, opcode, OPCODE_JUMPMAP[opcode as usize]
                         )
                     }
                     CtrlPrint::Stack => {
-                        println!("PC:{} stack:{}", machine.program_counter(), machine.stack())
+                        println!("PC:{} stack:{}", machine.program_counter, machine.stack())
                     }
                     CtrlPrint::Memory => {
                         println!("memory:{}", hex::encode(&machine.memory.data()))

--- a/bins/revme/src/statetest/trace.rs
+++ b/bins/revme/src/statetest/trace.rs
@@ -39,7 +39,7 @@ impl<DB: Database> Inspector<DB> for CustomPrintTracer {
         data: &mut EVMData<'_, DB>,
         _is_static: bool,
     ) -> Return {
-        let opcode = unsafe { *machine.program_counter };
+        let opcode = machine.current_opcode();
         let opcode_str = opcode::OPCODE_JUMPMAP[opcode as usize];
 
         // calculate gas_block

--- a/bins/revme/src/statetest/trace.rs
+++ b/bins/revme/src/statetest/trace.rs
@@ -31,7 +31,7 @@ impl<DB: Database> Inspector<DB> for CustomPrintTracer {
         Return::Continue
     }
 
-    // get opcode by calling `machine.contract.opcode(machine.program_counter())`.
+    // get opcode by calling `machine.contract.opcode(machine.program_counter)`.
     // all other information can be obtained from machine.
     fn step(
         &mut self,
@@ -49,7 +49,7 @@ impl<DB: Database> Inspector<DB> for CustomPrintTracer {
         println!(
             "depth:{}, PC:{}, gas:{:#x}({}), OPCODE: {:?}({:?})  refund:{:#x}({}) Stack:{:?}, Data:",
             machine.call_depth,
-            machine.program_counter(),
+            machine.program_counter,
             machine.gas.remaining()+self.full_gas_block-self.reduced_gas_block,
             machine.gas.remaining()+self.full_gas_block-self.reduced_gas_block,
             opcode_str.unwrap(),
@@ -62,7 +62,7 @@ impl<DB: Database> Inspector<DB> for CustomPrintTracer {
 
         if info.gas_block_end {
             self.reduced_gas_block = 0;
-            self.full_gas_block = machine.contract.gas_block(machine.program_counter());
+            self.full_gas_block = machine.contract.gas_block(machine.program_counter);
         } else {
             self.reduced_gas_block += info.gas;
         }

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -23,6 +23,7 @@ use revm_precompiles::Precompiles;
 /// want to update anything on it. It enabled `transact_ref` and `inspect_ref` functions
 /// * Database+DatabaseCommit allow's dirrectly commiting changes of transaction. it enabled `transact_commit`
 /// and `inspect_commit`
+#[derive(Clone)]
 pub struct EVM<DB> {
     pub env: Env,
     pub db: Option<DB>,

--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -21,7 +21,7 @@ pub trait Inspector<DB: Database> {
         Return::Continue
     }
 
-    /// get opcode by calling `machine.contract.opcode(machine.program_counter())`.
+    /// get opcode by calling `machine.contract.opcode(machine.program_counter)`.
     /// all other information can be obtained from machine.
     fn step(
         &mut self,

--- a/crates/revm/src/instructions/i256.rs
+++ b/crates/revm/src/instructions/i256.rs
@@ -29,7 +29,7 @@ pub struct I256(pub Sign, pub U256);
 
 #[inline(always)]
 pub fn i256_sign<const DO_TWO_COMPL: bool>(val: &mut U256) -> Sign {
-    if unsafe { val.0.get_unchecked(3) } & SIGN_BITMASK_U64 == 0 {
+    if { val.0[3] } & SIGN_BITMASK_U64 == 0 {
         if val.is_zero() {
             Sign::Zero
         } else {
@@ -45,9 +45,7 @@ pub fn i256_sign<const DO_TWO_COMPL: bool>(val: &mut U256) -> Sign {
 
 #[inline(always)]
 fn u256_remove_sign(val: &mut U256) {
-    unsafe {
-        *val.0.get_unchecked_mut(3) = val.0.get_unchecked(3) & FLIPH_BITMASK_U64;
-    }
+    val.0[3] &= FLIPH_BITMASK_U64;
 }
 
 #[inline(always)]

--- a/crates/revm/src/instructions/misc.rs
+++ b/crates/revm/src/instructions/misc.rs
@@ -81,14 +81,14 @@ pub fn pop(machine: &mut Machine) -> Return {
 
 pub fn mload(machine: &mut Machine) -> Return {
     //gas!(machine, gas::VERYLOW);
-    pop!(machine, index);
 
-    let index = as_usize_or_fail!(index, Return::OutOfGas);
+    let top = match machine.stack.top_mut() {
+        Some(top) => top,
+        None => return Return::StackUnderflow,
+    };
+    let index = as_usize_or_fail!(top, Return::OutOfGas);
     memory_resize!(machine, index, 32);
-    push!(
-        machine,
-        util::be_to_u256(machine.memory.get_slice(index, 32))
-    );
+    *top = util::be_to_u256(machine.memory.get_slice(index, 32));
     Return::Continue
 }
 

--- a/crates/revm/src/instructions/misc.rs
+++ b/crates/revm/src/instructions/misc.rs
@@ -144,18 +144,18 @@ pub fn jumpi(machine: &mut Machine) -> Return {
         }
     } else {
         // if we are not doing jump, add next gas block.
-        machine.add_next_gas_block(machine.program_counter() - 1)
+        machine.add_next_gas_block(machine.program_counter - 1)
     }
 }
 
 pub fn jumpdest(machine: &mut Machine) -> Return {
     gas!(machine, gas::JUMPDEST);
-    machine.add_next_gas_block(machine.program_counter() - 1)
+    machine.add_next_gas_block(machine.program_counter - 1)
 }
 
 pub fn pc(machine: &mut Machine) -> Return {
     //gas!(machine, gas::BASE);
-    push!(machine, U256::from(machine.program_counter() - 1));
+    push!(machine, U256::from(machine.program_counter - 1));
     Return::Continue
 }
 

--- a/crates/revm/src/instructions/system.rs
+++ b/crates/revm/src/instructions/system.rs
@@ -289,9 +289,8 @@ pub fn log<H: Host, SPEC: Spec>(machine: &mut Machine, n: u8, host: &mut H) -> R
 
     let mut topics = Vec::with_capacity(n);
     for _ in 0..(n) {
-        /*** SAFETY stack bounds already checked few lines above */
         let mut t = H256::zero();
-        unsafe { machine.stack.pop_unsafe().to_big_endian(t.as_bytes_mut()) };
+        machine.stack.pop_unsafe().to_big_endian(t.as_bytes_mut());
         topics.push(t);
     }
 

--- a/crates/revm/src/instructions/system.rs
+++ b/crates/revm/src/instructions/system.rs
@@ -266,7 +266,7 @@ pub fn gas(machine: &mut Machine) -> Return {
     //gas!(machine, gas::BASE);
 
     push!(machine, U256::from(machine.gas.remaining()));
-    machine.add_next_gas_block(machine.program_counter() - 1)
+    machine.add_next_gas_block(machine.program_counter - 1)
 }
 
 pub fn log<H: Host, SPEC: Spec>(machine: &mut Machine, n: u8, host: &mut H) -> Return {
@@ -372,7 +372,7 @@ pub fn create<H: Host, SPEC: Spec>(
     machine.gas.reimburse_unspend(&reason, gas);
     match reason {
         Return::FatalNotSupported => Return::FatalNotSupported,
-        _ => machine.add_next_gas_block(machine.program_counter() - 1),
+        _ => machine.add_next_gas_block(machine.program_counter - 1),
     }
 }
 
@@ -525,5 +525,5 @@ pub fn call<H: Host, SPEC: Spec>(
             push!(machine, U256::zero());
         }
     }
-    machine.add_next_gas_block(machine.program_counter() - 1)
+    machine.add_next_gas_block(machine.program_counter - 1)
 }

--- a/crates/revm/src/machine/machine.rs
+++ b/crates/revm/src/machine/machine.rs
@@ -161,11 +161,6 @@ impl Machine {
         Return::Continue
     }
 
-    /// Return a reference of the program counter.
-    pub fn program_counter(&self) -> usize {
-        self.program_counter
-    }
-
     #[inline(always)]
     pub fn current_opcode(&self) -> u8 {
         self.contract.code[self.program_counter]

--- a/crates/revm/src/machine/memory.rs
+++ b/crates/revm/src/machine/memory.rs
@@ -60,8 +60,9 @@ impl Memory {
     /// Set memory region at given offset. The offset and value are already checked
     ///
     #[inline(always)]
-    pub unsafe fn set_byte(&mut self, index: usize, byte: u8) {
-        *self.data.get_unchecked_mut(index) = byte;
+    pub fn set_byte(&mut self, index: usize, byte: u8) {
+        self.data[index] = byte;
+        // *self.data.get_unchecked_mut(index) = byte;
     }
 
     #[inline(always)]
@@ -83,11 +84,7 @@ impl Memory {
     pub fn set_data(&mut self, memory_offset: usize, data_offset: usize, len: usize, data: &[u8]) {
         if data_offset >= data.len() {
             // nulify all memory slots
-            for i in memory_offset..memory_offset + len {
-                unsafe {
-                    *self.data.get_unchecked_mut(i) = 0;
-                }
-            }
+            self.data[memory_offset..memory_offset + len].fill(0);
             return;
         }
         let data_end = min(data_offset + len, data.len());
@@ -95,11 +92,7 @@ impl Memory {
         self.data[memory_offset..memory_data_end].copy_from_slice(&data[data_offset..data_end]);
 
         // nulify rest of memory slots
-        for i in memory_data_end..memory_offset + len {
-            unsafe {
-                *self.data.get_unchecked_mut(i) = 0;
-            }
-        }
+        self.data[memory_data_end..memory_offset + len].fill(0);
     }
 }
 

--- a/crates/revm/src/machine/stack.rs
+++ b/crates/revm/src/machine/stack.rs
@@ -66,6 +66,11 @@ impl Stack {
         }
     }
 
+    #[inline(always)]
+    pub fn top_mut(&mut self) -> Option<&mut U256> {
+        self.data.last_mut()
+    }
+
     #[inline]
     /// Pop a value from the stack. If the stack is already empty, returns the
     /// `StackUnderflow` error.


### PR DESCRIPTION
Replacing all unsafe code with safe equivalents resulted in a minor speed penalty, but that was easy to correct.

revm-test on current main branch:
```
0: 72.280883ms
1: 66.22685ms
2: 63.54688ms
3: 63.925157ms
4: 63.710048ms
5: 63.555763ms
6: 64.017038ms
7: 63.486204ms
8: 63.844067ms
9: 63.534811ms
```

after removing `unsafe`:
```
0: 75.006729ms
1: 70.62909ms
2: 65.881008ms
3: 65.937669ms
4: 65.571569ms
5: 65.658069ms
6: 66.056095ms
7: 65.523081ms
8: 65.74447ms
9: 65.561382ms
```

with some small performance improvements to speed it back up (mostly just avoiding some redundant bounds checks):
```
0: 72.207021ms
1: 66.552397ms
2: 64.265398ms
3: 63.883503ms
4: 64.146832ms
5: 63.8677ms
6: 64.196815ms
7: 64.071832ms
8: 63.978789ms
9: 63.875884ms
```

The `perf` stats are interesting. main branch:
```
             4,214      page-faults:u             #    6.393 K/sec                  
     2,315,735,367      cycles:u                  #    3.513 GHz                      (36.95%)
     5,222,993,976      instructions:u            #    2.26  insn per cycle           (44.84%)
       868,177,930      branches:u                #    1.317 G/sec                    (45.44%)
         9,404,860      branch-misses:u           #    1.08% of all branches          (46.05%)
     1,309,655,465      L1-dcache-loads:u         #    1.987 G/sec                    (46.66%)
         4,189,485      L1-dcache-load-misses:u   #    0.32% of all L1-dcache accesses  (47.26%)
           225,908      LLC-loads:u               #  342.730 K/sec                    (31.55%)
             9,317      LLC-load-misses:u         #    4.12% of all LL-cache accesses  (31.55%)
   <not supported>      L1-icache-loads:u                                           
         2,234,462      L1-icache-load-misses:u                                       (31.50%)
     1,314,240,932      dTLB-loads:u              #    1.994 G/sec                    (30.89%)
             6,336      dTLB-load-misses:u        #    0.00% of all dTLB cache accesses  (30.28%)
            10,869      iTLB-loads:u              #   16.490 K/sec                    (29.68%)
            50,216      iTLB-load-misses:u        #  462.01% of all iTLB cache accesses  (29.13%)

       0.659686018 seconds time elapsed
```

this pr:
```
             4,215      page-faults:u             #    6.395 K/sec                  
     2,315,675,125      cycles:u                  #    3.513 GHz                      (36.97%)
     5,791,821,992      instructions:u            #    2.50  insn per cycle           (44.86%)
       991,779,522      branches:u                #    1.505 G/sec                    (45.47%)
         8,825,326      branch-misses:u           #    0.89% of all branches          (46.08%)
     1,555,239,982      L1-dcache-loads:u         #    2.360 G/sec                    (46.70%)
         4,314,281      L1-dcache-load-misses:u   #    0.28% of all L1-dcache accesses  (47.30%)
           173,210      LLC-loads:u               #  262.795 K/sec                    (31.56%)
            15,407      LLC-load-misses:u         #    8.89% of all LL-cache accesses  (31.56%)
   <not supported>      L1-icache-loads:u                                           
         1,583,901      L1-icache-load-misses:u                                       (31.47%)
     1,563,702,853      dTLB-loads:u              #    2.372 G/sec                    (30.86%)
            16,128      dTLB-load-misses:u        #    0.00% of all dTLB cache accesses  (30.26%)
            37,748      iTLB-loads:u              #   57.271 K/sec                    (29.64%)
             5,155      iTLB-load-misses:u        #   13.66% of all iTLB cache accesses  (29.12%)

       0.659681422 seconds time elapsed
```
so, the safe code results in more instructions and more branches (which seem to all be predicted correctly), but for this test code at least, it all comes out equal in the end. (No idea what's going on with iTLB-load-misses on the main branch)