### PR TITLE
don't delete account and storage entries on commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "arrayref",
  "auto_impl",

--- a/bins/revme/src/statetest/merkle_trie.rs
+++ b/bins/revme/src/statetest/merkle_trie.rs
@@ -34,7 +34,6 @@ pub fn state_merkle_trie_root(
 ) -> H256 {
     let vec = accounts
         .iter()
-        .filter(|(_, info)| !info.is_empty())
         .map(|(address, info)| {
             let storage = storage.get(address).cloned().unwrap_or_default();
             let storage_root = trie_account_rlp(info, storage);

--- a/bins/revme/src/statetest/merkle_trie.rs
+++ b/bins/revme/src/statetest/merkle_trie.rs
@@ -34,6 +34,7 @@ pub fn state_merkle_trie_root(
 ) -> H256 {
     let vec = accounts
         .iter()
+        .filter(|(_, info)| !info.is_empty())
         .map(|(address, info)| {
             let storage = storage.get(address).cloned().unwrap_or_default();
             let storage_root = trie_account_rlp(info, storage);

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["no_std", "ethereum", "evm", "revm"]
 license = "MIT"
 name = "revm"
 repository = "https://github.com/bluealloy/revm"
-version = "1.5.0"
+version = "1.6.0"
 
 [dependencies]
 arrayref  = "0.3"

--- a/crates/revm/src/db/in_memory_db.rs
+++ b/crates/revm/src/db/in_memory_db.rs
@@ -24,6 +24,7 @@ impl InMemoryDB {
 pub struct CacheDB<ExtDB: DatabaseRef> {
     /// Dummy account info where `code` is always `None`.
     /// Code bytes can be found in `contracts`.
+    changes: Map<H160, AccountInfo>,
     cache: Map<H160, AccountInfo>,
     storage: Map<H160, Map<U256, U256>>,
     contracts: Map<H256, Bytes>,
@@ -38,6 +39,7 @@ impl<ExtDB: DatabaseRef> CacheDB<ExtDB> {
         contracts.insert(KECCAK_EMPTY, Bytes::new());
         contracts.insert(H256::zero(), Bytes::new());
         Self {
+            changes: Map::new(),
             cache: Map::new(),
             storage: Map::new(),
             contracts,
@@ -45,6 +47,9 @@ impl<ExtDB: DatabaseRef> CacheDB<ExtDB> {
             block_hashes: Map::new(),
             db,
         }
+    }
+    pub fn changes(&self) -> &Map<H160, AccountInfo> {
+        &self.changes
     }
 
     pub fn cache(&self) -> &Map<H160, AccountInfo> {
@@ -55,7 +60,7 @@ impl<ExtDB: DatabaseRef> CacheDB<ExtDB> {
         &self.storage
     }
 
-    pub fn insert_cache(&mut self, address: H160, mut account: AccountInfo) {
+    fn insert_contract(&mut self, account: &mut AccountInfo) {
         let code = core::mem::take(&mut account.code);
         if let Some(code) = code {
             if !code.is_empty() {
@@ -67,6 +72,15 @@ impl<ExtDB: DatabaseRef> CacheDB<ExtDB> {
         if account.code_hash.is_zero() {
             account.code_hash = KECCAK_EMPTY;
         }
+    }
+
+    pub fn insert_change(&mut self, address: H160, mut account: AccountInfo) {
+        self.insert_contract(&mut account);
+        self.changes.insert(address, account);
+    }
+
+    pub fn insert_cache(&mut self, address: H160, mut account: AccountInfo) {
+        self.insert_contract(&mut account);
         self.cache.insert(address, account);
     }
 
@@ -96,10 +110,10 @@ impl<ExtDB: DatabaseRef> DatabaseCommit for CacheDB<ExtDB> {
         for (add, acc) in changes {
             if acc.is_empty() || matches!(acc.filth, Filth::Destroyed) {
                 // clear account data, but don't remove entry
-                self.cache.insert(add, Default::default());
+                self.changes.insert(add, Default::default());
                 self.storage.get_mut(&add).map(clear_storage);
             } else {
-                self.insert_cache(add, acc.info);
+                self.insert_change(add, acc.info);
                 let storage = self.storage.entry(add).or_default();
                 if acc.filth.abandon_old_storage() {
                     clear_storage(storage);
@@ -123,14 +137,18 @@ impl<ExtDB: DatabaseRef> Database for CacheDB<ExtDB> {
     }
 
     fn basic(&mut self, address: H160) -> AccountInfo {
-        match self.cache.entry(address) {
-            Entry::Occupied(entry) => entry.get().clone(),
-            Entry::Vacant(entry) => {
-                let acc = self.db.basic(address);
-                if !acc.is_empty() {
-                    entry.insert(acc.clone());
+        if let Some(changed) = self.changes.get(&address) {
+            changed.clone()
+        } else {
+            match self.cache.entry(address) {
+                Entry::Occupied(entry) => entry.get().clone(),
+                Entry::Vacant(entry) => {
+                    let acc = self.db.basic(address);
+                    if !acc.is_empty() {
+                        entry.insert(acc.clone());
+                    }
+                    acc
                 }
-                acc
             }
         }
     }


### PR DESCRIPTION
As discovered here https://github.com/foundry-rs/foundry/issues/1894

deleting storage or account entries does not play nice with fork mode which basically does:

```rust
if !db.contains(acc) {
    // fetch from remote 
}
```

So deleting accounts/slots (when empty) would result in the fork's account/slot being served and not 0 or the empty account.

# Solution

* on `CacheDb::commit` don't delete `AccountInfo` or storage entries in the CacheDb's maps 

* also bumps to v1.6.0