### PR TITLE
fix_gas_charge

### DIFF
--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -249,7 +249,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
             acc_caller.info.balance = acc_caller
                 .info
                 .balance
-                .saturating_add(effective_gas_price * U256::from(gas.remaining() + gas_refunded));
+                .saturating_add(effective_gas_price * U256::from(gas.remaining()));
 
             // EIP-1559
             let coinbase_gas_price = if SPEC::enabled(LONDON) {


### PR DESCRIPTION
While analysing this tx https://snowtrace.io/tx/0xac70b6e2e046be765ac18c1b4e74a342015575eebf778f49eaee5ed1565903c1
I noticed that on chain the this tx reduced the balance on account `0x77420e96f0e5f1dcfa8fcdd6ba6a3a9d3ad0c6c4` by `12510080000000000`, while the revm reduced the balance by only `12435880000000000`.

The seems to a refund being deducted in revm. 2800 * (25000000000 + 1500000000).

This line also seems to indicate that the refund is already included in the spend so shouldn't be added to remaining above?
https://github.com/bluealloy/revm/blob/main/crates/revm/src/evm_impl.rs#L277