### PR TITLE
Export StorageSlot

### DIFF
--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -28,7 +28,7 @@ pub use instructions::{
 pub use interpreter::{
     Bytecode, BytecodeLocked, BytecodeState, Contract, Interpreter, Memory, Stack,
 };
-pub use journaled_state::{Account, JournalEntry, JournaledState};
+pub use journaled_state::{Account, JournalEntry, JournaledState, StorageSlot};
 pub use models::*;
 pub use specification::*;
 


### PR DESCRIPTION
I am evaluating the migration from SputnikVM to REVM for a project of my company. 
Anyway, I am currently unable to migrate some of our unit tests because the Account storage is defined as `Map<U256, StorageSlot>` but the `StorageSlot` is not visible outside of this crate. This PR would fix the issue by exporting it.