### PR TITLE
Add distinct error code for state changes triggered during a staticcall

### DIFF
--- a/crates/revm/src/instructions.rs
+++ b/crates/revm/src/instructions.rs
@@ -54,6 +54,7 @@ pub enum Return {
     InvalidJump,
     InvalidMemoryRange,
     NotActivated,
+    StateChangeDuringStaticCall,
     StackUnderflow,
     StackOverflow,
     OutOfOffset,

--- a/crates/revm/src/instructions/host.rs
+++ b/crates/revm/src/instructions/host.rs
@@ -142,7 +142,7 @@ pub fn sload<H: Host, SPEC: Spec>(interp: &mut Interpreter, host: &mut H) -> Ret
 }
 
 pub fn sstore<H: Host, SPEC: Spec>(interp: &mut Interpreter, host: &mut H) -> Return {
-    check!(!SPEC::IS_STATIC_CALL);
+    staticcall!(!SPEC::IS_STATIC_CALL);
 
     pop!(interp, index, value);
     let ret = host.sstore(interp.contract.address, index, value);
@@ -159,7 +159,7 @@ pub fn sstore<H: Host, SPEC: Spec>(interp: &mut Interpreter, host: &mut H) -> Re
 }
 
 pub fn log<H: Host, SPEC: Spec>(interp: &mut Interpreter, n: u8, host: &mut H) -> Return {
-    check!(!SPEC::IS_STATIC_CALL);
+    staticcall!(!SPEC::IS_STATIC_CALL);
 
     pop!(interp, offset, len);
     let len = as_usize_or_fail!(len, Return::OutOfGas);
@@ -189,7 +189,7 @@ pub fn log<H: Host, SPEC: Spec>(interp: &mut Interpreter, n: u8, host: &mut H) -
 }
 
 pub fn selfdestruct<H: Host, SPEC: Spec>(interp: &mut Interpreter, host: &mut H) -> Return {
-    check!(!SPEC::IS_STATIC_CALL);
+    staticcall!(!SPEC::IS_STATIC_CALL);
     pop_address!(interp, target);
 
     let res = host.selfdestruct(interp.contract.address, target);
@@ -212,7 +212,7 @@ pub fn create<H: Host, SPEC: Spec>(
     is_create2: bool,
     host: &mut H,
 ) -> Return {
-    check!(!SPEC::IS_STATIC_CALL);
+    staticcall!(!SPEC::IS_STATIC_CALL);
     if is_create2 {
         // EIP-1014: Skinny CREATE2
         check!(SPEC::enabled(PETERSBURG));

--- a/crates/revm/src/instructions/macros.rs
+++ b/crates/revm/src/instructions/macros.rs
@@ -8,6 +8,14 @@ macro_rules! check {
     };
 }
 
+macro_rules! staticcall {
+    ($expresion:expr) => {
+        if !$expresion {
+            return Return::StateChangeDuringStaticCall;
+        }
+    };
+}
+
 macro_rules! gas {
     ($interp:expr, $gas:expr) => {
         if crate::USE_GAS {


### PR DESCRIPTION
The current behavior when a state change is attempted (through sstore, log, selfdestruct, or create) during a static call is to return the NotActive error code, which refers to something not being supported on the current EVM version. 

When encountering this, I found it to be confusing and somewhat inaccurate. I think this specific instance should be given its own error code, StateChangeDuringStaticCall.

