### PR TITLE
refactor: simplify DatabaseComponentError

### DIFF
--- a/crates/primitives/src/db.rs
+++ b/crates/primitives/src/db.rs
@@ -8,8 +8,7 @@ use auto_impl::auto_impl;
 use hashbrown::HashMap as Map;
 
 pub use components::{
-    BlockHash, BlockHashRef, DatabaseComponentError, DatabaseComponentRefError, DatabaseComponents,
-    State, StateRef,
+    BlockHash, BlockHashRef, DatabaseComponentError, DatabaseComponents, State, StateRef,
 };
 
 #[auto_impl(& mut, Box)]

--- a/crates/primitives/src/db/components.rs
+++ b/crates/primitives/src/db/components.rs
@@ -11,8 +11,8 @@ use crate::{
 };
 
 pub struct DatabaseComponents<S, BH> {
-    state: S,
-    block_hash: BH,
+    pub state: S,
+    pub block_hash: BH,
 }
 
 pub enum DatabaseComponentError<SE, BHE> {

--- a/crates/primitives/src/db/components.rs
+++ b/crates/primitives/src/db/components.rs
@@ -15,18 +15,13 @@ pub struct DatabaseComponents<S, BH> {
     block_hash: BH,
 }
 
-pub enum DatabaseComponentError<S: State, BH: BlockHash> {
-    State(S::Error),
-    BlockHash(BH::Error),
-}
-
-pub enum DatabaseComponentRefError<S: StateRef, BH: BlockHashRef> {
-    State(S::Error),
-    BlockHash(BH::Error),
+pub enum DatabaseComponentError<SE, BHE> {
+    State(SE),
+    BlockHash(BHE),
 }
 
 impl<S: State, BH: BlockHash> Database for DatabaseComponents<S, BH> {
-    type Error = DatabaseComponentError<S, BH>;
+    type Error = DatabaseComponentError<S::Error, BH::Error>;
 
     fn basic(&mut self, address: B160) -> Result<Option<AccountInfo>, Self::Error> {
         self.state.basic(address).map_err(Self::Error::State)
@@ -52,7 +47,7 @@ impl<S: State, BH: BlockHash> Database for DatabaseComponents<S, BH> {
 }
 
 impl<S: StateRef, BH: BlockHashRef> DatabaseRef for DatabaseComponents<S, BH> {
-    type Error = DatabaseComponentRefError<S, BH>;
+    type Error = DatabaseComponentError<S::Error, BH::Error>;
 
     fn basic(&self, address: B160) -> Result<Option<AccountInfo>, Self::Error> {
         self.state.basic(address).map_err(Self::Error::State)


### PR DESCRIPTION
Also makes fields public, such that an instance of the struct can be constructed