### PR TITLE
Bugfix: if returndatacopy is len 0 return after initial cost

### DIFF
--- a/crates/revm/src/instructions/system.rs
+++ b/crates/revm/src/instructions/system.rs
@@ -127,20 +127,19 @@ pub fn returndatacopy<SPEC: Spec>(interp: &mut Interpreter) -> Return {
     pop!(interp, memory_offset, offset, len);
     let len = as_usize_or_fail!(len, Return::OutOfGas);
     gas_or_fail!(interp, gas::verylowcopy_cost(len as u64));
-    if len == 0 {
-        return Return::Continue;
-    }
-    let memory_offset = as_usize_or_fail!(memory_offset, Return::OutOfGas);
     let data_offset = as_usize_saturated!(offset);
-    memory_resize!(interp, memory_offset, len);
     let (data_end, overflow) = data_offset.overflowing_add(len);
     if overflow || data_end > interp.return_data_buffer.len() {
         return Return::OutOfOffset;
     }
-    interp.memory.set(
-        memory_offset,
-        &interp.return_data_buffer[data_offset..data_end],
-    );
+    if len != 0 {
+        let memory_offset = as_usize_or_fail!(memory_offset, Return::OutOfGas);
+        memory_resize!(interp, memory_offset, len);
+        interp.memory.set(
+            memory_offset,
+            &interp.return_data_buffer[data_offset..data_end],
+        );
+    }
     Return::Continue
 }
 

--- a/crates/revm/src/instructions/system.rs
+++ b/crates/revm/src/instructions/system.rs
@@ -127,6 +127,9 @@ pub fn returndatacopy<SPEC: Spec>(interp: &mut Interpreter) -> Return {
     pop!(interp, memory_offset, offset, len);
     let len = as_usize_or_fail!(len, Return::OutOfGas);
     gas_or_fail!(interp, gas::verylowcopy_cost(len as u64));
+    if len == 0 {
+        return Return::Continue;
+    }
     let memory_offset = as_usize_or_fail!(memory_offset, Return::OutOfGas);
     let data_offset = as_usize_saturated!(offset);
     memory_resize!(interp, memory_offset, len);


### PR DESCRIPTION
Fixes this issue: https://github.com/bluealloy/revm/issues/255 "Tx unexpectedly reverts with "out of gas" reason"