### PR TITLE
chore: do not pin k256 patch version

### DIFF
--- a/crates/revm_precompiles/Cargo.toml
+++ b/crates/revm_precompiles/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.4.0"
 [dependencies]
 bn = { package = "substrate-bn", version = "0.6", default-features = false }
 bytes = { version = "1.1", default-features = false }
-k256 = { version = "0.10.3", default-features = false, features = ["ecdsa", "keccak256"], optional = true }
+k256 = { version = "0.10", default-features = false, features = ["ecdsa", "keccak256"], optional = true }
 num = { version = "0.4.0", default-features = false, features = ["alloc"] }
 primitive-types = { version = "0.11", default-features = false, features = ["rlp"] }
 ripemd = { version = "0.1", default-features = false }


### PR DESCRIPTION
as title, supersedes #80 