### PR TITLE
feat(state): Use preloaded bundle inside state

### DIFF
--- a/crates/revm/src/db/states/cache_account.rs
+++ b/crates/revm/src/db/states/cache_account.rs
@@ -1,6 +1,6 @@
 use super::{
-    plain_account::PlainStorage, AccountStatus, PlainAccount, StorageWithOriginalValues,
-    TransitionAccount,
+    plain_account::PlainStorage, AccountStatus, BundleAccount, PlainAccount,
+    StorageWithOriginalValues, TransitionAccount,
 };
 use revm_interpreter::primitives::{AccountInfo, KECCAK_EMPTY, U256};
 use revm_precompile::HashMap;
@@ -12,6 +12,23 @@ use revm_precompile::HashMap;
 pub struct CacheAccount {
     pub account: Option<PlainAccount>,
     pub status: AccountStatus,
+}
+
+impl From<BundleAccount> for CacheAccount {
+    fn from(account: BundleAccount) -> Self {
+        let storage = account
+            .storage
+            .iter()
+            .map(|(k, v)| (*k, v.present_value))
+            .collect();
+        let plain_account = account
+            .account_info()
+            .map(|info| PlainAccount { info, storage });
+        Self {
+            account: plain_account,
+            status: account.status,
+        }
+    }
 }
 
 impl CacheAccount {


### PR DESCRIPTION
Preloaded bundle was added to the builder but was not used inside state.

Note that when the account is loaded both account info and storage are transferred from the bundle to the cache. So we don't have a fetch of storage for the preloaded bundle. While the contract is behaving the same as the account.