### PR TITLE
fix: make DatabaseRef::basic consistent with Database

### DIFF
--- a/bins/revme/src/debugger/ctrl/ctrl.rs
+++ b/bins/revme/src/debugger/ctrl/ctrl.rs
@@ -172,7 +172,7 @@ impl<DB: Database> Inspector<DB> for Controller {
                         println!("PC:{} stack:{}", interp.program_counter(), interp.stack())
                     }
                     CtrlPrint::Memory => {
-                        println!("memory:{}", hex::encode(&interp.memory.data()))
+                        println!("memory:{}", hex::encode(interp.memory.data()))
                     }
                 },
                 Ctrl::Continue => {

--- a/bins/revme/src/statetest/runner.rs
+++ b/bins/revme/src/statetest/runner.rs
@@ -85,7 +85,7 @@ pub fn execute_test_suit(path: &Path, elapsed: &Arc<Mutex<Duration>>) -> Result<
         return Ok(());
     }
 
-    let json_reader = std::fs::read(&path).unwrap();
+    let json_reader = std::fs::read(path).unwrap();
     let suit: TestSuit = serde_json::from_reader(&*json_reader)?;
 
     let map_caller_keys: HashMap<_, _> = vec![

--- a/crates/revm/src/db/in_memory_db.rs
+++ b/crates/revm/src/db/in_memory_db.rs
@@ -282,7 +282,7 @@ impl<ExtDB: DatabaseRef> DatabaseRef for CacheDB<ExtDB> {
 
     fn basic(&self, address: H160) -> Result<Option<AccountInfo>, Self::Error> {
         match self.accounts.get(&address) {
-            Some(acc) => Ok(Some(acc.info.clone())),
+            Some(acc) => Ok(acc.info()),
             None => self.db.basic(address),
         }
     }

--- a/crates/revm/src/db/in_memory_db.rs
+++ b/crates/revm/src/db/in_memory_db.rs
@@ -344,7 +344,7 @@ impl DatabaseRef for EmptyDB {
     fn block_hash(&self, number: U256) -> Result<H256, Self::Error> {
         let mut buffer: [u8; 4 * 8] = [0; 4 * 8];
         number.to_big_endian(&mut buffer);
-        Ok(H256::from_slice(&Keccak256::digest(&buffer)))
+        Ok(H256::from_slice(&Keccak256::digest(buffer)))
     }
 }
 

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -820,9 +820,9 @@ pub fn create2_address(caller: H160, code_hash: H256, salt: U256) -> H160 {
     salt.to_big_endian(&mut temp);
 
     let mut hasher = Keccak256::new();
-    hasher.update(&[0xff]);
+    hasher.update([0xff]);
     hasher.update(&caller[..]);
-    hasher.update(&temp);
+    hasher.update(temp);
     hasher.update(&code_hash[..]);
     H160::from_slice(&hasher.finalize().as_slice()[12..])
 }


### PR DESCRIPTION
make Database::basic consistent in DatabaseRef::basic.

Reported here: https://github.com/bluealloy/revm/issues/200