### PR TITLE
Do gas calculation using u64 and not U256

### DIFF
--- a/crates/revm/src/gas/calc.rs
+++ b/crates/revm/src/gas/calc.rs
@@ -102,27 +102,15 @@ pub fn exp_cost<SPEC: Spec>(power: U256) -> Option<u64> {
     }
 }
 
-pub fn verylowcopy_cost(len: U256) -> Option<u64> {
-    let wordd = len / U256::from(32);
-    let wordr = len % U256::from(32);
-
-    let gas =
-        U256::from(VERYLOW).checked_add(U256::from(COPY).checked_mul(if wordr.is_zero() {
-            wordd
-        } else {
-            wordd + U256::one()
-        })?)?;
-
-    if gas > U256::from(u64::MAX) {
-        return None;
-    }
-
-    Some(gas.as_u64())
+pub fn verylowcopy_cost(len: u64) -> Option<u64> {
+    let wordd = len / 32;
+    let wordr = len % 32;
+    VERYLOW.checked_add(COPY.checked_mul(if wordr == 0 { wordd } else { wordd + 1 })?)
 }
 
-pub fn extcodecopy_cost<SPEC: Spec>(len: U256, is_cold: bool) -> Option<u64> {
-    let wordd = len / U256::from(32);
-    let wordr = len % U256::from(32);
+pub fn extcodecopy_cost<SPEC: Spec>(len: u64, is_cold: bool) -> Option<u64> {
+    let wordd = len / 32;
+    let wordr = len % 32;
 
     let base_gas: u64 = if SPEC::enabled(BERLIN) && is_cold {
         // WARM_STORAGE_READ_COST is already calculated
@@ -130,19 +118,7 @@ pub fn extcodecopy_cost<SPEC: Spec>(len: U256, is_cold: bool) -> Option<u64> {
     } else {
         0
     };
-    // TODO make this u64 friendly, U256 does not make sense.
-    let gas =
-        U256::from(base_gas).checked_add(U256::from(COPY).checked_mul(if wordr.is_zero() {
-            wordd
-        } else {
-            wordd + U256::one()
-        })?)?;
-
-    if gas > U256::from(u64::MAX) {
-        return None;
-    }
-
-    Some(gas.as_u64())
+    base_gas.checked_add(COPY.checked_mul(if wordr == 0 { wordd } else { wordd + 1 })?)
 }
 
 pub fn account_access_gas<SPEC: Spec>(is_cold: bool) -> u64 {
@@ -159,34 +135,15 @@ pub fn account_access_gas<SPEC: Spec>(is_cold: bool) -> u64 {
     }
 }
 
-pub fn log_cost(n: u8, len: U256) -> Option<u64> {
-    let gas = U256::from(LOG)
-        .checked_add(U256::from(LOGDATA).checked_mul(len)?)?
-        .checked_add(U256::from(LOGTOPIC * n as u64))?;
-
-    if gas > U256::from(u64::MAX) {
-        return None;
-    }
-
-    Some(gas.as_u64())
+pub fn log_cost(n: u8, len: u64) -> Option<u64> {
+    LOG.checked_add(LOGDATA.checked_mul(len)?)?
+        .checked_add(LOGTOPIC * n as u64)
 }
 
-pub fn sha3_cost(len: U256) -> Option<u64> {
-    let wordd = len / U256::from(32);
-    let wordr = len % U256::from(32);
-
-    let gas =
-        U256::from(SHA3).checked_add(U256::from(SHA3WORD).checked_mul(if wordr.is_zero() {
-            wordd
-        } else {
-            wordd + U256::one()
-        })?)?;
-
-    if gas > U256::from(u64::MAX) {
-        return None;
-    }
-
-    Some(gas.as_u64())
+pub fn sha3_cost(len: u64) -> Option<u64> {
+    let wordd = len / 32;
+    let wordr = len % 32;
+    SHA3.checked_add(SHA3WORD.checked_mul(if wordr == 0 { wordd } else { wordd + 1 })?)
 }
 
 pub fn sload_cost<SPEC: Spec>(is_cold: bool) -> u64 {

--- a/crates/revm/src/instructions/host.rs
+++ b/crates/revm/src/instructions/host.rs
@@ -92,8 +92,8 @@ pub fn extcodecopy<H: Host, SPEC: Spec>(interp: &mut Interpreter, host: &mut H) 
     }
     let (code, is_cold) = ret.unwrap();
 
-    gas_or_fail!(interp, gas::extcodecopy_cost::<SPEC>(len_u256, is_cold));
     let len = as_usize_or_fail!(len_u256, Return::OutOfGas);
+    gas_or_fail!(interp, gas::extcodecopy_cost::<SPEC>(len as u64, is_cold));
     if len == 0 {
         return Return::Continue;
     }
@@ -162,8 +162,8 @@ pub fn log<H: Host, SPEC: Spec>(interp: &mut Interpreter, n: u8, host: &mut H) -
     check!(!SPEC::IS_STATIC_CALL);
 
     pop!(interp, offset, len);
-    gas_or_fail!(interp, gas::log_cost(n, len));
     let len = as_usize_or_fail!(len, Return::OutOfGas);
+    gas_or_fail!(interp, gas::log_cost(n, len as u64));
     let data = if len == 0 {
         Bytes::new()
     } else {

--- a/crates/revm/src/instructions/system.rs
+++ b/crates/revm/src/instructions/system.rs
@@ -7,8 +7,8 @@ use sha3::{Digest, Keccak256};
 
 pub fn sha3(interp: &mut Interpreter) -> Return {
     pop!(interp, from, len);
-    gas_or_fail!(interp, gas::sha3_cost(len));
     let len = as_usize_or_fail!(len, Return::OutOfGas);
+    gas_or_fail!(interp, gas::sha3_cost(len as u64));
     let h256 = if len == 0 {
         KECCAK_EMPTY
     } else {
@@ -44,8 +44,8 @@ pub fn codesize(interp: &mut Interpreter) -> Return {
 
 pub fn codecopy(interp: &mut Interpreter) -> Return {
     pop!(interp, memory_offset, code_offset, len);
-    gas_or_fail!(interp, gas::verylowcopy_cost(len));
     let len = as_usize_or_fail!(len, Return::OutOfGas);
+    gas_or_fail!(interp, gas::verylowcopy_cost(len as u64));
     if len == 0 {
         return Return::Continue;
     }
@@ -98,8 +98,8 @@ pub fn callvalue(interp: &mut Interpreter) -> Return {
 
 pub fn calldatacopy(interp: &mut Interpreter) -> Return {
     pop!(interp, memory_offset, data_offset, len);
-    gas_or_fail!(interp, gas::verylowcopy_cost(len));
     let len = as_usize_or_fail!(len, Return::OutOfGas);
+    gas_or_fail!(interp, gas::verylowcopy_cost(len as u64));
     if len == 0 {
         return Return::Continue;
     }
@@ -127,8 +127,8 @@ pub fn returndatacopy<SPEC: Spec>(interp: &mut Interpreter) -> Return {
     // EIP-211: New opcodes: RETURNDATASIZE and RETURNDATACOPY
     check!(SPEC::enabled(BYZANTIUM));
     pop!(interp, memory_offset, offset, len);
-    gas_or_fail!(interp, gas::verylowcopy_cost(len));
     let len = as_usize_or_fail!(len, Return::OutOfGas);
+    gas_or_fail!(interp, gas::verylowcopy_cost(len as u64));
     let memory_offset = as_usize_or_fail!(memory_offset, Return::OutOfGas);
     let data_offset = as_usize_saturated!(offset);
     memory_resize!(interp, memory_offset, len);


### PR DESCRIPTION
Minor cleanup on gas calculation by removing U256 and using native u64.

When testing on snailtracer i got very small to no signification improvement with this change, I am assuming that compiler did optimization with U256 as we use `as_usize_or_fail` every time. 