### PR TITLE
fix(interpreter): mcopy call order

### DIFF
--- a/crates/interpreter/src/instructions/memory.rs
+++ b/crates/interpreter/src/instructions/memory.rs
@@ -68,5 +68,5 @@ pub fn mcopy<SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut dyn Host) {
     // resize memory
     memory_resize!(interpreter, src, resize);
     // copy memory in place
-    interpreter.memory.copy(src, dest, len);
+    interpreter.memory.copy(dest, src, len);
 }

--- a/crates/interpreter/src/instructions/memory.rs
+++ b/crates/interpreter/src/instructions/memory.rs
@@ -64,7 +64,7 @@ pub fn mcopy<SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut dyn Host) {
     let dest = as_usize_or_fail!(interpreter, dest, InstructionResult::InvalidOperandOOG);
     let src = as_usize_or_fail!(interpreter, src, InstructionResult::InvalidOperandOOG);
     // memory resize
-    let resize = max(dest, len).saturating_add(len);
+    let resize = max(dest, src).saturating_add(len);
     // resize memory
     memory_resize!(interpreter, src, resize);
     // copy memory in place


### PR DESCRIPTION
`Memory::copy` argument order is `dst, src, len`, while it is being called with `src, dst, len`.