### PR TITLE
feat: add contract+target to selfdestruct hook

### DIFF
--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -988,7 +988,7 @@ impl<'a, GSPEC: Spec, DB: Database + 'a, const INSPECT: bool> Host
 
     fn selfdestruct(&mut self, address: B160, target: B160) -> Option<SelfDestructResult> {
         if INSPECT {
-            self.inspector.selfdestruct();
+            self.inspector.selfdestruct(address, target);
         }
         self.data
             .journaled_state

--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -136,6 +136,6 @@ pub trait Inspector<DB: Database> {
         (ret, address, remaining_gas, out)
     }
 
-    /// Called when a contract has been self-destructed.
-    fn selfdestruct(&mut self) {}
+    /// Called when a contract has been self-destructed with funds transferred to target.
+    fn selfdestruct(&mut self, _contract: B160, _target: B160) {}
 }

--- a/crates/revm/src/inspector/customprinter.rs
+++ b/crates/revm/src/inspector/customprinter.rs
@@ -125,9 +125,8 @@ impl<DB: Database> Inspector<DB> for CustomPrintTracer {
         (InstructionResult::Continue, None, Gas::new(0), Bytes::new())
     }
 
-    fn selfdestruct(&mut self) {
-        //, address: B160, target: B160) {
-        println!("SELFDESTRUCT on "); //{:?} target: {:?}", address, target);
+    fn selfdestruct(&mut self, contract: B160, target: B160) {
+        println!("SELFDESTRUCT on {contract:?} refund target: {target:?}");
     }
 }
 


### PR DESCRIPTION
adds back the addresses to the selfdestruct hook.