### PR TITLE
empty keccak constant and remove access_list.clone

### DIFF
--- a/crates/revm/src/instructions/system.rs
+++ b/crates/revm/src/instructions/system.rs
@@ -1,5 +1,4 @@
-use crate::{gas, interpreter::Interpreter, Return, Spec, SpecId::*};
-use bytes::Bytes;
+use crate::{gas, interpreter::Interpreter, Return, Spec, SpecId::*, KECCAK_EMPTY};
 use primitive_types::{H256, U256};
 
 use sha3::{Digest, Keccak256};
@@ -9,11 +8,7 @@ pub fn sha3(interp: &mut Interpreter) -> Return {
     gas_or_fail!(interp, gas::sha3_cost(len));
     let len = as_usize_or_fail!(len, Return::OutOfGas);
     let h256 = if len == 0 {
-        H256([
-            0xc5, 0xd2, 0x46, 0x01, 0x86, 0xf7, 0x23, 0x3c, 0x92, 0x7e, 0x7d, 0xb2, 0xdc, 0xc7,
-            0x03, 0xc0, 0xe5, 0x00, 0xb6, 0x53, 0xca, 0x82, 0x27, 0x3b, 0x7b, 0xfa, 0xd8, 0x04,
-            0x5d, 0x85, 0xa4, 0x70,
-        ])
+        KECCAK_EMPTY
     } else {
         let from = as_usize_or_fail!(from, Return::OutOfGas);
         memory_resize!(interp, from, len);


### PR DESCRIPTION
\+ empty constant keccak taken from [here](https://docs.rs/keccak-hash/latest/src/keccak_hash/lib.rs.html#18-21)
\- bytes.copy before keccak (not sure if it would get optimized away anyway...)
\- access_list.clone 
