### PR TITLE
improvement: add logs & return value to revert

### DIFF
--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -24,7 +24,11 @@ pub enum ExecutionResult {
         output: Output,
     },
     /// Reverted by `REVERT` opcode that doesn't spend all gas.
-    Revert { gas_used: u64 },
+    Revert {
+        gas_used: u64,
+        logs: Vec<Log>,
+        return_value: Bytes,
+    },
     /// Reverted for various reasons and spend all gas.
     Halt {
         reason: Halt,
@@ -51,7 +55,7 @@ impl ExecutionResult {
 
     pub fn gas_used(&self) -> u64 {
         let (Self::Success { gas_used, .. }
-        | Self::Revert { gas_used }
+        | Self::Revert { gas_used, .. }
         | Self::Halt { gas_used, .. }) = self;
 
         *gas_used

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -24,11 +24,7 @@ pub enum ExecutionResult {
         output: Output,
     },
     /// Reverted by `REVERT` opcode that doesn't spend all gas.
-    Revert {
-        gas_used: u64,
-        logs: Vec<Log>,
-        return_value: Bytes,
-    },
+    Revert { gas_used: u64, output: Bytes },
     /// Reverted for various reasons and spend all gas.
     Halt {
         reason: Halt,

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -225,7 +225,14 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact<DB::Error>
                 logs,
                 output,
             },
-            SuccessOrHalt::Revert => ExecutionResult::Revert { gas_used },
+            SuccessOrHalt::Revert => ExecutionResult::Revert {
+                gas_used,
+                logs,
+                return_value: match output {
+                    Output::Call(return_value) => return_value,
+                    Output::Create(return_value, _) => return_value,
+                },
+            },
             SuccessOrHalt::Halt(reason) => ExecutionResult::Halt { reason, gas_used },
             SuccessOrHalt::FatalExternalError => {
                 return Err(EVMError::Database(self.data.error.take().unwrap()))

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -227,8 +227,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact<DB::Error>
             },
             SuccessOrHalt::Revert => ExecutionResult::Revert {
                 gas_used,
-                logs,
-                return_value: match output {
+                output: match output {
                     Output::Call(return_value) => return_value,
                     Output::Create(return_value, _) => return_value,
                 },


### PR DESCRIPTION
The EVM allows you to call the `revert` opcode with an error message, which needs to be returned as the return value.

Additionally, I added the logs that are collected up to the point `revert` was called. This allows debugging tools built on top of `revm` without adding additional cost - as we're just bubbling up the data.