### PR TITLE
chore: Bundle inspector crate/call calls

### DIFF
--- a/crates/primitives/src/state.rs
+++ b/crates/primitives/src/state.rs
@@ -20,11 +20,12 @@ bitflags! {
     #[cfg_attr(feature = "serde", serde(transparent))]
     pub struct AccountStatus: u8 {
         /// When account is loaded but not touched or interacted with.
+        /// This is the default state.
         const Loaded = 0b00000000;
         /// When account is newly created we will not access database
         /// to fetch storage values
         const Created = 0b00000001;
-        /// If account is marked for self destruct.
+        /// If account is marked for self destruction.
         const SelfDestructed = 0b00000010;
         /// Only when account is marked as touched we will save it to database.
         const Touched = 0b00000100;

--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -83,7 +83,6 @@ pub trait Inspector<DB: Database> {
         &mut self,
         _data: &mut EVMData<'_, DB>,
         _inputs: &mut CallInputs,
-        _is_static: bool,
     ) -> (InstructionResult, Gas, Bytes) {
         (InstructionResult::Continue, Gas::new(0), Bytes::new())
     }
@@ -99,7 +98,6 @@ pub trait Inspector<DB: Database> {
         remaining_gas: Gas,
         ret: InstructionResult,
         out: Bytes,
-        _is_static: bool,
     ) -> (InstructionResult, Gas, Bytes) {
         (ret, remaining_gas, out)
     }

--- a/crates/revm/src/inspector/customprinter.rs
+++ b/crates/revm/src/inspector/customprinter.rs
@@ -71,10 +71,9 @@ impl<DB: Database> Inspector<DB> for CustomPrintTracer {
         remaining_gas: Gas,
         ret: InstructionResult,
         out: Bytes,
-        is_static: bool,
     ) -> (InstructionResult, Gas, Bytes) {
         self.gas_inspector
-            .call_end(data, inputs, remaining_gas, ret, out.clone(), is_static);
+            .call_end(data, inputs, remaining_gas, ret, out.clone());
         (ret, remaining_gas, out)
     }
 
@@ -96,13 +95,12 @@ impl<DB: Database> Inspector<DB> for CustomPrintTracer {
         &mut self,
         _data: &mut EVMData<'_, DB>,
         inputs: &mut CallInputs,
-        is_static: bool,
     ) -> (InstructionResult, Gas, Bytes) {
         println!(
             "SM CALL:   {:?},context:{:?}, is_static:{:?}, transfer:{:?}, input_size:{:?}",
             inputs.contract,
             inputs.context,
-            is_static,
+            inputs.is_static,
             inputs.transfer,
             inputs.input.len(),
         );

--- a/crates/revm/src/inspector/gas.rs
+++ b/crates/revm/src/inspector/gas.rs
@@ -71,7 +71,6 @@ impl<DB: Database> Inspector<DB> for GasInspector {
         remaining_gas: Gas,
         ret: InstructionResult,
         out: Bytes,
-        _is_static: bool,
     ) -> (InstructionResult, Gas, Bytes) {
         (ret, remaining_gas, out)
     }
@@ -157,9 +156,8 @@ mod tests {
             &mut self,
             data: &mut EVMData<'_, DB>,
             call: &mut CallInputs,
-            is_static: bool,
         ) -> (InstructionResult, Gas, Bytes) {
-            self.gas_inspector.call(data, call, is_static);
+            self.gas_inspector.call(data, call);
 
             (
                 InstructionResult::Continue,
@@ -175,10 +173,9 @@ mod tests {
             remaining_gas: Gas,
             ret: InstructionResult,
             out: Bytes,
-            is_static: bool,
         ) -> (InstructionResult, Gas, Bytes) {
             self.gas_inspector
-                .call_end(data, inputs, remaining_gas, ret, out.clone(), is_static);
+                .call_end(data, inputs, remaining_gas, ret, out.clone());
             (ret, remaining_gas, out)
         }
 

--- a/crates/revm/src/inspector/tracer_eip3155.rs
+++ b/crates/revm/src/inspector/tracer_eip3155.rs
@@ -97,7 +97,6 @@ impl<DB: Database> Inspector<DB> for TracerEip3155 {
         &mut self,
         data: &mut EVMData<'_, DB>,
         _inputs: &mut CallInputs,
-        _is_static: bool,
     ) -> (InstructionResult, Gas, Bytes) {
         self.print_log_line(data.journaled_state.depth());
         (InstructionResult::Continue, Gas::new(0), Bytes::new())
@@ -110,10 +109,9 @@ impl<DB: Database> Inspector<DB> for TracerEip3155 {
         remaining_gas: Gas,
         ret: InstructionResult,
         out: Bytes,
-        is_static: bool,
     ) -> (InstructionResult, Gas, Bytes) {
         self.gas_inspector
-            .call_end(data, inputs, remaining_gas, ret, out.clone(), is_static);
+            .call_end(data, inputs, remaining_gas, ret, out.clone());
         // self.log_step(interp, data, is_static, eval);
         self.skip = true;
         if data.journaled_state.depth() == 0 {


### PR DESCRIPTION
Move all inspector call from `call_inner` and `create_inner` to one place inside `Host` trait