### PR TITLE
fix(transient_storage): set previous value in journal

### DIFF
--- a/crates/revm/src/journaled_state.rs
+++ b/crates/revm/src/journaled_state.rs
@@ -720,7 +720,7 @@ impl JournaledState {
             // check if previous value is same
             if previous_value != new {
                 // if it is different, insert previous values inside journal.
-                Some(new)
+                Some(previous_value)
             } else {
                 None
             }


### PR DESCRIPTION
Journaled values (Value that we revert to) should have been the previous value and not the new value

Introduced in initial EIP here: https://github.com/bluealloy/revm/pull/546
found when running eth tests. Tests will be added in ci in next commit.

@tynes fyi