### PR TITLE
fix(revm): include CREATE/CREATE2 in EIP3155 inspector

### DIFF
--- a/crates/revm/src/inspector/tracer_eip3155.rs
+++ b/crates/revm/src/inspector/tracer_eip3155.rs
@@ -125,6 +125,20 @@ impl<DB: Database> Inspector<DB> for TracerEip3155 {
         (ret, remaining_gas, out)
     }
 
+    fn create(
+        &mut self,
+        data: &mut EVMData<'_, DB>,
+        _inputs: &mut CreateInputs,
+    ) -> (InstructionResult, Option<B160>, Gas, Bytes) {
+        self.print_log_line(data.journaled_state.depth());
+        (
+            InstructionResult::Continue,
+            None,
+            Gas::new(0),
+            Bytes::default(),
+        )
+    }
+
     fn create_end(
         &mut self,
         data: &mut EVMData<'_, DB>,


### PR DESCRIPTION
## Description

The EIP-3155 tracer omits display of CREATE opcodes. This arises from use of
the default implementation of the `fn create()` method of the `Inspector` trait.

## Changes

Add a custom implementation for the `create` method that mirrors the default, but includes
a log.

```rs
self.print_log_line(data.journaled_state.depth());
```
This results in the the inclusion of the CREATE opcode in the trace.

## Discussion

Transaction with index 185 in block 17190873 is an example. The 84th opcode should be
CREATE, but this is omitted. However, CREATE has been executed as the subsequent
opcodes proceed as expected, including an increase
in call depth, correct gas accounting and a cleared stack.

REVM trace, erroneously showing an increase in context depth following a PUSH1.
```json
{"pc":97,"op":145,"gas":"0xe621e","gasCost":"0x3","memSize":384,"stack":["0x8467be0d","0x43","0x5","0x0","0x177","0x80","0x80"],"depth":1,"opName":"SWAP2"}
{"pc":98,"op":3,"gas":"0xe621b","gasCost":"0x3","memSize":384,"stack":["0x8467be0d","0x43","0x5","0x0","0x80","0x80","0x177"],"depth":1,"opName":"SUB"}
{"pc":99,"op":144,"gas":"0xe6218","gasCost":"0x3","memSize":384,"stack":["0x8467be0d","0x43","0x5","0x0","0x80","0xf7"],"depth":1,"opName":"SWAP1"}
{"pc":100,"op":96,"gas":"0xe6215","gasCost":"0x3","memSize":384,"stack":["0x8467be0d","0x43","0x5","0x0","0xf7","0x80"],"depth":1,"opName":"PUSH1"}
# Should be CREATE here
{"pc":0,"op":96,"gas":"0xdad6e","gasCost":"0x3","memSize":0,"stack":[],"depth":2,"opName":"PUSH1"}
{"pc":2,"op":96,"gas":"0xdad6b","gasCost":"0x3","memSize":0,"stack":["0x80"],"depth":2,"opName":"PUSH1"}
{"pc":4,"op":82,"gas":"0xdad68","gasCost":"0xc","memSize":0,"stack":["0x80","0x40"],"depth":2,"opName":"MSTORE"}
```

Geth trace, showing CREATE at 84th step.
```
[80]	97	SWAP2	942622	3	1
[81]	98	SUB	942619	3	1
[82]	99	SWAP1	942616	3	1
[83]	100	PUSH1	942613	3	1
[84]	102	CREATE	942610	32016	1     # CREATE, correct behaviour.
[85]	0	PUSH1	896366	3	2
[86]	2	PUSH1	896363	3	2
[87]	4	MSTORE	896360	12	2
```

REVM trace after this change included.

```json
{"pc":97,"op":145,"gas":"0xe621e","gasCost":"0x3","memSize":384,"stack":["0x8467be0d","0x43","0x5","0x0","0x177","0x80","0x80"],"depth":1,"opName":"SWAP2"}
{"pc":98,"op":3,"gas":"0xe621b","gasCost":"0x3","memSize":384,"stack":["0x8467be0d","0x43","0x5","0x0","0x80","0x80","0x177"],"depth":1,"opName":"SUB"}
{"pc":99,"op":144,"gas":"0xe6218","gasCost":"0x3","memSize":384,"stack":["0x8467be0d","0x43","0x5","0x0","0x80","0xf7"],"depth":1,"opName":"SWAP1"}
{"pc":100,"op":96,"gas":"0xe6215","gasCost":"0x3","memSize":384,"stack":["0x8467be0d","0x43","0x5","0x0","0xf7","0x80"],"depth":1,"opName":"PUSH1"}
{"pc":102,"op":240,"gas":"0xe6212","gasCost":"0x3","memSize":384,"stack":["0x8467be0d","0x43","0x5","0x0","0xf7","0x80","0x0"],"depth":1,"opName":"CREATE"}
{"pc":0,"op":96,"gas":"0xdad6e","gasCost":"0x3","memSize":0,"stack":[],"depth":2,"opName":"PUSH1"}
{"pc":2,"op":96,"gas":"0xdad6b","gasCost":"0x3","memSize":0,"stack":["0x80"],"depth":2,"opName":"PUSH1"}
{"pc":4,"op":82,"gas":"0xdad68","gasCost":"0xc","memSize":0,"stack":["0x80","0x40"],"depth":2,"opName":"MSTORE"}
```
Create is included.