### PR TITLE
fix(state): Regresion, remove present info on selfdestruct

### DIFF
--- a/crates/revm/src/db/states/bundle_account.rs
+++ b/crates/revm/src/db/states/bundle_account.rs
@@ -222,6 +222,7 @@ impl BundleAccount {
                     _ => unreachable!("Invalid transition to Destroyed account from: {self:?} to {updated_info:?} {updated_status:?}"),
                 };
                 self.status = AccountStatus::Destroyed;
+                self.info = None;
                 // set present to destroyed.
                 Some(ret)
             }


### PR DESCRIPTION
Introduced with removal of this line: https://github.com/bluealloy/revm/commit/aee1d1c657673a48f5293a68a7023ee2fa513956#diff-c5993d59b61489bc36107b91d05b568e09d8213c9a03087d68343847461d39c5L235

We should have set the destroyed account to `None`