### PR TITLE
chore: Load caller in finalization fn

### DIFF
--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -267,7 +267,12 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
             };
 
             // return balance of not spend gas.
-            let caller_account = self.data.journaled_state.state().get_mut(&caller).unwrap();
+            let Ok((caller_account, _)) =
+                self.data.journaled_state.load_account(caller, self.data.db)
+            else {
+                panic!("caller account not found");
+            };
+
             caller_account.info.balance = caller_account
                 .info
                 .balance


### PR DESCRIPTION
The caller is already loaded inside `journaled_state` but if `env.tx.caller` gets changed this would panic on unwrap as it is happening inside the foundry.

So we are now loading an account is a safe way to mitigate this. This will call `Database` to fetch account