### PR TITLE
use Infallible for memory db's error type

### DIFF
--- a/crates/revm/src/db/in_memory_db.rs
+++ b/crates/revm/src/db/in_memory_db.rs
@@ -2,10 +2,10 @@ use super::{DatabaseCommit, DatabaseRef};
 use crate::{interpreter::bytecode::Bytecode, Database, KECCAK_EMPTY};
 use crate::{Account, AccountInfo, Log};
 use alloc::vec::Vec;
+use core::convert::Infallible;
 use hashbrown::{hash_map::Entry, HashMap as Map};
 use primitive_types::{H160, H256, U256};
 use sha3::{Digest, Keccak256};
-use core::convert::Infallible;
 
 pub type InMemoryDB = CacheDB<EmptyDB>;
 

--- a/crates/revm/src/db/in_memory_db.rs
+++ b/crates/revm/src/db/in_memory_db.rs
@@ -5,6 +5,7 @@ use alloc::vec::Vec;
 use hashbrown::{hash_map::Entry, HashMap as Map};
 use primitive_types::{H160, H256, U256};
 use sha3::{Digest, Keccak256};
+use std::convert::Infallible;
 
 pub type InMemoryDB = CacheDB<EmptyDB>;
 
@@ -325,7 +326,7 @@ impl<ExtDB: DatabaseRef> DatabaseRef for CacheDB<ExtDB> {
 pub struct EmptyDB();
 
 impl DatabaseRef for EmptyDB {
-    type Error = ();
+    type Error = Infallible;
     /// Get basic account information.
     fn basic(&self, _address: H160) -> Result<Option<AccountInfo>, Self::Error> {
         Ok(None)
@@ -361,7 +362,7 @@ impl BenchmarkDB {
 }
 
 impl Database for BenchmarkDB {
-    type Error = ();
+    type Error = Infallible;
     /// Get basic account information.
     fn basic(&mut self, address: H160) -> Result<Option<AccountInfo>, Self::Error> {
         if address == H160::zero() {

--- a/crates/revm/src/db/in_memory_db.rs
+++ b/crates/revm/src/db/in_memory_db.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use hashbrown::{hash_map::Entry, HashMap as Map};
 use primitive_types::{H160, H256, U256};
 use sha3::{Digest, Keccak256};
-use std::convert::Infallible;
+use core::convert::Infallible;
 
 pub type InMemoryDB = CacheDB<EmptyDB>;
 


### PR DESCRIPTION
The `Database(Ref) impl for `EmptyDb` never returns an error.

use `Infallible` as error type to indicate that `<EmptyDb as Database(Ref)::...` will never return an error