### PR TITLE
feat: allow block gas limit to be toggled off

### DIFF
--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -28,9 +28,10 @@ web3 = { version = "0.18", optional = true }
 
 [features]
 default = ["std", "secp256k1"]
-dev = ["memory_limit", "optional_eip3607"]
+dev = ["memory_limit", "optional_block_gas_limit", "optional_eip3607"]
 memory_limit = []
 no_gas_measuring = []
+optional_block_gas_limit = []
 optional_eip3607 = []
 std = ["bytes/std", "num_enum/std", "primitive-types/std", "sha3/std", "rlp/std"]
 secp256k1 = ["revm_precompiles/secp256k1"]

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -66,8 +66,14 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact
             }
             // check if priority fee is lower then max fee
         }
+
+        #[cfg(feature = "optional_block_gas_limit")]
+        let disable_block_gas_limit = self.env().cfg.disable_block_gas_limit;
+        #[cfg(not(feature = "optional_block_gas_limit"))]
+        let disable_block_gas_limit = false;
+
         // unusual to be found here, but check if gas_limit is more then block_gas_limit
-        if U256::from(gas_limit) > self.data.env.block.gas_limit {
+        if !disable_block_gas_limit && U256::from(gas_limit) > self.data.env.block.gas_limit {
             return exit(Return::CallerGasLimitMoreThenBlock);
         }
 

--- a/crates/revm/src/models.rs
+++ b/crates/revm/src/models.rs
@@ -240,6 +240,11 @@ pub struct CfgEnv {
     /// EIP-1985.
     #[cfg(feature = "memory_limit")]
     pub memory_limit: u64,
+    /// There are use cases where it's allowed to provide a gas limit that's higher than a block's gas limit. To that
+    /// end, you can disable the block gas limit validation.
+    /// By default, it is set to `false`.
+    #[cfg(feature = "optional_block_gas_limit")]
+    pub disable_block_gas_limit: bool,
     /// EIP-3607 rejects transactions from senders with deployed code. In development, it can be desirable to simulate
     /// calls from contracts, which this setting allows.
     /// By default, it is set to `false`.
@@ -266,6 +271,8 @@ impl Default for CfgEnv {
             limit_contract_code_size: None,
             #[cfg(feature = "memory_limit")]
             memory_limit: 2u64.pow(32) - 1,
+            #[cfg(feature = "optional_block_gas_limit")]
+            disable_block_gas_limit: false,
             #[cfg(feature = "optional_eip3607")]
             disable_eip3607: false,
         }


### PR DESCRIPTION
Fixes #236.

This PR should be merged after #237, as it also amends the `dev` feature flag.