### PR TITLE
fix: remove stipend from sstore gas calculations

### DIFF
--- a/crates/revm/src/gas/calc.rs
+++ b/crates/revm/src/gas/calc.rs
@@ -215,9 +215,8 @@ pub fn sstore_cost<SPEC: Spec>(
     original: U256,
     current: U256,
     new: U256,
-    gas: u64,
     is_cold: bool,
-) -> Option<u64> {
+) -> u64 {
     // TODO untangle this mess and make it more elegant
     let (gas_sload, gas_sstore_reset) = if SPEC::enabled(BERLIN) {
         (STORAGE_READ_WARM, SSTORE_RESET - SLOAD_COLD)
@@ -225,10 +224,6 @@ pub fn sstore_cost<SPEC: Spec>(
         (sload_cost::<SPEC>(is_cold), SSTORE_RESET)
     };
     let gas_cost = if SPEC::enabled(CONSTANTINOPLE) {
-        if SPEC::enabled(CONSTANTINOPLE) && gas <= CALL_STIPEND {
-            return None;
-        }
-
         if new == current {
             gas_sload
         } else {
@@ -251,9 +246,9 @@ pub fn sstore_cost<SPEC: Spec>(
     };
     // In EIP-2929 we charge extra if the slot has not been used yet in this transaction
     if SPEC::enabled(BERLIN) && is_cold {
-        Some(gas_cost + SLOAD_COLD)
+        gas_cost + SLOAD_COLD
     } else {
-        Some(gas_cost)
+        gas_cost
     }
 }
 

--- a/crates/revm/src/instructions/host.rs
+++ b/crates/revm/src/instructions/host.rs
@@ -115,10 +115,7 @@ pub fn sstore<H: Host, SPEC: Spec>(interp: &mut Interpreter, host: &mut H) -> Re
 
     pop!(interp, index, value);
     let (original, old, new, is_cold) = host.sstore(interp.contract.address, index, value);
-    gas_or_fail!(interp, {
-        let remaining_gas = interp.gas.remaining();
-        gas::sstore_cost::<SPEC>(original, old, new, remaining_gas, is_cold)
-    });
+    gas!(interp, gas::sstore_cost::<SPEC>(original, old, new, is_cold));
     refund!(interp, gas::sstore_refund::<SPEC>(original, old, new));
     Return::Continue
 }


### PR DESCRIPTION
Not sure what the reasoning was for including the stipend for SSTORE originally. Couldn't find any other EVM implementations doing this check.

Encountered the issue when testing a number of scenarios using [cast](https://github.com/foundry-rs/foundry/tree/master/cast).

Specifically:
```
cast run 0x10c305ada9cb1066b396d6558d1d195d21abfaef6c76e5ae1568354b58daab64
```

The transaction would fail due the storage slot of the `reentrancy` guard being reset. 