### PR TITLE
fix(revm): EIP-3155 tracer tx output without debug artefact

### DIFF
--- a/crates/revm/src/inspector/tracer_eip3155.rs
+++ b/crates/revm/src/inspector/tracer_eip3155.rs
@@ -109,18 +109,14 @@ impl<DB: Database> Inspector<DB> for TracerEip3155 {
         if data.journaled_state.depth() == 0 {
             let log_line = json!({
                 //stateroot
-                "output": format!("{out:?}"),
+                "output": format!("0x{}", hex::encode(out.as_ref())),
                 "gasUsed": format!("0x{:x}", self.gas_inspector.gas_remaining()),
                 //time
                 //fork
             });
 
-            writeln!(
-                self.output,
-                "{:?}",
-                serde_json::to_string(&log_line).unwrap()
-            )
-            .expect("If output fails we can ignore the logging");
+            writeln!(self.output, "{}", serde_json::to_string(&log_line).unwrap())
+                .expect("If output fails we can ignore the logging");
         }
         (ret, remaining_gas, out)
     }


### PR DESCRIPTION
## Description

EIP-3155 tracer output section included debug (`?`) artefacts

## Changes

- Use non-debug newline-delineated JSON representation.
- Include 0x-prefixed hex encoding for `output` field.

Before:
```sh
{"pc":379,"op":253,"gas":"0x66048","gasCost":"0x0","memSize":1024,"stack":["0xda218207","0x88","0x80","0x1c0","0x200","0x7a250d5630b4cf539739df2c5dacb4c659f2488d","0x0","0x240","0x0","0x2a0","0x631","0x80","0x240","0x200","0x7a250d5630b4cf539739df2c5dacb4c659f2488d","0x0","0x3","0x0","0x0","0x0","0x64","0x300"],"depth":1,"opName":"REVERT"}
"{\"output\":\"b\\\"\\\\x08\\\\xc3y\\\\xa0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0 \\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\x06On god\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\"\",\"gasUsed\":\"0x66048\"}"
```
After
```sh
{"pc":379,"op":253,"gas":"0x66048","gasCost":"0x0","memSize":1024,"stack":["0xda218207","0x88","0x80","0x1c0","0x200","0x7a250d5630b4cf539739df2c5dacb4c659f2488d","0x0","0x240","0x0","0x2a0","0x631","0x80","0x240","0x200","0x7a250d5630b4cf539739df2c5dacb4c659f2488d","0x0","0x3","0x0","0x0","0x0","0x64","0x300"],"depth":1,"opName":"REVERT"}
{"output":"0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000064f6e20676f640000000000000000000000000000000000000000000000000000","gasUsed":"0x66048"}
```

## Discussion

The EIP is not explicit ([empty table cell](https://eips.ethereum.org/EIPS/eip-3155#summary-and-error-handling)) about the data type in `output`. 

While [EVMOne](https://github.com/ethereum/evmone/pull/325) has hex encoding without an 0x-prefix, the prefix seemed more appropriate for a JSON hex-number.