### PR TITLE
Borrow self and add derive traits for OpCode

### DIFF
--- a/crates/revm/src/db/in_memory_db.rs
+++ b/crates/revm/src/db/in_memory_db.rs
@@ -9,8 +9,8 @@ use sha3::{Digest, Keccak256};
 
 pub type InMemoryDB = CacheDB<EmptyDB>;
 
-impl InMemoryDB {
-    pub fn default() -> Self {
+impl Default for InMemoryDB {
+    fn default() -> Self {
         CacheDB::new(EmptyDB {})
     }
 }

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -300,7 +300,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
 
         if crate::USE_GAS {
             let zero_data_len = input.iter().filter(|v| **v == 0).count() as u64;
-            let non_zero_data_len = (input.len() as u64 - zero_data_len) as u64;
+            let non_zero_data_len = input.len() as u64 - zero_data_len;
             let (accessed_accounts, accessed_slots) = {
                 if SPEC::enabled(BERLIN) {
                     let mut accessed_slots = 0_u64;

--- a/crates/revm/src/instructions/opcode.rs
+++ b/crates/revm/src/instructions/opcode.rs
@@ -1,6 +1,7 @@
 use crate::gas;
 use crate::SpecId;
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct OpCode(u8);
 
 pub const STOP: u8 = 0x00;
@@ -164,7 +165,7 @@ impl OpCode {
     }
 
     #[inline(always)]
-    pub const fn u8(self) -> u8 {
+    pub const fn u8(&self) -> u8 {
         self.0
     }
 }

--- a/crates/revm_precompiles/src/lib.rs
+++ b/crates/revm_precompiles/src/lib.rs
@@ -100,7 +100,7 @@ pub enum SpecId {
 
 impl SpecId {
     pub const fn enabled(self, spec_id: u8) -> bool {
-        spec_id as u8 >= self as u8
+        spec_id >= self as u8
     }
 }
 


### PR DESCRIPTION
Making `OpCode` easier to convert into `u8` using `u8()` method by not taking ownership and adding some derive traits to the `OpCode` struct