### PR TITLE
feat: `Inspector::log`

### DIFF
--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -608,6 +608,9 @@ impl<'a, GSPEC: Spec, DB: Database + 'a, const INSPECT: bool> Host
     }
 
     fn log(&mut self, address: H160, topics: Vec<H256>, data: Bytes) {
+        if INSPECT {
+            self.inspector.log(&mut self.data, &address, &topics, &data);
+        }
         let log = Log {
             address,
             topics,

--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use primitive_types::H160;
+use primitive_types::{H160, H256};
 
 use crate::{evm_impl::EVMData, CallInputs, CreateInputs, Database, Gas, Interpreter, Return};
 use auto_impl::auto_impl;
@@ -34,6 +34,16 @@ pub trait Inspector<DB: Database> {
         _is_static: bool,
     ) -> Return {
         Return::Continue
+    }
+
+    /// Called when a log is emitted.
+    fn log(
+        &mut self,
+        _evm_data: &mut EVMData<'_, DB>,
+        _address: &H160,
+        _topics: &[H256],
+        _data: &Bytes,
+    ) {
     }
 
     /// Called after `step` when the instruction has been executed.


### PR DESCRIPTION
In Foundry we need to collect logs even if the call reverts, so we had an `extract_log` function that basically was a peeking version of `log` in REVM but it also meant that we did double work most of the time. This just adds a log hook for inspectors