### PR TITLE
chore: nits and renamings

### DIFF
--- a/crates/revm/src/db/states/bundle_state.rs
+++ b/crates/revm/src/db/states/bundle_state.rs
@@ -357,7 +357,7 @@ impl BundleState {
     /// Consume `TransitionState` by applying the changes and creating the reverts
     ///
     /// If [BundleRetention::includes_reverts] is `true`, then the reverts will be retained.
-    pub fn apply_block_substate_and_create_reverts(
+    pub fn apply_transitions_and_create_reverts(
         &mut self,
         transitions: TransitionState,
         retention: BundleRetention,
@@ -637,7 +637,7 @@ mod tests {
         };
 
         // apply first transition
-        bundle_state.apply_block_substate_and_create_reverts(
+        bundle_state.apply_transitions_and_create_reverts(
             TransitionState::single(address, transition.clone()),
             BundleRetention::Reverts,
         );

--- a/crates/revm/src/db/states/cache_account.rs
+++ b/crates/revm/src/db/states/cache_account.rs
@@ -5,9 +5,8 @@ use super::{
 use revm_interpreter::primitives::{AccountInfo, KECCAK_EMPTY, U256};
 use revm_precompile::HashMap;
 
-/// Cache account is to store account from database be able
-/// to be updated from output of revm and while doing that
-/// create TransitionAccount needed for BundleState.
+/// Cache account contains plain state that gets updated
+/// at every transaction when evm output is applied to CacheState.
 #[derive(Clone, Debug)]
 pub struct CacheAccount {
     pub account: Option<PlainAccount>,

--- a/crates/revm/src/db/states/reverts.rs
+++ b/crates/revm/src/db/states/reverts.rs
@@ -167,6 +167,8 @@ impl AccountRevert {
     }
 }
 
+/// Depending on previous state of account info this
+/// will tell us what to do on revert.
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub enum AccountInfoRevert {
     #[default]

--- a/crates/revm/src/db/states/state.rs
+++ b/crates/revm/src/db/states/state.rs
@@ -130,7 +130,7 @@ impl<'a, DBError> State<'a, DBError> {
         if let Some(transition_state) = self.transition_state.as_mut().map(TransitionState::take) {
             self.bundle_state
                 .get_or_insert(BundleState::default())
-                .apply_block_substate_and_create_reverts(transition_state, retention);
+                .apply_transitions_and_create_reverts(transition_state, retention);
         }
     }
 


### PR DESCRIPTION
`apply_block_substate_and_create_reverts` is renamed to `apply_transitions_and_create_reverts` to better reflect what is going on