### PR TITLE
Cache precompile HashMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1833,6 +1833,7 @@ dependencies = [
  "hex",
  "k256",
  "num",
+ "once_cell",
  "primitive-types 0.11.1",
  "ripemd",
  "secp256k1 0.24.0",

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -144,7 +144,7 @@ macro_rules! create_evm {
             $db,
             $env,
             $inspector,
-            Precompiles::new::<{ SpecId::to_precompile_id($spec::SPEC_ID) }>(),
+            Precompiles::new(SpecId::to_precompile_id($spec::SPEC_ID)).clone(),
         )) as Box<dyn Transact + 'a>
     };
 }

--- a/crates/revm/src/specification.rs
+++ b/crates/revm/src/specification.rs
@@ -29,16 +29,14 @@ pub enum SpecId {
 }
 
 impl SpecId {
-    pub const fn to_precompile_id(self) -> u8 {
+    pub const fn to_precompile_id(self) -> PrecompileId {
         match self {
             FRONTIER | FRONTIER_THAWING | HOMESTEAD | DAO_FORK | TANGERINE | SPURIOUS_DRAGON => {
-                PrecompileId::HOMESTEAD as u8
+                PrecompileId::HOMESTEAD
             }
-            BYZANTIUM | CONSTANTINOPLE | PETERSBURG => PrecompileId::BYZANTIUM as u8,
-            ISTANBUL | MUIR_GLACIER => PrecompileId::ISTANBUL as u8,
-            BERLIN | LONDON | ARROW_GLACIER | GRAY_GLACIER | MERGE | LATEST => {
-                PrecompileId::BERLIN as u8
-            }
+            BYZANTIUM | CONSTANTINOPLE | PETERSBURG => PrecompileId::BYZANTIUM,
+            ISTANBUL | MUIR_GLACIER => PrecompileId::ISTANBUL,
+            BERLIN | LONDON | ARROW_GLACIER | GRAY_GLACIER | MERGE | LATEST => PrecompileId::BERLIN,
         }
     }
 

--- a/crates/revm_precompiles/Cargo.toml
+++ b/crates/revm_precompiles/Cargo.toml
@@ -19,6 +19,7 @@ secp256k1 = { version = "0.24.0", default-features = false, features = ["alloc",
 sha2 = { version = "0.10.2", default-features = false }
 sha3 = { version = "0.10.1", default-features = false }
 hashbrown = { version = "0.12" }
+once_cell = "1.13"
 
 [dev-dependencies]
 hex = "0.4"


### PR DESCRIPTION
Small optimization: we dont need to recreate HashMap with precompiles every time.