### PR TITLE
feat(state): Make Bundle extend wipe aware

### DIFF
--- a/crates/revm/src/db/states/bundle_account.rs
+++ b/crates/revm/src/db/states/bundle_account.rs
@@ -91,7 +91,7 @@ impl BundleAccount {
             }
             AccountInfoRevert::RevertTo(info) => self.info = Some(info),
         };
-        // revert stoarge
+        // revert storage
         for (key, slot) in revert.storage {
             match slot {
                 RevertToSlot::Some(value) => {
@@ -109,24 +109,6 @@ impl BundleAccount {
             }
         }
         false
-    }
-
-    /// Extend account with another account.
-    ///
-    /// It is similar with the update but it is done with another BundleAccount.
-    ///
-    /// Original values of acccount and storage stay the same.
-    pub(crate) fn extend(&mut self, other: Self) {
-        self.status = other.status;
-        self.info = other.info;
-        // extend storage
-        for (key, storage_slot) in other.storage {
-            // update present value or insert storage slot.
-            self.storage
-                .entry(key)
-                .or_insert(storage_slot)
-                .present_value = storage_slot.present_value;
-        }
     }
 
     /// Update to new state and generate AccountRevert that if applied to new state will

--- a/crates/revm/src/db/states/bundle_state.rs
+++ b/crates/revm/src/db/states/bundle_state.rs
@@ -295,55 +295,51 @@ impl BundleState {
 
     /// Extend the state with state that is build on top of it.
     ///
-    /// For other state, if there is wipe storage inside `this` copy its state
-    /// to `other` revert (if there is no duplicates of course).
+    /// For other state, if there a wipe storage flag set inside Revert copy the state
+    /// from `this` to `other` revert (if there is no duplicates of course).
     ///
     /// Check if `this` bundle was selfdestroyed if it is and if `other`
-    /// has was selfdestroyed too we need to invalidate second (`other`) wipe flag
+    /// was selfdestroyed too we need to invalidate second (`other`) wipe flag
     /// as wiping from database is done only once and we already transferred
     /// all potentially missing storages to the `other` revert.
     ///
     /// Additionally update the `other` state only if there is no selfdestruct inside
-    // `other` revert.
+    /// `other` revert.
     pub fn extend(&mut self, mut other: Self) {
         // Extend the state.
 
-        // iterate over reverts and if its storage is wiped try to add previous bundle
-        // state as there is potential missing slots.
-        for i in other.reverts.iter_mut() {
-            for (address, revert_account) in i.iter_mut() {
-                if revert_account.wipe_storage {
-                    // If there is wipe storage in other revert
-                    // we need to copy the storage from this revert
-                    // to other revert.
-                    if let Some(account) = self.state.get(address) {
-                        for (key, value) in &account.storage {
-                            revert_account
-                                .storage
-                                .entry(*key)
-                                .or_insert(RevertToSlot::Some(value.present_value));
-                        }
-
-                        // nullify this wipe as database wipe is done in `this`.
-                        if account.was_destroyed() {
-                            revert_account.wipe_storage = false;
-                        }
-                    }
-                }
-            }
-        }
-
-        for (address, other) in other.state {
+        for (address, other_account) in other.state {
             match self.state.entry(address) {
                 hash_map::Entry::Occupied(mut entry) => {
+                    // iterate over reverts and if its storage is wiped try to add previous bundle
+                    // state as there is potential missing slots.
+
                     let this = entry.get_mut();
+                    for (_, revert_account) in other.reverts.iter_mut().flatten() {
+                        if revert_account.wipe_storage {
+                            // If there is wipe storage in other revert
+                            // we need to copy the storage from this revert
+                            // to other revert.
+                            for (key, value) in &this.storage {
+                                revert_account
+                                    .storage
+                                    .entry(*key)
+                                    .or_insert(RevertToSlot::Some(value.present_value));
+                            }
+
+                            // nullify this wipe as database wipe is done in `this`.
+                            if this.was_destroyed() {
+                                revert_account.wipe_storage = false;
+                            }
+                        }
+                    }
                     // if other was destroyed. replace `this` storage with
                     // the `other one.
-                    if other.was_destroyed() {
-                        this.storage = other.storage;
+                    if other_account.was_destroyed() {
+                        this.storage = other_account.storage;
                     } else {
                         // otherwise extend this storage with other
-                        for (key, storage_slot) in other.storage {
+                        for (key, storage_slot) in other_account.storage {
                             // update present value or insert storage slot.
                             this.storage
                                 .entry(key)
@@ -351,12 +347,12 @@ impl BundleState {
                                 .present_value = storage_slot.present_value;
                         }
                     }
-                    this.status = other.status;
-                    this.info = other.info;
+                    this.status = other_account.status;
+                    this.info = other_account.info;
                 }
                 hash_map::Entry::Vacant(entry) => {
                     // just insert if empty
-                    entry.insert(other);
+                    entry.insert(other_account);
                 }
             }
         }

--- a/crates/revm/src/db/states/state.rs
+++ b/crates/revm/src/db/states/state.rs
@@ -502,7 +502,7 @@ mod tests {
                         previous_or_original_value: U256::ZERO,
                         present_value: U256::from(1),
                     }
-                )])
+                )]),
             }),
             "The latest state of the new account is incorrect"
         );
@@ -542,7 +542,7 @@ mod tests {
                             present_value: U256::from(3_000),
                         },
                     ),
-                ])
+                ]),
             }),
             "The latest state of the existing account is incorrect"
         );
@@ -813,7 +813,7 @@ mod tests {
                             present_value: U256::from(2),
                         },
                     )]),
-                    status: AccountStatus::DestroyedChanged
+                    status: AccountStatus::DestroyedChanged,
                 }
             )])
         );
@@ -826,7 +826,7 @@ mod tests {
                     account: AccountInfoRevert::DoNothing,
                     previous_status: AccountStatus::Loaded,
                     storage: HashMap::from([(slot2, RevertToSlot::Destroyed)]),
-                    wipe_storage: true
+                    wipe_storage: true,
                 }
             )])])
         )


### PR DESCRIPTION
Previously this was not the case and updating storage every time was a bug.

If both this and other bundle are presents. We iterate over `other` reverts to find if it has wipe flag, if it is true, we take the bundle state of `this` and expand revert with this state (If there are slots missing).

We nullify `other` wipe flag if `this` wipe flag is present. 

And replace the state if `other` wipe flag is present, else we just extend `this` plain state.