### PR TITLE
Bump v17 tag, revm v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag. 
+Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
+
+# v17 tag
+date: 12.11.2022
+code with the tag can be found in `release/v17` branch, reason is that `ruint` commit merged in `main` isn't going in this release.
+
+* revm: v2.2.0 consensus bug fix
 
 # v16 tag
 date: 25.09.2022
@@ -8,7 +14,7 @@ date: 25.09.2022
 # v15 tag
 date: 10.09.2022
 
-* revm: v2.0.0
+* revm: v2.0.0 consensus bug fix
 * revm_precompiles: v1.1.1
 # v14 tag
 date: 09.08.2022

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "arrayref",
  "auto_impl",

--- a/crates/revm/CHANGELOG.md
+++ b/crates/revm/CHANGELOG.md
@@ -1,3 +1,17 @@
+# v2.2.0
+date: 12.11.2022
+
+Small release that contains consensus bug fix. Additionaly added few small feature flags needed for hardhat, opcode utility function and removal of web3db block number check. 
+
+* dc3414a - Added OEF spec for tests. Skip HighGasPrice (4 minutes ago) <rakita>
+* f462f9d - Bugfix: if returndatacopy is len 0 return after initial cost (#259) (4 minutes ago) <gd>
+* ea2f2a2 - fix web3db sanity check (#245) (12 days ago) <Wulder>
+* 9f8cdbd - feat: allow block gas limit to be toggled off (#238) (3 weeks ago) <Wodann>
+* efd9afc - feat: allow eip3607 to be toggled off (#237) (3 weeks ago) <Wodann>
+* 88c72a7 - fix: return out of gas code for precompiled contracts (#234) (3 weeks ago) <Wodann>
+* 30462a3 - Fix: typos (#232) (3 weeks ago) <omahs>
+* 9f513c1 - Borrow self and add derive traits for OpCode (#231) (4 weeks ago) <Franfran>
+
 # v2.1.0
 date: 25.09.2022
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["no_std", "ethereum", "evm", "revm"]
 license = "MIT"
 name = "revm"
 repository = "https://github.com/bluealloy/revm"
-version = "2.1.0"
+version = "2.2.0"
 readme = "../../README.md"
 
 [dependencies]


### PR DESCRIPTION
bump release noted and revm version.

real release is going to be in `release/v17` branch