### PR TITLE
Various fixes

### DIFF
--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -5,7 +5,8 @@ use crate::{
     models::SelfDestructResult,
     return_ok,
     subroutine::{Account, State, SubRoutine},
-    CallContext, CallInputs, CreateInputs, CreateScheme, Env, Gas, Inspector, Log, Return, Spec,
+    CallContext, CallInputs, CallScheme, CreateInputs, CreateScheme, Env, Gas, Inspector, Log,
+    Return, Spec,
     SpecId::*,
     TransactOut, TransactTo, Transfer, KECCAK_EMPTY,
 };
@@ -115,7 +116,9 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact
                 let context = CallContext {
                     caller,
                     address,
+                    code_address: address,
                     apparent_value: value,
+                    scheme: CallScheme::Call,
                 };
                 let mut call_input = CallInputs {
                     contract: address,

--- a/crates/revm/src/instructions/host.rs
+++ b/crates/revm/src/instructions/host.rs
@@ -290,17 +290,23 @@ pub fn call<H: Host, SPEC: Spec>(
         CallScheme::Call | CallScheme::StaticCall => CallContext {
             address: to,
             caller: interp.contract.address,
+            code_address: to,
             apparent_value: value,
+            scheme,
         },
         CallScheme::CallCode => CallContext {
             address: interp.contract.address,
             caller: interp.contract.address,
+            code_address: to,
             apparent_value: value,
+            scheme,
         },
         CallScheme::DelegateCall => CallContext {
             address: interp.contract.address,
             caller: interp.contract.caller,
+            code_address: to,
             apparent_value: interp.contract.value,
+            scheme,
         },
     };
 

--- a/crates/revm/src/models.rs
+++ b/crates/revm/src/models.rs
@@ -161,8 +161,6 @@ pub struct CallContext {
     /// Apparent value of the EVM.
     pub apparent_value: U256,
     /// The scheme used for the call.
-    ///
-    /// Defaults to [CallScheme::Call].
     pub scheme: CallScheme,
 }
 

--- a/crates/revm/src/models.rs
+++ b/crates/revm/src/models.rs
@@ -68,13 +68,19 @@ impl AccountInfo {
     }
 }
 
+/// Inputs for a call.
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CallInputs {
+    /// The target of the call.
     pub contract: H160,
+    /// The transfer, if any, in this call.
     pub transfer: Transfer,
+    /// The call data of the call.
     #[cfg_attr(feature = "with-serde", serde(with = "serde_hex_bytes"))]
     pub input: Bytes,
+    /// The gas limit of the call.
     pub gas_limit: u64,
+    /// The context of the call.
     pub context: CallContext,
 }
 
@@ -128,6 +134,7 @@ pub enum CreateScheme {
     },
 }
 
+/// Call schemes.
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CallScheme {
@@ -142,15 +149,33 @@ pub enum CallScheme {
 }
 
 /// CallContext of the runtime.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CallContext {
     /// Execution address.
     pub address: H160,
     /// Caller of the EVM.
     pub caller: H160,
+    /// The address the contract code was loaded from, if any.
+    pub code_address: H160,
     /// Apparent value of the EVM.
     pub apparent_value: U256,
+    /// The scheme used for the call.
+    ///
+    /// Defaults to [CallScheme::Call].
+    pub scheme: CallScheme,
+}
+
+impl Default for CallContext {
+    fn default() -> Self {
+        CallContext {
+            address: H160::default(),
+            caller: H160::default(),
+            code_address: H160::default(),
+            apparent_value: U256::default(),
+            scheme: CallScheme::Call,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default)]

--- a/crates/revm/src/subroutine.rs
+++ b/crates/revm/src/subroutine.rs
@@ -251,7 +251,10 @@ impl SubRoutine {
         from.info.balance -= value;
 
         let to = self.log_dirty(to, |_| {});
-        to.info.balance += value;
+        to.info
+            .balance
+            .checked_add(value)
+            .ok_or(Return::OverflowPayment)?;
 
         Ok((from_is_cold, to_is_cold))
     }

--- a/crates/revm/src/subroutine.rs
+++ b/crates/revm/src/subroutine.rs
@@ -251,7 +251,8 @@ impl SubRoutine {
         from.info.balance -= value;
 
         let to = self.log_dirty(to, |_| {});
-        to.info
+        to.info.balance = to
+            .info
             .balance
             .checked_add(value)
             .ok_or(Return::OverflowPayment)?;


### PR DESCRIPTION
- Prevents overflows in `SubRoutine::transfer` for the recipient
- Allows inspectors to see what kind of call is being made - some inspectors in Foundry manage state that depend on this info
