### PR TITLE
Improve EthersDB::new

### DIFF
--- a/crates/revm/src/db/ethersdb.rs
+++ b/crates/revm/src/db/ethersdb.rs
@@ -35,7 +35,9 @@ where
         out.block_number = if block_number.is_some() {
             block_number
         } else {
-            Some(BlockId::from(out.block_on(out.client.get_block_number()).ok()?))
+            Some(BlockId::from(
+                out.block_on(out.client.get_block_number()).ok()?,
+            ))
         };
 
         Some(out)

--- a/crates/revm/src/db/ethersdb.rs
+++ b/crates/revm/src/db/ethersdb.rs
@@ -19,7 +19,7 @@ where
     M: Middleware,
 {
     /// create ethers db connector inputs are url and block on what we are basing our database (None for latest)
-    pub fn new(client: Arc<M>, block_number: Option<u64>) -> Option<Self> {
+    pub fn new(client: Arc<M>, block_number: Option<BlockId>) -> Option<Self> {
         let runtime = Handle::try_current()
             .is_err()
             .then(|| Runtime::new().unwrap());
@@ -31,13 +31,13 @@ where
             runtime,
             block_number: None,
         };
-        let bnum = if let Some(block_number) = block_number {
-            block_number.into()
+
+        out.block_number = if let Some(block_number) = block_number {
+            Some(block_number)
         } else {
-            out.block_on(out.client.get_block_number()).ok()?
+            Some(BlockId::from(out.block_on(out.client.get_block_number()).ok()?))
         };
 
-        out.block_number = Some(BlockId::from(bnum));
         Some(out)
     }
 

--- a/crates/revm/src/db/ethersdb.rs
+++ b/crates/revm/src/db/ethersdb.rs
@@ -32,8 +32,8 @@ where
             block_number: None,
         };
 
-        out.block_number = if let Some(block_number) = block_number {
-            Some(block_number)
+        out.block_number = if block_number.is_some() {
+            block_number
         } else {
             Some(BlockId::from(out.block_on(out.client.get_block_number()).ok()?))
         };
@@ -138,7 +138,7 @@ mod tests {
 
         let mut ethersdb = EthersDB::new(
             Arc::clone(&client), // public infura mainnet
-            Some(16148323),
+            Some(BlockId::from(16148323)),
         )
         .unwrap();
 
@@ -164,7 +164,7 @@ mod tests {
 
         let mut ethersdb = EthersDB::new(
             Arc::clone(&client), // public infura mainnet
-            Some(16148323),
+            Some(BlockId::from(16148323)),
         )
         .unwrap();
 


### PR DESCRIPTION
Changing `Option<u64>` to `Option<BlockId>` will allow us to pass more flexible parameters like `BlockId::Number(BlockNumber::Latest)` instead of always `BlockNumber::Number`.