### PR TITLE
feat: change memory resize gas cost recording to deltas

### DIFF
--- a/crates/revm/src/gas.rs
+++ b/crates/revm/src/gas.rs
@@ -65,15 +65,14 @@ impl Gas {
     }
 
     /// used in memory_resize! macro
-    pub fn record_memory(&mut self, gas_memory: u64) -> bool {
-        if gas_memory > self.memory {
-            let (all_used_gas, overflow) = self.used.overflowing_add(gas_memory);
-            if overflow || self.limit < all_used_gas {
-                return false;
-            }
-            self.memory = gas_memory;
-            self.all_used_gas = all_used_gas;
+    pub fn record_memory(&mut self, cost_delta: u64) -> bool {
+        let (all_used_gas, overflow) = self.all_used_gas.overflowing_add(cost_delta);
+        if overflow || self.limit < all_used_gas {
+            return false;
         }
+
+        self.memory += cost_delta;
+        self.all_used_gas = all_used_gas;
         true
     }
 

--- a/crates/revm/src/instructions/macros.rs
+++ b/crates/revm/src/instructions/macros.rs
@@ -51,10 +51,11 @@ macro_rules! memory_resize {
 
             if new_size > $interp.memory.len() {
                 if crate::USE_GAS {
-                    let num_bytes = new_size / 32;
-                    if !$interp.gas.record_memory(crate::gas::memory_gas(num_bytes)) {
+                    let new_cost = crate::gas::memory_gas(new_size / 32);
+                    if !$interp.gas.record_memory(new_cost - $interp.memory_last_gas_cost) {
                         return Return::OutOfGas;
                     }
+                    $interp.memory_last_gas_cost = new_cost;
                 }
                 $interp.memory.resize(new_size);
             }

--- a/crates/revm/src/interpreter.rs
+++ b/crates/revm/src/interpreter.rs
@@ -33,6 +33,8 @@ pub struct Interpreter {
     pub return_data_buffer: Bytes,
     /// Return value.
     pub return_range: Range<usize>,
+    /// Last absolute cost of expanded memory.
+    pub memory_last_gas_cost: u64,
     /// Memory limit. See [`crate::CfgEnv`].
     #[cfg(feature = "memory_limit")]
     pub memory_limit: u64,
@@ -52,6 +54,7 @@ impl Interpreter {
             return_data_buffer: Bytes::new(),
             contract,
             gas: Gas::new(gas_limit),
+            memory_last_gas_cost: 0,
         }
     }
 
@@ -69,6 +72,7 @@ impl Interpreter {
             return_data_buffer: Bytes::new(),
             contract,
             gas: Gas::new(gas_limit),
+            memory_last_gas_cost: 0,
             memory_limit,
         }
     }


### PR DESCRIPTION
While debugging the following [issue](https://github.com/foundry-rs/foundry/issues/4523), I found out that memory gas cost is replaced with new total cost on each memory resize. This does not play nicely with gas metering functionality of `foundry` which expects gas cost deltas to be recorded instead.

I've prepared a minimal change which converts memory gas recording to use deltas as well, and produces expected result in the issue linked above. Added one additional `subtraction` and `addition` on `u64` compared to previous implementation so performance shouldn't be impacted too much.

If this gets merged I'll prepare a PR for `main` branch as well.