### PR TITLE
chore(interpreter): enable `proptest` with `arbitrary` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "proptest-derive"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051d9d20dbe9e9dfe594328b6eaab72ccf571fee818991dd1c1ba5469b5f32d4"
+checksum = "90b46295382dc76166cb7cf2bb4a97952464e4b7ed5a43e6cd34e1fec3349ddc"
 dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -33,11 +33,13 @@ sha3 = { version = "0.10", default-features = false, features = [] }
 # optional
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 arbitrary = { version = "1.2", features = ["derive"], optional = true }
+proptest = { version = "1.0", optional = true }
+proptest-derive = { version = "0.3", optional = true }
 
 [dev-dependencies]
 arbitrary = { version = "1.2", features = ["derive"] }
 proptest = { version = "1.0" }
-proptest-derive = "0.2.0"
+proptest-derive = "0.3"
 ruint = { version = "1.7.0", features = [
     "primitive-types",
     "rlp",
@@ -68,4 +70,10 @@ serde = [
     "ruint/serde",
     "bytes/serde",
 ]
-arbitrary = ["dep:arbitrary", "ruint/arbitrary", "ruint/proptest"]
+arbitrary = [
+    "ruint/arbitrary",
+    "ruint/proptest",
+    "dep:arbitrary",
+    "dep:proptest",
+    "dep:proptest-derive"
+]

--- a/crates/interpreter/src/bits.rs
+++ b/crates/interpreter/src/bits.rs
@@ -1,24 +1,21 @@
 use derive_more::{AsRef, Deref};
 use fixed_hash::{construct_fixed_hash, impl_fixed_hash_conversions};
 
-#[cfg(test)]
-use proptest_derive::Arbitrary as PropTestArbitrary;
-
 #[cfg(any(test, feature = "arbitrary"))]
 use arbitrary::Arbitrary;
+#[cfg(any(test, feature = "arbitrary"))]
+use proptest_derive::Arbitrary as PropTestArbitrary;
 
 construct_fixed_hash! {
     /// revm 256 bits type.
-    #[cfg_attr(test, derive(PropTestArbitrary))]
-    #[cfg_attr(any(test, feature = "arbitrary"), derive(Arbitrary))]
+    #[cfg_attr(any(test, feature = "arbitrary"), derive(Arbitrary, PropTestArbitrary))]
     #[derive(AsRef,Deref)]
     pub struct B256(32);
 }
 
 construct_fixed_hash! {
     /// revm 160 bits type.
-    #[cfg_attr(test, derive(PropTestArbitrary))]
-    #[cfg_attr(any(test, feature = "arbitrary"), derive(Arbitrary))]
+    #[cfg_attr(any(test, feature = "arbitrary"), derive(Arbitrary, PropTestArbitrary))]
     #[derive(AsRef,Deref)]
     pub struct B160(20);
 }


### PR DESCRIPTION
Also bumps `proptest-derive` since it was wrongly set to a previous version