### PR TITLE
feat(StateBuilder): switch builder option from without_bundle to with_bundle

### DIFF
--- a/bins/revme/src/statetest/runner.rs
+++ b/bins/revme/src/statetest/runner.rs
@@ -257,6 +257,7 @@ pub fn execute_test_suit(
                 ));
                 let mut state = revm::db::StateBuilder::default()
                     .with_cached_prestate(cache)
+                    .with_bundle_update()
                     .build();
                 let mut evm = revm::new();
                 evm.database(&mut state);
@@ -294,6 +295,7 @@ pub fn execute_test_suit(
                     ));
                     let mut state = revm::db::StateBuilder::default()
                         .with_cached_prestate(cache)
+                        .with_bundle_update()
                         .build();
                     evm.database(&mut state);
                     let _ =

--- a/crates/revm/src/db/states/state.rs
+++ b/crates/revm/src/db/states/state.rs
@@ -310,7 +310,7 @@ mod tests {
     /// state of the account before the block.
     #[test]
     fn reverts_preserve_old_values() {
-        let mut state = StateBuilder::default().build();
+        let mut state = StateBuilder::default().with_bundle_update().build();
 
         let (slot1, slot2, slot3) = (U256::from(1), U256::from(2), U256::from(3));
 
@@ -555,7 +555,7 @@ mod tests {
     /// Checks that the accounts and storages that are changed within the block and reverted to their previous state do not appear in the reverts.
     #[test]
     fn bundle_scoped_reverts_collapse() {
-        let mut state = StateBuilder::default().build();
+        let mut state = StateBuilder::default().with_bundle_update().build();
 
         // Non-existing account.
         let new_account_address = B160::from_slice(&[0x1; 20]);
@@ -721,7 +721,7 @@ mod tests {
     /// Checks that the behavior of selfdestruct within the block is correct.
     #[test]
     fn selfdestruct_state_and_reverts() {
-        let mut state = StateBuilder::default().build();
+        let mut state = StateBuilder::default().with_bundle_update().build();
 
         // Existing account.
         let existing_account_address = B160::from_slice(&[0x1; 20]);

--- a/crates/revm/src/db/states/state_builder.rs
+++ b/crates/revm/src/db/states/state_builder.rs
@@ -6,26 +6,26 @@ use revm_interpreter::primitives::{db::Database, B256};
 
 /// Allows building of State and initializing it with different options.
 pub struct StateBuilder<'a, DBError> {
-    pub with_state_clear: bool,
+    with_state_clear: bool,
     /// Optional database that we use to fetch data from. If database is not present, we will
     /// return not existing account and storage.
     ///
     /// Note: It is marked as Send so database can be shared between threads.
-    pub database: Box<dyn Database<Error = DBError> + Send + 'a>,
+    database: Box<dyn Database<Error = DBError> + Send + 'a>,
     /// if there is prestate that we want to use.
     /// This would mean that we have additional state layer between evm and disk/database.
-    pub with_bundle_prestate: Option<BundleState>,
+    with_bundle_prestate: Option<BundleState>,
     /// This will initialize cache to this state.
-    pub with_cache_prestate: Option<CacheState>,
+    with_cache_prestate: Option<CacheState>,
     /// Do we want to create reverts and update bundle state.
     /// Default is false.
-    pub with_bundle_update: bool,
+    with_bundle_update: bool,
     /// Do we want to merge transitions in background.
     /// This will allows evm to continue executing.
     /// Default is false.
-    pub with_background_transition_merge: bool,
+    with_background_transition_merge: bool,
     /// If we want to set different block hashes
-    pub with_block_hashes: BTreeMap<u64, B256>,
+    with_block_hashes: BTreeMap<u64, B256>,
 }
 
 impl Default for StateBuilder<'_, Infallible> {
@@ -90,7 +90,7 @@ impl<'a, DBError> StateBuilder<'a, DBError> {
     ///
     /// This is needed option if we want to create reverts
     /// and getting output of changed states.
-    pub fn witho_bundle_update(self) -> Self {
+    pub fn with_bundle_update(self) -> Self {
         Self {
             with_bundle_update: true,
             ..self

--- a/crates/revm/src/db/states/state_builder.rs
+++ b/crates/revm/src/db/states/state_builder.rs
@@ -18,8 +18,8 @@ pub struct StateBuilder<'a, DBError> {
     /// This will initialize cache to this state.
     pub with_cache_prestate: Option<CacheState>,
     /// Do we want to create reverts and update bundle state.
-    /// Default is true.
-    pub without_bundle_update: bool,
+    /// Default is false.
+    pub with_bundle_update: bool,
     /// Do we want to merge transitions in background.
     /// This will allows evm to continue executing.
     /// Default is false.
@@ -35,7 +35,7 @@ impl Default for StateBuilder<'_, Infallible> {
             database: Box::<EmptyDB>::default(),
             with_cache_prestate: None,
             with_bundle_prestate: None,
-            without_bundle_update: false,
+            with_bundle_update: false,
             with_background_transition_merge: false,
             with_block_hashes: BTreeMap::new(),
         }
@@ -59,7 +59,7 @@ impl<'a, DBError> StateBuilder<'a, DBError> {
             database,
             with_cache_prestate: self.with_cache_prestate,
             with_bundle_prestate: self.with_bundle_prestate,
-            without_bundle_update: self.without_bundle_update,
+            with_bundle_update: self.with_bundle_update,
             with_background_transition_merge: self.with_background_transition_merge,
             with_block_hashes: self.with_block_hashes,
         }
@@ -86,13 +86,13 @@ impl<'a, DBError> StateBuilder<'a, DBError> {
         }
     }
 
-    /// Don't make transitions and don't update bundle state.
+    /// Make transitions and update bundle state.
     ///
-    /// This is good option if we don't care about creating reverts
-    /// or getting output of changed states.
-    pub fn without_bundle_update(self) -> Self {
+    /// This is needed option if we want to create reverts
+    /// and getting output of changed states.
+    pub fn witho_bundle_update(self) -> Self {
         Self {
-            without_bundle_update: true,
+            with_bundle_update: true,
             ..self
         }
     }
@@ -136,10 +136,10 @@ impl<'a, DBError> StateBuilder<'a, DBError> {
                 .with_cache_prestate
                 .unwrap_or(CacheState::new(self.with_state_clear)),
             database: self.database,
-            transition_state: if self.without_bundle_update {
-                None
-            } else {
+            transition_state: if self.with_bundle_update {
                 Some(TransitionState::default())
+            } else {
+                None
             },
             bundle_state: self.with_bundle_prestate,
             use_preloaded_bundle,


### PR DESCRIPTION
In general output state and creating of revert is better to be something to be enabled, and not disabled.