### PR TITLE
Gas fixes

### DIFF
--- a/crates/revm/src/interpreter.rs
+++ b/crates/revm/src/interpreter.rs
@@ -53,7 +53,7 @@ impl Interpreter {
         &self.contract
     }
 
-    pub fn gas(&mut self) -> &Gas {
+    pub fn gas(&self) -> &Gas {
         &self.gas
     }
 


### PR DESCRIPTION
The gas returned by the EVM did not account for refunds, and `Interpreter::gas` took `&mut self` without needing to

I also made `finalize` not return a `Result` since there was no path where it would return `Err`