### PR TITLE
fix(state): check if storage revert is empty

### DIFF
--- a/crates/revm/src/db/states/bundle_state.rs
+++ b/crates/revm/src/db/states/bundle_state.rs
@@ -213,12 +213,14 @@ impl BundleState {
                 }
             }
 
-            account_storage_changed.sort_by(|a, b| a.0.cmp(&b.0));
-            // append storage changes to account.
-            storage.push((
-                address,
-                (account.status.was_destroyed(), account_storage_changed),
-            ));
+            if !account_storage_changed.is_empty() {
+                account_storage_changed.sort_by(|a, b| a.0.cmp(&b.0));
+                // append storage changes to account.
+                storage.push((
+                    address,
+                    (account.status.was_destroyed(), account_storage_changed),
+                ));
+            }
         }
 
         accounts.par_sort_unstable_by(|a, b| a.0.cmp(&b.0));


### PR DESCRIPTION
## Description

Check if storage revert is empty before adding it to the storage set.