### PR TITLE
fix(state): return RevertToSlot struct with more info

### DIFF
--- a/crates/revm/src/db/states/bundle_state.rs
+++ b/crates/revm/src/db/states/bundle_state.rs
@@ -258,10 +258,8 @@ impl BundleState {
                     AccountInfoRevert::DoNothing => (),
                 }
                 if revert_account.wipe_storage || !revert_account.storage.is_empty() {
-                    let mut account_storage = Vec::with_capacity(revert_account.storage.len());
-                    for (key, revert_slot) in revert_account.storage {
-                        account_storage.push((key, revert_slot.to_previous_value()));
-                    }
+                    let mut account_storage =
+                        revert_account.storage.into_iter().collect::<Vec<_>>();
                     account_storage.par_sort_unstable_by(|a, b| a.0.cmp(&b.0));
                     storage.push((address, revert_account.wipe_storage, account_storage));
                 }

--- a/crates/revm/src/db/states/changes.rs
+++ b/crates/revm/src/db/states/changes.rs
@@ -1,3 +1,4 @@
+use super::RevertToSlot;
 use revm_interpreter::primitives::{AccountInfo, Bytecode, B160, B256, U256};
 
 /// Sorted accounts/storages/contracts for inclusion into database.
@@ -39,4 +40,4 @@ impl StateReverts {
 }
 
 /// Storage reverts
-pub type StorageRevert = Vec<Vec<(B160, bool, Vec<(U256, U256)>)>>;
+pub type StorageRevert = Vec<Vec<(B160, bool, Vec<(U256, RevertToSlot)>)>>;

--- a/crates/revm/src/db/states/reverts.rs
+++ b/crates/revm/src/db/states/reverts.rs
@@ -110,7 +110,7 @@ pub enum AccountInfoRevert {
 ///
 /// Note: It is completely different state if Storage is Zero or Some or if Storage was
 /// Destroyed. Because if it is destroyed, previous values can be found in database or it can be zero.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub enum RevertToSlot {
     Some(U256),
     Destroyed,


### PR DESCRIPTION
Returns more information for storage. If storage previous values are known we would have `RevertToSlot::Some` while if the first selfdestruct happened we wouldn't know the previous value inside revm and would have `RevertToSlot::Destroyed` and need to check with whipped database storage if there is one, if not ZERO should be used in revert.

Change inside reth to accompany this: https://github.com/paradigmxyz/reth/commit/2c62da3c8bc35fe6de499baa0b4e76b2c42af576