### PR TITLE
fix(state): retain destroyed account status on bundle extend

### DIFF
--- a/crates/revm/src/db/states/account_status.rs
+++ b/crates/revm/src/db/states/account_status.rs
@@ -15,6 +15,26 @@ pub enum AccountStatus {
 }
 
 impl AccountStatus {
+    /// Transition to other state while preserving
+    /// invariance of this state.
+    ///
+    /// It this account was Destroyed and other account is not:
+    /// we should mark extended account as destroyed too.
+    /// and as other account had some changes, extended account
+    /// should be marked as DestroyedChanged.
+    ///
+    /// If both account are not destroyed and if this account is in memory:
+    /// this means that extended account is in memory too.
+    ///
+    /// otherwise if both are destroyed or other is destroyed:
+    /// set other status to extended account.
+    pub fn transition(&mut self, other: Self) {
+        *self = match (self.was_destroyed(), other.was_destroyed()) {
+            (true, false) => Self::DestroyedChanged,
+            (false, false) if *self == Self::InMemoryChange => Self::InMemoryChange,
+            _ => other,
+        };
+    }
     /// Account is not modified and just loaded from database.
     pub fn not_modified(&self) -> bool {
         matches!(

--- a/crates/revm/src/db/states/bundle_state.rs
+++ b/crates/revm/src/db/states/bundle_state.rs
@@ -366,27 +366,7 @@ impl BundleState {
                         }
                     }
                     this.info = other_account.info;
-                    // if this status was destroyed this means we know all the storages
-                    // and new status need to contains that "Destroyed" flag.
-                    this.status = match (
-                        this.status.was_destroyed(),
-                        other_account.status.was_destroyed(),
-                    ) {
-                        // It this account was Destroyed and other
-                        // account is not, we should mark extended account as destroyed too.
-                        // and as other account had some changes, extended account
-                        // should be marked as DestroyedChanged.
-                        (true, false) => AccountStatus::DestroyedChanged,
-                        // If both account are not destroyed
-                        // and if this account is in memory
-                        // this means that extended account is in memory too.
-                        (false, false) if this.status == AccountStatus::InMemoryChange => {
-                            AccountStatus::InMemoryChange
-                        }
-                        // otherwise if both are destroyed or other is destroyed.
-                        // set other status to extended account.
-                        _ => other_account.status,
-                    };
+                    this.status.transition(other_account.status);
                 }
                 hash_map::Entry::Vacant(entry) => {
                     // just insert if empty


### PR DESCRIPTION
Retail destroyed account status when extending bundle state.

This handles extended account status in a more precise way.