### PR TITLE
fix(db): preserve existing account state

### DIFF
--- a/crates/revm/src/db/in_memory_db.rs
+++ b/crates/revm/src/db/in_memory_db.rs
@@ -92,9 +92,9 @@ pub enum AccountState {
 }
 
 impl AccountState {
-    /// Returns `true` if EVM didn't interact with this account
-    pub fn is_none(&self) -> bool {
-        matches!(self, AccountState::None)
+    /// Returns `true` if EVM cleared storage of this account
+    pub fn is_storage_cleared(&self) -> bool {
+        matches!(self, AccountState::StorageCleared)
     }
 }
 
@@ -190,9 +190,9 @@ impl<ExtDB: DatabaseRef> DatabaseCommit for CacheDB<ExtDB> {
             db_account.account_state = if account.storage_cleared {
                 db_account.storage.clear();
                 AccountState::StorageCleared
-            } else if !db_account.account_state.is_none() {
+            } else if db_account.account_state.is_storage_cleared() {
                 // Preserve old account state if it already exists
-                db_account.account_state.clone()
+                AccountState::StorageCleared
             } else {
                 AccountState::Touched
             };

--- a/crates/revm/src/db/in_memory_db.rs
+++ b/crates/revm/src/db/in_memory_db.rs
@@ -91,6 +91,13 @@ pub enum AccountState {
     None,
 }
 
+impl AccountState {
+    /// Returns `true` if EVM didn't interact with this account
+    pub fn is_none(&self) -> bool {
+        matches!(self, AccountState::None)
+    }
+}
+
 impl<ExtDB: DatabaseRef> CacheDB<ExtDB> {
     pub fn new(db: ExtDB) -> Self {
         let mut contracts = HashMap::new();
@@ -183,6 +190,9 @@ impl<ExtDB: DatabaseRef> DatabaseCommit for CacheDB<ExtDB> {
             db_account.account_state = if account.storage_cleared {
                 db_account.storage.clear();
                 AccountState::StorageCleared
+            } else if !db_account.account_state.is_none() {
+                // Preserve old account state if it already exists
+                db_account.account_state
             } else {
                 AccountState::Touched
             };

--- a/crates/revm/src/db/in_memory_db.rs
+++ b/crates/revm/src/db/in_memory_db.rs
@@ -192,7 +192,7 @@ impl<ExtDB: DatabaseRef> DatabaseCommit for CacheDB<ExtDB> {
                 AccountState::StorageCleared
             } else if !db_account.account_state.is_none() {
                 // Preserve old account state if it already exists
-                db_account.account_state
+                db_account.account_state.clone()
             } else {
                 AccountState::Touched
             };


### PR DESCRIPTION
## Bug

If the account already existed, its state would get reset to `Touched` after any change.
This is not ideal for accounts which had their storage cleared.

## Fix
Preserve existing account state if any.