### PR TITLE
fix: replace SHA3 with KECCAK256 opcode name

### DIFF
--- a/crates/interpreter/src/instructions/opcode.rs
+++ b/crates/interpreter/src/instructions/opcode.rs
@@ -214,7 +214,7 @@ pub const OPCODE_JUMPMAP: [Option<&'static str>; 256] = [
     /* 0x1d */ Some("SAR"),
     /* 0x1e */ None,
     /* 0x1f */ None,
-    /* 0x20 */ Some("SHA3"),
+    /* 0x20 */ Some("KECCAK256"),
     /* 0x21 */ None,
     /* 0x22 */ None,
     /* 0x23 */ None,


### PR DESCRIPTION
this mirrors geth's naming 

https://github.com/ethereum/go-ethereum/blob/73697529994e14996b7740730481e926d5ec3e40/core/vm/opcodes.go#L261-L261