### PR TITLE
Cleanup, move hot fields toggether in Interpreter

### DIFF
--- a/crates/interpreter/src/gas.rs
+++ b/crates/interpreter/src/gas.rs
@@ -5,11 +5,16 @@ pub use calc::*;
 pub use constants::*;
 #[derive(Clone, Copy, Debug)]
 pub struct Gas {
+    /// Gas Limit
     limit: u64,
-    used: u64,
-    memory: u64,
-    refunded: i64,
+    /// used+memory gas.
     all_used_gas: u64,
+    /// Used gas without memory
+    used: u64,
+    /// Used gas for memory expansion
+    memory: u64,
+    /// Refunded gas. This gas is used only at the end of execution.
+    refunded: i64,
 }
 impl Gas {
     pub fn new(limit: u64) -> Self {
@@ -51,7 +56,7 @@ impl Gas {
         self.refunded += refund;
     }
 
-    /// Record an explict cost.
+    /// Record an explicit cost.
     #[inline(always)]
     pub fn record_cost(&mut self, cost: u64) -> bool {
         let (all_used_gas, overflow) = self.all_used_gas.overflowing_add(cost);
@@ -64,7 +69,7 @@ impl Gas {
         true
     }
 
-    /// used in memory_resize! macro
+    /// used in memory_resize! macro to record gas used for memory expansion.
     pub fn record_memory(&mut self, gas_memory: u64) -> bool {
         if gas_memory > self.memory {
             let (all_used_gas, overflow) = self.used.overflowing_add(gas_memory);
@@ -77,7 +82,8 @@ impl Gas {
         true
     }
 
-    /// used in gas_refund! macro
+    /// used in gas_refund! macro to record refund value.
+    /// Refund can be negative but self.refunded is always positive.
     pub fn gas_refund(&mut self, refund: i64) {
         self.refunded += refund;
     }

--- a/crates/interpreter/src/interpreter/contract.rs
+++ b/crates/interpreter/src/interpreter/contract.rs
@@ -3,7 +3,7 @@ use crate::{alloc::vec::Vec, CallContext, Spec, B160, U256};
 use bytes::Bytes;
 use std::sync::Arc;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Contract {
     /// Contracts data
     pub input: Bytes,

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -490,7 +490,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
         );
 
         #[cfg(feature = "memory_limit")]
-        let mut interpreter = Interpreter::new_with_memory_limit::<GSPEC>(
+        let mut interpreter = Interpreter::new_with_memory_limit(
             contract,
             gas.limit(),
             false,
@@ -498,7 +498,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
         );
 
         #[cfg(not(feature = "memory_limit"))]
-        let mut interpreter = Interpreter::new::<GSPEC>(contract, gas.limit(), false);
+        let mut interpreter = Interpreter::new(contract, gas.limit(), false);
 
         if INSPECT {
             self.inspector
@@ -546,7 +546,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
                 }
                 // if we have enought gas
                 self.data.journaled_state.checkpoint_commit();
-                // Do analasis of bytecode streight away.
+                // Do analysis of bytecode streight away.
                 let bytecode = match self.data.env.cfg.perf_analyse_created_bytecodes {
                     AnalysisKind::Raw => Bytecode::new_raw(bytes.clone()),
                     AnalysisKind::Check => Bytecode::new_raw(bytes.clone()).to_checked(),
@@ -692,7 +692,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
             );
 
             #[cfg(feature = "memory_limit")]
-            let mut interpreter = Interpreter::new_with_memory_limit::<GSPEC>(
+            let mut interpreter = Interpreter::new_with_memory_limit(
                 contract,
                 gas.limit(),
                 inputs.is_static,
@@ -700,8 +700,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
             );
 
             #[cfg(not(feature = "memory_limit"))]
-            let mut interpreter =
-                Interpreter::new::<GSPEC>(contract, gas.limit(), inputs.is_static);
+            let mut interpreter = Interpreter::new(contract, gas.limit(), inputs.is_static);
 
             if INSPECT {
                 // create is always no static call.


### PR DESCRIPTION
Moving some fields in interpreter together seems to make execution more stable. 

Did some cleaning up of code added few comments.