### PR TITLE
fix: typo in eip-3155 output

### DIFF
--- a/crates/revm/src/inspector/tracer_eip3155.rs
+++ b/crates/revm/src/inspector/tracer_eip3155.rs
@@ -110,7 +110,7 @@ impl<DB: Database> Inspector<DB> for TracerEip3155 {
             let log_line = json!({
                 //stateroot
                 "output": format!("{out:?}"),
-                "gasUser": format!("0x{:x}", self.gas_inspector.gas_remaining()),
+                "gasUsed": format!("0x{:x}", self.gas_inspector.gas_remaining()),
                 //time
                 //fork
             });


### PR DESCRIPTION
The output from the eip-3155 tracer returns `gasUser` rather than `gasUsed` ([spec](https://eips.ethereum.org/EIPS/eip-3155))

current:
```
"{\"output\":\"b\\\"\\\"\",\"gasUser\":\"0xd772\"}"
```
spec:
```
"{\"output\":\"b\\\"\\\"\",\"gasUsed\":\"0xd772\"}"
```