### PR TITLE
perf(interpreter): improve i256 instructions

### DIFF
--- a/crates/interpreter/src/instructions/i256.rs
+++ b/crates/interpreter/src/instructions/i256.rs
@@ -1,28 +1,27 @@
 use crate::primitives::U256;
 use core::cmp::Ordering;
 
-#[cfg(test)]
-use proptest_derive::Arbitrary as PropTestArbitrary;
-
-#[cfg(any(test, feature = "arbitrary"))]
-use arbitrary::Arbitrary;
-
-#[cfg_attr(test, derive(PropTestArbitrary))]
-#[cfg_attr(any(test, feature = "arbitrary"), derive(Arbitrary))]
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub enum Sign {
-    Plus,
-    Minus,
-    Zero,
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    any(test, feature = "arbitrary"),
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
+#[repr(i8)]
+pub(super) enum Sign {
+    // same as `cmp::Ordering`
+    Minus = -1,
+    Zero = 0,
+    #[allow(dead_code)] // "constructed" with `mem::transmute`
+    Plus = 1,
 }
 
-pub const _SIGN_BIT_MASK: U256 = U256::from_limbs([
+pub(super) const _SIGN_BIT_MASK: U256 = U256::from_limbs([
     0xFFFFFFFFFFFFFFFF,
     0xFFFFFFFFFFFFFFFF,
     0xFFFFFFFFFFFFFFFF,
     0x7FFFFFFFFFFFFFFF,
 ]);
-pub const MIN_NEGATIVE_VALUE: U256 = U256::from_limbs([
+pub(super) const MIN_NEGATIVE_VALUE: U256 = U256::from_limbs([
     0x0000000000000000,
     0x0000000000000000,
     0x0000000000000000,
@@ -31,102 +30,101 @@ pub const MIN_NEGATIVE_VALUE: U256 = U256::from_limbs([
 
 const FLIPH_BITMASK_U64: u64 = 0x7FFFFFFFFFFFFFFF;
 
-#[cfg_attr(test, derive(PropTestArbitrary))]
-#[cfg_attr(any(test, feature = "arbitrary"), derive(Arbitrary))]
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub struct I256(pub Sign, pub U256);
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    any(test, feature = "arbitrary"),
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
+pub(super) struct I256(pub(super) Sign, pub(super) U256);
 
 #[inline(always)]
-pub fn i256_sign<const DO_TWO_COMPL: bool>(val: &mut U256) -> Sign {
-    if !val.bit(U256::BITS - 1) {
-        if *val == U256::ZERO {
-            Sign::Zero
-        } else {
-            Sign::Plus
-        }
-    } else {
-        if DO_TWO_COMPL {
-            two_compl_mut(val);
-        }
+pub(super) fn i256_sign(val: &U256) -> Sign {
+    if val.bit(U256::BITS - 1) {
         Sign::Minus
+    } else {
+        // SAFETY: false == 0 == Zero, true == 1 == Plus
+        unsafe { core::mem::transmute(*val != U256::ZERO) }
     }
 }
 
 #[inline(always)]
+pub(super) fn i256_sign_compl(val: &mut U256) -> Sign {
+    let sign = i256_sign(val);
+    if sign == Sign::Minus {
+        two_compl_mut(val);
+    }
+    sign
+}
+
+#[inline(always)]
 fn u256_remove_sign(val: &mut U256) {
+    // SAFETY: U256 does not have any padding bytes
     unsafe {
         val.as_limbs_mut()[3] &= FLIPH_BITMASK_U64;
     }
 }
 
 #[inline(always)]
-pub fn two_compl_mut(op: &mut U256) {
+pub(super) fn two_compl_mut(op: &mut U256) {
     *op = two_compl(*op);
 }
 
-pub fn two_compl(op: U256) -> U256 {
+#[inline(always)]
+pub(super) fn two_compl(op: U256) -> U256 {
     op.wrapping_neg()
 }
 
 #[inline(always)]
-pub fn i256_cmp(mut first: U256, mut second: U256) -> Ordering {
-    let first_sign = i256_sign::<false>(&mut first);
-    let second_sign = i256_sign::<false>(&mut second);
-    match (first_sign, second_sign) {
-        (Sign::Zero, Sign::Zero) => Ordering::Equal,
-        (Sign::Zero, Sign::Plus) => Ordering::Less,
-        (Sign::Zero, Sign::Minus) => Ordering::Greater,
-        (Sign::Minus, Sign::Zero) => Ordering::Less,
-        (Sign::Minus, Sign::Plus) => Ordering::Less,
-        (Sign::Minus, Sign::Minus) => first.cmp(&second),
-        (Sign::Plus, Sign::Minus) => Ordering::Greater,
-        (Sign::Plus, Sign::Zero) => Ordering::Greater,
-        (Sign::Plus, Sign::Plus) => first.cmp(&second),
+pub(super) fn i256_cmp(first: &U256, second: &U256) -> Ordering {
+    let first_sign = i256_sign(first);
+    let second_sign = i256_sign(second);
+    match first_sign.cmp(&second_sign) {
+        // note: adding `if first_sign != Sign::Zero` to short circuit zero comparisons performs
+        // slower on average, as of #582
+        Ordering::Equal => first.cmp(second),
+        o => o,
     }
 }
 
 #[inline(always)]
-pub fn i256_div(mut first: U256, mut second: U256) -> U256 {
-    let second_sign = i256_sign::<true>(&mut second);
+pub(super) fn i256_div(mut first: U256, mut second: U256) -> U256 {
+    let second_sign = i256_sign_compl(&mut second);
     if second_sign == Sign::Zero {
         return U256::ZERO;
     }
-    let first_sign = i256_sign::<true>(&mut first);
+    let first_sign = i256_sign_compl(&mut first);
     if first_sign == Sign::Minus && first == MIN_NEGATIVE_VALUE && second == U256::from(1) {
         return two_compl(MIN_NEGATIVE_VALUE);
     }
 
-    //let mut d = first / second;
-    let mut d = first.div_rem(second).0;
+    let mut d = first.wrapping_div(second);
 
+    // set sign bit to zero
     u256_remove_sign(&mut d);
-    //set sign bit to zero
 
     if d == U256::ZERO {
         return U256::ZERO;
     }
 
-    match (first_sign, second_sign) {
-        (Sign::Zero, Sign::Plus)
-        | (Sign::Plus, Sign::Zero)
-        | (Sign::Zero, Sign::Zero)
-        | (Sign::Plus, Sign::Plus)
-        | (Sign::Minus, Sign::Minus) => d,
-        (Sign::Zero, Sign::Minus)
-        | (Sign::Plus, Sign::Minus)
-        | (Sign::Minus, Sign::Zero)
-        | (Sign::Minus, Sign::Plus) => two_compl(d),
+    // do complement if signs are different
+    // note: this condition has better codegen than an exhaustive match as of #582
+    if (first_sign == Sign::Minus && second_sign != Sign::Minus)
+        || (second_sign == Sign::Minus && first_sign != Sign::Minus)
+    {
+        two_compl(d)
+    } else {
+        d
     }
 }
 
 #[inline(always)]
-pub fn i256_mod(mut first: U256, mut second: U256) -> U256 {
-    let first_sign = i256_sign::<true>(&mut first);
+pub(super) fn i256_mod(mut first: U256, mut second: U256) -> U256 {
+    let first_sign = i256_sign_compl(&mut first);
     if first_sign == Sign::Zero {
         return U256::ZERO;
     }
 
-    let _ = i256_sign::<true>(&mut second);
+    let _ = i256_sign_compl(&mut second);
     let mut r = first % second;
     u256_remove_sign(&mut r);
     if r == U256::ZERO {

--- a/crates/interpreter/src/instructions/i256.rs
+++ b/crates/interpreter/src/instructions/i256.rs
@@ -87,10 +87,6 @@ pub(super) fn i256_div(mut first: U256, mut second: U256) -> U256 {
     // set sign bit to zero
     u256_remove_sign(&mut d);
 
-    if d == U256::ZERO {
-        return U256::ZERO;
-    }
-
     // two's complement only if the signs are different
     // note: this condition has better codegen than an exhaustive match, as of #582
     if (first_sign == Sign::Minus && second_sign != Sign::Minus)
@@ -116,9 +112,7 @@ pub(super) fn i256_mod(mut first: U256, mut second: U256) -> U256 {
 
     // set sign bit to zero
     u256_remove_sign(&mut r);
-    if r == U256::ZERO {
-        return U256::ZERO;
-    }
+
     if first_sign == Sign::Minus {
         two_compl(r)
     } else {


### PR DESCRIPTION
Split off from #582

Summary:
- `i256_sign`:
  - is split into the two possible variants as before (with the const bool), so we can use it with an immutable reference, avoiding copies in `i256_cmp` (see `slt`, `sgt` impls). `i256_sign_compl` gets optimized away like `i256_sign::<true>` before
  - by sorting  `Sign`  variants we can leverage derived `Eq, Ord` impls, which are can be further optimized by the compiler. Also, by using `-1, 0, 1` it will be the exact same `cmp::Ordering` and the `signum` function result, which helps in the sign function (where we transmute `num != 0` directly to `Sign`)
- `i256_div`: if condition generates better code than a fully exhaustive match (branchless vs multiple branches). I don't know why, I would assume the two to be identical ... godbolt: <https://godbolt.org/z/939obPrsj>
- other small changes are for readability: `overflowing().0` == `wrapping()`, `>> == wrapping_shr`