### PR TITLE
fix: compiler error when secp256k1 is disabled

### DIFF
--- a/crates/revm_precompiles/src/lib.rs
+++ b/crates/revm_precompiles/src/lib.rs
@@ -109,6 +109,7 @@ impl Precompiles {
         static INSTANCE: OnceCell<Precompiles> = OnceCell::new();
         INSTANCE.get_or_init(|| {
             let fun = vec![
+                #[cfg(feature = "secp256k1")]
                 secp256k1::ECRECOVER,
                 hash::SHA256,
                 hash::RIPEMD160,


### PR DESCRIPTION
Resolves an error that was happening when you disabled default features for revm:

```
failed to resolve: use of undeclared crate or module `secp256k1`
  --> revm_precompiles-1.1.1\src\secp256k1.rs:80:21
   |
80 |     let out = match secp256k1::ecrecover(&sig, &msg) {
   |                     ^^^^^^^^^ use of undeclared crate or module `secp256k1`
```