### PR TITLE
improvement: derive Debug for DatabaseComponentError

### DIFF
--- a/crates/primitives/src/db/components.rs
+++ b/crates/primitives/src/db/components.rs
@@ -16,6 +16,7 @@ pub struct DatabaseComponents<S, BH> {
     pub block_hash: BH,
 }
 
+#[derive(Debug)]
 pub enum DatabaseComponentError<SE, BHE> {
     State(SE),
     BlockHash(BHE),


### PR DESCRIPTION
In #363 I added it for `DatabaseComponents` and not for `DatabaseComponentError` after incorporating suggestions