### PR TITLE
fix: touched account on creation

### DIFF
--- a/crates/revm/src/journaled_state.rs
+++ b/crates/revm/src/journaled_state.rs
@@ -254,10 +254,13 @@ impl JournaledState {
         acc.info.code_hash = KECCAK_EMPTY;
         acc.info.code = None;
 
-        self.journal
-            .last_mut()
-            .unwrap()
-            .push(JournalEntry::AccountTouched { address });
+        if !acc.is_touched {
+            acc.is_touched = true;
+            self.journal
+                .last_mut()
+                .unwrap()
+                .push(JournalEntry::AccountTouched { address });
+        }
         Ok(true)
     }
 


### PR DESCRIPTION
# Problem

The contract account might have been touched before the creation.
e.g. The contract address is deterministic and it was touched prior to creation.

This causes a bug during the revert of the journal state here and the account is marked untouched.
https://github.com/bluealloy/revm/blob/fcbd2d93a0c31d5cfbfdbc8d5e7c6a49142ba90d/crates/revm/src/journaled_state.rs#L283

## Repro

https://etherscan.io/tx/0xa50b1bd15b43783fbdd69d39c57cd30b339b4583274595f404ab0ae2b24300e6

# Solution

Check if the account was already touched on contract creation before pushing the touched journal entry.

# Additional Context

Technically, this bug is impossible before Constantinople/Petersburg hard fork and introduction of `CREATE2` since there is no way to know the contract address beforehand. 