### PR TITLE
fix(interpreter): halt on `CreateInitcodeSizeLimit`

### DIFF
--- a/crates/interpreter/src/instruction_result.rs
+++ b/crates/interpreter/src/instruction_result.rs
@@ -130,7 +130,7 @@ impl From<InstructionResult> for SuccessOrHalt {
             InstructionResult::CreateContractStartingWithEF => {
                 Self::Halt(Halt::CreateContractSizeLimit)
             }
-            InstructionResult::CreateInitcodeSizeLimit => Self::Internal,
+            InstructionResult::CreateInitcodeSizeLimit => Self::Halt(Halt::CreateInitcodeSizeLimit),
             InstructionResult::FatalExternalError => Self::FatalExternalError,
         }
     }

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -147,6 +147,8 @@ pub enum Halt {
     CreateContractSizeLimit,
     /// Error on created contract that begins with EF
     CreateContractStartingWithEF,
+    /// EIP-3860: Limit and meter initcode. Initcode size limit exceeded.
+    CreateInitcodeSizeLimit,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]


### PR DESCRIPTION
From [EIP 3860](https://eips.ethereum.org/EIPS/eip-3860#rules):

> If length of initcode to CREATE or CREATE2 instructions exceeds MAX_INITCODE_SIZE, instruction execution exceptionally aborts (as if it runs out of gas).