### PR TITLE
Add B160/B256 From primitive_types traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1633,6 +1633,7 @@ dependencies = [
  "hashbrown 0.13.2",
  "hex",
  "hex-literal",
+ "primitive-types",
  "proptest",
  "proptest-derive",
  "rlp",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -13,6 +13,7 @@ readme = "../../README.md"
 bytes = { version = "1.4", default-features = false }
 hashbrown = { version = "0.13" }
 hex = { version = "0.4", default-features = false }
+primitive-types = { version = "0.12", default-features = false }
 rlp = { version = "0.5", default-features = false } # used for create2 address calculation
 ruint = { version = "1.7.0", features = ["primitive-types", "rlp"] }
 auto_impl = "1.0"

--- a/crates/primitives/src/bits.rs
+++ b/crates/primitives/src/bits.rs
@@ -30,6 +30,30 @@ impl From<u64> for B160 {
     }
 }
 
+impl From<primitive_types::H160> for B160 {
+    fn from(fr: primitive_types::H160) -> Self {
+        B160(fr.0)
+    }
+}
+
+impl From<primitive_types::H256> for B256 {
+    fn from(fr: primitive_types::H256) -> Self {
+        B256(fr.0)
+    }
+}
+
+impl From<B160> for primitive_types::H160 {
+    fn from(fr: B160) -> Self {
+        primitive_types::H160(fr.0)
+    }
+}
+
+impl From<B256> for primitive_types::H256 {
+    fn from(fr: B256) -> Self {
+        primitive_types::H256(fr.0)
+    }
+}
+
 impl_fixed_hash_conversions!(B256, B160);
 
 #[cfg(feature = "serde")]
@@ -275,4 +299,38 @@ mod tests {
     fn arbitrary() {
         proptest::proptest!(|(_v1: B160, _v2: B256)| {});
     }
+
+    #[test]
+    fn should_convert_from_primitive_types_h160() {
+        let h160 = primitive_types::H160::random();
+        let b160: B160 = h160.into();
+        let new_h160: primitive_types::H160 = b160.into();
+        assert_eq!(h160, new_h160)
+    }
+
+
+    #[test]
+    fn should_convert_to_primitive_types_h160() {
+        let b160 = B160::random();
+        let h160: primitive_types::H160 = b160.into();
+        let new_b160: B160 = h160.into();
+        assert_eq!(b160, new_b160)
+    }
+
+    #[test]
+    fn should_convert_from_primitive_types_h256() {
+        let h256 = primitive_types::H256::random();
+        let b256: B256 = h256.into();
+        let new_h256: primitive_types::H256 = b256.into();
+        assert_eq!(h256, new_h256)
+    }
+
+    #[test]
+    fn should_convert_to_primitive_types_h256() {
+        let b256 = B256::random();
+        let h256: primitive_types::H256 = b256.into();
+        let new_b256: B256 = h256.into();
+        assert_eq!(b256, new_b256)
+    }
+
 }

--- a/crates/primitives/src/bits.rs
+++ b/crates/primitives/src/bits.rs
@@ -308,7 +308,6 @@ mod tests {
         assert_eq!(h160, new_h160)
     }
 
-
     #[test]
     fn should_convert_to_primitive_types_h160() {
         let b160 = B160::random();
@@ -332,5 +331,4 @@ mod tests {
         let new_b256: B256 = h256.into();
         assert_eq!(b256, new_b256)
     }
-
 }


### PR DESCRIPTION
REVM 3 does not use `primitive_types` anymore. Numerical types compatibility is already provided by `ruint` `primitive_types` feature. This PR adds type conversion between the hashes types (i.e. `B160` and `B256`) and their counterparts in `primitive_types`.