### PR TITLE
feat: allow inspectors to override block env

### DIFF
--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -5,7 +5,8 @@ use crate::{
     models::SelfDestructResult,
     return_ok,
     subroutine::{Account, State, SubRoutine},
-    CallContext, CallInputs, CreateInputs, CreateScheme, Env, Gas, Inspector, Log, Return, Spec,
+    BlockEnv, CallContext, CallInputs, CreateInputs, CreateScheme, Env, Gas, Inspector, Log,
+    Return, Spec,
     SpecId::*,
     TransactOut, TransactTo, Transfer, KECCAK_EMPTY,
 };
@@ -559,6 +560,14 @@ impl<'a, GSPEC: Spec, DB: Database + 'a, const INSPECT: bool> Host
         self.data.env
     }
 
+    fn block_env(&self) -> &BlockEnv {
+        if let Some(env) = self.inspector.block_env() {
+            env
+        } else {
+            &self.data.env.block
+        }
+    }
+
     fn block_hash(&mut self, number: U256) -> H256 {
         self.data.db.block_hash(number)
     }
@@ -672,6 +681,7 @@ pub trait Host {
     fn step_end(&mut self, interp: &mut Interpreter, is_static: bool, ret: Return) -> Return;
 
     fn env(&mut self) -> &mut Env;
+    fn block_env(&self) -> &BlockEnv;
 
     /// load account. Returns (is_cold,is_new_account)
     fn load_account(&mut self, address: H160) -> (bool, bool);

--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -1,11 +1,17 @@
 use bytes::Bytes;
 use primitive_types::{H160, H256};
 
-use crate::{evm_impl::EVMData, CallInputs, CreateInputs, Database, Gas, Interpreter, Return};
+use crate::{
+    evm_impl::EVMData, BlockEnv, CallInputs, CreateInputs, Database, Gas, Interpreter, Return,
+};
 use auto_impl::auto_impl;
 
 #[auto_impl(&mut, Box)]
 pub trait Inspector<DB: Database> {
+    fn block_env(&self) -> Option<&BlockEnv> {
+        None
+    }
+
     /// Called Before the interpreter is initialized.
     ///
     /// If anything other than [Return::Continue] is returned then execution of the interpreter is

--- a/crates/revm/src/instructions/host_env.rs
+++ b/crates/revm/src/instructions/host_env.rs
@@ -11,31 +11,31 @@ pub fn chainid<H: Host, SPEC: Spec>(interp: &mut Interpreter, host: &mut H) -> R
 
 pub fn coinbase<H: Host>(interp: &mut Interpreter, host: &mut H) -> Return {
     // gas!(interp, gas::BASE);
-    push_h256!(interp, host.env().block.coinbase.into());
+    push_h256!(interp, host.block_env().coinbase.into());
     Return::Continue
 }
 
 pub fn timestamp<H: Host>(interp: &mut Interpreter, host: &mut H) -> Return {
     // gas!(interp, gas::BASE);
-    push!(interp, host.env().block.timestamp);
+    push!(interp, host.block_env().timestamp);
     Return::Continue
 }
 
 pub fn number<H: Host>(interp: &mut Interpreter, host: &mut H) -> Return {
     // gas!(interp, gas::BASE);
-    push!(interp, host.env().block.number);
+    push!(interp, host.block_env().number);
     Return::Continue
 }
 
 pub fn difficulty<H: Host>(interp: &mut Interpreter, host: &mut H) -> Return {
     // gas!(interp, gas::BASE);
-    push!(interp, host.env().block.difficulty);
+    push!(interp, host.block_env().difficulty);
     Return::Continue
 }
 
 pub fn gaslimit<H: Host>(interp: &mut Interpreter, host: &mut H) -> Return {
     // gas!(interp, gas::BASE);
-    push!(interp, host.env().block.gas_limit);
+    push!(interp, host.block_env().gas_limit);
     Return::Continue
 }
 
@@ -49,7 +49,7 @@ pub fn basefee<H: Host, SPEC: Spec>(interp: &mut Interpreter, host: &mut H) -> R
     // gas!(interp, gas::BASE);
     // EIP-3198: BASEFEE opcode
     check!(SPEC::enabled(LONDON));
-    push!(interp, host.env().block.basefee);
+    push!(interp, host.block_env().basefee);
     Return::Continue
 }
 


### PR DESCRIPTION
I'm not sure if this is the best way to go about it: we have some cheatcodes in Foundry that alter information about blocks (`cheats.fee` to set `basefee`, `cheats.warp` to set `timestamp` and `cheats.roll` to set `number`). 

When we run tests in fork mode (i.e. using state from mainnet) we also set these things to reflect mainnet (`basefee` etc). Because the basefee is high in this scenario, and because the gas limit is always high for tests, we end up in a scenario where REVM will say we are out of funds, when in reality we do not care if we are out of funds for the main call.

This PR adds the ability to override the block environment, which fixes our problem. We can set all the gas prices etc. to 0 on our side, and in our inspector we can override the block environment with the actual information

Ref https://github.com/gakonst/foundry/pull/997/commits/37c2bbcade00fe32e63bfcb117e44e6a7b6f9764