### PR TITLE
`revm`: mark `with-serde` feature as deprecated

### DIFF
--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -54,4 +54,4 @@ ethersdb = ["tokio", "futures", "ethers-providers", "ethers-core"]
 serde = ["dep:serde", "hex/serde", "hashbrown/serde", "revm-interpreter/serde"]
 # deprecated feature
 web3db = []
-with-serde = ["dep:serde", "hex/serde", "hashbrown/serde", "revm-interpreter/serde"]
+with-serde = []

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -54,3 +54,4 @@ ethersdb = ["tokio", "futures", "ethers-providers", "ethers-core"]
 serde = ["dep:serde", "hex/serde", "hashbrown/serde", "revm-interpreter/serde"]
 # deprecated feature
 web3db = []
+with-serde = ["dep:serde", "hex/serde", "hashbrown/serde", "revm-interpreter/serde"]

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -6,6 +6,9 @@ mod evm_impl;
 mod inspector;
 mod journaled_state;
 
+#[cfg(feature = "with-serde")]
+compile_error!("`with-serde` feature has been renamed to `serde`.");
+
 pub(crate) const USE_GAS: bool = !cfg!(feature = "no_gas_measuring");
 pub type DummyStateDB = InMemoryDB;
 

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -6,7 +6,7 @@ mod evm_impl;
 mod inspector;
 mod journaled_state;
 
-#[cfg(all(feature = "with-serde", not("serde" )]
+#[cfg(all(feature = "with-serde", not(feature = "serde")))]
 compile_error!("`with-serde` feature has been renamed to `serde`.");
 
 pub(crate) const USE_GAS: bool = !cfg!(feature = "no_gas_measuring");

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -6,7 +6,7 @@ mod evm_impl;
 mod inspector;
 mod journaled_state;
 
-#[cfg(feature = "with-serde")]
+#[cfg(all(feature = "with-serde", not("serde" )]
 compile_error!("`with-serde` feature has been renamed to `serde`.");
 
 pub(crate) const USE_GAS: bool = !cfg!(feature = "no_gas_measuring");


### PR DESCRIPTION
Closes #327.

Marks the `with-serde` feature as deprecated, pointing out that it has been renamed to `serde.`