### PR TITLE
chore: add refunds saturated

### DIFF
--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -229,7 +229,8 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
                 .get_mut(&caller)
                 .unwrap()
                 .info
-                .balance += effective_gas_price * (gas.remaining() + gas_refunded);
+                .balance
+                .saturating_add(effective_gas_price * (gas.remaining() + gas_refunded));
 
             // EIP-1559
             let coinbase_gas_price = if SPEC::enabled(LONDON) {


### PR DESCRIPTION
in theory, adding refunds should not lead to overflows since it is subtracted beforehand:

https://github.com/bluealloy/revm/blob/24622a4c9e450217f6a723008a75e3faa3b7cc5d/crates/revm/src/evm_impl.rs#L90-L104


however in forge test there are scenarios where we start with an `effective_gas_price` of `0` and an initial balance of `U256::MAX` and modify the env (gas price) via cheat codes so that we could theoretically end up with a refund that will increase the balance in some situations.

using saturated add here would prevent a panic in such situations.