### PR TITLE
perf: pre-allocate inner bundle state

### DIFF
--- a/crates/revm/src/db/states/changes.rs
+++ b/crates/revm/src/db/states/changes.rs
@@ -28,5 +28,15 @@ pub struct StateReverts {
     pub storage: StorageRevert,
 }
 
+impl StateReverts {
+    /// Constructs new [StateReverts] with pre-allocated capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            accounts: Vec::with_capacity(capacity),
+            storage: Vec::with_capacity(capacity),
+        }
+    }
+}
+
 /// Storage reverts
 pub type StorageRevert = Vec<Vec<(B160, bool, Vec<(U256, U256)>)>>;

--- a/crates/revm/src/db/states/transition_state.rs
+++ b/crates/revm/src/db/states/transition_state.rs
@@ -23,6 +23,7 @@ impl TransitionState {
         transitions.insert(address, transition);
         TransitionState { transitions }
     }
+
     /// Return transition id and all account transitions. Leave empty transition map.
     pub fn take(&mut self) -> TransitionState {
         core::mem::take(self)


### PR DESCRIPTION
## Description

Pre-allocate `Vec` with capacity where applicable. In some places, the pre-allocation is pessimistic and assumes that _all_ accounts have been changed (appropriate comments were added).