### PR TITLE
feat: Introduce account status as bitflag inside JournalState

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a6904aef64d73cf10ab17ebace7befb918b82164785cb89907993be7f83813"
+dependencies = [
+ "arbitrary",
+ "serde",
+]
+
+[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,7 +237,7 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "strsim",
  "textwrap",
  "unicode-width",
@@ -1482,7 +1492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
 dependencies = [
  "bit-set",
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "lazy_static",
  "num-traits",
@@ -1588,7 +1598,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1703,6 +1713,7 @@ version = "1.1.2"
 dependencies = [
  "arbitrary",
  "auto_impl",
+ "bitflags 2.2.1",
  "bitvec",
  "bytes",
  "derive_more",
@@ -1854,7 +1865,7 @@ version = "0.37.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -14,10 +14,12 @@ bytes = { version = "1.4", default-features = false }
 hashbrown = { version = "0.13" }
 hex = { version = "0.4", default-features = false }
 primitive-types = { version = "0.12", default-features = false }
-rlp = { version = "0.5", default-features = false } # used for create2 address calculation
+rlp = { version = "0.5", default-features = false }                        # used for create2 address calculation
 ruint = { version = "1.8.0", features = ["primitive-types", "rlp"] }
 auto_impl = "1.0"
 bitvec = { version = "1", default-features = false, features = ["alloc"] }
+
+bitflags = { version = "2.2.1", default-features = false}
 
 # bits B256 B160 crate
 fixed-hash = { version = "0.8", default-features = false, features = [
@@ -66,14 +68,15 @@ optional_block_gas_limit = []
 optional_eip3607 = []
 optional_gas_refund = []
 optional_no_base_fee = []
-std = ["bytes/std", "rlp/std", "hex/std", "bitvec/std"]
+std = ["bytes/std", "rlp/std", "hex/std", "bitvec/std", "bitflags/std"]
 serde = [
     "dep:serde",
     "hex/serde",
     "hashbrown/serde",
     "ruint/serde",
     "bytes/serde",
-    "bitvec/serde"
+    "bitvec/serde",
+    "bitflags/serde",
 ]
 arbitrary = [
     "std",
@@ -82,4 +85,5 @@ arbitrary = [
     "dep:arbitrary",
     "dep:proptest",
     "dep:proptest-derive",
+    "bitflags/arbitrary",
 ]

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -544,32 +544,15 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
         let checkpoint = self.data.journaled_state.checkpoint();
 
         // Create contract account and check for collision
-        match self.data.journaled_state.create_account(
-            created_address,
-            self.precompiles.contains(&created_address),
-            self.data.db,
-        ) {
-            Ok(false) => {
-                self.data.journaled_state.checkpoint_revert(checkpoint);
-                return self.create_end(
-                    inputs,
-                    InstructionResult::CreateCollision,
-                    ret,
-                    gas,
-                    Bytes::new(),
-                );
-            }
-            Err(err) => {
-                self.data.error = Some(err);
-                return self.create_end(
-                    inputs,
-                    InstructionResult::FatalExternalError,
-                    ret,
-                    gas,
-                    Bytes::new(),
-                );
-            }
-            Ok(true) => (),
+        if !self.data.journaled_state.create_account(created_address) {
+            self.data.journaled_state.checkpoint_revert(checkpoint);
+            return self.create_end(
+                inputs,
+                InstructionResult::CreateCollision,
+                ret,
+                gas,
+                Bytes::new(),
+            );
         }
 
         // Transfer value to contract address

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -675,7 +675,6 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
                     AnalysisKind::Check => Bytecode::new_raw(bytes.clone()).to_checked(),
                     AnalysisKind::Analyse => to_analysed(Bytecode::new_raw(bytes.clone())),
                 };
-
                 self.data
                     .journaled_state
                     .set_code(created_address, bytecode);


### PR DESCRIPTION
Added `AccountStatus` inside Journal state that is `bitflags`struct, it makes account smaller and makes setting flag more straightforward.

Simplified a little account creating, I will do another PR on that part that will remove some unnecessary access to hashmap.