### PR TITLE
feat: add ord derives to specid

### DIFF
--- a/crates/revm/src/specification.rs
+++ b/crates/revm/src/specification.rs
@@ -3,7 +3,7 @@ use num_enum::TryFromPrimitive;
 use revm_precompiles::SpecId as PrecompileId;
 
 #[repr(u8)]
-#[derive(Debug, Copy, Clone, TryFromPrimitive, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, TryFromPrimitive, Eq, PartialEq, Hash, Ord, PartialOrd)]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(non_camel_case_types)]
 pub enum SpecId {


### PR DESCRIPTION
this allows checks like 

`if env.cfg.spec_id >= SpecId::LONDON { }`