### PR TITLE
chore: export some `unreachable_pub` items

### DIFF
--- a/crates/primitives/src/state.rs
+++ b/crates/primitives/src/state.rs
@@ -240,7 +240,7 @@ mod tests {
     use crate::Account;
 
     #[test]
-    pub fn account_state() {
+    fn account_state() {
         let mut account = Account::default();
 
         assert!(!account.is_touched());

--- a/crates/revm/src/db/in_memory_db.rs
+++ b/crates/revm/src/db/in_memory_db.rs
@@ -416,7 +416,7 @@ mod tests {
     use crate::primitives::{db::Database, AccountInfo, Address, U256};
 
     #[test]
-    pub fn test_insert_account_storage() {
+    fn test_insert_account_storage() {
         let account = Address::with_last_byte(42);
         let nonce = 42;
         let mut init_state = CacheDB::new(EmptyDB::default());
@@ -437,7 +437,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_replace_account_storage() {
+    fn test_replace_account_storage() {
         let account = Address::with_last_byte(42);
         let nonce = 42;
         let mut init_state = CacheDB::new(EmptyDB::default());

--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -5,19 +5,23 @@ use crate::primitives::{db::Database, Address, Bytes, B256};
 use auto_impl::auto_impl;
 
 #[cfg(feature = "std")]
-pub mod customprinter;
-pub mod gas;
-pub mod noop;
+mod customprinter;
+mod gas;
+mod noop;
 #[cfg(all(feature = "std", feature = "serde"))]
-pub mod tracer_eip3155;
+mod tracer_eip3155;
 
 /// All Inspectors implementations that revm has.
 pub mod inspectors {
     #[cfg(feature = "std")]
+    #[doc(inline)]
     pub use super::customprinter::CustomPrintTracer;
+    #[doc(inline)]
     pub use super::gas::GasInspector;
+    #[doc(inline)]
     pub use super::noop::NoOpInspector;
     #[cfg(all(feature = "std", feature = "serde"))]
+    #[doc(inline)]
     pub use super::tracer_eip3155::TracerEip3155;
 }
 

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![warn(unreachable_pub)]
 
 #[macro_use]
 extern crate alloc;
@@ -19,9 +20,9 @@ pub type DummyStateDB = InMemoryDB;
 pub use db::{CacheState, StateBuilder, TransitionAccount, TransitionState};
 
 pub use db::{Database, DatabaseCommit, InMemoryDB, State};
-pub use evm::{evm_inner, new, EVM};
-pub use evm_impl::EVMData;
-pub use journaled_state::{JournalEntry, JournaledState};
+pub use evm::{evm_inner, new, to_precompile_id, EVM};
+pub use evm_impl::{EVMData, EVMImpl, Transact};
+pub use journaled_state::{is_precompile, JournalCheckpoint, JournalEntry, JournaledState};
 
 // reexport `revm_precompiles`
 #[doc(inline)]
@@ -35,6 +36,6 @@ pub use revm_interpreter as interpreter;
 #[doc(inline)]
 pub use revm_interpreter::primitives;
 
-/// Reexport Inspector implementations
+// reexport inspector implementations
 pub use inspector::inspectors;
 pub use inspector::Inspector;


### PR DESCRIPTION
Some items, like `to_precompile_id`, aren't exported at the crate level, even if their visibility is `pub`.