### PR TITLE
[WIP] Use Result type for instruction functions

### DIFF
--- a/bins/revme/src/debugger/ctrl/ctrl.rs
+++ b/bins/revme/src/debugger/ctrl/ctrl.rs
@@ -110,7 +110,7 @@ impl<DB: Database> Inspector<DB> for Controller {
         machine: &mut revm::Machine,
         data: &mut EVMData<'_, DB>,
         _is_static: bool,
-    ) -> Return {
+    ) -> Result<(), Return> {
         loop {
             match Ctrl::next(self.state_machine, &self.history_path) {
                 Ctrl::Help => {
@@ -192,11 +192,15 @@ impl<DB: Database> Inspector<DB> for Controller {
                 Ctrl::None => break,
             }
         }
-        Return::Continue
+        Ok(())
     }
 
-    fn step_end(&mut self, _eval: revm::Return, _machine: &mut revm::Machine) -> Return {
-        Return::Continue
+    fn step_end(
+        &mut self,
+        _eval: Result<(), revm::Return>,
+        _machine: &mut revm::Machine,
+    ) -> Result<(), Return> {
+        Ok(())
     }
 
     fn call(

--- a/bins/revme/src/debugger/ctrl/ctrl.rs
+++ b/bins/revme/src/debugger/ctrl/ctrl.rs
@@ -135,7 +135,7 @@ impl<DB: Database> Inspector<DB> for Controller {
                         let opcode = machine
                             .contract
                             .code
-                            .get(machine.program_counter())
+                            .get(machine.program_counter)
                             .cloned()
                             .unwrap();
                         let gas_spend = machine.gas().spend();
@@ -144,7 +144,7 @@ impl<DB: Database> Inspector<DB> for Controller {
                             "call_depth:{} PC:{} Opcode: {:#x} {:?} gas(spend,remaining):({},{})\n\
                             Stack:{}",
                             machine.call_depth,
-                            machine.program_counter(),
+                            machine.program_counter,
                             opcode,
                             OPCODE_JUMPMAP[opcode as usize].unwrap_or("Invalid"),
                             gas_spend,
@@ -153,20 +153,14 @@ impl<DB: Database> Inspector<DB> for Controller {
                         );
                     }
                     CtrlPrint::Opcode => {
-                        let opcode = *machine
-                            .contract
-                            .code
-                            .get(machine.program_counter())
-                            .unwrap();
+                        let opcode = *machine.contract.code.get(machine.program_counter).unwrap();
                         println!(
                             "PC:{} OpCode: {:#x} {:?}",
-                            machine.program_counter(),
-                            opcode,
-                            OPCODE_JUMPMAP[opcode as usize]
+                            machine.program_counter, opcode, OPCODE_JUMPMAP[opcode as usize]
                         )
                     }
                     CtrlPrint::Stack => {
-                        println!("PC:{} stack:{}", machine.program_counter(), machine.stack())
+                        println!("PC:{} stack:{}", machine.program_counter, machine.stack())
                     }
                     CtrlPrint::Memory => {
                         println!("memory:{}", hex::encode(&machine.memory.data()))

--- a/bins/revme/src/statetest/trace.rs
+++ b/bins/revme/src/statetest/trace.rs
@@ -39,7 +39,7 @@ impl<DB: Database> Inspector<DB> for CustomPrintTracer {
         data: &mut EVMData<'_, DB>,
         _is_static: bool,
     ) -> Return {
-        let opcode = unsafe { *machine.program_counter };
+        let opcode = machine.current_opcode();
         let opcode_str = opcode::OPCODE_JUMPMAP[opcode as usize];
 
         // calculate gas_block

--- a/bins/revme/src/statetest/trace.rs
+++ b/bins/revme/src/statetest/trace.rs
@@ -26,9 +26,9 @@ impl<DB: Database> Inspector<DB> for CustomPrintTracer {
         machine: &mut revm::Machine,
         _data: &mut EVMData<'_, DB>,
         _is_static: bool,
-    ) -> Return {
+    ) -> Result<(), Return> {
         self.full_gas_block = machine.contract.first_gas_block();
-        Return::Continue
+        Ok(())
     }
 
     // get opcode by calling `machine.contract.opcode(machine.program_counter)`.
@@ -38,7 +38,7 @@ impl<DB: Database> Inspector<DB> for CustomPrintTracer {
         machine: &mut revm::Machine,
         data: &mut EVMData<'_, DB>,
         _is_static: bool,
-    ) -> Return {
+    ) -> Result<(), Return> {
         let opcode = machine.current_opcode();
         let opcode_str = opcode::OPCODE_JUMPMAP[opcode as usize];
 
@@ -67,15 +67,19 @@ impl<DB: Database> Inspector<DB> for CustomPrintTracer {
             self.reduced_gas_block += info.gas;
         }
 
-        Return::Continue
+        Ok(())
     }
 
     // fn load_account(&mut self, address: &H160) {
     //     println!("ACCOUNT LOADED:{:?}", address);
     // }
 
-    fn step_end(&mut self, _eval: revm::Return, _machine: &mut revm::Machine) -> Return {
-        Return::Continue
+    fn step_end(
+        &mut self,
+        _eval: Result<(), revm::Return>,
+        _machine: &mut revm::Machine,
+    ) -> Result<(), Return> {
+        Ok(())
     }
 
     // fn sload(&mut self, address: &H160, slot: &U256, value: &U256, is_cold: bool) {

--- a/bins/revme/src/statetest/trace.rs
+++ b/bins/revme/src/statetest/trace.rs
@@ -31,7 +31,7 @@ impl<DB: Database> Inspector<DB> for CustomPrintTracer {
         Return::Continue
     }
 
-    // get opcode by calling `machine.contract.opcode(machine.program_counter())`.
+    // get opcode by calling `machine.contract.opcode(machine.program_counter)`.
     // all other information can be obtained from machine.
     fn step(
         &mut self,
@@ -49,7 +49,7 @@ impl<DB: Database> Inspector<DB> for CustomPrintTracer {
         println!(
             "depth:{}, PC:{}, gas:{:#x}({}), OPCODE: {:?}({:?})  refund:{:#x}({}) Stack:{:?}, Data:",
             machine.call_depth,
-            machine.program_counter(),
+            machine.program_counter,
             machine.gas.remaining()+self.full_gas_block-self.reduced_gas_block,
             machine.gas.remaining()+self.full_gas_block-self.reduced_gas_block,
             opcode_str.unwrap(),
@@ -62,7 +62,7 @@ impl<DB: Database> Inspector<DB> for CustomPrintTracer {
 
         if info.gas_block_end {
             self.reduced_gas_block = 0;
-            self.full_gas_block = machine.contract.gas_block(machine.program_counter());
+            self.full_gas_block = machine.contract.gas_block(machine.program_counter);
         } else {
             self.reduced_gas_block += info.gas;
         }

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -19,7 +19,7 @@ num_enum = { version = "0.5", default-features = false }#used for SpecId from u8
 parking_lot = { version = "0.11.2", optional = true }
 primitive-types = { version = "0.10", default-features = false, features = ["rlp"] }
 revm_precompiles = { path = "../revm_precompiles", version = "0.4", default-features = false }
-rlp = { version = "0.5", default-features = false }#used for create2 address calculation 
+rlp = { version = "0.5", default-features = false }#used for create2 address calculation
 sha3 = { version = "0.10", default-features = false }
 tokio = { version = "1.14", features = ["rt-multi-thread", "macros"], optional = true }
 web3 = { version = "0.17", optional = true }

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -23,6 +23,7 @@ use revm_precompiles::Precompiles;
 /// want to update anything on it. It enabled `transact_ref` and `inspect_ref` functions
 /// * Database+DatabaseCommit allow's dirrectly commiting changes of transaction. it enabled `transact_commit`
 /// and `inspect_commit`
+#[derive(Clone)]
 pub struct EVM<DB> {
     pub env: Env,
     pub db: Option<DB>,

--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -21,7 +21,7 @@ pub trait Inspector<DB: Database> {
         Return::Continue
     }
 
-    /// get opcode by calling `machine.contract.opcode(machine.program_counter())`.
+    /// get opcode by calling `machine.contract.opcode(machine.program_counter)`.
     /// all other information can be obtained from machine.
     fn step(
         &mut self,

--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -17,8 +17,8 @@ pub trait Inspector<DB: Database> {
         _machine: &mut Machine,
         _data: &mut EVMData<'_, DB>,
         _is_static: bool,
-    ) -> Return {
-        Return::Continue
+    ) -> Result<(), Return> {
+        Ok(())
     }
 
     /// get opcode by calling `machine.contract.opcode(machine.program_counter)`.
@@ -28,13 +28,17 @@ pub trait Inspector<DB: Database> {
         _machine: &mut Machine,
         _data: &mut EVMData<'_, DB>,
         _is_static: bool,
-    ) -> Return {
-        Return::Continue
+    ) -> Result<(), Return> {
+        Ok(())
     }
 
     /// Called after `step` when instruction is executed.
-    fn step_end(&mut self, _eval: Return, _machine: &mut Machine) -> Return {
-        Return::Continue
+    fn step_end(
+        &mut self,
+        _eval: Result<(), Return>,
+        _machine: &mut Machine,
+    ) -> Result<(), Return> {
+        Ok(())
     }
 
     // TODO introduce some struct
@@ -100,8 +104,8 @@ impl<DB: Database> Inspector<DB> for NoOpInspector {
         _machine: &mut Machine,
         _data: &mut EVMData<'_, DB>,
         _is_static: bool,
-    ) -> Return {
-        Return::Continue
+    ) -> Result<(), Return> {
+        Ok(())
     }
 
     fn step(
@@ -109,12 +113,16 @@ impl<DB: Database> Inspector<DB> for NoOpInspector {
         _machine: &mut Machine,
         _data: &mut EVMData<'_, DB>,
         _is_static: bool,
-    ) -> Return {
-        Return::Continue
+    ) -> Result<(), Return> {
+        Ok(())
     }
 
-    fn step_end(&mut self, _eval: Return, _machine: &mut Machine) -> Return {
-        Return::Continue
+    fn step_end(
+        &mut self,
+        _eval: Result<(), Return>,
+        _machine: &mut Machine,
+    ) -> Result<(), Return> {
+        Ok(())
     }
 
     fn call(

--- a/crates/revm/src/instructions/arithmetic.rs
+++ b/crates/revm/src/instructions/arithmetic.rs
@@ -74,13 +74,13 @@ pub fn exp(op1: U256, op2: U256) -> U256 {
     r
 }
 
-pub fn eval_exp<SPEC: Spec>(machine: &mut Machine) -> Return {
-    pop!(machine, op1, op2);
+pub fn eval_exp<SPEC: Spec>(machine: &mut Machine) -> Result<(), Return> {
+    let (op1, op2) = machine.stack.pop2()?;
     gas_or_fail!(machine, gas::exp_cost::<SPEC>(op2));
     let ret = exp(op1, op2);
-    push!(machine, ret);
+    machine.stack.push_unchecked(ret);
 
-    Return::Continue
+    Ok(())
 }
 
 /// In the yellow paper `SIGNEXTEND` is defined to take two inputs, we will call them

--- a/crates/revm/src/instructions/i256.rs
+++ b/crates/revm/src/instructions/i256.rs
@@ -29,7 +29,7 @@ pub struct I256(pub Sign, pub U256);
 
 #[inline(always)]
 pub fn i256_sign<const DO_TWO_COMPL: bool>(val: &mut U256) -> Sign {
-    if unsafe { val.0.get_unchecked(3) } & SIGN_BITMASK_U64 == 0 {
+    if { val.0[3] } & SIGN_BITMASK_U64 == 0 {
         if val.is_zero() {
             Sign::Zero
         } else {
@@ -45,9 +45,7 @@ pub fn i256_sign<const DO_TWO_COMPL: bool>(val: &mut U256) -> Sign {
 
 #[inline(always)]
 fn u256_remove_sign(val: &mut U256) {
-    unsafe {
-        *val.0.get_unchecked_mut(3) = val.0.get_unchecked(3) & FLIPH_BITMASK_U64;
-    }
+    val.0[3] &= FLIPH_BITMASK_U64;
 }
 
 #[inline(always)]

--- a/crates/revm/src/instructions/macros.rs
+++ b/crates/revm/src/instructions/macros.rs
@@ -1,27 +1,11 @@
 pub use crate::Return;
-
-macro_rules! try_or_fail {
-    ( $e:expr ) => {
-        match $e {
-            Ok(v) => v,
-            Err(e) => return e,
-        }
-    };
-}
-
-macro_rules! check {
-    ($expresion:expr) => {
-        if !$expresion {
-            return Return::NotActivated;
-        }
-    };
-}
+use primitive_types::U256;
 
 macro_rules! gas {
     ($machine:expr, $gas:expr) => {
         if crate::USE_GAS {
             if !$machine.gas.record_cost(($gas)) {
-                return Return::OutOfGas;
+                return Err(Return::OutOfGas);
             }
         }
     };
@@ -40,7 +24,7 @@ macro_rules! gas_or_fail {
         if crate::USE_GAS {
             match $gas {
                 Some(gas_used) => gas!($machine, gas_used),
-                None => return Return::OutOfGas,
+                None => return Err(Return::OutOfGas),
             }
         }
     };
@@ -60,123 +44,25 @@ macro_rules! memory_resize {
                         .gas
                         .record_memory(crate::instructions::gas::memory_gas(num_bytes))
                     {
-                        return Return::OutOfGas;
+                        return Err(Return::OutOfGas);
                     }
                 }
                 $machine.memory.resize(new_size);
             }
         } else {
-            return Return::OutOfGas;
+            return Err(Return::OutOfGas);
         }
     }};
-}
-
-macro_rules! pop_address {
-    ( $machine:expr, $x1:ident) => {
-        if $machine.stack.len() < 1 {
-            return Return::StackUnderflow;
-        }
-        let mut temp = H256::zero();
-        let $x1: H160 = {
-            $machine
-                .stack
-                .pop_unsafe()
-                .to_big_endian(temp.as_bytes_mut());
-            temp.into()
-        };
-    };
-    ( $machine:expr, $x1:ident, $x2:ident) => {
-        if $machine.stack.len() < 2 {
-            return Return::StackUnderflow;
-        }
-        let mut temp = H256::zero();
-        $x1: H160 = {
-            $machine
-                .stack
-                .pop_unsafe()
-                .to_big_endian(temp.as_bytes_mut());
-            temp.into()
-        };
-        $x2: H160 = {
-            temp = H256::zero();
-            $machine
-                .stack
-                .pop_unsafe()
-                .to_big_endian(temp.as_bytes_mut());
-            temp.into();
-        };
-    };
-}
-
-macro_rules! top2 {
-    ( $machine:expr, $x1:ident, $x2:ident) => {
-        if $machine.stack.len() < 2 {
-            return Return::StackUnderflow;
-        }
-        let $x1 = $machine.stack.pop_unsafe();
-        let $x2 = $machine.stack.top_mut().unwrap();
-    };
-}
-
-macro_rules! pop {
-    ( $machine:expr, $x1:ident) => {
-        if $machine.stack.len() < 1 {
-            return Return::StackUnderflow;
-        }
-        let $x1 = $machine.stack.pop_unsafe();
-    };
-    ( $machine:expr, $x1:ident, $x2:ident) => {
-        if $machine.stack.len() < 2 {
-            return Return::StackUnderflow;
-        }
-        let ($x1, $x2) = $machine.stack.pop2_unsafe();
-    };
-    ( $machine:expr, $x1:ident, $x2:ident, $x3:ident) => {
-        if $machine.stack.len() < 3 {
-            return Return::StackUnderflow;
-        }
-        let ($x1, $x2, $x3) = $machine.stack.pop3_unsafe();
-    };
-
-    ( $machine:expr, $x1:ident, $x2:ident, $x3:ident, $x4:ident) => {
-        if $machine.stack.len() < 4 {
-            return Return::StackUnderflow;
-        }
-        let ($x1, $x2, $x3, $x4) = $machine.stack.pop4_unsafe();
-    };
-}
-
-macro_rules! push_h256 {
-	( $machine:expr, $( $x:expr ),* ) => (
-		$(
-		    match $machine.stack.push_h256($x) {
-			Ok(()) => (),
-			Err(e) => return e,
-		    }
-		)*
-	)
-}
-
-macro_rules! push {
-    ( $machine:expr, $( $x:expr ),* ) => (
-		$(
-		    match $machine.stack.push($x) {
-			Ok(()) => (),
-			Err(e) => return e,
-		    }
-		)*
-	)
 }
 
 macro_rules! op1_u256_fn {
     ( $machine:expr, $op:path ) => {{
         //gas!($machine, $gas);
-        if let Some(op1) = $machine.stack.top_mut() {
-            *op1 = $op(*op1);
-            Return::Continue
-        } else {
-            Return::StackUnderflow
-        }
+
+        let op1 = $machine.stack.pop()?;
+        let ret = $op(op1);
+        $machine.stack.push_unchecked(ret);
+        Ok(())
     }};
 }
 
@@ -184,11 +70,12 @@ macro_rules! op2_u256_bool_ref {
     ( $machine:expr, $op:ident) => {{
         //gas!($machine, $gas);
 
-        top2!($machine, op1, op2);
-        let ret = op1.$op(op2);
-        *op2 = if ret { U256::one() } else { U256::zero() };
-
-        Return::Continue
+        let (op1, op2) = $machine.stack.pop2()?;
+        let ret = op1.$op(&op2);
+        $machine
+            .stack
+            .push_unchecked(if ret { U256::one() } else { U256::zero() });
+        Ok(())
     }};
 }
 
@@ -196,10 +83,10 @@ macro_rules! op2_u256 {
     ( $machine:expr, $op:ident) => {{
         //gas!($machine, $gas);
 
-        top2!($machine, op1, op2);
-        *op2 = op1.$op(*op2);
-
-        Return::Continue
+        let (op1, op2) = $machine.stack.pop2()?;
+        let ret = op1.$op(op2);
+        $machine.stack.push_unchecked(ret);
+        Ok(())
     }};
 }
 
@@ -207,11 +94,10 @@ macro_rules! op2_u256_tuple {
     ( $machine:expr, $op:ident) => {{
         //gas!($machine, $gas);
 
-        top2!($machine, op1, op2);
-        let (ret, ..) = op1.$op(*op2);
-        *op2 = ret;
-
-        Return::Continue
+        let (op1, op2) = $machine.stack.pop2()?;
+        let (ret, ..) = op1.$op(op2);
+        $machine.stack.push_unchecked(ret);
+        Ok(())
     }};
 }
 
@@ -219,10 +105,10 @@ macro_rules! op2_u256_fn {
     ( $machine:expr, $op:path ) => {{
         //gas!($machine, $gas);
 
-        top2!($machine, op1, op2);
-        *op2 = $op(op1, *op2);
-
-        Return::Continue
+        let (op1, op2) = $machine.stack.pop2()?;
+        let ret = $op(op1, op2);
+        $machine.stack.push_unchecked(ret);
+        Ok(())
     }};
     ( $machine:expr, $op:path, $enabled:expr) => {{
         check!(($enabled));
@@ -234,11 +120,10 @@ macro_rules! op3_u256_fn {
     ( $machine:expr, $op:path) => {{
         //gas!($machine, $gas);
 
-        pop!($machine, op1, op2, op3);
+        let (op1, op2, op3) = $machine.stack.pop3()?;
         let ret = $op(op1, op2, op3);
-        push!($machine, ret);
-
-        Return::Continue
+        $machine.stack.push_unchecked(ret);
+        Ok(())
     }};
     ( $machine:expr, $op:path, $spec:ident :: $enabled:ident) => {{
         check!($spec::$enabled);
@@ -256,20 +141,10 @@ macro_rules! as_usize_saturated {
     }};
 }
 
-macro_rules! as_usize_or_fail {
-    ( $v:expr ) => {{
-        if { $v.0[1] != 0 || $v.0[2] != 0 || $v.0[3] != 0 } {
-            return Return::OutOfGas;
-        }
-
-        $v.0[0] as usize
-    }};
-
-    ( $v:expr, $reason:expr ) => {{
-        if { $v.0[1] != 0 || $v.0[2] != 0 || $v.0[3] != 0 } {
-            return $reason;
-        }
-
-        $v.0[0] as usize
-    }};
+// XXX move
+pub fn as_usize_or_fail(v: &U256, err: Return) -> Result<usize, Return> {
+    if v.0[1] != 0 || v.0[2] != 0 || v.0[3] != 0 {
+        return Err(err);
+    }
+    Ok(v.0[0] as usize)
 }

--- a/crates/revm/src/instructions/misc.rs
+++ b/crates/revm/src/instructions/misc.rs
@@ -81,14 +81,14 @@ pub fn pop(machine: &mut Machine) -> Return {
 
 pub fn mload(machine: &mut Machine) -> Return {
     //gas!(machine, gas::VERYLOW);
-    pop!(machine, index);
 
-    let index = as_usize_or_fail!(index, Return::OutOfGas);
+    let top = match machine.stack.top_mut() {
+        Some(top) => top,
+        None => return Return::StackUnderflow,
+    };
+    let index = as_usize_or_fail!(top, Return::OutOfGas);
     memory_resize!(machine, index, 32);
-    push!(
-        machine,
-        util::be_to_u256(machine.memory.get_slice(index, 32))
-    );
+    *top = util::be_to_u256(machine.memory.get_slice(index, 32));
     Return::Continue
 }
 

--- a/crates/revm/src/instructions/misc.rs
+++ b/crates/revm/src/instructions/misc.rs
@@ -144,18 +144,18 @@ pub fn jumpi(machine: &mut Machine) -> Return {
         }
     } else {
         // if we are not doing jump, add next gas block.
-        machine.add_next_gas_block(machine.program_counter() - 1)
+        machine.add_next_gas_block(machine.program_counter - 1)
     }
 }
 
 pub fn jumpdest(machine: &mut Machine) -> Return {
     gas!(machine, gas::JUMPDEST);
-    machine.add_next_gas_block(machine.program_counter() - 1)
+    machine.add_next_gas_block(machine.program_counter - 1)
 }
 
 pub fn pc(machine: &mut Machine) -> Return {
     //gas!(machine, gas::BASE);
-    push!(machine, U256::from(machine.program_counter() - 1));
+    push!(machine, U256::from(machine.program_counter - 1));
     Return::Continue
 }
 

--- a/crates/revm/src/instructions/system.rs
+++ b/crates/revm/src/instructions/system.rs
@@ -289,9 +289,8 @@ pub fn log<H: Host, SPEC: Spec>(machine: &mut Machine, n: u8, host: &mut H) -> R
 
     let mut topics = Vec::with_capacity(n);
     for _ in 0..(n) {
-        /*** SAFETY stack bounds already checked few lines above */
         let mut t = H256::zero();
-        unsafe { machine.stack.pop_unsafe().to_big_endian(t.as_bytes_mut()) };
+        machine.stack.pop_unsafe().to_big_endian(t.as_bytes_mut());
         topics.push(t);
     }
 

--- a/crates/revm/src/instructions/system.rs
+++ b/crates/revm/src/instructions/system.rs
@@ -266,7 +266,7 @@ pub fn gas(machine: &mut Machine) -> Return {
     //gas!(machine, gas::BASE);
 
     push!(machine, U256::from(machine.gas.remaining()));
-    machine.add_next_gas_block(machine.program_counter() - 1)
+    machine.add_next_gas_block(machine.program_counter - 1)
 }
 
 pub fn log<H: Host, SPEC: Spec>(machine: &mut Machine, n: u8, host: &mut H) -> Return {
@@ -372,7 +372,7 @@ pub fn create<H: Host, SPEC: Spec>(
     machine.gas.reimburse_unspend(&reason, gas);
     match reason {
         Return::FatalNotSupported => Return::FatalNotSupported,
-        _ => machine.add_next_gas_block(machine.program_counter() - 1),
+        _ => machine.add_next_gas_block(machine.program_counter - 1),
     }
 }
 
@@ -525,5 +525,5 @@ pub fn call<H: Host, SPEC: Spec>(
             push!(machine, U256::zero());
         }
     }
-    machine.add_next_gas_block(machine.program_counter() - 1)
+    machine.add_next_gas_block(machine.program_counter - 1)
 }

--- a/crates/revm/src/machine/machine.rs
+++ b/crates/revm/src/machine/machine.rs
@@ -161,11 +161,6 @@ impl Machine {
         Return::Continue
     }
 
-    /// Return a reference of the program counter.
-    pub fn program_counter(&self) -> usize {
-        self.program_counter
-    }
-
     #[inline(always)]
     pub fn current_opcode(&self) -> u8 {
         self.contract.code[self.program_counter]

--- a/crates/revm/src/machine/memory.rs
+++ b/crates/revm/src/machine/memory.rs
@@ -60,8 +60,9 @@ impl Memory {
     /// Set memory region at given offset. The offset and value are already checked
     ///
     #[inline(always)]
-    pub unsafe fn set_byte(&mut self, index: usize, byte: u8) {
-        *self.data.get_unchecked_mut(index) = byte;
+    pub fn set_byte(&mut self, index: usize, byte: u8) {
+        self.data[index] = byte;
+        // *self.data.get_unchecked_mut(index) = byte;
     }
 
     #[inline(always)]
@@ -83,11 +84,7 @@ impl Memory {
     pub fn set_data(&mut self, memory_offset: usize, data_offset: usize, len: usize, data: &[u8]) {
         if data_offset >= data.len() {
             // nulify all memory slots
-            for i in memory_offset..memory_offset + len {
-                unsafe {
-                    *self.data.get_unchecked_mut(i) = 0;
-                }
-            }
+            self.data[memory_offset..memory_offset + len].fill(0);
             return;
         }
         let data_end = min(data_offset + len, data.len());
@@ -95,11 +92,7 @@ impl Memory {
         self.data[memory_offset..memory_data_end].copy_from_slice(&data[data_offset..data_end]);
 
         // nulify rest of memory slots
-        for i in memory_data_end..memory_offset + len {
-            unsafe {
-                *self.data.get_unchecked_mut(i) = 0;
-            }
-        }
+        self.data[memory_data_end..memory_offset + len].fill(0);
     }
 }
 

--- a/crates/revm/src/machine/memory.rs
+++ b/crates/revm/src/machine/memory.rs
@@ -121,7 +121,7 @@ mod tests {
                 continue;
             }
             let next_multiple = x + 32 - (x % 32);
-            assert_eq!(Some(next_multiple), next_multiple_of_32(x.into()));
+            assert_eq!(Some(next_multiple), next_multiple_of_32(x));
         }
 
         // // next_multiple_of_32 returns None when the next multiple of 32 is too big

--- a/crates/revm/src/machine/stack.rs
+++ b/crates/revm/src/machine/stack.rs
@@ -66,6 +66,11 @@ impl Stack {
         }
     }
 
+    #[inline(always)]
+    pub fn top_mut(&mut self) -> Option<&mut U256> {
+        self.data.last_mut()
+    }
+
     #[inline]
     /// Pop a value from the stack. If the stack is already empty, returns the
     /// `StackUnderflow` error.

--- a/crates/revm/src/spec/spec_impl.rs
+++ b/crates/revm/src/spec/spec_impl.rs
@@ -1,4 +1,4 @@
-use crate::SpecId;
+use crate::{Return, SpecId};
 
 pub(crate) trait NotStaticSpec {}
 
@@ -10,6 +10,24 @@ pub trait Spec: Sized {
     fn enabled(spec_id: SpecId) -> bool {
         Self::SPEC_ID as u8 >= spec_id as u8
     }
+    #[inline(always)]
+    fn require(spec_id: SpecId) -> Result<(), Return> {
+        if Self::enabled(spec_id) {
+            Ok(())
+        } else {
+            Err(Return::NotActivated)
+        }
+    }
+
+    #[inline(always)]
+    fn err_if_static_call() -> Result<(), Return> {
+        if Self::IS_STATIC_CALL {
+            Err(Return::NotActivated)
+        } else {
+            Ok(())
+        }
+    }
+
     const SPEC_ID: SpecId;
     /// static flag used in STATIC type;
     const IS_STATIC_CALL: bool;


### PR DESCRIPTION
This is sort of an experiment, and isn't entirely finished; if you're not interested in these changes, no hard feelings.

This builds on #47, and removes some macros in favor of using rust's `Result` type and `?` operator. (Note that `Result<(), Return>` is the same size as `Return`; there should be no downside to using Result/? instead of explicit tests and returns).

This is motivated by the fact that some of the macros are doing almost exactly what the more idiomatic, safe equivalent does.

For example,
```
pop!(machine, op1);

macro_rules! pop {
    ( $machine:expr, $x1:ident) => {
        if $machine.stack.len() < 1 {
            return Return::StackUnderflow;
        }
        let $x1 = unsafe { $machine.stack.pop_unsafe() };
    };
    ...
}
pub unsafe fn pop_unsafe(&mut self) -> U256 {
    let mut len = self.data.len();
    len -= 1;
    self.data.set_len(len);
    *self.data.get_unchecked(len)
}
```
should compile down to exactly the same thing as this:
```
let op1 = machine.stack.pop()?;

pub fn pop(&mut self) -> Result<U256, Return> {
    self.data.pop().ok_or(Return::StackUnderflow)
}
```
Of course, it's not *exactly* the same :)
There's a small speed loss again, which could maybe be mitigated.

revm-test on main branch:
`9: 63.577744ms`
this pr:
`9: 66.229494ms`