### PR TITLE
feat: add Memory::shrink_to_fit

### DIFF
--- a/crates/revm/src/interpreter/memory.rs
+++ b/crates/revm/src/interpreter/memory.rs
@@ -46,6 +46,11 @@ impl Memory {
         &self.data
     }
 
+    /// Shrinks the capacity of the data buffer as much as possible.
+    pub fn shrink_to_fit(&mut self) {
+        self.data.shrink_to_fit()
+    }
+
     /// Resize the memory. asume that we already checked if
     /// we have enought gas to resize this vector and that we made new_size as multiply of 32
     pub fn resize(&mut self, new_size: usize) {


### PR DESCRIPTION
add another delegate function to `Memory` that allows shrinking the allocated 4 * 1024 bytes down to what's actually used.

this is likely the cause for the memory hog in foundry's tracer impl

cc @shekhirin 