### PR TITLE
feat(state): Block hash cache and overrides

### DIFF
--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -9,6 +9,7 @@ use crate::{
     Host, InstructionResult, Transfer,
 };
 use core::cmp::min;
+use revm_primitives::BLOCK_HASH_HISTORY;
 
 pub fn balance<SPEC: Spec>(interpreter: &mut Interpreter, host: &mut dyn Host) {
     pop_address!(interpreter, address);
@@ -137,7 +138,7 @@ pub fn blockhash(interpreter: &mut Interpreter, host: &mut dyn Host) {
     if let Some(diff) = host.env().block.number.checked_sub(*number) {
         let diff = as_usize_saturated!(diff);
         // blockhash should push zero if number is same as current block number.
-        if diff <= 256 && diff != 0 {
+        if diff <= BLOCK_HASH_HISTORY && diff != 0 {
             let ret = host.block_hash(*number);
             if ret.is_none() {
                 interpreter.instruction_result = InstructionResult::FatalExternalError;

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -9,6 +9,9 @@ pub const CALL_STACK_LIMIT: u64 = 1024;
 /// By default limit is 0x6000 (~25kb)
 pub const MAX_CODE_SIZE: usize = 0x6000;
 
+/// Number of blocks hashes that EVM can access in the past
+pub const BLOCK_HASH_HISTORY: usize = 256;
+
 /// EIP-3860: Limit and meter initcode
 ///
 /// Limit of maximum initcode size is 2 * MAX_CODE_SIZE


### PR DESCRIPTION
Allow setting block hash overrides inside `StateBuilder` and cache last `256` block hashes.