### PR TITLE
reexport revm_precompiles as precompiles

### DIFF
--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -34,3 +34,8 @@ pub use specification::*;
 extern crate alloc;
 
 pub(crate) const USE_GAS: bool = !cfg!(feature = "no_gas_measuring");
+
+// reexport `revm_precompiles`
+pub mod precompiles {
+    pub use revm_precompiles::*;
+}


### PR DESCRIPTION
`revm_precompiles` is already a dependency, for convenience, reexport `revm_precompiles` as `precompiles` within `revm`