### PR TITLE
Expose Ethereum test utilities in revme crate 

### DIFF
--- a/bins/revme/src/lib.rs
+++ b/bins/revme/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod statetest;

--- a/bins/revme/src/statetest/mod.rs
+++ b/bins/revme/src/statetest/mod.rs
@@ -1,6 +1,6 @@
 mod cmd;
-mod merkle_trie;
-mod models;
+pub mod merkle_trie;
+pub mod models;
 mod runner;
 mod trace;
 


### PR DESCRIPTION
I found these modules useful for loading and running state tests, so I'm wondering if the `revme` crate could expose them or if the modules could be moved to a separate crate ("test-utils", or something like that).

I'm currently using a fork of revm with these changes but this creates issues when I'm also using parts of foundry (that also depends on revm) as a dependency. 

I realize the crate is currently described as binary crate so marking this as a draft.