### PR TITLE
add feature for ignoring base fee check

### DIFF
--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -38,6 +38,7 @@ dev = [
     "optional_block_gas_limit",
     "optional_eip3607",
     "optional_gas_refund",
+    "optional_no_base_fee",
 ]
 memory_limit = ["revm-primitives/memory_limit"]
 no_gas_measuring = ["revm-primitives/no_gas_measuring"]
@@ -45,6 +46,7 @@ optional_balance_check = ["revm-primitives/optional_balance_check"]
 optional_block_gas_limit = ["revm-primitives/optional_block_gas_limit"]
 optional_eip3607 = ["revm-primitives/optional_eip3607"]
 optional_gas_refund = ["revm-primitives/optional_gas_refund"]
+optional_no_base_fee = ["revm-primitives/optional_no_base_fee"]
 std = ["revm-primitives/std"]
 serde = [
     "dep:serde",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -57,6 +57,7 @@ dev = [
     "optional_block_gas_limit",
     "optional_eip3607",
     "optional_gas_refund",
+    "optional_no_base_fee",
 ]
 memory_limit = []
 no_gas_measuring = []
@@ -64,6 +65,7 @@ optional_balance_check = []
 optional_block_gas_limit = []
 optional_eip3607 = []
 optional_gas_refund = []
+optional_no_base_fee = []
 std = ["bytes/std", "rlp/std", "hex/std", "bitvec/std"]
 serde = [
     "dep:serde",

--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -115,6 +115,10 @@ pub struct CfgEnv {
     /// By default, it is set to `false`.
     #[cfg(feature = "optional_gas_refund")]
     pub disable_gas_refund: bool,
+    /// Disables base fee checks for EIP-1559 transactions.
+    /// This is useful for testing method calls with zero gas price.
+    #[cfg(feature = "optional_no_base_fee")]
+    pub disable_base_fee: bool,
 }
 
 #[derive(Clone, Default, Debug, Eq, PartialEq)]
@@ -144,6 +148,8 @@ impl Default for CfgEnv {
             disable_eip3607: false,
             #[cfg(feature = "optional_gas_refund")]
             disable_gas_refund: false,
+            #[cfg(feature = "optional_no_base_fee")]
+            disable_base_fee: false,
         }
     }
 }

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -40,6 +40,7 @@ dev = [
     "optional_block_gas_limit",
     "optional_eip3607",
     "optional_gas_refund",
+    "optional_no_base_fee",
 ]
 secp256k1 = ["revm-precompile/secp256k1"]
 memory_limit = ["revm-interpreter/memory_limit"]
@@ -48,6 +49,7 @@ optional_balance_check = ["revm-interpreter/optional_balance_check"]
 optional_block_gas_limit = ["revm-interpreter/optional_block_gas_limit"]
 optional_eip3607 = ["revm-interpreter/optional_eip3607"]
 optional_gas_refund = ["revm-interpreter/optional_gas_refund"]
+optional_no_base_fee = ["revm-interpreter/optional_no_base_fee"]
 std = ["revm-interpreter/std"]
 ethersdb = ["tokio", "futures", "ethers-providers", "ethers-core"]
 serde = ["dep:serde","dep:serde_json", "revm-interpreter/serde"]

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -60,10 +60,15 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact<DB::Error>
             }
             let basefee = self.data.env.block.basefee;
 
+            #[cfg(feature = "optional_no_base_fee")]
+            let disable_base_fee = self.env().cfg.disable_base_fee;
+            #[cfg(not(feature = "optional_no_base_fee"))]
+            let disable_base_fee = false;
+
             // check minimal cost against basefee
             // TODO maybe do this checks when creating evm. We already have all data there
             // or should be move effective_gas_price inside transact fn
-            if effective_gas_price < basefee {
+            if !disable_base_fee && effective_gas_price < basefee {
                 return Err(InvalidTransaction::GasPriceLessThanBasefee.into());
             }
             // check if priority fee is lower then max fee


### PR DESCRIPTION
This is analogous to the geth EVM `NoBaseFee` option:
https://github.com/ethereum/go-ethereum/blob/ee8e83fa5f6cb261dad2ed0a7bbcde4930c41e6c/core/vm/interpreter.go#L30

Which is used in `eth_call` and other RPCs that make calls, since they may have a gas price of zero:
https://github.com/ethereum/go-ethereum/blob/ee8e83fa5f6cb261dad2ed0a7bbcde4930c41e6c/internal/ethapi/api.go#L985