### PR TITLE
bump k256 to 0.10.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,9 +973,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "587f53e46eb6dc82b53cda7ebf3ae3ad568ed987ced60962fc845f7fe22904e3"
+checksum = "19c3a5e0a0b8450278feda242592512e09f61c72e018b8cd5c859482802daf2d"
 dependencies = [
  "cfg-if 1.0.0",
  "ecdsa",


### PR DESCRIPTION
per suggestion in https://github.com/bluealloy/revm/issues/77#issuecomment-1069134023, was my mistake forgot to bump cargo lock in #81 