### PR TITLE
Cfg choose create analysis, option on bytecode size limit

### DIFF
--- a/bins/revm-test/Cargo.toml
+++ b/bins/revm-test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-test"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Dragan Rakita <dragan0rakita@gmail.com>"]
-edition = "2018"
+edition = "2021"
 name = "revme"
 keywords = ["ethereum", "evm"]
 license = "MIT"

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Dragan Rakita <dragan0rakita@gmail.com>"]
 description = "REVM - Rust Ethereum Virtual Machine"
-edition = "2018"
+edition = "2021"
 keywords = ["no_std", "ethereum", "evm", "revm"]
 license = "MIT"
 name = "revm"

--- a/crates/revm/src/models.rs
+++ b/crates/revm/src/models.rs
@@ -226,11 +226,13 @@ pub struct CfgEnv {
     /// safe to be set to `true`, depending on the chain.
     pub perf_all_precompiles_have_balance: bool,
     /// Bytecode that is created with CREATE/CREATE2 is by default analysed and jumptable is created.
-    /// This is very benefitial for testing and speeds up execution of that bytecode when
-    pub perf_analyse_created_bytecodes: bool,
-    /// Effects EIP-170: Contract code size limit. Usefull to increase this because of tests.
+    /// This is very benefitial for testing and speeds up execution of that bytecode when.
+    /// It will have side effect if it is enabled in client that switches between forks.
+    /// Default: Analyse
+    pub perf_analyse_created_bytecodes: AnalysisKind,
+    /// If some it will effects EIP-170: Contract code size limit. Usefull to increase this because of tests.
     /// By default it is 0x6000 (~25kb).
-    pub limit_contract_code_size: usize,
+    pub limit_contract_code_size: Option<usize>,
     /// A hard memory limit in bytes beyond which [Memory] cannot be resized.
     ///
     /// In cases where the gas limit may be extraordinarily high, it is recommended to set this to
@@ -240,14 +242,23 @@ pub struct CfgEnv {
     pub memory_limit: u64,
 }
 
+#[derive(Clone, Default, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum AnalysisKind {
+    Raw,
+    Check,
+    #[default]
+    Analyse,
+}
+
 impl Default for CfgEnv {
     fn default() -> CfgEnv {
         CfgEnv {
             chain_id: 1.into(),
             spec_id: SpecId::LATEST,
             perf_all_precompiles_have_balance: false,
-            perf_analyse_created_bytecodes: true,
-            limit_contract_code_size: 0x6000,
+            perf_analyse_created_bytecodes: Default::default(),
+            limit_contract_code_size: None,
             #[cfg(feature = "memory_limit")]
             memory_limit: 2u64.pow(32) - 1,
         }

--- a/crates/revm_precompiles/Cargo.toml
+++ b/crates/revm_precompiles/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Dragan Rakita <dragan0rakita@gmail.com>"]
 description = "REVM Precompiles - Ethereum compatible precompiled contracts"
-edition = "2018"
+edition = "2021"
 keywords = ["no_std", "ethereum", "evm", "precompiles"]
 license = "MIT"
 name = "revm_precompiles"

--- a/crates/revmjs/Cargo.toml
+++ b/crates/revmjs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Dragan Rakita <dragan0rakita@gmail.com>"]
 description = "REVM WASM - Rust Ethereum Virtual Machine Web Assembly lib"
-edition = "2018"
+edition = "2021"
 keywords = ["ethereum", "evm", "rust"]
 license = "MIT"
 name = "revmjs"


### PR DESCRIPTION
Allow to configure if created bytecode is going to by analysed, checked or saved as raw code. By default it will be analysed, only time when this becomes relevant is when you want to switch between forks as analysis takes into account what spec is currently using and it is different from spec to spec. 

In future we will probably add spec friendly analysis with only jump table and without gas blocks.

One more small change is around making cfg perf bytecode limit as `Option` if not set consensus value would be used.