### PR TITLE
feat: call insp end functions on early return

### DIFF
--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -297,7 +297,9 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
         if INSPECT {
             let (ret, address, gas, out) = self.inspector.create(&mut self.data, inputs);
             if ret != Return::Continue {
-                return (ret, address, gas, out);
+                return self
+                    .inspector
+                    .create_end(&mut self.data, inputs, ret, address, gas, out);
             }
         }
 
@@ -435,7 +437,14 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
                 .inspector
                 .call(&mut self.data, inputs, SPEC::IS_STATIC_CALL);
             if ret != Return::Continue {
-                return (ret, gas, out);
+                return self.inspector.call_end(
+                    &mut self.data,
+                    inputs,
+                    gas,
+                    ret,
+                    out,
+                    SPEC::IS_STATIC_CALL,
+                );
             }
         }
 


### PR DESCRIPTION
We need to call the `end` functions on the inspectors in case we return early, since some inspectors might have internal state that should change on every call (e.g. the Foundry tracer).

- When `create` returns early, `create_end` is also called
- When `call` returns early, `call_end` is also called