### PR TITLE
chore: Revert test, not change storage check , renaming of original slot value

### DIFF
--- a/crates/primitives/src/db.rs
+++ b/crates/primitives/src/db.rs
@@ -11,7 +11,7 @@ pub use components::{
     BlockHash, BlockHashRef, DatabaseComponentError, DatabaseComponents, State, StateRef,
 };
 
-#[auto_impl(& mut, Box)]
+#[auto_impl(&mut, Box)]
 pub trait Database {
     type Error;
     /// Get basic account information.

--- a/crates/primitives/src/state.rs
+++ b/crates/primitives/src/state.rs
@@ -128,7 +128,7 @@ impl From<AccountInfo> for Account {
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StorageSlot {
-    pub original_value: U256,
+    pub previous_or_original_value: U256,
     /// When loaded with sload present value is set to original value
     pub present_value: U256,
 }
@@ -136,25 +136,25 @@ pub struct StorageSlot {
 impl StorageSlot {
     pub fn new(original: U256) -> Self {
         Self {
-            original_value: original,
+            previous_or_original_value: original,
             present_value: original,
         }
     }
 
-    pub fn new_changed(original_value: U256, present_value: U256) -> Self {
+    pub fn new_changed(previous_or_original_value: U256, present_value: U256) -> Self {
         Self {
-            original_value,
+            previous_or_original_value,
             present_value,
         }
     }
 
     /// Returns true if the present value differs from the original value
     pub fn is_changed(&self) -> bool {
-        self.original_value != self.present_value
+        self.previous_or_original_value != self.present_value
     }
 
     pub fn original_value(&self) -> U256 {
-        self.original_value
+        self.previous_or_original_value
     }
 
     pub fn present_value(&self) -> U256 {

--- a/crates/revm/src/db/states/bundle_account.rs
+++ b/crates/revm/src/db/states/bundle_account.rs
@@ -148,8 +148,6 @@ impl BundleAccount {
             |this_storage: &mut StorageWithOriginalValues,
              storage_update: StorageWithOriginalValues| {
                 for (key, value) in storage_update {
-                    // TODO small optimization but if present and original values are same we can
-                    // remove this entry from this storage.
                     this_storage.entry(key).or_insert(value).present_value = value.present_value;
                 }
             };
@@ -158,8 +156,10 @@ impl BundleAccount {
             |updated_storage: &StorageWithOriginalValues| -> HashMap<U256, RevertToSlot> {
                 updated_storage
                     .iter()
-                    .filter(|s| s.1.original_value != s.1.present_value)
-                    .map(|(key, value)| (*key, RevertToSlot::Some(value.original_value)))
+                    .filter(|s| s.1.previous_or_original_value != s.1.present_value)
+                    .map(|(key, value)| {
+                        (*key, RevertToSlot::Some(value.previous_or_original_value))
+                    })
                     .collect()
             };
 

--- a/crates/revm/src/db/states/bundle_state.rs
+++ b/crates/revm/src/db/states/bundle_state.rs
@@ -343,14 +343,12 @@ impl BundleState {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::{db::StorageWithOriginalValues, TransitionAccount};
     use revm_interpreter::primitives::KECCAK_EMPTY;
 
-    use crate::{db::StorageWithOriginalValues, TransitionAccount};
-
-    use super::*;
-
     #[test]
-    fn transition_all_states() {
+    fn transition_states() {
         // dummy data
         let address = B160([0x01; 20]);
         let acc1 = AccountInfo {
@@ -378,5 +376,115 @@ mod tests {
             address,
             transition.clone(),
         ));
+    }
+
+    fn account1() -> B160 {
+        [0x60; 20].into()
+    }
+
+    fn account2() -> B160 {
+        [0x61; 20].into()
+    }
+
+    fn slot() -> U256 {
+        U256::from(5)
+    }
+
+    /// Test bundle one
+    fn test_bundle1() -> BundleState {
+        // block changes
+
+        let bundle = BundleState::new(
+            vec![
+                (
+                    account1(),
+                    None,
+                    Some(AccountInfo {
+                        nonce: 1,
+                        balance: U256::from(10),
+                        code_hash: KECCAK_EMPTY,
+                        code: None,
+                    }),
+                    HashMap::from([(slot(), (U256::from(0), U256::from(10)))]),
+                ),
+                (
+                    account2(),
+                    None,
+                    Some(AccountInfo {
+                        nonce: 1,
+                        balance: U256::from(10),
+                        code_hash: KECCAK_EMPTY,
+                        code: None,
+                    }),
+                    HashMap::from([]),
+                ),
+            ],
+            vec![vec![
+                (account1(), Some(None), vec![(slot(), U256::from(0))]),
+                (account2(), Some(None), vec![]),
+            ]],
+            vec![],
+        );
+        bundle
+    }
+
+    /// Test bundle two
+    fn test_bundle2() -> BundleState {
+        // block changes
+        let bundle = BundleState::new(
+            vec![
+                ((
+                    account1(),
+                    None,
+                    Some(AccountInfo {
+                        nonce: 3,
+                        balance: U256::from(20),
+                        code_hash: KECCAK_EMPTY,
+                        code: None,
+                    }),
+                    HashMap::from([(slot(), (U256::from(0), U256::from(15)))]),
+                )),
+            ],
+            vec![vec![(
+                account1(),
+                Some(Some(AccountInfo {
+                    nonce: 1,
+                    balance: U256::from(10),
+                    code_hash: KECCAK_EMPTY,
+                    code: None,
+                })),
+                vec![(slot(), U256::from(10))],
+            )]],
+            vec![],
+        );
+        bundle
+    }
+
+    #[test]
+    fn sanity_path() {
+        let bundle1 = test_bundle1();
+        let bundle2 = test_bundle2();
+
+        let mut extended = bundle1.clone();
+        extended.extend(bundle2.clone());
+
+        let mut reverted = extended.clone();
+        // revert zero does nothing.
+        reverted.revert(0);
+        assert_eq!(reverted, extended);
+
+        // revert by one gives us bundle one.
+        reverted.revert(1);
+        assert_eq!(reverted, bundle1);
+
+        // reverted by additional one gives us empty bundle.
+        reverted.revert(1);
+        assert_eq!(reverted, BundleState::default());
+
+        let mut reverted = extended.clone();
+
+        // reverted by bigger number gives us empty bundle
+        reverted.revert(10);
+        assert_eq!(reverted, BundleState::default());
     }
 }

--- a/crates/revm/src/db/states/plain_account.rs
+++ b/crates/revm/src/db/states/plain_account.rs
@@ -20,10 +20,6 @@ impl PlainAccount {
     }
 }
 
-/// TODO Rename this to become StorageWithOriginalValues or something like that.
-/// This is used inside EVM and for block state. It is needed for block state to
-/// be able to create changeset agains bundle state.
-///
 /// This storage represent values that are before block changed.
 ///
 /// Note: Storage that we get EVM contains original values before t
@@ -31,7 +27,6 @@ pub type StorageWithOriginalValues = HashMap<U256, StorageSlot>;
 
 /// Simple plain storage that does not have previous value.
 /// This is used for loading from database, cache and for bundle state.
-///
 pub type PlainStorage = HashMap<U256, U256>;
 
 impl From<AccountInfo> for PlainAccount {

--- a/crates/revm/src/journaled_state.rs
+++ b/crates/revm/src/journaled_state.rs
@@ -677,7 +677,7 @@ impl JournaledState {
 
         // new value is same as present, we dont need to do anything
         if present == new {
-            return Ok((slot.original_value, present, new, is_cold));
+            return Ok((slot.previous_or_original_value, present, new, is_cold));
         }
 
         self.journal
@@ -690,7 +690,7 @@ impl JournaledState {
             });
         // insert value into present state.
         slot.present_value = new;
-        Ok((slot.original_value, present, new, is_cold))
+        Ok((slot.previous_or_original_value, present, new, is_cold))
     }
 
     /// Read transient storage tied to the account.


### PR DESCRIPTION
Rename `original` storage slot to `previous_or_original_value`

Check if storage is changed, remove it if it is the same.

Added tests for bundle revert