### PR TITLE
chore: export evm_inner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "arrayref",
  "auto_impl",

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["no_std", "ethereum", "evm", "revm"]
 license = "MIT"
 name = "revm"
 repository = "https://github.com/bluealloy/revm"
-version = "1.4.0"
+version = "1.4.1"
 
 [dependencies]
 arrayref  = "0.3"

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -17,7 +17,7 @@ pub use evm_impl::{EVMData, Host};
 pub type DummyStateDB = InMemoryDB;
 
 pub use db::{Database, DatabaseCommit, InMemoryDB};
-pub use evm::{new, EVM};
+pub use evm::{evm_inner, new, EVM};
 pub use gas::Gas;
 pub use inspector::{Inspector, NoOpInspector, OverrideSpec};
 pub use instructions::{


### PR DESCRIPTION
access to this is useful to replicate `Evm::inspect_ref` with a custom `Database`, other than `RefDBWrapper`

I guess alternatively this could be achieved by making `RefDBWrapper` generic but would require breaking changes.