### PR TITLE
chore(ci): use ethtests profile for CI tests

### DIFF
--- a/.github/workflows/ethereum-tests.yml
+++ b/.github/workflows/ethereum-tests.yml
@@ -34,4 +34,4 @@ jobs:
           cache-on-failure: true
 
       - name: Run Ethereum tests
-        run: cargo run --release -p revme -- statetest ethtests/GeneralStateTests
+        run: cargo run --profile ethtests -p revme -- statetest ethtests/GeneralStateTests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ default-members = ["crates/revm"]
 
 [profile.release]
 # debug = true
+
+[profile.ethtests]
+inherits = "test"
+opt-level = 3


### PR DESCRIPTION
```console
➜  revm git:(ethtests-profile) git revert 7ecc92095c14566a264df790cf9f8792a3341b22    
[ethtests-profile 3d77606] Revert "Revert "refactor(revm): use u64 for gas refund counter (#180)" (#187)"
 4 files changed, 11 insertions(+), 11 deletions(-)

➜  revm git:(ethtests-profile) ✗ cargo run --profile ethtests -p revme -- statetest ethtests/GeneralStateTests
    Finished ethtests [optimized + debuginfo] target(s) in 0.30s
     Running `target/ethtests/revme statetest ethtests/GeneralStateTests`
Start running tests on: "ethtests/GeneralStateTests"
█████████████████████████████████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 626/2607
thread '<unnamed>' panicked at 'attempt to subtract with overflow', /Users/shekhirin/Projects/revm/crates/revm/src/gas/calc.rs:24:25
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 1559/2607
thread '<unnamed>' panicked at 'attempt to subtract with overflow', /Users/shekhirin/Projects/revm/crates/revm/src/gas/calc.rs:24:25
thread '<unnamed>' panicked at 'attempt to subtract with overflow', /Users/shekhirin/Projects/revm/crates/revm/src/gas/calc.rs:24:25
thread '<unnamed>' panicked at 'attempt to subtract with overflow', /Users/shekhirin/Projects/revm/crates/revm/src/gas/calc.rs:24:25
Error: Statetest(SystemError)
```

```console
➜  revm git:(ethtests-profile) ✗ git reset --hard HEAD~1                            
HEAD is now at a5bdcae chore(ci): use ethtests profile for CI tests

➜  revm git:(ethtests-profile) ✗ cargo run --profile ethtests -p revme -- statetest ethtests/GeneralStateTests
    Finished ethtests [optimized + debuginfo] target(s) in 18.86s
     Running `target/ethtests/revme statetest ethtests/GeneralStateTests`
Start running tests on: "ethtests/GeneralStateTests"
██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 2607/2607
Finished execution. Time:25.927294972s
```