### PR TITLE
chore: refactor interpreter run and remove inspector static flag

### DIFF
--- a/crates/interpreter/src/host.rs
+++ b/crates/interpreter/src/host.rs
@@ -10,11 +10,10 @@ pub use dummy_host::DummyHost;
 
 /// EVM context host.
 pub trait Host {
-    fn step(&mut self, interpreter: &mut Interpreter, is_static: bool) -> InstructionResult;
+    fn step(&mut self, interpreter: &mut Interpreter) -> InstructionResult;
     fn step_end(
         &mut self,
         interpreter: &mut Interpreter,
-        is_static: bool,
         ret: InstructionResult,
     ) -> InstructionResult;
 

--- a/crates/interpreter/src/host/dummy_host.rs
+++ b/crates/interpreter/src/host/dummy_host.rs
@@ -26,14 +26,13 @@ impl DummyHost {
 }
 
 impl Host for DummyHost {
-    fn step(&mut self, _interp: &mut Interpreter, _is_static: bool) -> InstructionResult {
+    fn step(&mut self, _interp: &mut Interpreter) -> InstructionResult {
         InstructionResult::Continue
     }
 
     fn step_end(
         &mut self,
         _interp: &mut Interpreter,
-        _is_static: bool,
         _ret: InstructionResult,
     ) -> InstructionResult {
         InstructionResult::Continue

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -149,14 +149,14 @@ impl Interpreter {
     pub fn run_inspect<H: Host, SPEC: Spec>(&mut self, host: &mut H) -> InstructionResult {
         while self.instruction_result == InstructionResult::Continue {
             // step
-            let ret = host.step(self, self.is_static);
+            let ret = host.step(self);
             if ret != InstructionResult::Continue {
                 return ret;
             }
             self.step::<H, SPEC>(host);
 
             // step ends
-            let ret = host.step_end(self, self.is_static, self.instruction_result);
+            let ret = host.step_end(self, self.instruction_result);
             if ret != InstructionResult::Continue {
                 return ret;
             }

--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -31,7 +31,6 @@ pub trait Inspector<DB: Database> {
         &mut self,
         _interp: &mut Interpreter,
         _data: &mut EVMData<'_, DB>,
-        _is_static: bool,
     ) -> InstructionResult {
         InstructionResult::Continue
     }
@@ -48,7 +47,6 @@ pub trait Inspector<DB: Database> {
         &mut self,
         _interp: &mut Interpreter,
         _data: &mut EVMData<'_, DB>,
-        _is_static: bool,
     ) -> InstructionResult {
         InstructionResult::Continue
     }
@@ -70,7 +68,6 @@ pub trait Inspector<DB: Database> {
         &mut self,
         _interp: &mut Interpreter,
         _data: &mut EVMData<'_, DB>,
-        _is_static: bool,
         _eval: InstructionResult,
     ) -> InstructionResult {
         InstructionResult::Continue

--- a/crates/revm/src/inspector/customprinter.rs
+++ b/crates/revm/src/inspector/customprinter.rs
@@ -14,21 +14,14 @@ impl<DB: Database> Inspector<DB> for CustomPrintTracer {
         &mut self,
         interp: &mut Interpreter,
         data: &mut EVMData<'_, DB>,
-        is_static: bool,
     ) -> InstructionResult {
-        self.gas_inspector
-            .initialize_interp(interp, data, is_static);
+        self.gas_inspector.initialize_interp(interp, data);
         InstructionResult::Continue
     }
 
     // get opcode by calling `interp.contract.opcode(interp.program_counter())`.
     // all other information can be obtained from interp.
-    fn step(
-        &mut self,
-        interp: &mut Interpreter,
-        data: &mut EVMData<'_, DB>,
-        is_static: bool,
-    ) -> InstructionResult {
+    fn step(&mut self, interp: &mut Interpreter, data: &mut EVMData<'_, DB>) -> InstructionResult {
         let opcode = interp.current_opcode();
         let opcode_str = opcode::OPCODE_JUMPMAP[opcode as usize];
 
@@ -48,7 +41,7 @@ impl<DB: Database> Inspector<DB> for CustomPrintTracer {
             interp.memory.data().len(),
         );
 
-        self.gas_inspector.step(interp, data, is_static);
+        self.gas_inspector.step(interp, data);
 
         InstructionResult::Continue
     }
@@ -57,10 +50,9 @@ impl<DB: Database> Inspector<DB> for CustomPrintTracer {
         &mut self,
         interp: &mut Interpreter,
         data: &mut EVMData<'_, DB>,
-        is_static: bool,
         eval: InstructionResult,
     ) -> InstructionResult {
-        self.gas_inspector.step_end(interp, data, is_static, eval);
+        self.gas_inspector.step_end(interp, data, eval);
         InstructionResult::Continue
     }
 

--- a/crates/revm/src/inspector/gas.rs
+++ b/crates/revm/src/inspector/gas.rs
@@ -27,7 +27,6 @@ impl<DB: Database> Inspector<DB> for GasInspector {
         &mut self,
         interp: &mut crate::interpreter::Interpreter,
         _data: &mut EVMData<'_, DB>,
-        _is_static: bool,
     ) -> InstructionResult {
         self.gas_remaining = interp.gas.limit();
         InstructionResult::Continue
@@ -41,7 +40,6 @@ impl<DB: Database> Inspector<DB> for GasInspector {
         &mut self,
         _interp: &mut crate::interpreter::Interpreter,
         _data: &mut EVMData<'_, DB>,
-        _is_static: bool,
     ) -> InstructionResult {
         InstructionResult::Continue
     }
@@ -51,7 +49,6 @@ impl<DB: Database> Inspector<DB> for GasInspector {
         &mut self,
         interp: &mut crate::interpreter::Interpreter,
         _data: &mut EVMData<'_, DB>,
-        _is_static: bool,
         _eval: InstructionResult,
     ) -> InstructionResult {
         let last_gas = self.gas_remaining;
@@ -111,10 +108,8 @@ mod tests {
             &mut self,
             interp: &mut Interpreter,
             data: &mut EVMData<'_, DB>,
-            is_static: bool,
         ) -> InstructionResult {
-            self.gas_inspector
-                .initialize_interp(interp, data, is_static);
+            self.gas_inspector.initialize_interp(interp, data);
             InstructionResult::Continue
         }
 
@@ -122,10 +117,9 @@ mod tests {
             &mut self,
             interp: &mut Interpreter,
             data: &mut EVMData<'_, DB>,
-            is_static: bool,
         ) -> InstructionResult {
             self.pc = interp.program_counter();
-            self.gas_inspector.step(interp, data, is_static);
+            self.gas_inspector.step(interp, data);
             InstructionResult::Continue
         }
 
@@ -143,10 +137,9 @@ mod tests {
             &mut self,
             interp: &mut Interpreter,
             data: &mut EVMData<'_, DB>,
-            is_static: bool,
             eval: InstructionResult,
         ) -> InstructionResult {
-            self.gas_inspector.step_end(interp, data, is_static, eval);
+            self.gas_inspector.step_end(interp, data, eval);
             self.gas_remaining_steps
                 .push((self.pc, self.gas_inspector.gas_remaining()));
             eval

--- a/crates/revm/src/inspector/tracer_eip3155.rs
+++ b/crates/revm/src/inspector/tracer_eip3155.rs
@@ -51,22 +51,15 @@ impl<DB: Database> Inspector<DB> for TracerEip3155 {
         &mut self,
         interp: &mut Interpreter,
         data: &mut EVMData<'_, DB>,
-        is_static: bool,
     ) -> InstructionResult {
-        self.gas_inspector
-            .initialize_interp(interp, data, is_static);
+        self.gas_inspector.initialize_interp(interp, data);
         InstructionResult::Continue
     }
 
     // get opcode by calling `interp.contract.opcode(interp.program_counter())`.
     // all other information can be obtained from interp.
-    fn step(
-        &mut self,
-        interp: &mut Interpreter,
-        data: &mut EVMData<'_, DB>,
-        is_static: bool,
-    ) -> InstructionResult {
-        self.gas_inspector.step(interp, data, is_static);
+    fn step(&mut self, interp: &mut Interpreter, data: &mut EVMData<'_, DB>) -> InstructionResult {
+        self.gas_inspector.step(interp, data);
         self.stack = interp.stack.clone();
         self.pc = interp.program_counter();
         self.opcode = interp.current_opcode();
@@ -80,10 +73,9 @@ impl<DB: Database> Inspector<DB> for TracerEip3155 {
         &mut self,
         interp: &mut Interpreter,
         data: &mut EVMData<'_, DB>,
-        is_static: bool,
         eval: InstructionResult,
     ) -> InstructionResult {
-        self.gas_inspector.step_end(interp, data, is_static, eval);
+        self.gas_inspector.step_end(interp, data, eval);
         if self.skip {
             self.skip = false;
             return InstructionResult::Continue;


### PR DESCRIPTION
Remove `is_static` from inspector as this field can be found in the interpreter.

move run of interpreter from `call_inner` and `create_inner` to standalone function.