### PR TITLE
feat(`interpreter`): add hash to bytecode

### DIFF
--- a/crates/interpreter/src/interpreter/contract.rs
+++ b/crates/interpreter/src/interpreter/contract.rs
@@ -1,7 +1,7 @@
 use super::analysis::{to_analysed, BytecodeLocked};
 use crate::primitives::{Bytecode, Bytes, B160, U256};
 use crate::CallContext;
-use revm_primitives::{Env, TransactTo};
+use revm_primitives::{Env, TransactTo, B256};
 
 #[derive(Clone, Default)]
 pub struct Contract {
@@ -10,6 +10,8 @@ pub struct Contract {
     /// Bytecode contains contract code, size of original code, analysis with gas block and jump table.
     /// Note that current code is extended with push padding and STOP at end.
     pub bytecode: BytecodeLocked,
+    /// Bytecode hash.
+    pub hash: B256,
     /// Contract address
     pub address: B160,
     /// Caller of the EVM.
@@ -20,11 +22,13 @@ pub struct Contract {
 
 impl Contract {
     pub fn new(input: Bytes, bytecode: Bytecode, address: B160, caller: B160, value: U256) -> Self {
+        let hash = bytecode.hash_slow();
         let bytecode = to_analysed(bytecode).try_into().expect("it is analyzed");
 
         Self {
             input,
             bytecode,
+            hash,
             address,
             caller,
             value,

--- a/crates/interpreter/src/interpreter/contract.rs
+++ b/crates/interpreter/src/interpreter/contract.rs
@@ -21,8 +21,7 @@ pub struct Contract {
 }
 
 impl Contract {
-    pub fn new(input: Bytes, bytecode: Bytecode, address: B160, caller: B160, value: U256) -> Self {
-        let hash = bytecode.hash_slow();
+    pub fn new(input: Bytes, bytecode: Bytecode, hash: B256,address: B160, caller: B160, value: U256) -> Self {
         let bytecode = to_analysed(bytecode).try_into().expect("it is analyzed");
 
         Self {
@@ -36,7 +35,7 @@ impl Contract {
     }
 
     /// Create new contract from environment
-    pub fn new_env(env: &Env, bytecode: Bytecode) -> Self {
+    pub fn new_env(env: &Env, bytecode: Bytecode, hash: B256) -> Self {
         let contract_address = match env.tx.transact_to {
             TransactTo::Call(caller) => caller,
             TransactTo::Create(..) => B160::zero(),
@@ -44,6 +43,7 @@ impl Contract {
         Self::new(
             env.tx.data.clone(),
             bytecode,
+            hash,
             contract_address,
             env.tx.caller,
             env.tx.value,
@@ -54,10 +54,11 @@ impl Contract {
         self.bytecode.jump_map().is_valid(possition)
     }
 
-    pub fn new_with_context(input: Bytes, bytecode: Bytecode, call_context: &CallContext) -> Self {
+    pub fn new_with_context(input: Bytes, bytecode: Bytecode, hash: B256, call_context: &CallContext) -> Self {
         Self::new(
             input,
             bytecode,
+            hash,
             call_context.address,
             call_context.caller,
             call_context.apparent_value,

--- a/crates/interpreter/src/interpreter/contract.rs
+++ b/crates/interpreter/src/interpreter/contract.rs
@@ -21,7 +21,14 @@ pub struct Contract {
 }
 
 impl Contract {
-    pub fn new(input: Bytes, bytecode: Bytecode, hash: B256,address: B160, caller: B160, value: U256) -> Self {
+    pub fn new(
+        input: Bytes,
+        bytecode: Bytecode,
+        hash: B256,
+        address: B160,
+        caller: B160,
+        value: U256,
+    ) -> Self {
         let bytecode = to_analysed(bytecode).try_into().expect("it is analyzed");
 
         Self {
@@ -54,7 +61,12 @@ impl Contract {
         self.bytecode.jump_map().is_valid(possition)
     }
 
-    pub fn new_with_context(input: Bytes, bytecode: Bytecode, hash: B256, call_context: &CallContext) -> Self {
+    pub fn new_with_context(
+        input: Bytes,
+        bytecode: Bytecode,
+        hash: B256,
+        call_context: &CallContext,
+    ) -> Self {
         Self::new(
             input,
             bytecode,

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -397,12 +397,11 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
         };
 
         let bytecode = Bytecode::new_raw(inputs.init_code.clone());
-        let hash = bytecode.hash_slow();
 
         let contract = Box::new(Contract::new(
             Bytes::new(),
             bytecode,
-            hash,
+            code_hash,
             created_address,
             inputs.caller,
             inputs.value,

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -396,9 +396,13 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
             }
         };
 
+        let bytecode = Bytecode::new_raw(inputs.init_code.clone());
+        let hash = bytecode.hash_slow();
+
         let contract = Box::new(Contract::new(
             Bytes::new(),
-            Bytecode::new_raw(inputs.init_code.clone()),
+            bytecode,
+            hash,
             created_address,
             inputs.caller,
             inputs.value,
@@ -640,9 +644,12 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
             });
         }
 
+        let hash = bytecode.hash_slow();
+
         let contract = Box::new(Contract::new_with_context(
             inputs.input.clone(),
             bytecode,
+            hash,
             &inputs.context,
         ));
 


### PR DESCRIPTION
Caches the bytecode on `Contract` to only call `hash_slow` once during `Contract`'s creation.

Should speed up the coverage interpreter in foundry. cc @rakita 