### PR TITLE
fix: revert of selfdestruct with lost balance

### DIFF
--- a/crates/revm/src/journaled_state.rs
+++ b/crates/revm/src/journaled_state.rs
@@ -295,8 +295,10 @@ impl JournaledState {
                     account.is_destroyed = was_destroyed;
                     account.info.balance += had_balance;
 
-                    let target = state.get_mut(&target).unwrap();
-                    target.info.balance -= had_balance;
+                    if address != target {
+                        let target = state.get_mut(&target).unwrap();
+                        target.info.balance -= had_balance;
+                    }
                 }
                 JournalEntry::BalanceTransfer { from, to, balance } => {
                     // we dont need to check overflow and underflow when adding sub subtracting the balance.


### PR DESCRIPTION
## Problem

When the selfdestruct's recepient is the account that's being destroyed, the balance is lost as shown in the code below.
https://github.com/bluealloy/revm/blob/c594d1cf17d7f828d0ba2233acb682b859a7f9a6/crates/revm/src/journaled_state.rs#L380-L384

The revert of selfdestruct journal entry doesn't handle this edge case.

## Solution 

Fix the revert of the selfdestruct journaled entry to handle this case. Do not subtract the value from the target balance if the balance was lost.

## Example

https://goerli.etherscan.io/tx/0x904391de6af08cd62e80392dc14249f7cc24e53d45b763139ee8b7acb1e56c3e