### PR TITLE
chore(interpreter): use `let else`

### DIFF
--- a/crates/interpreter/src/instructions/macros.rs
+++ b/crates/interpreter/src/instructions/macros.rs
@@ -39,8 +39,8 @@ macro_rules! gas_or_fail {
     ($interp:expr, $gas:expr) => {
         if crate::USE_GAS {
             match $gas {
-                Some(gas_used) if $interp.gas.record_cost(gas_used) => {}
-                _ => {
+                Some(gas_used) => gas!($interp, gas_used),
+                None => {
                     $interp.instruction_result = InstructionResult::OutOfGas;
                     return;
                 }

--- a/crates/interpreter/src/instructions/macros.rs
+++ b/crates/interpreter/src/instructions/macros.rs
@@ -1,5 +1,3 @@
-pub use crate::InstructionResult;
-
 macro_rules! check_staticcall {
     ($interp:expr) => {
         if $interp.is_static {
@@ -21,7 +19,7 @@ macro_rules! check {
 macro_rules! gas {
     ($interp:expr, $gas:expr) => {
         if crate::USE_GAS {
-            if !$interp.gas.record_cost(($gas)) {
+            if !$interp.gas.record_cost($gas) {
                 $interp.instruction_result = InstructionResult::OutOfGas;
                 return;
             }
@@ -30,19 +28,19 @@ macro_rules! gas {
 }
 
 macro_rules! refund {
-    ($interp:expr, $gas:expr) => {{
+    ($interp:expr, $gas:expr) => {
         if crate::USE_GAS {
-            $interp.gas.gas_refund($gas);
+            $interp.gas.record_refund($gas);
         }
-    }};
+    };
 }
 
 macro_rules! gas_or_fail {
     ($interp:expr, $gas:expr) => {
         if crate::USE_GAS {
             match $gas {
-                Some(gas_used) => gas!($interp, gas_used),
-                None => {
+                Some(gas_used) if $interp.gas.record_cost(gas_used) => {}
+                _ => {
                     $interp.instruction_result = InstructionResult::OutOfGas;
                     return;
                 }
@@ -52,11 +50,9 @@ macro_rules! gas_or_fail {
 }
 
 macro_rules! memory_resize {
-    ($interp:expr, $offset:expr, $len:expr) => {{
-        let len: usize = $len;
-        let offset: usize = $offset;
+    ($interp:expr, $offset:expr, $len:expr) => {
         if let Some(new_size) =
-            crate::interpreter::memory::next_multiple_of_32(offset.saturating_add(len))
+            crate::interpreter::memory::next_multiple_of_32($offset.saturating_add($len))
         {
             #[cfg(feature = "memory_limit")]
             if new_size > ($interp.memory_limit as usize) {
@@ -78,7 +74,7 @@ macro_rules! memory_resize {
             $interp.instruction_result = InstructionResult::MemoryOOG;
             return;
         }
-    }};
+    };
 }
 
 macro_rules! pop_address {
@@ -115,7 +111,7 @@ macro_rules! pop_address {
 }
 
 macro_rules! pop {
-    ( $interp:expr, $x1:ident) => {
+    ($interp:expr, $x1:ident) => {
         if $interp.stack.len() < 1 {
             $interp.instruction_result = InstructionResult::StackUnderflow;
             return;
@@ -123,7 +119,7 @@ macro_rules! pop {
         // Safety: Length is checked above.
         let $x1 = unsafe { $interp.stack.pop_unsafe() };
     };
-    ( $interp:expr, $x1:ident, $x2:ident) => {
+    ($interp:expr, $x1:ident, $x2:ident) => {
         if $interp.stack.len() < 2 {
             $interp.instruction_result = InstructionResult::StackUnderflow;
             return;
@@ -131,7 +127,7 @@ macro_rules! pop {
         // Safety: Length is checked above.
         let ($x1, $x2) = unsafe { $interp.stack.pop2_unsafe() };
     };
-    ( $interp:expr, $x1:ident, $x2:ident, $x3:ident) => {
+    ($interp:expr, $x1:ident, $x2:ident, $x3:ident) => {
         if $interp.stack.len() < 3 {
             $interp.instruction_result = InstructionResult::StackUnderflow;
             return;
@@ -140,7 +136,7 @@ macro_rules! pop {
         let ($x1, $x2, $x3) = unsafe { $interp.stack.pop3_unsafe() };
     };
 
-    ( $interp:expr, $x1:ident, $x2:ident, $x3:ident, $x4:ident) => {
+    ($interp:expr, $x1:ident, $x2:ident, $x3:ident, $x4:ident) => {
         if $interp.stack.len() < 4 {
             $interp.instruction_result = InstructionResult::StackUnderflow;
             return;
@@ -151,7 +147,7 @@ macro_rules! pop {
 }
 
 macro_rules! pop_top {
-    ( $interp:expr, $x1:ident) => {
+    ($interp:expr, $x1:ident) => {
         if $interp.stack.len() < 1 {
             $interp.instruction_result = InstructionResult::StackUnderflow;
             return;
@@ -159,7 +155,7 @@ macro_rules! pop_top {
         // Safety: Length is checked above.
         let $x1 = unsafe { $interp.stack.top_unsafe() };
     };
-    ( $interp:expr, $x1:ident, $x2:ident) => {
+    ($interp:expr, $x1:ident, $x2:ident) => {
         if $interp.stack.len() < 2 {
             $interp.instruction_result = InstructionResult::StackUnderflow;
             return;
@@ -167,7 +163,7 @@ macro_rules! pop_top {
         // Safety: Length is checked above.
         let ($x1, $x2) = unsafe { $interp.stack.pop_top_unsafe() };
     };
-    ( $interp:expr, $x1:ident, $x2:ident, $x3:ident) => {
+    ($interp:expr, $x1:ident, $x2:ident, $x3:ident) => {
         if $interp.stack.len() < 3 {
             $interp.instruction_result = InstructionResult::StackUnderflow;
             return;
@@ -178,59 +174,57 @@ macro_rules! pop_top {
 }
 
 macro_rules! push_b256 {
-	( $interp:expr, $( $x:expr ),* ) => (
-		$(
-			match $interp.stack.push_b256($x) {
-				Ok(()) => (),
-				Err(e) => {
-                    $interp.instruction_result = e;
-                    return
-                },
-			}
-		)*
-	)
+	($interp:expr, $($x:expr),* $(,)?) => ($(
+        match $interp.stack.push_b256($x) {
+            Ok(()) => {},
+            Err(e) => {
+                $interp.instruction_result = e;
+                return;
+            },
+        }
+    )*)
 }
 
 macro_rules! push {
-    ( $interp:expr, $( $x:expr ),* ) => (
-		$(
-			match $interp.stack.push($x) {
-				Ok(()) => (),
-				Err(e) => { $interp.instruction_result = e;
-                    return
-                } ,
-			}
-		)*
-	)
+    ($interp:expr, $($x:expr),* $(,)?) => ($(
+        match $interp.stack.push($x) {
+            Ok(()) => {},
+            Err(e) => {
+                $interp.instruction_result = e;
+                return;
+            }
+        }
+    )*)
 }
 
 macro_rules! as_u64_saturated {
-    ( $v:expr ) => {{
-        if $v.as_limbs()[1] != 0 || $v.as_limbs()[2] != 0 || $v.as_limbs()[3] != 0 {
-            u64::MAX
+    ($v:expr) => {{
+        let x: &[u64; 4] = $v.as_limbs();
+        if x[1] == 0 && x[2] == 0 && x[3] == 0 {
+            x[0]
         } else {
-            $v.as_limbs()[0]
+            u64::MAX
         }
     }};
 }
 
 macro_rules! as_usize_saturated {
-    ( $v:expr ) => {{
+    ($v:expr) => {
         as_u64_saturated!($v) as usize
-    }};
+    };
 }
 
 macro_rules! as_usize_or_fail {
-    (  $interp:expr, $v:expr ) => {{
+    ($interp:expr, $v:expr) => {
         as_usize_or_fail!($interp, $v, InstructionResult::InvalidOperandOOG)
-    }};
+    };
 
-    (  $interp:expr, $v:expr, $reason:expr ) => {{
-        if $v.as_limbs()[1] != 0 || $v.as_limbs()[2] != 0 || $v.as_limbs()[3] != 0 {
+    ($interp:expr, $v:expr, $reason:expr) => {{
+        let x = $v.as_limbs();
+        if x[1] != 0 || x[2] != 0 || x[3] != 0 {
             $interp.instruction_result = $reason;
             return;
         }
-
-        $v.as_limbs()[0] as usize
+        x[0] as usize
     }};
 }


### PR DESCRIPTION
Split off from #582

And macros style changes.

Improves readability. MSRV for this feature is 1.65 but I see it's already present in `revm`.