### PR TITLE
chore: deprecate `RefDBWrapper`

### DIFF
--- a/crates/interpreter/src/gas.rs
+++ b/crates/interpreter/src/gas.rs
@@ -79,6 +79,8 @@ impl Gas {
 
     /// Records an explicit cost.
     ///
+    /// Returns `false` if the gas limit is exceeded.
+    ///
     /// This function is called on every instruction in the interpreter if the feature
     /// `no_gas_measuring` is not enabled.
     #[inline(always)]

--- a/crates/primitives/src/db.rs
+++ b/crates/primitives/src/db.rs
@@ -74,32 +74,41 @@ impl<T: DatabaseRef> Database for WrapDatabaseRef<T> {
     }
 }
 
-pub struct RefDBWrapper<'a, Error> {
-    pub db: &'a dyn DatabaseRef<Error = Error>,
+/// Wraps a `dyn DatabaseRef` to provide a [`Database`] implementation.
+#[doc(hidden)]
+#[deprecated = "use `WrapDatabaseRef` instead"]
+pub struct RefDBWrapper<'a, E> {
+    pub db: &'a dyn DatabaseRef<Error = E>,
 }
 
-impl<'a, Error> RefDBWrapper<'a, Error> {
-    pub fn new(db: &'a dyn DatabaseRef<Error = Error>) -> Self {
+#[allow(deprecated)]
+impl<'a, E> RefDBWrapper<'a, E> {
+    #[inline]
+    pub fn new(db: &'a dyn DatabaseRef<Error = E>) -> Self {
         Self { db }
     }
 }
 
-impl<'a, Error> Database for RefDBWrapper<'a, Error> {
-    type Error = Error;
-    /// Get basic account information.
+#[allow(deprecated)]
+impl<'a, E> Database for RefDBWrapper<'a, E> {
+    type Error = E;
+
+    #[inline]
     fn basic(&mut self, address: B160) -> Result<Option<AccountInfo>, Self::Error> {
         self.db.basic(address)
     }
-    /// Get account code by its hash
+
+    #[inline]
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
         self.db.code_by_hash(code_hash)
     }
-    /// Get storage value of address at index.
+
+    #[inline]
     fn storage(&mut self, address: B160, index: U256) -> Result<U256, Self::Error> {
         self.db.storage(address, index)
     }
 
-    // History related
+    #[inline]
     fn block_hash(&mut self, number: U256) -> Result<B256, Self::Error> {
         self.db.block_hash(number)
     }

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -1,11 +1,12 @@
 use crate::primitives::{specification, EVMError, EVMResult, Env, ExecutionResult, SpecId};
 use crate::{
-    db::{Database, DatabaseCommit, DatabaseRef, RefDBWrapper},
+    db::{Database, DatabaseCommit, DatabaseRef},
     evm_impl::{EVMImpl, Transact},
     inspectors::NoOpInspector,
     Inspector,
 };
 use alloc::boxed::Box;
+use revm_interpreter::primitives::db::WrapDatabaseRef;
 use revm_interpreter::primitives::ResultAndState;
 use revm_precompile::Precompiles;
 
@@ -60,6 +61,7 @@ impl<DB: Database + DatabaseCommit> EVM<DB> {
         self.db.as_mut().unwrap().commit(state);
         Ok(result)
     }
+
     /// Inspect transaction and commit changes to database.
     pub fn inspect_commit<INSP: Inspector<DB>>(
         &mut self,
@@ -75,21 +77,17 @@ impl<DB: Database> EVM<DB> {
     /// Do checks that could make transaction fail before call/create
     pub fn preverify_transaction(&mut self) -> Result<(), EVMError<DB::Error>> {
         if let Some(db) = self.db.as_mut() {
-            let mut noop = NoOpInspector {};
-            let out = evm_inner::<DB, false>(&mut self.env, db, &mut noop).preverify_transaction();
-            out
+            evm_inner::<DB, false>(&mut self.env, db, &mut NoOpInspector).preverify_transaction()
         } else {
             panic!("Database needs to be set");
         }
     }
 
-    /// Skip preverification steps and execute transaction
-    /// without writing to DB, return change state.
+    /// Skip preverification steps and execute transaction without writing to DB, return change
+    /// state.
     pub fn transact_preverified(&mut self) -> EVMResult<DB::Error> {
         if let Some(db) = self.db.as_mut() {
-            let mut noop = NoOpInspector {};
-            let out = evm_inner::<DB, false>(&mut self.env, db, &mut noop).transact_preverified();
-            out
+            evm_inner::<DB, false>(&mut self.env, db, &mut NoOpInspector).transact_preverified()
         } else {
             panic!("Database needs to be set");
         }
@@ -98,9 +96,7 @@ impl<DB: Database> EVM<DB> {
     /// Execute transaction without writing to DB, return change state.
     pub fn transact(&mut self) -> EVMResult<DB::Error> {
         if let Some(db) = self.db.as_mut() {
-            let mut noop = NoOpInspector {};
-            let out = evm_inner::<DB, false>(&mut self.env, db, &mut noop).transact();
-            out
+            evm_inner::<DB, false>(&mut self.env, db, &mut NoOpInspector).transact()
         } else {
             panic!("Database needs to be set");
         }
@@ -120,13 +116,12 @@ impl<'a, DB: DatabaseRef> EVM<DB> {
     /// Do checks that could make transaction fail before call/create
     pub fn preverify_transaction_ref(&self) -> Result<(), EVMError<DB::Error>> {
         if let Some(db) = self.db.as_ref() {
-            let mut noop = NoOpInspector {};
-            let mut db = RefDBWrapper::new(db);
-            let db = &mut db;
-            let out =
-                evm_inner::<RefDBWrapper<DB::Error>, false>(&mut self.env.clone(), db, &mut noop)
-                    .preverify_transaction();
-            out
+            evm_inner::<_, false>(
+                &mut self.env.clone(),
+                &mut WrapDatabaseRef(db),
+                &mut NoOpInspector,
+            )
+            .preverify_transaction()
         } else {
             panic!("Database needs to be set");
         }
@@ -136,13 +131,12 @@ impl<'a, DB: DatabaseRef> EVM<DB> {
     /// without writing to DB, return change state.
     pub fn transact_preverified_ref(&self) -> EVMResult<DB::Error> {
         if let Some(db) = self.db.as_ref() {
-            let mut noop = NoOpInspector {};
-            let mut db = RefDBWrapper::new(db);
-            let db = &mut db;
-            let out =
-                evm_inner::<RefDBWrapper<DB::Error>, false>(&mut self.env.clone(), db, &mut noop)
-                    .transact_preverified();
-            out
+            evm_inner::<_, false>(
+                &mut self.env.clone(),
+                &mut WrapDatabaseRef(db),
+                &mut NoOpInspector,
+            )
+            .transact_preverified()
         } else {
             panic!("Database needs to be set");
         }
@@ -151,33 +145,29 @@ impl<'a, DB: DatabaseRef> EVM<DB> {
     /// Execute transaction without writing to DB, return change state.
     pub fn transact_ref(&self) -> EVMResult<DB::Error> {
         if let Some(db) = self.db.as_ref() {
-            let mut noop = NoOpInspector {};
-            let mut db = RefDBWrapper::new(db);
-            let db = &mut db;
-            let out =
-                evm_inner::<RefDBWrapper<DB::Error>, false>(&mut self.env.clone(), db, &mut noop)
-                    .transact();
-            out
+            evm_inner::<_, false>(
+                &mut self.env.clone(),
+                &mut WrapDatabaseRef(db),
+                &mut NoOpInspector,
+            )
+            .transact()
         } else {
             panic!("Database needs to be set");
         }
     }
 
     /// Execute transaction with given inspector, without wring to DB. Return change state.
-    pub fn inspect_ref<INSP: Inspector<RefDBWrapper<'a, DB::Error>>>(
+    pub fn inspect_ref<I: Inspector<WrapDatabaseRef<&'a DB>>>(
         &'a self,
-        mut inspector: INSP,
+        mut inspector: I,
     ) -> EVMResult<DB::Error> {
         if let Some(db) = self.db.as_ref() {
-            let mut db = RefDBWrapper::new(db);
-            let db = &mut db;
-            let out = evm_inner::<RefDBWrapper<DB::Error>, true>(
+            evm_inner::<_, true>(
                 &mut self.env.clone(),
-                db,
+                &mut WrapDatabaseRef(db),
                 &mut inspector,
             )
-            .transact();
-            out
+            .transact()
         } else {
             panic!("Database needs to be set");
         }
@@ -208,17 +198,6 @@ impl<DB> EVM<DB> {
     }
 }
 
-macro_rules! create_evm {
-    ($spec:ident, $db:ident, $env:ident, $inspector:ident) => {
-        Box::new(EVMImpl::<'a, $spec, DB, INSPECT>::new(
-            $db,
-            $env,
-            $inspector,
-            Precompiles::new(to_precompile_id($spec::SPEC_ID)).clone(),
-        )) as Box<dyn Transact<DB::Error> + 'a>
-    };
-}
-
 pub fn to_precompile_id(spec_id: SpecId) -> revm_precompile::SpecId {
     match spec_id {
         SpecId::FRONTIER
@@ -247,22 +226,33 @@ pub fn evm_inner<'a, DB: Database, const INSPECT: bool>(
     db: &'a mut DB,
     insp: &'a mut dyn Inspector<DB>,
 ) -> Box<dyn Transact<DB::Error> + 'a> {
+    macro_rules! create_evm {
+        ($spec:ident) => {
+            Box::new(EVMImpl::<'a, $spec, DB, INSPECT>::new(
+                db,
+                env,
+                insp,
+                Precompiles::new(to_precompile_id($spec::SPEC_ID)).clone(),
+            )) as Box<dyn Transact<DB::Error> + 'a>
+        };
+    }
+
     use specification::*;
     match env.cfg.spec_id {
-        SpecId::FRONTIER | SpecId::FRONTIER_THAWING => create_evm!(FrontierSpec, db, env, insp),
-        SpecId::HOMESTEAD | SpecId::DAO_FORK => create_evm!(HomesteadSpec, db, env, insp),
-        SpecId::TANGERINE => create_evm!(TangerineSpec, db, env, insp),
-        SpecId::SPURIOUS_DRAGON => create_evm!(SpuriousDragonSpec, db, env, insp),
-        SpecId::BYZANTIUM => create_evm!(ByzantiumSpec, db, env, insp),
-        SpecId::PETERSBURG | SpecId::CONSTANTINOPLE => create_evm!(PetersburgSpec, db, env, insp),
-        SpecId::ISTANBUL | SpecId::MUIR_GLACIER => create_evm!(IstanbulSpec, db, env, insp),
-        SpecId::BERLIN => create_evm!(BerlinSpec, db, env, insp),
+        SpecId::FRONTIER | SpecId::FRONTIER_THAWING => create_evm!(FrontierSpec),
+        SpecId::HOMESTEAD | SpecId::DAO_FORK => create_evm!(HomesteadSpec),
+        SpecId::TANGERINE => create_evm!(TangerineSpec),
+        SpecId::SPURIOUS_DRAGON => create_evm!(SpuriousDragonSpec),
+        SpecId::BYZANTIUM => create_evm!(ByzantiumSpec),
+        SpecId::PETERSBURG | SpecId::CONSTANTINOPLE => create_evm!(PetersburgSpec),
+        SpecId::ISTANBUL | SpecId::MUIR_GLACIER => create_evm!(IstanbulSpec),
+        SpecId::BERLIN => create_evm!(BerlinSpec),
         SpecId::LONDON | SpecId::ARROW_GLACIER | SpecId::GRAY_GLACIER => {
-            create_evm!(LondonSpec, db, env, insp)
+            create_evm!(LondonSpec)
         }
-        SpecId::MERGE => create_evm!(MergeSpec, db, env, insp),
-        SpecId::SHANGHAI => create_evm!(ShanghaiSpec, db, env, insp),
-        SpecId::CANCUN => create_evm!(CancunSpec, db, env, insp),
-        SpecId::LATEST => create_evm!(LatestSpec, db, env, insp),
+        SpecId::MERGE => create_evm!(MergeSpec),
+        SpecId::SHANGHAI => create_evm!(ShanghaiSpec),
+        SpecId::CANCUN => create_evm!(CancunSpec),
+        SpecId::LATEST => create_evm!(LatestSpec),
     }
 }

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -586,7 +586,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
 
     /// Call precompile contract
     fn call_precompile(&mut self, inputs: &CallInputs, mut gas: Gas) -> CallResult {
-        let input_data = inputs.input.clone();
+        let input_data = &inputs.input;
         let contract = inputs.contract;
 
         let precompile = self
@@ -595,8 +595,8 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
             .get(&contract)
             .expect("Check for precompile should be already done");
         let out = match precompile {
-            Precompile::Standard(fun) => fun(&input_data, gas.limit()),
-            Precompile::Custom(fun) => fun(&input_data, gas.limit()),
+            Precompile::Standard(fun) => fun(input_data, gas.limit()),
+            Precompile::Custom(fun) => fun(input_data, gas.limit()),
         };
         match out {
             Ok((gas_used, data)) => {
@@ -615,13 +615,13 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
                 }
             }
             Err(e) => {
-                let ret = if precompile::Error::OutOfGas == e {
+                let result = if precompile::Error::OutOfGas == e {
                     InstructionResult::PrecompileOOG
                 } else {
                     InstructionResult::PrecompileError
                 };
                 CallResult {
-                    result: ret,
+                    result,
                     gas,
                     return_value: Bytes::new(),
                 }

--- a/crates/revm/src/inspector/noop.rs
+++ b/crates/revm/src/inspector/noop.rs
@@ -3,6 +3,6 @@
 use crate::{Database, Inspector};
 
 #[derive(Clone, Copy)]
-pub struct NoOpInspector();
+pub struct NoOpInspector;
 
 impl<DB: Database> Inspector<DB> for NoOpInspector {}


### PR DESCRIPTION
There is no point in having a separate type for `dyn Trait` when there is one for `impl Trait` already.