### PR TITLE
impl NonceTooHigh/ NonceTooLow checks

### DIFF
--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -102,8 +102,16 @@ pub enum InvalidTransaction {
     },
     /// Overflow payment in transaction.
     OverflowPaymentInTransaction,
-    /// Nonce overflows in transaction,
+    /// Nonce overflows in transaction.
     NonceOverflowInTransaction,
+    NonceTooHigh {
+        tx: u64,
+        state: u64,
+    },
+    NonceTooLow {
+        tx: u64,
+        state: u64,
+    },
     /// EIP-3860: Limit and meter initcode
     CreateInitcodeSizeLimit,
 }

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -98,6 +98,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact<DB::Error>
             return Err(InvalidTransaction::RejectCallerWithCode.into());
         }
 
+        // Check that the transaction's nonce is correct
         if self.data.env.tx.nonce.is_some() {
             let state_nonce = self.data.journaled_state.state.get(&caller).unwrap().info.nonce;
             let tx_nonce = self.data.env.tx.nonce.unwrap();

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -100,7 +100,14 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact<DB::Error>
 
         // Check that the transaction's nonce is correct
         if self.data.env.tx.nonce.is_some() {
-            let state_nonce = self.data.journaled_state.state.get(&caller).unwrap().info.nonce;
+            let state_nonce = self.
+                data.
+                journaled_state.
+                state.
+                get(&caller).
+                unwrap().
+                info.
+                nonce;
             let tx_nonce = self.data.env.tx.nonce.unwrap();
             if state_nonce < tx_nonce {
                 return Err(InvalidTransaction::NonceTooHigh {

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -117,15 +117,15 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact<DB::Error>
                         state: state_nonce,
                     }
                     .into());
-                },
+                }
                 Ordering::Less => {
                     return Err(InvalidTransaction::NonceTooLow {
                         tx: tx_nonce,
                         state: state_nonce,
                     }
                     .into());
-                },
-                _ => {},
+                }
+                _ => {}
             }
         }
 

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -100,14 +100,14 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact<DB::Error>
 
         // Check that the transaction's nonce is correct
         if self.data.env.tx.nonce.is_some() {
-            let state_nonce = self.
-                data.
-                journaled_state.
-                state.
-                get(&caller).
-                unwrap().
-                info.
-                nonce;
+            let state_nonce = self
+                .data
+                .journaled_state
+                .state
+                .get(&caller)
+                .unwrap()
+                .info
+                .nonce;
             let tx_nonce = self.data.env.tx.nonce.unwrap();
             if state_nonce < tx_nonce {
                 return Err(InvalidTransaction::NonceTooHigh {


### PR DESCRIPTION
Implements missing nonce checks. 

Using a feature flag to disable the nonce checks was discussed in telegram but I noticed that the `nonce` parameter in the `TxEnv` struct was optional so I've put the check behind that. If this isn't what the Optional nonce was for then I can put it behind a feature flag, just let me know :D.

Matched to Geth: https://github.com/ethereum/go-ethereum/blob/fe01a2f63b8591d8226742726d8d6aaad4cd981e/core/state_transition.go#L240