### PR TITLE
expose hashbrown::HashMap in primitives

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -22,6 +22,7 @@ pub type Hash = B256;
 
 pub use bytecode::*;
 pub use env::*;
+pub use hashbrown::{hash_map, HashMap};
 pub use log::Log;
 pub use precompile::*;
 pub use result::*;
@@ -30,4 +31,3 @@ pub use ruint::aliases::U256;
 pub use specification::*;
 pub use state::*;
 pub use utilities::*;
-pub use hashbrown::{hash_map, HashMap};

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -30,4 +30,4 @@ pub use ruint::aliases::U256;
 pub use specification::*;
 pub use state::*;
 pub use utilities::*;
-pub use hashbrown::HashMap;
+pub use hashbrown::{hash_map, HashMap};

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -30,3 +30,4 @@ pub use ruint::aliases::U256;
 pub use specification::*;
 pub use state::*;
 pub use utilities::*;
+pub use hashbrown::HashMap;


### PR DESCRIPTION
Issue: #344 

`EVM::transact` returns `ResultAndState` which contains `type State = HashMap<B160, Account>;`

State is internal to `revm` and requires `hashbrown` to form the type in user-called code.

Likewise, `Account` contains:

```
    pub storage: HashMap<U256, StorageSlot>,
```

By exposing `HashMap` in primitives it provides user the ability to use this type independently and insulates them from changes to the type.
