### PR TITLE
refactor: decouple EVMData from Inspector trait

### DIFF
--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -1,4 +1,5 @@
 use crate::primitives::{specification, EVMError, EVMResult, Env, ExecutionResult, SpecId};
+use crate::JournaledState;
 use crate::{
     db::{Database, DatabaseCommit, DatabaseRef, RefDBWrapper},
     evm_impl::{EVMImpl, Transact},
@@ -61,7 +62,7 @@ impl<DB: Database + DatabaseCommit> EVM<DB> {
         Ok(result)
     }
     /// Inspect transaction and commit changes to database.
-    pub fn inspect_commit<INSP: Inspector<DB>>(
+    pub fn inspect_commit<INSP: Inspector<DB::Error>>(
         &mut self,
         inspector: INSP,
     ) -> Result<ExecutionResult, EVMError<DB::Error>> {
@@ -84,7 +85,10 @@ impl<DB: Database> EVM<DB> {
     }
 
     /// Execute transaction with given inspector, without wring to DB. Return change state.
-    pub fn inspect<INSP: Inspector<DB>>(&mut self, mut inspector: INSP) -> EVMResult<DB::Error> {
+    pub fn inspect<INSP: Inspector<DB::Error>>(
+        &mut self,
+        mut inspector: INSP,
+    ) -> EVMResult<DB::Error> {
         if let Some(db) = self.db.as_mut() {
             evm_inner::<DB, true>(&mut self.env, db, &mut inspector).transact()
         } else {
@@ -110,7 +114,7 @@ impl<'a, DB: DatabaseRef> EVM<DB> {
     }
 
     /// Execute transaction with given inspector, without wring to DB. Return change state.
-    pub fn inspect_ref<INSP: Inspector<RefDBWrapper<'a, DB::Error>>>(
+    pub fn inspect_ref<INSP: Inspector<DB::Error>>(
         &'a self,
         mut inspector: INSP,
     ) -> EVMResult<DB::Error> {
@@ -191,7 +195,7 @@ pub fn to_precompile_id(spec_id: SpecId) -> revm_precompile::SpecId {
 pub fn evm_inner<'a, DB: Database, const INSPECT: bool>(
     env: &'a mut Env,
     db: &'a mut DB,
-    insp: &'a mut dyn Inspector<DB>,
+    insp: &'a mut dyn Inspector<DB::Error>,
 ) -> Box<dyn Transact<DB::Error> + 'a> {
     use specification::*;
     match env.cfg.spec_id {
@@ -211,4 +215,19 @@ pub fn evm_inner<'a, DB: Database, const INSPECT: bool>(
         SpecId::CANCUN => create_evm!(CancunSpec, db, env, insp),
         SpecId::LATEST => create_evm!(LatestSpec, db, env, insp),
     }
+}
+
+/// Trait that exposes internal EVM data.
+pub trait EVMData<E> {
+    /// Returns a mutable reference to the EVM's environment.
+    fn env(&mut self) -> &mut Env;
+
+    /// Returns a mutable reference to the [`JournaledState`] of the evm.
+    fn journaled_state(&mut self) -> &mut JournaledState;
+
+    /// Returns a mutable reference to the [`Database`] of the evm.
+    fn database(&mut self) -> &mut dyn Database<Error = E>;
+
+    /// Returns a mutable reference to the last error, if one occured.
+    fn error(&mut self) -> &mut Option<E>;
 }

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -1,3 +1,4 @@
+use crate::evm::EVMData;
 use crate::interpreter::{
     analysis::to_analysed, gas, instruction_result::SuccessOrHalt, return_ok, return_revert,
     CallContext, CallInputs, CallScheme, Contract, CreateInputs, CreateScheme, Gas, Host,
@@ -19,17 +20,35 @@ use revm_interpreter::gas::initial_tx_gas;
 use revm_interpreter::MAX_CODE_SIZE;
 use revm_precompile::{Precompile, Precompiles};
 
-pub struct EVMData<'a, DB: Database> {
-    pub env: &'a mut Env,
-    pub journaled_state: JournaledState,
-    pub db: &'a mut DB,
-    pub error: Option<DB::Error>,
-    pub precompiles: Precompiles,
+pub(crate) struct EVMDataImpl<'a, DB: Database> {
+    pub(crate) env: &'a mut Env,
+    pub(crate) journaled_state: JournaledState,
+    pub(crate) db: &'a mut DB,
+    pub(crate) error: Option<DB::Error>,
+    pub(crate) precompiles: Precompiles,
+}
+
+impl<'a, DB: Database> EVMData<DB::Error> for EVMDataImpl<'a, DB> {
+    fn env(&mut self) -> &mut Env {
+        self.env
+    }
+
+    fn journaled_state(&mut self) -> &mut JournaledState {
+        &mut self.journaled_state
+    }
+
+    fn database(&mut self) -> &mut dyn Database<Error = DB::Error> {
+        self.db
+    }
+
+    fn error(&mut self) -> &mut Option<DB::Error> {
+        &mut self.error
+    }
 }
 
 pub struct EVMImpl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> {
-    data: EVMData<'a, DB>,
-    inspector: &'a mut dyn Inspector<DB>,
+    data: EVMDataImpl<'a, DB>,
+    inspector: &'a mut dyn Inspector<DB::Error>,
     _phantomdata: PhantomData<GSPEC>,
 }
 
@@ -227,7 +246,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
     pub fn new(
         db: &'a mut DB,
         env: &'a mut Env,
-        inspector: &'a mut dyn Inspector<DB>,
+        inspector: &'a mut dyn Inspector<DB::Error>,
         precompiles: Precompiles,
     ) -> Self {
         let journaled_state = if GSPEC::enabled(SpecId::SPURIOUS_DRAGON) {
@@ -236,7 +255,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
             JournaledState::new_legacy(precompiles.len())
         };
         Self {
-            data: EVMData {
+            data: EVMDataImpl {
                 env,
                 journaled_state,
                 db,

--- a/crates/revm/src/inspector/gas.rs
+++ b/crates/revm/src/inspector/gas.rs
@@ -1,8 +1,9 @@
 //! GasIspector. Helper Inspector to calculate gas for others.
 //!
+use crate::evm::EVMData;
 use crate::interpreter::{CallInputs, CreateInputs, Gas, InstructionResult};
-use crate::primitives::{db::Database, Bytes, B160};
-use crate::{evm_impl::EVMData, Inspector};
+use crate::primitives::{Bytes, B160};
+use crate::Inspector;
 
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Default)]
@@ -21,12 +22,12 @@ impl GasInspector {
     }
 }
 
-impl<DB: Database> Inspector<DB> for GasInspector {
+impl<E> Inspector<E> for GasInspector {
     #[cfg(not(feature = "no_gas_measuring"))]
     fn initialize_interp(
         &mut self,
         interp: &mut crate::interpreter::Interpreter,
-        _data: &mut EVMData<'_, DB>,
+        _data: &mut dyn EVMData<E>,
     ) -> InstructionResult {
         self.gas_remaining = interp.gas.limit();
         InstructionResult::Continue
@@ -39,7 +40,7 @@ impl<DB: Database> Inspector<DB> for GasInspector {
     fn step(
         &mut self,
         _interp: &mut crate::interpreter::Interpreter,
-        _data: &mut EVMData<'_, DB>,
+        _data: &mut dyn EVMData<E>,
     ) -> InstructionResult {
         InstructionResult::Continue
     }
@@ -48,7 +49,7 @@ impl<DB: Database> Inspector<DB> for GasInspector {
     fn step_end(
         &mut self,
         interp: &mut crate::interpreter::Interpreter,
-        _data: &mut EVMData<'_, DB>,
+        _data: &mut dyn EVMData<E>,
         _eval: InstructionResult,
     ) -> InstructionResult {
         let last_gas = self.gas_remaining;
@@ -63,7 +64,7 @@ impl<DB: Database> Inspector<DB> for GasInspector {
 
     fn call_end(
         &mut self,
-        _data: &mut EVMData<'_, DB>,
+        _data: &mut dyn EVMData<E>,
         _inputs: &CallInputs,
         mut remaining_gas: Gas,
         ret: InstructionResult,
@@ -80,7 +81,7 @@ impl<DB: Database> Inspector<DB> for GasInspector {
 
     fn create_end(
         &mut self,
-        _data: &mut EVMData<'_, DB>,
+        _data: &mut dyn EVMData<E>,
         _inputs: &CreateInputs,
         ret: InstructionResult,
         address: Option<B160>,
@@ -94,13 +95,14 @@ impl<DB: Database> Inspector<DB> for GasInspector {
 #[cfg(test)]
 mod tests {
     use crate::db::BenchmarkDB;
+    use crate::evm::EVMData;
     use crate::interpreter::{
         opcode, CallInputs, CreateInputs, Gas, InstructionResult, Interpreter, OpCode,
     };
     use crate::primitives::{
         hex_literal::hex, Bytecode, Bytes, ResultAndState, TransactTo, B160, B256,
     };
-    use crate::{inspectors::GasInspector, Database, EVMData, Inspector};
+    use crate::{inspectors::GasInspector, Inspector};
 
     #[derive(Default, Debug)]
     struct StackInspector {
@@ -109,11 +111,11 @@ mod tests {
         gas_remaining_steps: Vec<(usize, u64)>,
     }
 
-    impl<DB: Database> Inspector<DB> for StackInspector {
+    impl<E> Inspector<E> for StackInspector {
         fn initialize_interp(
             &mut self,
             interp: &mut Interpreter,
-            data: &mut EVMData<'_, DB>,
+            data: &mut dyn EVMData<E>,
         ) -> InstructionResult {
             self.gas_inspector.initialize_interp(interp, data);
             InstructionResult::Continue
@@ -122,7 +124,7 @@ mod tests {
         fn step(
             &mut self,
             interp: &mut Interpreter,
-            data: &mut EVMData<'_, DB>,
+            data: &mut dyn EVMData<E>,
         ) -> InstructionResult {
             self.pc = interp.program_counter();
             self.gas_inspector.step(interp, data);
@@ -131,7 +133,7 @@ mod tests {
 
         fn log(
             &mut self,
-            evm_data: &mut EVMData<'_, DB>,
+            evm_data: &mut dyn EVMData<E>,
             address: &B160,
             topics: &[B256],
             data: &Bytes,
@@ -142,7 +144,7 @@ mod tests {
         fn step_end(
             &mut self,
             interp: &mut Interpreter,
-            data: &mut EVMData<'_, DB>,
+            data: &mut dyn EVMData<E>,
             eval: InstructionResult,
         ) -> InstructionResult {
             self.gas_inspector.step_end(interp, data, eval);
@@ -153,7 +155,7 @@ mod tests {
 
         fn call(
             &mut self,
-            data: &mut EVMData<'_, DB>,
+            data: &mut dyn EVMData<E>,
             call: &mut CallInputs,
         ) -> (InstructionResult, Gas, Bytes) {
             self.gas_inspector.call(data, call);
@@ -167,7 +169,7 @@ mod tests {
 
         fn call_end(
             &mut self,
-            data: &mut EVMData<'_, DB>,
+            data: &mut dyn EVMData<E>,
             inputs: &CallInputs,
             remaining_gas: Gas,
             ret: InstructionResult,
@@ -180,7 +182,7 @@ mod tests {
 
         fn create(
             &mut self,
-            data: &mut EVMData<'_, DB>,
+            data: &mut dyn EVMData<E>,
             call: &mut CreateInputs,
         ) -> (InstructionResult, Option<B160>, Gas, Bytes) {
             self.gas_inspector.create(data, call);
@@ -195,7 +197,7 @@ mod tests {
 
         fn create_end(
             &mut self,
-            data: &mut EVMData<'_, DB>,
+            data: &mut dyn EVMData<E>,
             inputs: &CreateInputs,
             status: InstructionResult,
             address: Option<B160>,

--- a/crates/revm/src/inspector/noop.rs
+++ b/crates/revm/src/inspector/noop.rs
@@ -1,8 +1,8 @@
 //! Dummy NoOp Inspector, helpful as standalone replacement.
 
-use crate::{Database, Inspector};
+use crate::Inspector;
 
 #[derive(Clone, Copy)]
 pub struct NoOpInspector();
 
-impl<DB: Database> Inspector<DB> for NoOpInspector {}
+impl<E> Inspector<E> for NoOpInspector {}

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -20,8 +20,8 @@ pub type DummyStateDB = InMemoryDB;
 pub use db::{CacheState, StateBuilder, TransitionAccount, TransitionState};
 
 pub use db::{Database, DatabaseCommit, InMemoryDB, State};
-pub use evm::{evm_inner, new, to_precompile_id, EVM};
-pub use evm_impl::{EVMData, EVMImpl, Transact};
+pub use evm::{evm_inner, new, to_precompile_id, EVMData, EVM};
+pub use evm_impl::{EVMImpl, Transact};
 pub use journaled_state::{is_precompile, JournalCheckpoint, JournalEntry, JournaledState};
 
 // reexport `revm_precompiles`


### PR DESCRIPTION
Currently, the `Inspector` trait has a `Database` generic that imposes its lifetime constraints onto the `Inspector`. This would prohibit user-provided `Inspector` implementations from being used in async contexts as when the `Database` implementation is using references, as lifetimes need to be `'static` in async contexts.

E.g.

```rust
fn build_evm<'s, 'b, E>(
  some_state: &'s dyn StateRef<E>,
  some_blockhash: &'b dyn BlockHashRef<E
) -> EVM<DatabaseComponents<&'s dyn StateRef<E>, &'b dyn BlockHashRef<E>> {
  let mut evm = revm::EVM::new();
  evm.database(DatabaseComponents {
    some_state,
    some_blockhash,
  });
  
  evm
}

fn run_transaction(
  evm: EVM<DatabaseComponents<&'s dyn StateRef<E>, &'b dyn BlockHashRef<E>>,
  inspector: &mut dyn Inspector<DatabaseComponents<&'s dyn StateRef<E>, &'b dyn BlockHashRef<E>>>
) {
  evm.inspect_ref(inspector)
}
```

The above example illustrates how the lifetimes imposed on the database bleed into the inspector. It is however impossible for a user to create a dynamic object with the lifetime constraints mentioned on the inspector's bounds.

This PR decouples the `Database` from the `Inspector` by using a strategy pattern: a `trait EVMData<E>` that returns a `&mut dyn Database<E>`

NOTE: This is a breaking change to the existing public API