### PR TITLE
chore: clippy and fmt

### DIFF
--- a/bins/revme/src/statetest/merkle_trie.rs
+++ b/bins/revme/src/statetest/merkle_trie.rs
@@ -59,7 +59,7 @@ pub fn trie_account_rlp(acc: &DbAccount) -> Bytes {
 }
 
 pub fn trie_root(acc_data: Vec<(H160, Bytes)>) -> B256 {
-    B256(sec_trie_root::<KeccakHasher, _, _, _>(acc_data.into_iter()).0)
+    B256(sec_trie_root::<KeccakHasher, _, _, _>(acc_data).0)
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Eq)]

--- a/crates/primitives/src/bits.rs
+++ b/crates/primitives/src/bits.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::incorrect_clone_impl_on_copy_type)]
+
 use derive_more::{AsRef, Deref};
 use fixed_hash::{construct_fixed_hash, impl_fixed_hash_conversions};
 
@@ -8,6 +10,7 @@ use proptest_derive::Arbitrary as PropTestArbitrary;
 
 construct_fixed_hash! {
     /// revm 256 bits type.
+    ///
     #[cfg_attr(any(test, feature = "arbitrary"), derive(Arbitrary, PropTestArbitrary))]
     #[derive(AsRef,Deref)]
     pub struct B256(32);

--- a/crates/primitives/src/bits.rs
+++ b/crates/primitives/src/bits.rs
@@ -10,7 +10,6 @@ use proptest_derive::Arbitrary as PropTestArbitrary;
 
 construct_fixed_hash! {
     /// revm 256 bits type.
-    ///
     #[cfg_attr(any(test, feature = "arbitrary"), derive(Arbitrary, PropTestArbitrary))]
     #[derive(AsRef,Deref)]
     pub struct B256(32);

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -591,7 +591,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
         }
     }
 
-    fn prepare_call(&mut self, inputs: &mut CallInputs) -> Result<PreparedCall, CallResult> {
+    fn prepare_call(&mut self, inputs: &CallInputs) -> Result<PreparedCall, CallResult> {
         let gas = Gas::new(inputs.gas_limit);
         // Load account and get code. Account is now hot.
         let Some((bytecode, _)) = self.code(inputs.contract) else {
@@ -649,7 +649,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
     }
 
     /// Main contract call of the EVM.
-    fn call_inner(&mut self, inputs: &mut CallInputs) -> CallResult {
+    fn call_inner(&mut self, inputs: &CallInputs) -> CallResult {
         let res = self.prepare_call(inputs);
 
         let prepared_call = match res {

--- a/crates/revm/src/journaled_state.rs
+++ b/crates/revm/src/journaled_state.rs
@@ -306,7 +306,7 @@ impl JournaledState {
     #[inline(always)]
     pub fn check_account_collision(
         address: B160,
-        account: &mut Account,
+        account: &Account,
         num_of_precompiles: usize,
     ) -> bool {
         // Check collision. Bytecode needs to be empty.


### PR DESCRIPTION
Fix clippy and fmt on newest rust compiler