### PR TITLE
Removed the last dependencies breaking no-std build.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,15 +258,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,12 +584,6 @@ dependencies = [
  "cast",
  "itertools",
 ]
-
-[[package]]
-name = "critical-section"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "crossbeam-channel"
@@ -1773,10 +1758,6 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-dependencies = [
- "atomic-polyfill",
- "critical-section",
-]
 
 [[package]]
 name = "oorandom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,8 +2412,8 @@ version = "2.0.3"
 dependencies = [
  "hex",
  "k256",
+ "lazy_static",
  "num",
- "once_cell",
  "revm-primitives",
  "ripemd",
  "secp256k1",
@@ -2444,7 +2444,6 @@ dependencies = [
  "ruint",
  "serde",
  "sha3",
- "to-binary",
 ]
 
 [[package]]
@@ -3147,15 +3146,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "to-binary"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424552bc848fd1afbcd81f0e8a54b7401b90fd81bb418655ad6dc6d0823bbe3"
-dependencies = [
- "hex",
-]
 
 [[package]]
 name = "tokio"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,6 +692,12 @@ dependencies = [
  "cast",
  "itertools",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "crossbeam-channel"
@@ -1886,6 +1901,10 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+dependencies = [
+ "atomic-polyfill",
+ "critical-section",
+]
 
 [[package]]
 name = "oorandom"
@@ -2383,7 +2402,6 @@ dependencies = [
  "futures",
  "hex",
  "hex-literal",
- "once_cell",
  "rayon",
  "revm-interpreter",
  "revm-precompile",
@@ -2412,8 +2430,8 @@ version = "2.0.3"
 dependencies = [
  "hex",
  "k256",
- "lazy_static",
  "num",
+ "once_cell",
  "revm-primitives",
  "ripemd",
  "secp256k1",

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -13,6 +13,7 @@ revm-primitives = { path = "../primitives", version = "1.1.2", default-features 
 bn = { package = "substrate-bn", version = "0.6", default-features = false }
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 num = { version = "0.4.0", default-features = false, features = ["alloc"] }
+once_cell = { version = "1.17", default-features = false }
 ripemd = { version = "0.1", default-features = false }
 secp256k1 = { version = "0.27.0", default-features = false, features = [
     "alloc",
@@ -20,13 +21,14 @@ secp256k1 = { version = "0.27.0", default-features = false, features = [
 ], optional = true }
 sha2 = { version = "0.10.5", default-features = false }
 sha3 = { version = "0.10.7", default-features = false }
-lazy_static = "1.4"
 
 [dev-dependencies]
 hex = "0.4"
 
 [features]
-default = ["secp256k1"]
+default = ["std", "secp256k1"]
+std = ["once_cell/std"]
+critical-section = ["once_cell/critical-section"]
 # secp256k1 is used as faster alternative to k256 lib. And in most cases should be default.
 # Only problem that it has, it fails to build for wasm target on windows and mac as it is c lib.
 # If you dont require wasm on win/mac, i would recommend its usage.

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -13,7 +13,7 @@ revm-primitives = { path = "../primitives", version = "1.1.2", default-features 
 bn = { package = "substrate-bn", version = "0.6", default-features = false }
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 num = { version = "0.4.0", default-features = false, features = ["alloc"] }
-once_cell = { version = "1.17", default-features = false }
+once_cell = { version = "1.17", default-features = false, features = ["alloc"] }
 ripemd = { version = "0.1", default-features = false }
 secp256k1 = { version = "0.27.0", default-features = false, features = [
     "alloc",
@@ -26,9 +26,7 @@ sha3 = { version = "0.10.7", default-features = false }
 hex = "0.4"
 
 [features]
-default = ["std", "secp256k1"]
-std = ["once_cell/std"]
-critical-section = ["once_cell/critical-section"]
+default = ["secp256k1"]
 # secp256k1 is used as faster alternative to k256 lib. And in most cases should be default.
 # Only problem that it has, it fails to build for wasm target on windows and mac as it is c lib.
 # If you dont require wasm on win/mac, i would recommend its usage.

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -9,15 +9,18 @@ repository = "https://github.com/bluealloy/revm"
 version = "2.0.3"
 
 [dependencies]
-revm-primitives = { path = "../primitives", version="1.1.2", default-features = false }
+revm-primitives = { path = "../primitives", version = "1.1.2", default-features = false }
 bn = { package = "substrate-bn", version = "0.6", default-features = false }
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 num = { version = "0.4.0", default-features = false, features = ["alloc"] }
-once_cell = "1.17"
 ripemd = { version = "0.1", default-features = false }
-secp256k1 = { version = "0.27.0", default-features = false, features = ["alloc", "recovery"], optional = true }
+secp256k1 = { version = "0.27.0", default-features = false, features = [
+    "alloc",
+    "recovery",
+], optional = true }
 sha2 = { version = "0.10.5", default-features = false }
 sha3 = { version = "0.10.7", default-features = false }
+lazy_static = "1.4"
 
 [dev-dependencies]
 hex = "0.4"
@@ -28,4 +31,3 @@ default = ["secp256k1"]
 # Only problem that it has, it fails to build for wasm target on windows and mac as it is c lib.
 # If you dont require wasm on win/mac, i would recommend its usage.
 secp256k1 = ["dep:secp256k1"]
-

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -10,6 +10,10 @@ mod identity;
 mod modexp;
 mod secp256k1;
 
+#[cfg(not(any(feature = "std", feature = "critical-section")))]
+compile_error!("Either feature \"std\" or \"critical-section\" must be enabled, otherwise OnceCell is unavailable.");
+
+use once_cell::sync::OnceCell;
 pub use primitives::{
     precompile::{PrecompileError as Error, *},
     Bytes, HashMap,
@@ -22,7 +26,6 @@ pub type B256 = [u8; 32];
 
 use alloc::vec::Vec;
 use core::fmt;
-use lazy_static::lazy_static;
 
 pub fn calc_linear_cost_u32(len: usize, base: u64, word: u64) -> u64 {
     (len as u64 + 32 - 1) / 32 * word + base
@@ -119,88 +122,76 @@ impl SpecId {
 
 impl Precompiles {
     pub fn homestead() -> &'static Self {
-        lazy_static! {
-            static ref INSTANCE: Precompiles = {
-                let fun = [
-                    secp256k1::ECRECOVER,
-                    hash::SHA256,
-                    hash::RIPEMD160,
-                    identity::FUN,
-                ]
-                .into_iter()
-                .map(From::from)
-                .collect();
-                Precompiles { fun }
-            };
-        }
-
-        &INSTANCE
+        static INSTANCE: OnceCell<Precompiles> = OnceCell::new();
+        INSTANCE.get_or_init(|| {
+            let fun = [
+                secp256k1::ECRECOVER,
+                hash::SHA256,
+                hash::RIPEMD160,
+                identity::FUN,
+            ]
+            .into_iter()
+            .map(From::from)
+            .collect();
+            Self { fun }
+        })
     }
 
     pub fn byzantium() -> &'static Self {
-        lazy_static! {
-            static ref INSTANCE: Precompiles = {
-                let mut precompiles = Precompiles::homestead().clone();
-                precompiles.fun.extend(
-                    [
-                        // EIP-196: Precompiled contracts for addition and scalar multiplication on the elliptic curve alt_bn128.
-                        // EIP-197: Precompiled contracts for optimal ate pairing check on the elliptic curve alt_bn128.
-                        bn128::add::BYZANTIUM,
-                        bn128::mul::BYZANTIUM,
-                        bn128::pair::BYZANTIUM,
-                        // EIP-198: Big integer modular exponentiation.
-                        modexp::BYZANTIUM,
-                    ]
-                    .into_iter()
-                    .map(From::from),
-                );
-                precompiles
-            };
-        }
-
-        &INSTANCE
+        static INSTANCE: OnceCell<Precompiles> = OnceCell::new();
+        INSTANCE.get_or_init(|| {
+            let mut precompiles = Self::homestead().clone();
+            precompiles.fun.extend(
+                [
+                    // EIP-196: Precompiled contracts for addition and scalar multiplication on the elliptic curve alt_bn128.
+                    // EIP-197: Precompiled contracts for optimal ate pairing check on the elliptic curve alt_bn128.
+                    bn128::add::BYZANTIUM,
+                    bn128::mul::BYZANTIUM,
+                    bn128::pair::BYZANTIUM,
+                    // EIP-198: Big integer modular exponentiation.
+                    modexp::BYZANTIUM,
+                ]
+                .into_iter()
+                .map(From::from),
+            );
+            precompiles
+        })
     }
 
     pub fn istanbul() -> &'static Self {
-        lazy_static! {
-            static ref INSTANCE: Precompiles = {
-                let mut precompiles = Precompiles::byzantium().clone();
-                precompiles.fun.extend(
-                    [
-                        // EIP-152: Add BLAKE2 compression function `F` precompile.
-                        blake2::FUN,
-                        // EIP-1108: Reduce alt_bn128 precompile gas costs.
-                        bn128::add::ISTANBUL,
-                        bn128::mul::ISTANBUL,
-                        bn128::pair::ISTANBUL,
-                    ]
-                    .into_iter()
-                    .map(From::from),
-                );
-                precompiles
-            };
-        }
-
-        &INSTANCE
+        static INSTANCE: OnceCell<Precompiles> = OnceCell::new();
+        INSTANCE.get_or_init(|| {
+            let mut precompiles = Self::byzantium().clone();
+            precompiles.fun.extend(
+                [
+                    // EIP-152: Add BLAKE2 compression function `F` precompile.
+                    blake2::FUN,
+                    // EIP-1108: Reduce alt_bn128 precompile gas costs.
+                    bn128::add::ISTANBUL,
+                    bn128::mul::ISTANBUL,
+                    bn128::pair::ISTANBUL,
+                ]
+                .into_iter()
+                .map(From::from),
+            );
+            precompiles
+        })
     }
 
     pub fn berlin() -> &'static Self {
-        lazy_static! {
-            static ref INSTANCE: Precompiles = {
-                let mut precompiles = Precompiles::istanbul().clone();
-                precompiles.fun.extend(
-                    [
-                        // EIP-2565: ModExp Gas Cost.
-                        modexp::BERLIN,
-                    ]
-                    .into_iter()
-                    .map(From::from),
-                );
-                precompiles
-            };
-        }
-
-        &INSTANCE
+        static INSTANCE: OnceCell<Precompiles> = OnceCell::new();
+        INSTANCE.get_or_init(|| {
+            let mut precompiles = Self::istanbul().clone();
+            precompiles.fun.extend(
+                [
+                    // EIP-2565: ModExp Gas Cost.
+                    modexp::BERLIN,
+                ]
+                .into_iter()
+                .map(From::from),
+            );
+            precompiles
+        })
     }
 
     pub fn latest() -> &'static Self {

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -10,10 +10,7 @@ mod identity;
 mod modexp;
 mod secp256k1;
 
-#[cfg(not(any(feature = "std", feature = "critical-section")))]
-compile_error!("Either feature \"std\" or \"critical-section\" must be enabled, otherwise OnceCell is unavailable.");
-
-use once_cell::sync::OnceCell;
+use once_cell::race::OnceBox;
 pub use primitives::{
     precompile::{PrecompileError as Error, *},
     Bytes, HashMap,
@@ -24,7 +21,7 @@ pub use revm_primitives as primitives;
 pub type B160 = [u8; 20];
 pub type B256 = [u8; 32];
 
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 
 pub fn calc_linear_cost_u32(len: usize, base: u64, word: u64) -> u64 {
@@ -122,7 +119,7 @@ impl SpecId {
 
 impl Precompiles {
     pub fn homestead() -> &'static Self {
-        static INSTANCE: OnceCell<Precompiles> = OnceCell::new();
+        static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
         INSTANCE.get_or_init(|| {
             let fun = [
                 secp256k1::ECRECOVER,
@@ -133,14 +130,14 @@ impl Precompiles {
             .into_iter()
             .map(From::from)
             .collect();
-            Self { fun }
+            Box::new(Self { fun })
         })
     }
 
     pub fn byzantium() -> &'static Self {
-        static INSTANCE: OnceCell<Precompiles> = OnceCell::new();
+        static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
         INSTANCE.get_or_init(|| {
-            let mut precompiles = Self::homestead().clone();
+            let mut precompiles = Box::new(Self::homestead().clone());
             precompiles.fun.extend(
                 [
                     // EIP-196: Precompiled contracts for addition and scalar multiplication on the elliptic curve alt_bn128.
@@ -159,9 +156,9 @@ impl Precompiles {
     }
 
     pub fn istanbul() -> &'static Self {
-        static INSTANCE: OnceCell<Precompiles> = OnceCell::new();
+        static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
         INSTANCE.get_or_init(|| {
-            let mut precompiles = Self::byzantium().clone();
+            let mut precompiles = Box::new(Self::byzantium().clone());
             precompiles.fun.extend(
                 [
                     // EIP-152: Add BLAKE2 compression function `F` precompile.
@@ -179,9 +176,9 @@ impl Precompiles {
     }
 
     pub fn berlin() -> &'static Self {
-        static INSTANCE: OnceCell<Precompiles> = OnceCell::new();
+        static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
         INSTANCE.get_or_init(|| {
-            let mut precompiles = Self::istanbul().clone();
+            let mut precompiles = Box::new(Self::istanbul().clone());
             precompiles.fun.extend(
                 [
                     // EIP-2565: ModExp Gas Cost.

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -14,18 +14,22 @@ bytes = { version = "1.4", default-features = false }
 hashbrown = "0.14"
 primitive-types = { version = "0.12", default-features = false }
 rlp = { version = "0.5", default-features = false } # used for create2 address calculation
-ruint = { version = "1.8.0", features = ["primitive-types", "rlp"] }
+ruint = { version = "1.8.0", default-features = false, features = [
+    "primitive-types",
+    "rlp",
+] }
 auto_impl = "1.1"
 bitvec = { version = "1", default-features = false, features = ["alloc"] }
 bitflags = { version = "2.4.0", default-features = false }
 
 # bits B256 B160 crate
-fixed-hash = { version = "0.8", default-features = false, features = ["rustc-hex"] }
+fixed-hash = { version = "0.8", default-features = false, features = [
+    "rustc-hex",
+] }
 
 #utility
 hex-literal = "0.4"
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
-to-binary = "0.4"
 derive_more = "0.99"
 enumn = "0.1"
 
@@ -42,7 +46,12 @@ proptest-derive = { version = "0.3", optional = true }
 arbitrary = { version = "1.3", features = ["derive"] }
 proptest = "1.1"
 proptest-derive = "0.3"
-ruint = { version = "1.10.1", features = ["primitive-types", "rlp", "proptest", "arbitrary"] }
+ruint = { version = "1.10.1", features = [
+    "primitive-types",
+    "rlp",
+    "proptest",
+    "arbitrary",
+] }
 
 [features]
 default = ["std"]

--- a/crates/primitives/src/bytecode.rs
+++ b/crates/primitives/src/bytecode.rs
@@ -13,7 +13,7 @@ pub struct JumpMap(pub Arc<BitVec<u8>>);
 impl Debug for JumpMap {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("JumpMap")
-            .field("map", &hex::encode(&self.0.as_raw_slice()))
+            .field("map", &hex::encode(self.0.as_raw_slice()))
             .finish()
     }
 }

--- a/crates/primitives/src/bytecode.rs
+++ b/crates/primitives/src/bytecode.rs
@@ -13,7 +13,7 @@ pub struct JumpMap(pub Arc<BitVec<u8>>);
 impl Debug for JumpMap {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("JumpMap")
-            .field("map", &self.0.as_raw_slice())
+            .field("map", &hex::encode(&self.0.as_raw_slice()))
             .finish()
     }
 }

--- a/crates/primitives/src/bytecode.rs
+++ b/crates/primitives/src/bytecode.rs
@@ -4,7 +4,6 @@ use bitvec::prelude::{bitvec, Lsb0};
 use bitvec::vec::BitVec;
 use bytes::Bytes;
 use core::fmt::Debug;
-use to_binary::BinaryString;
 
 /// A map of valid `jump` destinations.
 #[derive(Clone, Eq, PartialEq, Default)]
@@ -14,7 +13,7 @@ pub struct JumpMap(pub Arc<BitVec<u8>>);
 impl Debug for JumpMap {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("JumpMap")
-            .field("map", &BinaryString::from(self.0.as_raw_slice()))
+            .field("map", &self.0.as_raw_slice())
             .finish()
     }
 }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -20,7 +20,6 @@ pub use bytes;
 pub use bytes::Bytes;
 pub use hex;
 pub use hex_literal;
-pub use to_binary;
 /// Address type is last 20 bytes of hash of ethereum account
 pub type Address = B160;
 /// Hash, in Ethereum usually keccak256.

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -15,14 +15,16 @@ revm-interpreter = { path = "../interpreter", version = "1.1.2", default-feature
 
 #misc
 auto_impl = { version = "1.1", default-features = false }
-once_cell = { version = "1.17", default-features = false }
 
 # Optional
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 serde_json = { version = "1.0", features = ["preserve_order"], optional = true }
 
 # ethersdb
-tokio = { version = "1.32", features = ["rt-multi-thread", "macros"], optional = true }
+tokio = { version = "1.32", features = [
+    "rt-multi-thread",
+    "macros",
+], optional = true }
 ethers-providers = { version = "2.0", optional = true }
 ethers-core = { version = "2.0", optional = true }
 futures = { version = "0.3.27", optional = true }
@@ -40,6 +42,9 @@ criterion = "0.5"
 
 [features]
 default = ["std", "secp256k1"]
+# Without std, critical-section must be enabled and a critical section
+# implementation must be provided. See crate "critical_section".
+critical-section = ["revm-precompile/critical-section"]
 dev = [
     "memory_limit",
     "optional_balance_check",
@@ -56,7 +61,7 @@ optional_block_gas_limit = ["revm-interpreter/optional_block_gas_limit"]
 optional_eip3607 = ["revm-interpreter/optional_eip3607"]
 optional_gas_refund = ["revm-interpreter/optional_gas_refund"]
 optional_no_base_fee = ["revm-interpreter/optional_no_base_fee"]
-std = ["revm-interpreter/std", "once_cell/std", "rayon"]
+std = ["revm-interpreter/std", "revm-precompile/std", "rayon"]
 ethersdb = ["std", "tokio", "futures", "ethers-providers", "ethers-core"]
 serde = ["dep:serde", "dep:serde_json", "revm-interpreter/serde"]
 arbitrary = ["revm-interpreter/arbitrary"]

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -42,9 +42,6 @@ criterion = "0.5"
 
 [features]
 default = ["std", "secp256k1"]
-# Without std, critical-section must be enabled and a critical section
-# implementation must be provided. See crate "critical_section".
-critical-section = ["revm-precompile/critical-section"]
 dev = [
     "memory_limit",
     "optional_balance_check",
@@ -61,7 +58,7 @@ optional_block_gas_limit = ["revm-interpreter/optional_block_gas_limit"]
 optional_eip3607 = ["revm-interpreter/optional_eip3607"]
 optional_gas_refund = ["revm-interpreter/optional_gas_refund"]
 optional_no_base_fee = ["revm-interpreter/optional_no_base_fee"]
-std = ["revm-interpreter/std", "revm-precompile/std", "rayon"]
+std = ["revm-interpreter/std", "rayon"]
 ethersdb = ["std", "tokio", "futures", "ethers-providers", "ethers-core"]
 serde = ["dep:serde", "dep:serde_json", "revm-interpreter/serde"]
 arbitrary = ["revm-interpreter/arbitrary"]


### PR DESCRIPTION
Removed to_binary, which was used only in a debug display.

Replaced once_cell with lazy_static. The no-std build of once_cell did not support the Sync version of OnceCell, that was needed when creating static variables. On the other hand, lazy_static is the complete solution for lazyly initialized (Sync) static variables, and is no-std.

With this changes, revm builds on a no-std platform.