### PR TITLE
Use gas price in place of effective gas price for initial balance check

### DIFF
--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -113,13 +113,14 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact<DB::Error>
 
         let balance_check = U256::from(gas_limit)
             .checked_mul(self.data.env.tx.gas_price)
+            .and_then(|gas_cost| gas_cost.checked_add(value))
             .ok_or(EVMError::Transaction(
                 InvalidTransaction::OverflowPaymentInTransaction,
             ))?;
 
         // Check if account has enough balance for gas_limit*gas_price and value transfer.
         // Transfer will be done inside `*_inner` functions.
-        if balance_check + value > *caller_balance && !disable_balance_check {
+        if balance_check > *caller_balance && !disable_balance_check {
             return Err(InvalidTransaction::LackOfFundForGasLimit.into());
         }
 

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -282,7 +282,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
             acc_caller.info.balance = acc_caller
                 .info
                 .balance
-                .saturating_add(effective_gas_price * U256::from(gas.remaining() + gas_refunded));
+                .saturating_add(self.data.env.tx.gas_price * U256::from(gas.remaining() + gas_refunded));
 
             // EIP-1559
             let coinbase_gas_price = if SPEC::enabled(LONDON) {

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -112,7 +112,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact<DB::Error>
             .balance;
 
         let payment_value = U256::from(gas_limit)
-            .checked_mul(effective_gas_price)
+            .checked_mul(self.data.env.tx.gas_price)
             .ok_or(EVMError::Transaction(
                 InvalidTransaction::OverflowPaymentInTransaction,
             ))?;


### PR DESCRIPTION
The prelimary balance (LackOfFundForGasLimit) check revm does is different to Geth

revm checks: `effective_price * gas + value >= caller_balance` 
https://github.com/bluealloy/revm/blob/2e4e800b23b817a2be19f10313600f3d5dfacdf1/crates/revm/src/evm_impl.rs#L115

geth checks: `gas_fee_cap * gas + value >= caller_balance`. 
https://github.com/ethereum/go-ethereum/blob/3a79a99f804c4bd2002fe52768c965c4be8106ea/core/state_transition.go#L221

This change should align the revm check with Geth.