### PR TITLE
feat(revm): add post-tx state root to 3155 tracer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,13 +1668,17 @@ dependencies = [
  "ethers-core",
  "ethers-providers",
  "futures",
+ "hash-db",
  "hex",
  "hex-literal",
+ "plain_hasher",
  "revm-interpreter",
  "revm-precompile",
  "serde",
  "serde_json",
+ "sha3",
  "tokio",
+ "triehash",
 ]
 
 [[package]]

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -27,6 +27,10 @@ tokio = { version = "1.28", features = [
 ethers-providers = { version = "2.0", optional = true }
 ethers-core = { version = "2.0", optional = true }
 futures = { version = "0.3.27", optional = true }
+hash-db = "0.15"
+plain_hasher = "0.2"
+sha3 = { version = "0.10", default-features = false, features = [] }
+triehash = "0.8.4"
 
 [dev-dependencies]
 hex-literal = "0.4"
@@ -37,14 +41,7 @@ anyhow = "1.0.71"
 
 [features]
 default = ["std", "secp256k1"]
-dev = [
-    "memory_limit",
-    "optional_balance_check",
-    "optional_block_gas_limit",
-    "optional_eip3607",
-    "optional_gas_refund",
-    "optional_no_base_fee",
-]
+dev = ["memory_limit", "optional_balance_check", "optional_block_gas_limit", "optional_eip3607", "optional_gas_refund", "optional_no_base_fee"]
 secp256k1 = ["revm-precompile/secp256k1"]
 memory_limit = ["revm-interpreter/memory_limit"]
 no_gas_measuring = ["revm-interpreter/no_gas_measuring"]

--- a/crates/revm/src/inspector/tracer_eip3155.rs
+++ b/crates/revm/src/inspector/tracer_eip3155.rs
@@ -2,12 +2,18 @@
 
 use crate::inspectors::GasInspector;
 use crate::interpreter::{CallInputs, CreateInputs, Gas, InstructionResult};
+use crate::primitives;
 use crate::primitives::{db::Database, hex, Bytes, B160};
 use crate::{evm_impl::EVMData, Inspector};
-use revm_interpreter::primitives::U256;
+use ethers_core::types::{H160, H256};
+use ethers_core::utils::rlp::{self, RlpStream};
+use plain_hasher::PlainHasher;
+use revm_interpreter::primitives::{Account, SpecId, B256, U256};
 use revm_interpreter::{opcode, Interpreter, Memory, Stack};
 use serde_json::json;
+use sha3::{Digest, Keccak256};
 use std::io::Write;
+use triehash::sec_trie_root;
 
 pub struct TracerEip3155 {
     output: Box<dyn Write>,
@@ -105,10 +111,19 @@ impl<DB: Database> Inspector<DB> for TracerEip3155 {
         self.gas_inspector
             .call_end(data, inputs, remaining_gas, ret, out.clone());
         // self.log_step(interp, data, is_static, eval);
+        let is_legacy = !SpecId::enabled(data.env.cfg.spec_id, primitives::SpecId::SPURIOUS_DRAGON);
+
         self.skip = true;
         if data.journaled_state.depth() == 0 {
+            let state_root = state_merkle_trie_root(
+                data.journaled_state
+                    .state
+                    .iter()
+                    .filter(|(_address, acc)| account_is_part_of_trie(acc, is_legacy))
+                    .map(|(k, v)| (*k, v.clone())),
+            );
             let log_line = json!({
-                //stateroot
+                "stateRoot": format!("0x{state_root:x}"),
                 "output": format!("{out:?}"),
                 "gasUser": format!("0x{:x}", self.gas_inspector.gas_remaining()),
                 //time
@@ -174,4 +189,63 @@ fn short_hex(b: U256) -> String {
     } else {
         format!("0x{s}")
     }
+}
+
+// (&B160, &revm_interpreter::revm_primitives::Account)
+pub fn state_merkle_trie_root(accounts: impl Iterator<Item = (B160, Account)>) -> B256 {
+    let vec = accounts
+        .map(|(address, info)| {
+            let acc_root = trie_account_rlp(&info);
+            (H160::from(address.0), acc_root)
+        })
+        .collect();
+
+    trie_root(vec)
+}
+
+/// Returns the RLP for this account.
+pub fn trie_account_rlp(acc: &Account) -> Bytes {
+    let mut stream = RlpStream::new_list(4);
+    stream.append(&acc.info.nonce);
+    stream.append(&acc.info.balance);
+    stream.append(&{
+        sec_trie_root::<KeccakHasher, _, _, _>(
+            acc.storage
+                .iter()
+                .filter(|(_k, &ref v)| v.original_value != U256::ZERO)
+                .map(|(&k, v)| (H256::from(k.to_be_bytes()), rlp::encode(&v.original_value))),
+        )
+    });
+    stream.append(&acc.info.code_hash.0.as_ref());
+    stream.out().freeze()
+}
+
+pub fn trie_root(acc_data: Vec<(H160, Bytes)>) -> B256 {
+    B256(sec_trie_root::<KeccakHasher, _, _, _>(acc_data.into_iter()).0)
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct KeccakHasher;
+
+impl hash_db::Hasher for KeccakHasher {
+    type Out = H256;
+    type StdHasher = PlainHasher;
+    const LENGTH: usize = 32;
+    fn hash(x: &[u8]) -> Self::Out {
+        let out = Keccak256::digest(x);
+        H256::from_slice(out.as_slice())
+    }
+}
+
+/// Determines if an account should be included as part of the trie root calculation.
+///
+/// - Pre-spurious-dragon: existing and empty status were two separate states.
+/// - Post-spurious-dragon: empty means non-existent.
+fn account_is_part_of_trie(acc: &Account, is_legacy: bool) -> bool {
+    // Pre-spurious-dragon: exists
+    (is_legacy && !acc.is_loaded_as_not_existing())
+    // Post-spurious-dragon: exists
+    || !is_legacy && (!(acc.info.is_empty())
+    // Pre- or post-spurious-dragon: does not exist.
+    || !acc.info.exists())
 }


### PR DESCRIPTION
The eip-3155 ([spec](https://eips.ethereum.org/EIPS/eip-3155)) tracer does not return the post-transaction state root.

The `revme` binary crate had an implementation that I plugged in with a few modifications.

This involved adding a few dependencies, which seemed appropriate to place under the `ethersdb` feature flag.

- [ ] Test for correctness