### PR TITLE
feat(state): take N reverts from BundleState, struct refactor

### DIFF
--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -10,8 +10,8 @@ version = "3.3.0"
 readme = "../../README.md"
 
 [dependencies]
-revm-precompile = { path = "../precompile", version = "2.0.2", default-features = false }
 revm-interpreter = { path = "../interpreter", version = "1.1.2", default-features = false }
+revm-precompile = { path = "../precompile", version = "2.0.2", default-features = false }
 
 #misc
 auto_impl = { version = "1.1", default-features = false }

--- a/crates/revm/src/db/states.rs
+++ b/crates/revm/src/db/states.rs
@@ -17,7 +17,7 @@ pub use bundle_account::BundleAccount;
 pub use bundle_state::BundleState;
 pub use cache::CacheState;
 pub use cache_account::CacheAccount;
-pub use changes::{PlainStateReverts, StateChangeset};
+pub use changes::{PlainStateReverts, PlainStorageChangeset, PlainStorageRevert, StateChangeset};
 pub use plain_account::{PlainAccount, StorageWithOriginalValues};
 pub use reverts::{AccountRevert, RevertToSlot};
 pub use state::State;

--- a/crates/revm/src/db/states.rs
+++ b/crates/revm/src/db/states.rs
@@ -17,7 +17,7 @@ pub use bundle_account::BundleAccount;
 pub use bundle_state::BundleState;
 pub use cache::CacheState;
 pub use cache_account::CacheAccount;
-pub use changes::{StateChangeset, StateReverts};
+pub use changes::{PlainStateReverts, StateChangeset};
 pub use plain_account::{PlainAccount, StorageWithOriginalValues};
 pub use reverts::{AccountRevert, RevertToSlot};
 pub use state::State;

--- a/crates/revm/src/db/states/bundle_state.rs
+++ b/crates/revm/src/db/states/bundle_state.rs
@@ -609,6 +609,7 @@ mod tests {
 
         let mut extended = bundle1.clone();
         extended.extend(bundle2.clone());
+        
         // check that we have two reverts
         assert_eq!(extended.reverts.len(), 2);
 

--- a/crates/revm/src/db/states/bundle_state.rs
+++ b/crates/revm/src/db/states/bundle_state.rs
@@ -883,7 +883,6 @@ mod tests {
         );
     }
 
-
     #[test]
     fn test_sanity_path() {
         sanity_path(test_bundle1(), test_bundle2());

--- a/crates/revm/src/db/states/changes.rs
+++ b/crates/revm/src/db/states/changes.rs
@@ -17,7 +17,7 @@ pub struct StateChangeset {
 
 /// Plain storage changeset. Used to apply storage changes of plain state to
 /// the database.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct PlainStorageChangeset {
     /// Address of account
     pub address: B160,
@@ -26,7 +26,7 @@ pub struct PlainStorageChangeset {
 }
 
 /// Plain Storage Revert. Containing old values of changed storage.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct PlainStorageRevert {
     /// Address of account
     pub address: B160,

--- a/crates/revm/src/db/states/changes.rs
+++ b/crates/revm/src/db/states/changes.rs
@@ -10,26 +10,49 @@ pub struct StateChangeset {
     pub accounts: Vec<(B160, Option<AccountInfo>)>,
     /// Vector of storage presorted by address
     /// First bool is indicator if storage needs to be dropped.
-    pub storage: StorageChangeset,
+    pub storage: Vec<PlainStorageChangeset>,
     /// Vector of contracts presorted by bytecode hash
     pub contracts: Vec<(B256, Bytecode)>,
 }
 
-/// Storage changeset
-pub type StorageChangeset = Vec<(B160, (bool, Vec<(U256, U256)>))>;
-
+/// Plain storage changeset. Used to apply storage changes of plain state to
+/// the database.
 #[derive(Clone, Debug, Default)]
-pub struct StateReverts {
+pub struct PlainStorageChangeset {
+    /// Address of account
+    pub address: B160,
+    /// Storage key value pairs.
+    pub storage: Vec<(U256, U256)>,
+}
+
+/// Plain Storage Revert. Containing old values of changed storage.
+#[derive(Clone, Debug, Default)]
+pub struct PlainStorageRevert {
+    /// Address of account
+    pub address: B160,
+    /// Is storage wiped in this revert. Wiped flag is set on
+    /// first known selfdestruct and would require clearing the
+    /// state of this storage from database (And moving it to revert).
+    pub wiped: bool,
+    /// Contains the storage key and old values of that storage.
+    /// Assume they are sorted by the key.
+    pub storage_revert: Vec<(U256, RevertToSlot)>,
+}
+
+/// Plain state reverts are used to easily store reverts into database.
+///
+/// Note that accounts are assumed sorted by address.
+#[derive(Clone, Debug, Default)]
+pub struct PlainStateReverts {
     /// Vector of account presorted by address, with removed contracts bytecode
     ///
     /// Note: AccountInfo None means that account needs to be removed.
     pub accounts: Vec<Vec<(B160, Option<AccountInfo>)>>,
     /// Vector of storage presorted by address
-    /// U256::ZERO means that storage needs to be removed.
-    pub storage: StorageRevert,
+    pub storage: Vec<Vec<PlainStorageRevert>>,
 }
 
-impl StateReverts {
+impl PlainStateReverts {
     /// Constructs new [StateReverts] with pre-allocated capacity.
     pub fn with_capacity(capacity: usize) -> Self {
         Self {

--- a/crates/revm/src/db/states/state.rs
+++ b/crates/revm/src/db/states/state.rs
@@ -449,7 +449,7 @@ mod tests {
         // The new account revert should be `DeleteIt` since this was an account creation.
         // The existing account revert should be reverted to its previous state.
         assert_eq!(
-            bundle_state.reverts,
+            bundle_state.reverts.as_ref(),
             Vec::from([Vec::from([
                 (
                     new_account_address,
@@ -682,12 +682,10 @@ mod tests {
         state.merge_transitions(BundleRetention::Reverts);
 
         let mut bundle_state = state.take_bundle();
-        for revert in &mut bundle_state.reverts {
-            revert.sort_unstable_by_key(|(address, _)| *address);
-        }
+        bundle_state.reverts.sort();
 
         assert_eq!(
-            bundle_state.reverts,
+            bundle_state.reverts.as_ref(),
             Vec::from([Vec::from([
                 // new account is destroyed as if it never existed.
                 // ( ... )
@@ -818,7 +816,7 @@ mod tests {
         );
 
         assert_eq!(
-            bundle_state.reverts,
+            bundle_state.reverts.as_ref(),
             Vec::from([Vec::from([(
                 existing_account_address,
                 AccountRevert {


### PR DESCRIPTION
The original function `detach_lower_part_reverts ` didn't make sense to return `Self` as the returned Bundle state had just reverts. So remove it and make explicit function that handles return of the reverts.

Additionally added structures to the long storage types that we had inside `PlainStateRevert` and `PlainStateChangeset` this increased the readability of types.

This addresses few comments from this PR: https://github.com/bluealloy/revm/pull/663