### PR TITLE
revm/evm: Return `ExecutionResult`, which includes `gas_refunded`

### DIFF
--- a/bins/revm-test/src/bin/analysis.rs
+++ b/bins/revm-test/src/bin/analysis.rs
@@ -28,12 +28,12 @@ fn main() {
 
     // just to spead up processor.
     for _ in 0..10000 {
-        let (_, _, _, _, _) = evm.transact();
+        let (_, _) = evm.transact();
     }
 
     let timer = Instant::now();
     for _ in 0..30000 {
-        let (_, _, _, _, _) = evm.transact();
+        let (_, _) = evm.transact();
     }
     println!("Raw elapsed time: {:?}", timer.elapsed());
 
@@ -41,7 +41,7 @@ fn main() {
 
     let timer = Instant::now();
     for _ in 0..30000 {
-        let (_, _, _, _, _) = evm.transact();
+        let (_, _) = evm.transact();
     }
     println!("Checked elapsed time: {:?}", timer.elapsed());
 
@@ -49,7 +49,7 @@ fn main() {
 
     let timer = Instant::now();
     for _ in 0..30000 {
-        let (_, _, _, _, _) = evm.transact();
+        let (_, _) = evm.transact();
     }
     println!("Analysed elapsed time: {:?}", timer.elapsed());
 }

--- a/bins/revm-test/src/bin/snailtracer.rs
+++ b/bins/revm-test/src/bin/snailtracer.rs
@@ -23,7 +23,7 @@ pub fn simple_example() {
     let mut times = Vec::new();
     for _ in 0..30 {
         let timer = Instant::now();
-        let (_, _, _, _, _) = evm.transact();
+        let (_, _) = evm.transact();
         let i = timer.elapsed();
         times.push(i);
         elapsed += i;

--- a/crates/revm/src/models.rs
+++ b/crates/revm/src/models.rs
@@ -1,6 +1,6 @@
 use core::cmp::min;
 
-use crate::{alloc::vec::Vec, interpreter::bytecode::Bytecode, SpecId};
+use crate::{alloc::vec::Vec, interpreter::bytecode::Bytecode, Return, SpecId};
 use bytes::Bytes;
 use primitive_types::{H160, H256, U256};
 
@@ -104,7 +104,7 @@ impl TransactTo {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TransactOut {
     None,
@@ -386,5 +386,26 @@ pub(crate) mod serde_hex_bytes_opt {
 
         let value = OptionalBytes::deserialize(deserializer)?;
         Ok(value.0.map(|b| b.0))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ExecutionResult {
+    pub exit_reason: Return,
+    pub out: TransactOut,
+    pub gas_used: u64,
+    pub gas_refunded: u64,
+    pub logs: Vec<Log>,
+}
+
+impl ExecutionResult {
+    pub fn new_with_reason(reason: Return) -> ExecutionResult {
+        ExecutionResult {
+            exit_reason: reason,
+            out: TransactOut::None,
+            gas_used: 0,
+            gas_refunded: 0,
+            logs: Vec::new(),
+        }
     }
 }

--- a/crates/revmjs/src/lib.rs
+++ b/crates/revmjs/src/lib.rs
@@ -3,7 +3,10 @@ use core::convert::TryInto;
 use bn_rs::BN;
 use bytes::Bytes;
 use primitive_types::{H160, U256};
-use revm::{AccountInfo, Bytecode, DatabaseCommit, InMemoryDB, SpecId, TransactTo, EVM as rEVM};
+use revm::{
+    AccountInfo, Bytecode, DatabaseCommit, ExecutionResult, InMemoryDB, SpecId, TransactTo,
+    EVM as rEVM,
+};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -45,17 +48,28 @@ impl EVM {
     }
 
     pub fn transact(&mut self) -> u64 {
-        let (exit, data, gas, state, logs) = self.revm.transact();
+        let (
+            ExecutionResult {
+                exit_reason,
+                out,
+                gas_used,
+                gas_refunded,
+                logs,
+                ..
+            },
+            state,
+        ) = self.revm.transact();
         console_log!(
-            "Transact done, exit:{:?}, gas:{:?}, data:{:?}\nstate_chage:{:?}\nlogs:{:?}",
-            exit,
-            gas,
-            data,
+            "Transact done, exit:{:?}, gas:{:?} ({:?} refunded), data:{:?}\nstate_chage:{:?}\nlogs:{:?}",
+            exit_reason,
+            gas_used,
+            gas_refunded,
+            out,
             state,
             logs,
         );
         self.revm.db().unwrap().commit(state);
-        gas
+        gas_used
     }
 
     /****** DATABASE RELATED ********/


### PR DESCRIPTION
Following the discussion in #167 ; now the revm/evm `transact`/`inspect` methods are returning an `ExecutionResult` struct, which includes the `gas_refunded` value.