### PR TITLE
Matt/review 1

### DIFF
--- a/crates/revm/src/db/states/bundle_state.rs
+++ b/crates/revm/src/db/states/bundle_state.rs
@@ -8,7 +8,7 @@ use revm_interpreter::primitives::{
     AccountInfo, Bytecode, HashMap, StorageSlot, B160, B256, KECCAK_EMPTY, U256,
 };
 
-/// Bundle state contain only values that got changed
+/// Bundle state contains only values that got changed
 ///
 /// For every account it contains both original and present state.
 /// This is needed to decide if there were any changes to the account.
@@ -365,7 +365,7 @@ impl BundleState {
 
     /// This will return detached lower part of reverts
     ///
-    /// Note that plain state will stay the same and returned BundleState
+    /// Note that plain state will stay the same and returned [BundleState]
     /// will contain only reverts and will be considered broken.
     ///
     /// If given number is greater then number of reverts then None is returned.

--- a/crates/revm/src/db/states/cache_account.rs
+++ b/crates/revm/src/db/states/cache_account.rs
@@ -5,6 +5,8 @@ use super::{
 use revm_interpreter::primitives::{AccountInfo, KECCAK_EMPTY, U256};
 use revm_precompile::HashMap;
 
+// mattsse: can we rephrase this a bit? basically this is an account read from the database that represents the current state of the account inside the database?
+
 /// Cache account is to store account from database be able
 /// to be updated from output of revm and while doing that
 /// create TransitionAccount needed for BundleState.

--- a/crates/revm/src/db/states/changes.rs
+++ b/crates/revm/src/db/states/changes.rs
@@ -15,9 +15,11 @@ pub struct StateChangeset {
     pub contracts: Vec<(B256, Bytecode)>,
 }
 
+// mattsse: a lot of the type aliases are very hard to read, this looks like Address with some bool marker and a list of storage slots with values, but it is not obvious, Personally I'd prefer structs for these tuples or at the very least docs what these types represent.
 /// Storage changeset
 pub type StorageChangeset = Vec<(B160, (bool, Vec<(U256, U256)>))>;
 
+// mattsse: what is a StateRevert exactly?
 #[derive(Clone, Debug, Default)]
 pub struct StateReverts {
     /// Vector of account presorted by address, with removed contracts bytecode

--- a/crates/revm/src/db/states/reverts.rs
+++ b/crates/revm/src/db/states/reverts.rs
@@ -93,6 +93,7 @@ impl AccountRevert {
     }
 }
 
+// mattsse: what does this exactly represent? the action that needs to be taken on revert? maybe rename?
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub enum AccountInfoRevert {
     #[default]

--- a/crates/revm/src/db/states/transition_account.rs
+++ b/crates/revm/src/db/states/transition_account.rs
@@ -2,6 +2,9 @@ use super::{AccountRevert, BundleAccount, StorageWithOriginalValues};
 use crate::db::AccountStatus;
 use revm_interpreter::primitives::{hash_map, AccountInfo, Bytecode, B256};
 
+// mattsse: should this reference `BundleState` instead? unclear what Block state is
+// Does `transition` mean  the state of an account after a transaction.
+
 /// Account Created when EVM state is merged to cache state.
 /// And it is send to Block state.
 ///


### PR DESCRIPTION
overall this abstraction is very easy to follow.

most of my comments concern docs, it would be useful to give an overview of the used terms

* what exactly is a Bundle?
* what is an Transition
* and what is a Revert

especially the revert term could potentially be confusing, from what I understand is that this is the inverse of an applied change, so an applied change can be "reverted", which makes sense. But since "revert" is also used by "reverted" transactions, this could be confusing at first.

One suggestion I have regarding the various type aliases is to replace tuples of 3 or more fields with new types, just to make it clearer what exactly these types represent. especially since a lot of them are public types. 

my personal preference for map aliases like
`pub type StorageWithOriginalValues = HashMap<U256, StorageSlot>;` is to avoid them or wrap in a new type because I find them very hard to work with, because I always end up jumping to the alias definition. 