### PR TITLE
revm: Return `bytes` in Create calls

### DIFF
--- a/crates/revm/src/instructions/host.rs
+++ b/crates/revm/src/instructions/host.rs
@@ -266,7 +266,12 @@ pub fn create<const IS_CREATE2: bool, SPEC: Spec>(
     };
 
     let (return_reason, address, gas, return_data) = host.create(&mut create_input);
-    interpreter.return_data_buffer = return_data;
+    interpreter.return_data_buffer = match return_reason {
+        // Save data to return data buffer if the create reverted
+        return_revert!() => return_data,
+        // Otherwise clear it
+        _ => Bytes::new(),
+    };
 
     match return_reason {
         return_ok!() => {


### PR DESCRIPTION
In `create_inner`, `let b = Bytes::new();` was always returned, without ever being touched. The create calls should return the deployed contract bytecode.

This might relate to https://github.com/bluealloy/revm/issues/269 ?