### PR TITLE
feat(revm, revme): gas inspector

### DIFF
--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -357,23 +357,7 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_gas_inspector() {
-        let contract_data: Bytes = Bytes::from(vec![
-            opcode::PUSH1,
-            0x1,
-            opcode::PUSH1,
-            0xb,
-            opcode::JUMPI,
-            opcode::PUSH1,
-            0x1,
-            opcode::PUSH1,
-            0x1,
-            opcode::PUSH1,
-            0x1,
-            opcode::JUMPDEST,
-            opcode::STOP,
-        ]);
+    fn gas_inspector(contract_data: Bytes) {
         let bytecode = Bytecode::new_raw(contract_data);
 
         let mut evm = crate::new();
@@ -393,5 +377,34 @@ mod tests {
                 OpCode::try_from_u8(bytecode.bytes()[pc]).unwrap().as_str(),
             );
         }
+    }
+
+    #[test]
+    fn test_gas_inspector() {
+        gas_inspector(Bytes::from(vec![
+            opcode::PUSH1,
+            0x1,
+            opcode::PUSH1,
+            0xb,
+            opcode::JUMPI,
+            opcode::PUSH1,
+            0x1,
+            opcode::PUSH1,
+            0x1,
+            opcode::PUSH1,
+            0x1,
+            opcode::JUMPDEST,
+            opcode::STOP,
+        ]));
+        println!("\n");
+        gas_inspector(Bytes::from(vec![
+            opcode::PUSH1,
+            0x1,
+            opcode::PUSH1,
+            0x5,
+            opcode::JUMPI,
+            opcode::JUMPDEST,
+            opcode::STOP,
+        ]));
     }
 }

--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -128,8 +128,8 @@ impl<DB: Database> Inspector<DB> for NoOpInspector {}
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct GasInspector {
-    /// We now batch continual gas_block in one go, that means we need to reduce it ifwe want to get
-    /// correct gas remaining. Check revm/interp/contract/analyze for more information
+    /// We now batch continual gas_block in one go, that means we need to reduce it if we want
+    /// to get correct gas remaining. Check revm/interp/contract/analyze for more information
     reduced_gas_block: u64,
     full_gas_block: u64,
     was_return: bool,
@@ -200,7 +200,7 @@ impl<DB: Database> Inspector<DB> for GasInspector {
             }
             self.was_jumpi = None;
         } else if self.was_return {
-            // we are okey to decrement PC by one as it is return of call
+            // we are ok to decrement PC by one as it is return of call
             let previous_pc = pc - 1;
             self.full_gas_block = interp.contract.gas_block(previous_pc);
             self.was_return = false;

--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -358,7 +358,23 @@ mod tests {
         }
     }
 
-    fn gas_inspector(contract_data: Bytes) {
+    #[test]
+    fn test_gas_inspector() {
+        let contract_data: Bytes = Bytes::from(vec![
+            opcode::PUSH1,
+            0x1,
+            opcode::PUSH1,
+            0xb,
+            opcode::JUMPI,
+            opcode::PUSH1,
+            0x1,
+            opcode::PUSH1,
+            0x1,
+            opcode::PUSH1,
+            0x1,
+            opcode::JUMPDEST,
+            opcode::STOP,
+        ]);
         let bytecode = Bytecode::new_raw(contract_data);
 
         let mut evm = crate::new();
@@ -378,34 +394,5 @@ mod tests {
                 OpCode::try_from_u8(bytecode.bytes()[pc]).unwrap().as_str(),
             );
         }
-    }
-
-    #[test]
-    fn test_gas_inspector() {
-        gas_inspector(Bytes::from(vec![
-            opcode::PUSH1,
-            0x1,
-            opcode::PUSH1,
-            0xb,
-            opcode::JUMPI,
-            opcode::PUSH1,
-            0x1,
-            opcode::PUSH1,
-            0x1,
-            opcode::PUSH1,
-            0x1,
-            opcode::JUMPDEST,
-            opcode::STOP,
-        ]));
-        println!("\n");
-        gas_inspector(Bytes::from(vec![
-            opcode::PUSH1,
-            0x1,
-            opcode::PUSH1,
-            0x5,
-            opcode::JUMPI,
-            opcode::JUMPDEST,
-            opcode::STOP,
-        ]));
     }
 }

