### PR TITLE
feat: allow disabling of balance checks

### DIFF
--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -42,12 +42,14 @@ sha3 = { version = "0.10", default-features = false, features = [] }
 default = ["std", "secp256k1"]
 dev = [
     "memory_limit",
+    "optional_balance_check",
     "optional_block_gas_limit",
     "optional_eip3607",
     "optional_gas_refund",
 ]
 memory_limit = []
 no_gas_measuring = []
+optional_balance_check = []
 optional_block_gas_limit = []
 optional_eip3607 = []
 optional_gas_refund = []

--- a/crates/revm/src/db.rs
+++ b/crates/revm/src/db.rs
@@ -37,7 +37,7 @@ pub trait DatabaseCommit {
     fn commit(&mut self, changes: Map<B160, Account>);
 }
 
-#[auto_impl(&, Box)]
+#[auto_impl(&, Box, Arc)]
 pub trait DatabaseRef {
     type Error;
     /// Whether account at address exists.

--- a/crates/revm/src/models.rs
+++ b/crates/revm/src/models.rs
@@ -250,6 +250,9 @@ pub struct CfgEnv {
     /// EIP-1985.
     #[cfg(feature = "memory_limit")]
     pub memory_limit: u64,
+    /// Skip balance checks if true. Adds transaction cost to balance to ensure execution doesn't fail.
+    #[cfg(feature = "optional_balance_check")]
+    pub disable_balance_check: bool,
     /// There are use cases where it's allowed to provide a gas limit that's higher than a block's gas limit. To that
     /// end, you can disable the block gas limit validation.
     /// By default, it is set to `false`.
@@ -286,6 +289,8 @@ impl Default for CfgEnv {
             limit_contract_code_size: None,
             #[cfg(feature = "memory_limit")]
             memory_limit: 2u64.pow(32) - 1,
+            #[cfg(feature = "optional_balance_check")]
+            disable_balance_check: false,
             #[cfg(feature = "optional_block_gas_limit")]
             disable_block_gas_limit: false,
             #[cfg(feature = "optional_eip3607")]


### PR DESCRIPTION
Depends on/incorporates #256

Ethereumjs has the ability to disable balance checks. When this toggle is on and an account does not have sufficient balance to complete a transaction, the transaction will still be completed and the balance set to `0` (zero).