### PR TITLE
improvement: use alloc & core for Arc impl

### DIFF
--- a/crates/primitives/src/db/components/block_hash.rs
+++ b/crates/primitives/src/db/components/block_hash.rs
@@ -2,7 +2,9 @@
 //! it is used inside [crate::db::DatabaseComponents`]
 
 use crate::{B256, U256};
+use alloc::sync::Arc;
 use auto_impl::auto_impl;
+use core::ops::Deref;
 
 #[auto_impl(& mut, Box)]
 pub trait BlockHash {
@@ -31,15 +33,13 @@ where
     }
 }
 
-#[cfg(feature = "std")]
-impl<T> BlockHash for std::sync::Arc<T>
+impl<T> BlockHash for Arc<T>
 where
     T: BlockHashRef,
 {
     type Error = <T as BlockHashRef>::Error;
 
     fn block_hash(&mut self, number: U256) -> Result<B256, Self::Error> {
-        use std::ops::Deref;
         self.deref().block_hash(number)
     }
 }

--- a/crates/primitives/src/db/components/state.rs
+++ b/crates/primitives/src/db/components/state.rs
@@ -2,7 +2,9 @@
 //! it is used inside [crate::db::DatabaseComponents`]
 
 use crate::{AccountInfo, Bytecode, B160, B256, U256};
+use alloc::sync::Arc;
 use auto_impl::auto_impl;
+use core::ops::Deref;
 
 #[auto_impl(& mut, Box)]
 pub trait State {
@@ -49,25 +51,21 @@ where
     }
 }
 
-#[cfg(feature = "std")]
-impl<T> State for std::sync::Arc<T>
+impl<T> State for Arc<T>
 where
     T: StateRef,
 {
     type Error = <T as StateRef>::Error;
 
     fn basic(&mut self, address: B160) -> Result<Option<AccountInfo>, Self::Error> {
-        use std::ops::Deref;
         self.deref().basic(address)
     }
 
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
-        use std::ops::Deref;
         self.deref().code_by_hash(code_hash)
     }
 
     fn storage(&mut self, address: B160, index: U256) -> Result<U256, Self::Error> {
-        use std::ops::Deref;
         self.deref().storage(address, index)
     }
 }


### PR DESCRIPTION
Improves #360 & #361 by removing necessity for `std` feature