### PR TITLE
fix sanity check

### DIFF
--- a/crates/revm/src/db/web3db.rs
+++ b/crates/revm/src/db/web3db.rs
@@ -105,14 +105,8 @@ impl Database for Web3DB {
         if number > U256::from(u64::MAX) {
             return Ok(KECCAK_EMPTY);
         }
-        let number = u64::try_from(number).unwrap();
-        if let Some(block_num) = self.block_number {
-            match block_num {
-                BlockNumber::Number(t) if t.as_u64() > number => return Ok(KECCAK_EMPTY),
-                _ => (),
-            }
-        }
-        let number = wU64::from(number);
+        
+        let number = wU64::from(u64::try_from(number).unwrap());
         let f = async {
             self.web3
                 .eth()

--- a/crates/revm/src/db/web3db.rs
+++ b/crates/revm/src/db/web3db.rs
@@ -105,7 +105,6 @@ impl Database for Web3DB {
         if number > U256::from(u64::MAX) {
             return Ok(KECCAK_EMPTY);
         }
-        
         let number = wU64::from(u64::try_from(number).unwrap());
         let f = async {
             self.web3


### PR DESCRIPTION
Currently this check ensures the passed in value is greater than self.block_number. I think is likely a bug as I've seen transactions in the wild which succeed on geth but revert when using this revm code due to the sanity check.

I think ensuring the passed in value is less than self.block_number makes more sense as that excludes block numbers for blocks ahead of the self.block_number which may not exist yet.