### PR TITLE
Share memory between calls

### DIFF
--- a/crates/interpreter/src/host.rs
+++ b/crates/interpreter/src/host.rs
@@ -1,3 +1,5 @@
+use core::cell::RefCell;
+
 use crate::primitives::Bytecode;
 use crate::{
     primitives::{Bytes, Env, B160, B256, U256},
@@ -7,6 +9,8 @@ use alloc::vec::Vec;
 pub use dummy::DummyHost;
 
 mod dummy;
+use alloc::rc::Rc;
+use revm_primitives::shared_memory::SharedMemory;
 
 /// EVM context host.
 pub trait Host {
@@ -51,7 +55,12 @@ pub trait Host {
     fn create(
         &mut self,
         inputs: &mut CreateInputs,
+        shared_memory: &Rc<RefCell<SharedMemory>>,
     ) -> (InstructionResult, Option<B160>, Gas, Bytes);
     /// Invoke a call operation.
-    fn call(&mut self, input: &mut CallInputs) -> (InstructionResult, Gas, Bytes);
+    fn call(
+        &mut self,
+        input: &mut CallInputs,
+        shared_memory: &Rc<RefCell<SharedMemory>>,
+    ) -> (InstructionResult, Gas, Bytes);
 }

--- a/crates/interpreter/src/host/dummy.rs
+++ b/crates/interpreter/src/host/dummy.rs
@@ -1,9 +1,13 @@
+use core::cell::RefCell;
+
 use crate::primitives::{hash_map::Entry, Bytecode, Bytes, HashMap, U256};
 use crate::{
     primitives::{Env, Log, B160, B256, KECCAK_EMPTY},
     CallInputs, CreateInputs, Gas, Host, InstructionResult, Interpreter, SelfDestructResult,
 };
+use alloc::rc::Rc;
 use alloc::vec::Vec;
+use revm_primitives::shared_memory::SharedMemory;
 
 pub struct DummyHost {
     pub env: Env,
@@ -137,12 +141,17 @@ impl Host for DummyHost {
     fn create(
         &mut self,
         _inputs: &mut CreateInputs,
+        _shared_memory: &Rc<RefCell<SharedMemory>>,
     ) -> (InstructionResult, Option<B160>, Gas, Bytes) {
         panic!("Create is not supported for this host")
     }
 
     #[inline]
-    fn call(&mut self, _input: &mut CallInputs) -> (InstructionResult, Gas, Bytes) {
+    fn call(
+        &mut self,
+        _input: &mut CallInputs,
+        _shared_memory: &Rc<RefCell<SharedMemory>>,
+    ) -> (InstructionResult, Gas, Bytes) {
         panic!("Call is not supported for this host")
     }
 }

--- a/crates/interpreter/src/instructions/control.rs
+++ b/crates/interpreter/src/instructions/control.rs
@@ -50,7 +50,7 @@ pub fn ret(interpreter: &mut Interpreter, _host: &mut dyn Host) {
         interpreter.return_range = usize::MAX..usize::MAX;
     } else {
         let offset = as_usize_or_fail!(interpreter, start, InstructionResult::InvalidOperandOOG);
-        memory_resize!(interpreter, offset, len);
+        shared_memory_resize!(interpreter, offset, len);
         interpreter.return_range = offset..(offset + len);
     }
     interpreter.instruction_result = InstructionResult::Return;
@@ -66,7 +66,7 @@ pub fn revert<SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut dyn Host) {
         interpreter.return_range = usize::MAX..usize::MAX;
     } else {
         let offset = as_usize_or_fail!(interpreter, start, InstructionResult::InvalidOperandOOG);
-        memory_resize!(interpreter, offset, len);
+        shared_memory_resize!(interpreter, offset, len);
         interpreter.return_range = offset..(offset + len);
     }
     interpreter.instruction_result = InstructionResult::Revert;

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -320,7 +320,8 @@ pub fn create<const IS_CREATE2: bool, SPEC: Spec>(
         return;
     };
 
-    let (return_reason, address, gas, return_data) = host.create(&mut create_input);
+    let (return_reason, address, gas, return_data) =
+        host.create(&mut create_input, &mut interpreter.shared_memory);
 
     interpreter.return_data_buffer = match return_reason {
         // Save data to return data buffer if the create reverted
@@ -540,7 +541,7 @@ pub fn call_inner<SPEC: Spec>(
     };
 
     // Call host to interact with target contract
-    let (reason, gas, return_data) = host.call(&mut call_input);
+    let (reason, gas, return_data) = host.call(&mut call_input, &mut interpreter.shared_memory);
 
     interpreter.return_data_buffer = return_data;
 

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -555,7 +555,6 @@ pub fn call_inner<SPEC: Spec>(
     let (reason, gas, return_data) = host.call(&mut call_input, &interpreter.shared_memory);
 
     interpreter.return_data_buffer = return_data;
-
     let target_len = min(out_len, interpreter.return_data_buffer.len());
 
     match reason {

--- a/crates/interpreter/src/instructions/macros.rs
+++ b/crates/interpreter/src/instructions/macros.rs
@@ -49,18 +49,51 @@ macro_rules! gas_or_fail {
     };
 }
 
-macro_rules! memory_resize {
-    ($interp:expr, $offset:expr, $len:expr) => {
+// macro_rules! memory_resize {
+//     ($interp:expr, $offset:expr, $len:expr) => {{
+//         let len: usize = $len;
+//         let offset: usize = $offset;
+//         if let Some(new_size) =
+//             crate::interpreter::memory::next_multiple_of_32(offset.saturating_add(len))
+//         {
+//             #[cfg(feature = "memory_limit")]
+//             if new_size > ($interp.memory_limit as usize) {
+//                 $interp.instruction_result = InstructionResult::MemoryLimitOOG;
+//                 return;
+//             }
+//
+//             if new_size > $interp.memory.len() {
+//                 if crate::USE_GAS {
+//                     let num_bytes = new_size / 32;
+//                     if !$interp.gas.record_memory(crate::gas::memory_gas(num_bytes)) {
+//                         $interp.instruction_result = InstructionResult::MemoryLimitOOG;
+//                         return;
+//                     }
+//                 }
+//                 $interp.memory.resize(new_size);
+//             }
+//         } else {
+//             $interp.instruction_result = InstructionResult::MemoryOOG;
+//             return;
+//         }
+//     }};
+// }
+
+macro_rules! shared_memory_resize {
+    ($interp:expr, $offset:expr, $len:expr) => {{
+        let len: usize = $len;
+        let offset: usize = $offset;
+        let mut mem = $interp.shared_memory.borrow_mut();
         if let Some(new_size) =
-            crate::interpreter::memory::next_multiple_of_32($offset.saturating_add($len))
+            crate::interpreter::memory::next_multiple_of_32(offset.saturating_add(len))
         {
             #[cfg(feature = "memory_limit")]
-            if new_size > ($interp.memory_limit as usize) {
+            if new_size > (mem.limit as usize) {
                 $interp.instruction_result = InstructionResult::MemoryLimitOOG;
                 return;
             }
 
-            if new_size > $interp.memory.len() {
+            if new_size > mem.len() {
                 if crate::USE_GAS {
                     let num_bytes = new_size / 32;
                     if !$interp.gas.record_memory(crate::gas::memory_gas(num_bytes)) {
@@ -68,13 +101,13 @@ macro_rules! memory_resize {
                         return;
                     }
                 }
-                $interp.memory.resize(new_size);
+                mem.resize(new_size);
             }
         } else {
             $interp.instruction_result = InstructionResult::MemoryOOG;
             return;
         }
-    };
+    };};
 }
 
 macro_rules! pop_address {

--- a/crates/interpreter/src/instructions/memory.rs
+++ b/crates/interpreter/src/instructions/memory.rs
@@ -42,7 +42,7 @@ pub fn mstore8(interpreter: &mut Interpreter, _host: &mut dyn Host) {
     gas!(interpreter, gas::VERYLOW);
     pop!(interpreter, index, value);
     let index = as_usize_or_fail!(interpreter, index, InstructionResult::InvalidOperandOOG);
-    shared_memory_resize!(interpreter, index, 32);
+    shared_memory_resize!(interpreter, index, 1);
     let value = value.as_le_bytes()[0];
     // Safety: we resized our memory two lines above.
     unsafe {
@@ -57,7 +57,7 @@ pub fn msize(interpreter: &mut Interpreter, _host: &mut dyn Host) {
     gas!(interpreter, gas::BASE);
     push!(
         interpreter,
-        U256::from(interpreter.shared_memory.borrow().effective_len())
+        U256::from(interpreter.shared_memory.borrow().len())
     );
 }
 

--- a/crates/interpreter/src/instructions/memory.rs
+++ b/crates/interpreter/src/instructions/memory.rs
@@ -13,11 +13,16 @@ pub fn mload(interpreter: &mut Interpreter, _host: &mut dyn Host) {
     gas!(interpreter, gas::VERYLOW);
     pop!(interpreter, index);
     let index = as_usize_or_fail!(interpreter, index, InstructionResult::InvalidOperandOOG);
-    memory_resize!(interpreter, index, 32);
+    shared_memory_resize!(interpreter, index, 32);
     push!(
         interpreter,
         U256::from_be_bytes::<{ U256::BYTES }>(
-            interpreter.memory.get_slice(index, 32).try_into().unwrap()
+            interpreter
+                .shared_memory
+                .borrow()
+                .get_slice(index, 32)
+                .try_into()
+                .unwrap()
         )
     );
 }
@@ -26,23 +31,34 @@ pub fn mstore(interpreter: &mut Interpreter, _host: &mut dyn Host) {
     gas!(interpreter, gas::VERYLOW);
     pop!(interpreter, index, value);
     let index = as_usize_or_fail!(interpreter, index, InstructionResult::InvalidOperandOOG);
-    memory_resize!(interpreter, index, 32);
-    interpreter.memory.set_u256(index, value);
+    shared_memory_resize!(interpreter, index, 32);
+    interpreter
+        .shared_memory
+        .borrow_mut()
+        .set_u256(index, value);
 }
 
 pub fn mstore8(interpreter: &mut Interpreter, _host: &mut dyn Host) {
     gas!(interpreter, gas::VERYLOW);
     pop!(interpreter, index, value);
     let index = as_usize_or_fail!(interpreter, index, InstructionResult::InvalidOperandOOG);
-    memory_resize!(interpreter, index, 1);
+    shared_memory_resize!(interpreter, index, 32);
     let value = value.as_le_bytes()[0];
     // Safety: we resized our memory two lines above.
-    unsafe { interpreter.memory.set_byte(index, value) }
+    unsafe {
+        interpreter
+            .shared_memory
+            .borrow_mut()
+            .set_byte(index, value)
+    }
 }
 
 pub fn msize(interpreter: &mut Interpreter, _host: &mut dyn Host) {
     gas!(interpreter, gas::BASE);
-    push!(interpreter, U256::from(interpreter.memory.effective_len()));
+    push!(
+        interpreter,
+        U256::from(interpreter.shared_memory.borrow().effective_len())
+    );
 }
 
 // From EIP-5656 MCOPY
@@ -64,7 +80,7 @@ pub fn mcopy<SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut dyn Host) {
     let dest = as_usize_or_fail!(interpreter, dest, InstructionResult::InvalidOperandOOG);
     let src = as_usize_or_fail!(interpreter, src, InstructionResult::InvalidOperandOOG);
     // resize memory
-    memory_resize!(interpreter, max(dest, src), len);
+    shared_memory_resize!(interpreter, max(dest, src), len);
     // copy memory in place
-    interpreter.memory.copy(dest, src, len);
+    interpreter.shared_memory.borrow_mut().copy(dest, src, len);
 }

--- a/crates/interpreter/src/instructions/system.rs
+++ b/crates/interpreter/src/instructions/system.rs
@@ -14,8 +14,8 @@ pub fn calculate_keccak256(interpreter: &mut Interpreter, _host: &mut dyn Host) 
         KECCAK_EMPTY
     } else {
         let from = as_usize_or_fail!(interpreter, from, InstructionResult::InvalidOperandOOG);
-        memory_resize!(interpreter, from, len);
-        keccak256(interpreter.memory.get_slice(from, len))
+        shared_memory_resize!(interpreter, from, len);
+        keccak256(interpreter.shared_memory.borrow().get_slice(from, len))
     };
 
     push_b256!(interpreter, hash);
@@ -49,10 +49,10 @@ pub fn codecopy(interpreter: &mut Interpreter, _host: &mut dyn Host) {
         InstructionResult::InvalidOperandOOG
     );
     let code_offset = as_usize_saturated!(code_offset);
-    memory_resize!(interpreter, memory_offset, len);
+    shared_memory_resize!(interpreter, memory_offset, len);
 
     // Safety: set_data is unsafe function and memory_resize ensures us that it is safe to call it
-    interpreter.memory.set_data(
+    interpreter.shared_memory.borrow_mut().set_data(
         memory_offset,
         code_offset,
         len,
@@ -100,12 +100,15 @@ pub fn calldatacopy(interpreter: &mut Interpreter, _host: &mut dyn Host) {
         InstructionResult::InvalidOperandOOG
     );
     let data_offset = as_usize_saturated!(data_offset);
-    memory_resize!(interpreter, memory_offset, len);
+    shared_memory_resize!(interpreter, memory_offset, len);
 
     // Safety: set_data is unsafe function and memory_resize ensures us that it is safe to call it
-    interpreter
-        .memory
-        .set_data(memory_offset, data_offset, len, &interpreter.contract.input);
+    interpreter.shared_memory.borrow_mut().set_data(
+        memory_offset,
+        data_offset,
+        len,
+        &interpreter.contract.input,
+    );
 }
 
 pub fn returndatasize<SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut dyn Host) {
@@ -136,8 +139,8 @@ pub fn returndatacopy<SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut dyn
             memory_offset,
             InstructionResult::InvalidOperandOOG
         );
-        memory_resize!(interpreter, memory_offset, len);
-        interpreter.memory.set(
+        shared_memory_resize!(interpreter, memory_offset, len);
+        interpreter.shared_memory.borrow_mut().set(
             memory_offset,
             &interpreter.return_data_buffer[data_offset..data_end],
         );

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -37,7 +37,7 @@ pub struct Interpreter {
     /// left gas. Memory gas can be found in Memory field.
     pub gas: Gas,
     /// Memory.
-    pub memory: Memory,
+    // pub memory: Memory,
     /// Stack.
     pub stack: Stack,
     /// After call returns, its return data is saved here.
@@ -73,7 +73,7 @@ impl Interpreter {
             Self {
                 instruction_pointer: contract.bytecode.as_ptr(),
                 return_range: Range::default(),
-                memory: Memory::new(),
+                // memory: Memory::new(),
                 stack: Stack::new(),
                 return_data_buffer: Bytes::new(),
                 contract,
@@ -101,7 +101,7 @@ impl Interpreter {
         Self {
             instruction_pointer: contract.bytecode.as_ptr(),
             return_range: Range::default(),
-            memory: Memory::new(),
+            // memory: Memory::new(),
             stack: Stack::new(),
             return_data_buffer: Bytes::new(),
             contract,
@@ -122,9 +122,9 @@ impl Interpreter {
     }
 
     /// Reference of interpreter memory.
-    pub fn memory(&self) -> &Memory {
-        &self.memory
-    }
+    // pub fn memory(&self) -> &Memory {
+    //     &self.memory
+    // }
 
     /// Reference of interpreter stack.
     pub fn stack(&self) -> &Stack {
@@ -182,13 +182,15 @@ impl Interpreter {
     /// Copy and get the return value of the interpreter, if any.
     pub fn return_value(&self) -> Bytes {
         // if start is usize max it means that our return len is zero and we need to return empty
-        if self.return_range.start == usize::MAX {
+        let bytes = if self.return_range.start == usize::MAX {
             Bytes::new()
         } else {
             Bytes::copy_from_slice(self.shared_memory.borrow().get_slice(
                 self.return_range.start,
                 self.return_range.end - self.return_range.start,
             ))
-        }
+        };
+        self.shared_memory.borrow_mut().free_memory();
+        bytes
     }
 }

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -80,6 +80,7 @@ impl Interpreter {
                 instruction_result: InstructionResult::Continue,
                 is_static,
                 gas: Gas::new(gas_limit),
+                shared_memory: Rc::clone(shared_memory),
             }
         }
 
@@ -184,7 +185,7 @@ impl Interpreter {
         if self.return_range.start == usize::MAX {
             Bytes::new()
         } else {
-            Bytes::copy_from_slice(self.memory.get_slice(
+            Bytes::copy_from_slice(self.shared_memory.borrow().get_slice(
                 self.return_range.start,
                 self.return_range.end - self.return_range.start,
             ))

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -10,6 +10,7 @@ pub mod env;
 pub mod log;
 pub mod precompile;
 pub mod result;
+pub mod shared_memory;
 pub mod specification;
 pub mod state;
 pub mod utilities;

--- a/crates/primitives/src/shared_memory.rs
+++ b/crates/primitives/src/shared_memory.rs
@@ -1,0 +1,161 @@
+use crate::U256;
+use core::{
+    cmp::min,
+    ops::{BitAnd, Not},
+};
+
+pub struct SharedMemory {
+    pub data: Vec<u8>,
+    pub limit: u64,
+    /// Memory sizes checkpoint for each depth
+    pub msizes: Vec<usize>,
+    current_slice: *mut [u8],
+    current_len: usize,
+}
+
+impl SharedMemory {
+    fn get_current_slice(&self) -> &[u8] {
+        unsafe { &*self.current_slice }
+    }
+
+    fn get_current_slice_mut(&mut self) -> &mut [u8] {
+        unsafe { &mut *self.current_slice }
+    }
+
+    pub fn use_new_memory(&mut self) {
+        let base_offset = self.msizes.last().unwrap_or(&0);
+        let last_slice_offset = self.current_len;
+
+        self.msizes.push(base_offset + last_slice_offset);
+
+        let new_msize = self.msizes.last().unwrap();
+
+        let range = if new_msize == &0 {
+            0..
+        } else {
+            new_msize + 1..
+        };
+
+        self.current_slice = &mut self.data[range];
+        self.current_len = 0;
+    }
+
+    pub fn new(gas_limit: u64, memory_limit: Option<u64>) -> Self {
+        let upper_bound = ((589_312 + 512 * gas_limit) as f64).sqrt() - 768_f64;
+        let limit = if let Some(mlimit) = memory_limit {
+            mlimit
+        } else {
+            upper_bound as u64
+        };
+        // self.data = Vec::with_capacity(upper_bound as usize);
+        let mut data = vec![0; limit as usize];
+        let msizes = vec![0_usize; 1024];
+        let current_slice: *mut [u8] = &mut data[..];
+        SharedMemory {
+            data,
+            limit,
+            msizes,
+            current_slice,
+            current_len: 0,
+        }
+    }
+
+    /// Resize the memory. asume that we already checked if
+    /// we have enought gas to resize this vector and that we made new_size as multiply of 32
+    pub fn resize(&mut self, new_size: usize) {
+        if new_size as u64 >= self.limit {
+            panic!("Max limit reached")
+        }
+
+        let range = if new_size > self.current_len {
+            // extend with zeros
+            self.current_len + 1..=new_size
+        } else {
+            // truncate
+            new_size..=self.current_len
+        };
+
+        self.get_current_slice_mut()[range]
+            .iter_mut()
+            .for_each(|byte| *byte = 0);
+        self.current_len = new_size;
+    }
+
+    pub fn effective_len(&self) -> usize {
+        self.current_len
+    }
+
+    /// Get the length of the current memory range.
+    pub fn len(&self) -> usize {
+        self.current_len
+    }
+
+    /// Return true if current effective memory range is zero.
+    pub fn is_empty(&self) -> bool {
+        self.current_len == 0
+    }
+
+    /// Return the full memory.
+    pub fn data(&self) -> &[u8] {
+        self.get_current_slice()
+    }
+
+    /// Get memory region at given offset. Dont check offset and size
+    #[inline(always)]
+    pub fn get_slice(&self, offset: usize, size: usize) -> &[u8] {
+        &self.get_current_slice()[offset..offset + size]
+    }
+
+    #[inline(always)]
+    pub fn set_u256(&mut self, index: usize, value: U256) {
+        self.get_current_slice_mut()[index..index + 32]
+            .copy_from_slice(&value.to_be_bytes::<{ U256::BYTES }>());
+    }
+
+    /// Set memory region at given offset. The offset and value are already checked
+    #[inline(always)]
+    pub fn set(&mut self, offset: usize, value: &[u8]) {
+        if !value.is_empty() {
+            self.get_current_slice_mut()[offset..(value.len() + offset)].copy_from_slice(value);
+        }
+    }
+
+    /// Set memory from data. Our memory offset+len is expected to be correct but we
+    /// are doing bound checks on data/data_offeset/len and zeroing parts that is not copied.
+    #[inline(always)]
+    pub fn set_data(&mut self, memory_offset: usize, data_offset: usize, len: usize, data: &[u8]) {
+        if data_offset >= data.len() {
+            // nulify all memory slots
+            for i in &mut self.get_current_slice_mut()[memory_offset..memory_offset + len] {
+                *i = 0;
+            }
+            return;
+        }
+        let data_end = min(data_offset + len, data.len());
+        let memory_data_end = memory_offset + (data_end - data_offset);
+        self.get_current_slice_mut()[memory_offset..memory_data_end]
+            .copy_from_slice(&data[data_offset..data_end]);
+
+        // nulify rest of memory slots
+        // Safety: Memory is assumed to be valid. And it is commented where that assumption is made
+        for i in &mut self.get_current_slice_mut()[memory_data_end..memory_offset + len] {
+            *i = 0;
+        }
+    }
+
+    /// In memory copy given a src, dst, and length
+    ///
+    /// # Safety
+    /// The caller is responsible to check that we resized memory properly.
+    #[inline(always)]
+    pub fn copy(&mut self, dst: usize, src: usize, length: usize) {
+        self.get_current_slice_mut()
+            .copy_within(src..src + length, dst);
+    }
+}
+
+#[inline]
+pub(crate) fn next_multiple_of_32(x: usize) -> Option<usize> {
+    let r = x.bitand(31).not().wrapping_add(1).bitand(31);
+    x.checked_add(r)
+}

--- a/crates/primitives/src/shared_memory.rs
+++ b/crates/primitives/src/shared_memory.rs
@@ -1,14 +1,13 @@
+use crate::alloc::vec;
+use crate::alloc::vec::Vec;
 use crate::U256;
-use core::{
-    cmp::min,
-    ops::{BitAnd, Not},
-};
+use core::cmp::min;
 
 pub struct SharedMemory {
-    pub data: Vec<u8>,
+    data: Vec<u8>,
     pub limit: u64,
     /// Memory sizes checkpoint for each depth
-    pub msizes: Vec<usize>,
+    msizes: Vec<usize>,
     current_slice: *mut [u8],
     current_len: usize,
 }
@@ -26,63 +25,42 @@ impl SharedMemory {
         let base_offset = self.msizes.last().unwrap_or(&0);
         let last_slice_offset = self.current_len;
 
-        self.msizes.push(base_offset + last_slice_offset);
+        let new_msize = base_offset + last_slice_offset;
 
-        let new_msize = self.msizes.last().unwrap();
+        self.msizes.push(new_msize);
 
-        let range = if new_msize == &0 {
-            0..
-        } else {
-            new_msize + 1..
-        };
+        let range = new_msize..;
 
         self.current_slice = &mut self.data[range];
         self.current_len = 0;
     }
 
-    pub fn new(gas_limit: u64, memory_limit: Option<u64>) -> Self {
-        let upper_bound = ((589_312 + 512 * gas_limit) as f64).sqrt() - 768_f64;
-        let limit = if let Some(mlimit) = memory_limit {
-            mlimit
+    pub fn free_memory(&mut self) {
+        if let Some(old_size) = self.msizes.pop() {
+            self.resize(old_size);
+            let last = *self.msizes.last().unwrap_or(&0);
+            self.current_slice = &mut self.data[last..];
+            self.current_len = old_size - last;
         } else {
-            upper_bound as u64
-        };
-        // self.data = Vec::with_capacity(upper_bound as usize);
-        let mut data = vec![0; limit as usize];
-        let msizes = vec![0_usize; 1024];
+            panic!()
+        }
+    }
+
+    pub fn new(_gas_limit: u64, _memory_limit: Option<u64>) -> Self {
+        // https://2π.com/22/eth-max-mem/
+        // let mut upper_bound =
+        //     512 * 2_f32.sqrt() as isize * (gas_limit as f64 + 1151_f64).sqrt() as isize - 48 * 512;
+
+        let mut data = vec![0; u32::MAX as usize];
+        let msizes = Vec::with_capacity(1024);
         let current_slice: *mut [u8] = &mut data[..];
         SharedMemory {
             data,
-            limit,
+            limit: u64::MAX,
             msizes,
             current_slice,
             current_len: 0,
         }
-    }
-
-    /// Resize the memory. asume that we already checked if
-    /// we have enought gas to resize this vector and that we made new_size as multiply of 32
-    pub fn resize(&mut self, new_size: usize) {
-        if new_size as u64 >= self.limit {
-            panic!("Max limit reached")
-        }
-
-        let range = if new_size > self.current_len {
-            // extend with zeros
-            self.current_len + 1..=new_size
-        } else {
-            // truncate
-            new_size..=self.current_len
-        };
-
-        self.get_current_slice_mut()[range]
-            .iter_mut()
-            .for_each(|byte| *byte = 0);
-        self.current_len = new_size;
-    }
-
-    pub fn effective_len(&self) -> usize {
-        self.current_len
     }
 
     /// Get the length of the current memory range.
@@ -98,6 +76,27 @@ impl SharedMemory {
     /// Return the full memory.
     pub fn data(&self) -> &[u8] {
         self.get_current_slice()
+    }
+
+    /// Resize the memory. assume that we already checked if
+    /// we have enought gas to resize this vector and that we made new_size as multiply of 32
+    pub fn resize(&mut self, new_size: usize) {
+        if new_size as u64 >= self.limit {
+            panic!("Max limit reached")
+        }
+
+        let range = if new_size > self.current_len {
+            // extend with zeros
+            self.current_len..new_size
+        } else {
+            // truncate
+            new_size..self.current_len
+        };
+
+        self.get_current_slice_mut()[range]
+            .iter_mut()
+            .for_each(|byte| *byte = 0);
+        self.current_len = new_size;
     }
 
     /// Get memory region at given offset. Dont check offset and size
@@ -163,8 +162,202 @@ impl SharedMemory {
     }
 }
 
-#[inline]
-pub(crate) fn next_multiple_of_32(x: usize) -> Option<usize> {
-    let r = x.bitand(31).not().wrapping_add(1).bitand(31);
-    x.checked_add(r)
+// #[inline]
+// pub(crate) fn next_multiple_of_32(x: usize) -> Option<usize> {
+//     let r = x.bitand(31).not().wrapping_add(1).bitand(31);
+//     x.checked_add(r)
+// }
+
+#[cfg(test)]
+mod tests {
+    use core::{cell::RefCell, u8};
+
+    use alloc::rc::Rc;
+    use ruint::aliases::U256;
+
+    use super::SharedMemory;
+
+    // #[test]
+    // fn new() {
+    //     let gas_limit = 100_000;
+    //     let upper_bound = (512
+    //         * 2_f32.sqrt() as isize
+    //         * (gas_limit as f64 + 1151_f64).sqrt() as isize
+    //         - 48 * 512) as usize;
+    //     let mem = SharedMemory::new(gas_limit, None);
+    //
+    //     assert_eq!(mem.data.len(), upper_bound);
+    //     assert_eq!(mem.get_current_slice().len(), upper_bound);
+    //     assert_eq!(mem.current_len, 0);
+    // }
+
+    #[test]
+    fn use_new_memory_1() {
+        let mut mem = SharedMemory::new(100_000, None);
+
+        mem.use_new_memory();
+        assert_eq!(mem.len(), 0);
+        assert_eq!(mem.msizes, vec![0]);
+        assert_eq!(mem.len(), 0);
+        assert_eq!(mem.get_current_slice().len(), mem.data.len());
+    }
+
+    #[test]
+    fn set() {
+        let mut mem = SharedMemory::new(100_000, None);
+        mem.use_new_memory();
+
+        mem.set(32, &U256::MAX.to_le_bytes::<32>());
+        assert_eq!(
+            mem.get_current_slice()[32..64].to_vec(),
+            U256::MAX.to_le_bytes::<32>().to_vec()
+        );
+    }
+
+    #[test]
+    fn set_data() {
+        let mut mem = SharedMemory::new(100_000, None);
+        mem.use_new_memory();
+
+        mem.set_data(32, 0, 8, &U256::MAX.to_le_bytes::<32>());
+        assert_eq!(
+            mem.get_current_slice()[32..40].to_vec(),
+            [u8::MAX; 8].to_vec()
+        );
+    }
+
+    #[test]
+    fn set_byte() {
+        let mut mem = SharedMemory::new(100_000, None);
+        mem.use_new_memory();
+        unsafe {
+            mem.set_byte(2, 8);
+            mem.set_byte(1, 7);
+            mem.set_byte(0, 6);
+        };
+        assert_eq!(mem.get_current_slice()[0], 6);
+        assert_eq!(mem.get_current_slice()[1], 7);
+        assert_eq!(mem.get_current_slice()[2], 8);
+    }
+
+    #[test]
+    fn set_u256() {
+        let mut mem = SharedMemory::new(100_000, None);
+        mem.use_new_memory();
+
+        mem.set_u256(32, U256::MAX);
+        assert_ne!(
+            mem.get_current_slice()[0..32],
+            U256::MAX.to_le_bytes::<32>()
+        );
+        assert_eq!(
+            mem.get_current_slice()[32..64],
+            U256::MAX.to_le_bytes::<32>()
+        );
+    }
+
+    #[test]
+    fn resize_1() {
+        let mut mem = SharedMemory::new(100_000, None);
+        mem.use_new_memory();
+
+        mem.set_u256(0, U256::MAX);
+        mem.resize(32);
+        assert_eq!(
+            mem.get_current_slice()[..32],
+            U256::ZERO.to_le_bytes::<32>()
+        );
+        assert_eq!(mem.len(), 32);
+    }
+
+    #[test]
+    fn use_new_memory_2() {
+        let mut mem = SharedMemory::new(100_000, None);
+        mem.use_new_memory();
+
+        // mstore(0, U256::MAX) equivalent
+        mem.resize(32);
+        assert_eq!(mem.len(), 32);
+        mem.set_u256(0, U256::MAX);
+
+        // new depth
+        mem.use_new_memory();
+        assert_eq!(mem.msizes.len(), 2);
+        assert_eq!(mem.msizes[1], 32);
+
+        mem.set_u256(0, U256::MAX);
+        assert_eq!(
+            mem.data.get(32..64).unwrap(),
+            mem.get_current_slice()[..32].to_vec(),
+        );
+        assert_eq!(
+            mem.get_current_slice()[..32].to_vec(),
+            U256::MAX.to_le_bytes::<32>().to_vec()
+        );
+
+        mem.free_memory();
+        assert_eq!(
+            mem.data.get(..32).unwrap(),
+            mem.get_current_slice()[..32].to_vec(),
+        );
+        assert_eq!(
+            mem.data()[32..64].to_vec(),
+            U256::ZERO.to_le_bytes::<32>().to_vec()
+        );
+
+        assert_eq!(mem.len(), 32);
+        assert_eq!(mem.msizes.len(), 1);
+        assert_eq!(mem.msizes[0], 0);
+        assert_eq!(
+            mem.get_current_slice()[..32].to_vec(),
+            U256::MAX.to_le_bytes::<32>().to_vec()
+        );
+    }
+
+    #[test]
+    fn use_new_memory_3() {
+        let mem = Rc::new(RefCell::new(SharedMemory::new(100_000, None)));
+        let mem_1 = Rc::clone(&mem);
+        mem_1.borrow_mut().use_new_memory();
+
+        // mstore(0, U256::MAX) equivalent
+        mem_1.borrow_mut().resize(32);
+        assert_eq!(mem_1.borrow().len(), 32);
+        mem_1.borrow_mut().set_u256(0, U256::MAX);
+
+        // new depth
+        let mem_2 = Rc::clone(&mem);
+        mem_2.borrow_mut().use_new_memory();
+        assert_eq!(mem_2.borrow().msizes.len(), 2);
+        assert_eq!(mem_2.borrow().msizes[1], 32);
+
+        mem_2.borrow_mut().set_u256(0, U256::MAX);
+        assert_eq!(
+            mem_2.borrow().data.get(32..64).unwrap(),
+            mem_2.borrow().get_current_slice()[..32].to_vec(),
+        );
+        assert_eq!(
+            mem_2.borrow().get_current_slice()[..32].to_vec(),
+            U256::MAX.to_le_bytes::<32>().to_vec()
+        );
+
+        mem_2.borrow_mut().free_memory();
+        drop(mem_2);
+        assert_eq!(
+            mem_1.borrow().data.get(..32).unwrap(),
+            mem_1.borrow().get_current_slice()[..32].to_vec(),
+        );
+        assert_eq!(
+            mem_1.borrow().data()[32..64].to_vec(),
+            U256::ZERO.to_le_bytes::<32>().to_vec()
+        );
+
+        assert_eq!(mem_1.borrow().len(), 32);
+        assert_eq!(mem_1.borrow().msizes.len(), 1);
+        assert_eq!(mem_1.borrow().msizes[0], 0);
+        assert_eq!(
+            mem_1.borrow().get_current_slice()[..32].to_vec(),
+            U256::MAX.to_le_bytes::<32>().to_vec()
+        );
+    }
 }

--- a/crates/primitives/src/shared_memory.rs
+++ b/crates/primitives/src/shared_memory.rs
@@ -106,6 +106,15 @@ impl SharedMemory {
         &self.get_current_slice()[offset..offset + size]
     }
 
+    /// Set memory region at given offset
+    ///
+    /// # Safety
+    /// The caller is responsible for checking the offset and value
+    #[inline(always)]
+    pub unsafe fn set_byte(&mut self, index: usize, byte: u8) {
+        self.get_current_slice_mut()[index] = byte;
+    }
+
     #[inline(always)]
     pub fn set_u256(&mut self, index: usize, value: U256) {
         self.get_current_slice_mut()[index..index + 32]

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -589,10 +589,15 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
             shared_memory,
         ));
 
-        interpreter.shared_memory.borrow_mut().use_new_memory();
-
         #[cfg(not(feature = "memory_limit"))]
-        let mut interpreter = Box::new(Interpreter::new(contract, gas_limit, is_static));
+        let mut interpreter = Box::new(Interpreter::new(
+            contract,
+            gas_limit,
+            is_static,
+            shared_memory,
+        ));
+
+        interpreter.shared_memory.borrow_mut().use_new_memory();
 
         if INSPECT {
             self.inspector

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -746,10 +746,11 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
                 inputs.is_static,
                 shared_memory,
             );
+            let return_value = interpreter.return_value();
             CallResult {
                 result: exit_reason,
                 gas: interpreter.gas,
-                return_value: interpreter.return_value(),
+                return_value,
             }
         } else {
             CallResult {

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -13,9 +13,12 @@ use crate::primitives::{
 };
 use crate::{db::Database, journaled_state::JournaledState, precompile, Inspector};
 use alloc::boxed::Box;
+use alloc::rc::Rc;
 use alloc::vec::Vec;
+use core::cell::RefCell;
 use core::{cmp::min, marker::PhantomData};
 use revm_interpreter::gas::initial_tx_gas;
+use revm_interpreter::primitives::shared_memory::SharedMemory;
 use revm_interpreter::MAX_CODE_SIZE;
 use revm_precompile::{Precompile, Precompiles};
 
@@ -160,6 +163,8 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact<DB::Error>
 
         let transact_gas_limit = tx_gas_limit - initial_gas_spend;
 
+        let shared_memory = Rc::new(RefCell::new(SharedMemory::new(transact_gas_limit, None)));
+
         // call inner handling of call/create
         let (exit_reason, ret_gas, output) = match self.data.env.tx.transact_to {
             TransactTo::Call(address) => {
@@ -167,34 +172,40 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact<DB::Error>
                 caller_account.info.nonce =
                     caller_account.info.nonce.checked_add(1).unwrap_or(u64::MAX);
 
-                let (exit, gas, bytes) = self.call(&mut CallInputs {
-                    contract: address,
-                    transfer: Transfer {
-                        source: tx_caller,
-                        target: address,
-                        value: tx_value,
+                let (exit, gas, bytes) = self.call(
+                    &mut CallInputs {
+                        contract: address,
+                        transfer: Transfer {
+                            source: tx_caller,
+                            target: address,
+                            value: tx_value,
+                        },
+                        input: tx_data,
+                        gas_limit: transact_gas_limit,
+                        context: CallContext {
+                            caller: tx_caller,
+                            address,
+                            code_address: address,
+                            apparent_value: tx_value,
+                            scheme: CallScheme::Call,
+                        },
+                        is_static: false,
                     },
-                    input: tx_data,
-                    gas_limit: transact_gas_limit,
-                    context: CallContext {
-                        caller: tx_caller,
-                        address,
-                        code_address: address,
-                        apparent_value: tx_value,
-                        scheme: CallScheme::Call,
-                    },
-                    is_static: false,
-                });
+                    &shared_memory,
+                );
                 (exit, gas, Output::Call(bytes))
             }
             TransactTo::Create(scheme) => {
-                let (exit, address, ret_gas, bytes) = self.create(&mut CreateInputs {
-                    caller: tx_caller,
-                    scheme,
-                    value: tx_value,
-                    init_code: tx_data,
-                    gas_limit: transact_gas_limit,
-                });
+                let (exit, address, ret_gas, bytes) = self.create(
+                    &mut CreateInputs {
+                        caller: tx_caller,
+                        scheme,
+                        value: tx_value,
+                        init_code: tx_data,
+                        gas_limit: transact_gas_limit,
+                    },
+                    &shared_memory,
+                );
                 (exit, ret_gas, Output::Create(bytes, address))
             }
         };
@@ -446,7 +457,11 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
     }
 
     /// EVM create opcode for both initial crate and CREATE and CREATE2 opcodes.
-    fn create_inner(&mut self, inputs: &CreateInputs) -> CreateResult {
+    fn create_inner(
+        &mut self,
+        inputs: &CreateInputs,
+        shared_memory: &Rc<RefCell<SharedMemory>>,
+    ) -> CreateResult {
         // Prepare crate.
         let prepared_create = match self.prepare_create(inputs) {
             Ok(o) => o,
@@ -454,8 +469,12 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
         };
 
         // Create new interpreter and execute initcode
-        let (exit_reason, mut interpreter) =
-            self.run_interpreter(prepared_create.contract, prepared_create.gas.limit(), false);
+        let (exit_reason, mut interpreter) = self.run_interpreter(
+            prepared_create.contract,
+            prepared_create.gas.limit(),
+            false,
+            shared_memory,
+        );
 
         // Host error if present on execution
         match exit_reason {
@@ -558,6 +577,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
         contract: Box<Contract>,
         gas_limit: u64,
         is_static: bool,
+        shared_memory: &Rc<RefCell<SharedMemory>>,
     ) -> (InstructionResult, Box<Interpreter>) {
         // Create inspector
         #[cfg(feature = "memory_limit")]
@@ -566,7 +586,10 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
             gas_limit,
             is_static,
             self.data.env.cfg.memory_limit,
+            shared_memory,
         ));
+
+        interpreter.shared_memory.borrow_mut().use_new_memory();
 
         #[cfg(not(feature = "memory_limit"))]
         let mut interpreter = Box::new(Interpreter::new(contract, gas_limit, is_static));
@@ -697,7 +720,11 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
     }
 
     /// Main contract call of the EVM.
-    fn call_inner(&mut self, inputs: &CallInputs) -> CallResult {
+    fn call_inner(
+        &mut self,
+        inputs: &CallInputs,
+        shared_memory: &Rc<RefCell<SharedMemory>>,
+    ) -> CallResult {
         // Prepare call
         let prepared_call = match self.prepare_call(inputs) {
             Ok(o) => o,
@@ -712,6 +739,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
                 prepared_call.contract,
                 prepared_call.gas.limit(),
                 inputs.is_static,
+                shared_memory,
             );
             CallResult {
                 result: exit_reason,
@@ -868,6 +896,7 @@ impl<'a, GSPEC: Spec, DB: Database + 'a, const INSPECT: bool> Host
     fn create(
         &mut self,
         inputs: &mut CreateInputs,
+        shared_memory: &Rc<RefCell<SharedMemory>>,
     ) -> (InstructionResult, Option<B160>, Gas, Bytes) {
         // Call inspector
         if INSPECT {
@@ -878,7 +907,7 @@ impl<'a, GSPEC: Spec, DB: Database + 'a, const INSPECT: bool> Host
                     .create_end(&mut self.data, inputs, ret, address, gas, out);
             }
         }
-        let ret = self.create_inner(inputs);
+        let ret = self.create_inner(inputs, shared_memory);
         if INSPECT {
             self.inspector.create_end(
                 &mut self.data,
@@ -893,7 +922,11 @@ impl<'a, GSPEC: Spec, DB: Database + 'a, const INSPECT: bool> Host
         }
     }
 
-    fn call(&mut self, inputs: &mut CallInputs) -> (InstructionResult, Gas, Bytes) {
+    fn call(
+        &mut self,
+        inputs: &mut CallInputs,
+        shared_memory: &Rc<RefCell<SharedMemory>>,
+    ) -> (InstructionResult, Gas, Bytes) {
         if INSPECT {
             let (ret, gas, out) = self.inspector.call(&mut self.data, inputs);
             if ret != InstructionResult::Continue {
@@ -902,7 +935,7 @@ impl<'a, GSPEC: Spec, DB: Database + 'a, const INSPECT: bool> Host
                     .call_end(&mut self.data, inputs, gas, ret, out);
             }
         }
-        let ret = self.call_inner(inputs);
+        let ret = self.call_inner(inputs, shared_memory);
         if INSPECT {
             self.inspector.call_end(
                 &mut self.data,

--- a/crates/revm/src/inspector/customprinter.rs
+++ b/crates/revm/src/inspector/customprinter.rs
@@ -38,7 +38,7 @@ impl<DB: Database> Inspector<DB> for CustomPrintTracer {
             interp.gas.refunded(),
             interp.gas.refunded(),
             interp.stack.data(),
-            interp.memory.data().len(),
+            interp.shared_memory.borrow().len(),
         );
 
         self.gas_inspector.step(interp, data);

--- a/crates/revm/src/inspector/tracer_eip3155.rs
+++ b/crates/revm/src/inspector/tracer_eip3155.rs
@@ -63,7 +63,7 @@ impl<DB: Database> Inspector<DB> for TracerEip3155 {
         self.stack = interp.stack.clone();
         self.pc = interp.program_counter();
         self.opcode = interp.current_opcode();
-        self.mem_size = interp.memory.len();
+        self.mem_size = interp.shared_memory.borrow().len();
         self.gas = self.gas_inspector.gas_remaining();
         //
         InstructionResult::Continue


### PR DESCRIPTION
I tried to give a shot to https://github.com/bluealloy/revm/issues/445 just for fun and as a challenge with this draft PR, which is still WIP. 
This introduces a new struct called `SharedMemory` which is indeed shared between calls. I'd like a feedback on my implementation to see what it can done better. 

Here are some implementation choices I made:
- its API matches almost completely the 'old' interpreter `Memory` implementation
- memory is allocated using this estimate https://2π.com/22/eth-max-mem/ (more on this below)
- it has a pointer `current_slice` which is internally used to refer to the portion of data reserved for the current context. This requires two `unsafe` methods `get_current_slice` and `get_current_slice_mut` which deferences the raw pointer
- `current_slice` pointer is updated when entering a new context (which is when a new `Interpreter` instance is created) using the `use_new_memory` method (every name is still WIP too) and when exiting it, which happens when the `return_value` method of `Interpreter` is called
- in order to make `SharedMemory` work properly, it is wrapped in a `Rc` for dealing with recursive calls and with an `RefCell` to allow mutability

Little problem: now test passes because I always allocate `u32::MAX` bytes. If I use the estimation however they fail because some tests have an impressive gas limit (at least 4_503_599_627_349_304), and my system fails to allocate so much memory (34_359_713_280 bytes). I don't really know how to handle this at the moment

Thanks in advance for any feedback!