### PR TITLE
fix example compile error

### DIFF
--- a/examples/fork_ref_transact.rs
+++ b/examples/fork_ref_transact.rs
@@ -80,7 +80,7 @@ async fn main() -> Result<()> {
     // calldata formed via abigen
     evm.env.tx.data = Bytes::from(hex::decode(hex::encode(&encoded))?);
     // transaction value in wei
-    evm.env.tx.value = rU256::try_from(0)?;
+    evm.env.tx.value = rU256::from(0);
 
     // execute transaction without writing to the DB
     let ref_tx = evm.transact_ref().unwrap();


### PR DESCRIPTION
fix example compile error
```shell
> cargo run -p revm --features ethersdb --example fork_ref_transact
error[E0277]: the trait bound `ToUintError<revm::revm_primitives::ruint::Uint<256, 4>>: std::error::Error` is not satisfied
  --> crates/revm/../../examples/fork_ref_transact.rs:83:42
   |
83 |     evm.env.tx.value = rU256::try_from(0)?;
   |                                          ^ the trait `std::error::Error` is not implemented for `ToUintError<revm::revm_primitives::ruint::Uint<256, 4>>`
   |
   = help: the following other types implement trait `FromResidual<R>`:
             <Result<T, F> as FromResidual<Yeet<E>>>
             <Result<T, F> as FromResidual<Result<Infallible, E>>>
   = note: required for `anyhow::Error` to implement `From<ToUintError<revm::revm_primitives::ruint::Uint<256, 4>>>`
   = note: required for `Result<(), anyhow::Error>` to implement `FromResidual<Result<Infallible, ToUintError<revm::revm_primitives::ruint::Uint<256, 4>>>>`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `revm` (example "fork_ref_transact") due to previous error
```