### PR TITLE
chore: refactor to exact option combinators

### DIFF
--- a/bins/revme/src/debugger/ctrl/history.rs
+++ b/bins/revme/src/debugger/ctrl/history.rs
@@ -66,7 +66,7 @@ impl History for CliHistory {
                 .unwrap();
 
             if let Err(e) = writeln!(file, "{}", line) {
-                eprintln!("Couldn't write to history file: {}", e);
+                eprintln!("Couldn't write to history file: {e}");
             }
         }
     }
@@ -81,10 +81,7 @@ impl History for CliHistory {
         let mut idx = idx;
 
         loop {
-            let line = match self.entries.get(idx) {
-                Some(line) => line,
-                None => return None,
-            };
+            let line = self.entries.get(idx)?;
 
             if let Some(cursor) = style.match_against(pattern, line) {
                 return Some(SearchResult {
@@ -94,10 +91,7 @@ impl History for CliHistory {
                 });
             }
 
-            idx = match direction.next(idx) {
-                None => return None,
-                Some(idx) => idx,
-            };
+            idx = direction.next(idx)?;
         }
     }
 }

--- a/crates/revm_precompiles/src/lib.rs
+++ b/crates/revm_precompiles/src/lib.rs
@@ -137,11 +137,10 @@ impl Precompiles {
 
     pub fn get(&self, address: &Address) -> Option<Precompile> {
         //return None;
-        if let Some((_, precompile)) = self.fun.iter().find(|(t, _)| t == address) {
-            Some(precompile.clone())
-        } else {
-            None
-        }
+        self.fun
+            .iter()
+            .find(|(t, _)| t == address)
+            .map(|(_, precompile)| precompile.clone())
     }
 }
 


### PR DESCRIPTION
Plus use [captured identifiers from rust 1.58](https://blog.rust-lang.org/2022/01/13/Rust-1.58.0.html#captured-identifiers-in-format-strings),

Tool-aided by [comby-rust](https://github.com/huitseeker/comby-rust)