--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -172,6 +172,7 @@ impl<DB: Database> Inspector<DB> for GasInspector {
 
         let pc = interp.program_counter();
         if op == opcode::JUMPI {
+            self.reduced_gas_block += info.get_gas() as u64;
             self.was_jumpi = Some(pc);
         } else if info.is_gas_block_end() {
             self.reduced_gas_block = 0;

--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -1,7 +1,10 @@
 use bytes::Bytes;
 use primitive_types::{H160, H256};
 
-use crate::{evm_impl::EVMData, CallInputs, CreateInputs, Database, Gas, Interpreter, Return};
+use crate::{
+    evm_impl::EVMData, opcode, spec_opcode_gas, CallInputs, CreateInputs, Database, Gas,
+    Interpreter, Return,
+};
 use auto_impl::auto_impl;
 
 #[auto_impl(&mut, Box)]
@@ -122,3 +125,115 @@ pub trait Inspector<DB: Database> {
 pub struct NoOpInspector();
 
 impl<DB: Database> Inspector<DB> for NoOpInspector {}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct GasInspector {
+    /// We now batch continual gas_block in one go, that means we need to reduce it ifwe want to get
+    /// correct gas remaining. Check revm/interp/contract/analyze for more information
+    reduced_gas_block: u64,
+    full_gas_block: u64,
+    was_return: bool,
+    was_jumpi: Option<usize>,
+
+    gas_remaining: u64,
+}
+
+impl GasInspector {
+    pub fn gas_remaining(&self) -> u64 {
+        self.gas_remaining
+    }
+}
+
+impl<DB: Database> Inspector<DB> for GasInspector {
+    fn initialize_interp(
+        &mut self,
+        interp: &mut Interpreter,
+        _data: &mut EVMData<'_, DB>,
+        _is_static: bool,
+    ) -> Return {
+        self.full_gas_block = interp.contract.first_gas_block();
+        self.gas_remaining = interp.gas.limit();
+        Return::Continue
+    }
+
+    // get opcode by calling `interp.contract.opcode(interp.program_counter())`.
+    // all other information can be obtained from interp.
+    fn step(
+        &mut self,
+        interp: &mut Interpreter,
+        data: &mut EVMData<'_, DB>,
+        _is_static: bool,
+    ) -> Return {
+        let op = interp.current_opcode();
+
+        // calculate gas_block
+        let infos = spec_opcode_gas(data.env.cfg.spec_id);
+        let info = &infos[op as usize];
+
+        let pc = interp.program_counter();
+        if op == opcode::JUMPI {
+            self.was_jumpi = Some(pc);
+        } else if info.is_gas_block_end() {
+            self.reduced_gas_block = 0;
+            self.full_gas_block = interp.contract.gas_block(pc);
+        } else {
+            self.reduced_gas_block += info.get_gas() as u64;
+        }
+
+        Return::Continue
+    }
+
+    fn step_end(
+        &mut self,
+        interp: &mut Interpreter,
+        _data: &mut EVMData<'_, DB>,
+        _is_static: bool,
+        _eval: Return,
+    ) -> Return {
+        let pc = interp.program_counter();
+        if let Some(was_pc) = self.was_jumpi {
+            if let Some(new_pc) = pc.checked_sub(1) {
+                if was_pc == new_pc {
+                    self.reduced_gas_block = 0;
+                    self.full_gas_block = interp.contract.gas_block(was_pc);
+                }
+            }
+            self.was_jumpi = None;
+        } else if self.was_return {
+            // we are okey to decrement PC by one as it is return of call
+            let previous_pc = pc - 1;
+            self.full_gas_block = interp.contract.gas_block(previous_pc);
+            self.was_return = false;
+        }
+
+        self.gas_remaining = interp.gas.remaining() + self.full_gas_block - self.reduced_gas_block;
+
+        Return::Continue
+    }
+
+    fn call_end(
+        &mut self,
+        _data: &mut EVMData<'_, DB>,
+        _inputs: &CallInputs,
+        remaining_gas: Gas,
+        ret: Return,
+        out: Bytes,
+        _is_static: bool,
+    ) -> (Return, Gas, Bytes) {
+        self.was_return = true;
+        (ret, remaining_gas, out)
+    }
+
+    fn create_end(
+        &mut self,
+        _data: &mut EVMData<'_, DB>,
+        _inputs: &CreateInputs,
+        ret: Return,
+        address: Option<H160>,
+        remaining_gas: Gas,
+        out: Bytes,
+    ) -> (Return, Option<H160>, Gas, Bytes) {
+        self.was_return = true;
+        (ret, address, remaining_gas, out)
+    }
+}

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -19,7 +19,7 @@ pub type DummyStateDB = InMemoryDB;
 pub use db::{Database, DatabaseCommit, InMemoryDB};
 pub use evm::{evm_inner, new, EVM};
 pub use gas::Gas;
-pub use inspector::{Inspector, NoOpInspector};
+pub use inspector::{GasInspector, Inspector, NoOpInspector};
 pub use instructions::{
     opcode::{self, spec_opcode_gas, OpCode, OPCODE_JUMPMAP},
     Return,


### PR DESCRIPTION
Gas counting became a bit harder with the introduction of gas blocks composed during analysis. So `GasInspector` was introduced to make it easier to count remaining gas after each executed step.

Approach was adopted from https://github.com/bluealloy/revm/blob/1e25c99b544863d15610e9af8e623dd173397b48/bins/revme/src/statetest/trace.rs#L10-L17