### PR TITLE
feat: expose hash on `BytecodeLocked`

### DIFF
--- a/crates/revm/src/interpreter/bytecode.rs
+++ b/crates/revm/src/interpreter/bytecode.rs
@@ -279,6 +279,10 @@ impl BytecodeLocked {
         self.len
     }
 
+    pub fn hash(&self) -> H256 {
+        self.hash
+    }
+
     pub fn is_empty(&self) -> bool {
         self.len == 0
     }


### PR DESCRIPTION
Needed for https://github.com/foundry-rs/foundry/pull/2954