### PR TITLE
chore: mark CfgEnv as non_exhaustive

### DIFF
--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -78,6 +78,7 @@ pub enum CreateScheme {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 pub struct CfgEnv {
     pub chain_id: U256,
     pub spec_id: SpecId,


### PR DESCRIPTION
For future proofing updates make it non_exhaustive.
There is `Default` implementation to help with struct creating.