### PR TITLE
chore: `TransitionState::with_capacity` -> `TransitionState::single`

### DIFF
--- a/crates/revm/src/db/states/bundle_state.rs
+++ b/crates/revm/src/db/states/bundle_state.rs
@@ -378,7 +378,7 @@ mod tests {
         };
 
         // apply first transition
-        bundle_state.apply_block_substate_and_create_reverts(TransitionState::with_capacity(
+        bundle_state.apply_block_substate_and_create_reverts(TransitionState::single(
             address,
             transition.clone(),
         ));

--- a/crates/revm/src/db/states/transition_state.rs
+++ b/crates/revm/src/db/states/transition_state.rs
@@ -18,7 +18,7 @@ impl Default for TransitionState {
 
 impl TransitionState {
     /// Create new transition state with one transition.
-    pub fn with_capacity(address: B160, transition: TransitionAccount) -> Self {
+    pub fn single(address: B160, transition: TransitionAccount) -> Self {
         let mut transitions = HashMap::new();
         transitions.insert(address, transition);
         TransitionState { transitions }


### PR DESCRIPTION
## Description

`TransitionState::with_capacity` method name is misleading since `with_capacity` is usually used for pre-allocating memory.

## Solution

Change method name to `TransitionState::single`