### PR TITLE
fix(state): Revert from DestroyedChanged to DestroyedAgain

### DIFF
--- a/crates/revm/src/db/states/bundle_account.rs
+++ b/crates/revm/src/db/states/bundle_account.rs
@@ -326,18 +326,14 @@ impl BundleAccount {
                             None
                         }
                         AccountStatus::DestroyedChanged => {
-                            // From destroyed new to destroyed again.
-                            let ret = AccountRevert {
-                                // empty account
-                                account: AccountInfoRevert::RevertTo(
-                                    self.info.clone().unwrap_or_default(),
-                                ),
-                                // TODO(rakita) is this invalid?
-                                storage: previous_storage_from_update(&updated_storage),
-                                previous_status: AccountStatus::DestroyedChanged,
-                                wipe_storage: false,
-                            };
-                            Some(ret)
+                            // From destroyed changed to destroyed again.
+                            Some(AccountRevert::new_selfdestructed_again(
+                                // destroyed again will set empty account.
+                                AccountStatus::DestroyedChanged,
+                                AccountInfoRevert::RevertTo(self.info.clone().unwrap_or_default()),
+                                self.storage.drain().collect(),
+                                HashMap::default(),
+                            ))
                         }
                         _ => unreachable!("Invalid state to DestroyedAgain from {self:?}"),
                     }


### PR DESCRIPTION
TODO was right, it was invalid.

The storage that we should have used was the present storage of the bundle account. As this is transition to `DestroyedAgain` updated_storage would always be empty.