### PR TITLE
feat: OriginalValueKnown, and expose db box

### DIFF
--- a/crates/revm/src/db.rs
+++ b/crates/revm/src/db.rs
@@ -11,9 +11,9 @@ pub mod states;
 
 #[cfg(feature = "std")]
 pub use states::{
-    AccountRevert, AccountStatus, BundleAccount, BundleState, CacheState, PlainAccount,
-    RevertToSlot, State, StateBuilder, StateDBBox, StorageWithOriginalValues, TransitionAccount,
-    TransitionState,
+    AccountRevert, AccountStatus, BundleAccount, BundleState, CacheState, DBBox,
+    OriginalValuesKnown, PlainAccount, RevertToSlot, State, StateBuilder, StateDBBox,
+    StorageWithOriginalValues, TransitionAccount, TransitionState,
 };
 
 #[cfg(all(not(feature = "ethersdb"), feature = "web3db"))]

--- a/crates/revm/src/db.rs
+++ b/crates/revm/src/db.rs
@@ -12,7 +12,7 @@ pub mod states;
 #[cfg(feature = "std")]
 pub use states::{
     AccountRevert, AccountStatus, BundleAccount, BundleState, CacheState, PlainAccount,
-    RevertToSlot, State, StateBuilder, StorageWithOriginalValues, TransitionAccount,
+    RevertToSlot, State, StateBuilder, StateDBBox, StorageWithOriginalValues, TransitionAccount,
     TransitionState,
 };
 

--- a/crates/revm/src/db/states.rs
+++ b/crates/revm/src/db/states.rs
@@ -14,13 +14,13 @@ pub mod transition_state;
 /// Account status for Block and Bundle states.
 pub use account_status::AccountStatus;
 pub use bundle_account::BundleAccount;
-pub use bundle_state::BundleState;
+pub use bundle_state::{BundleState, OriginalValuesKnown};
 pub use cache::CacheState;
 pub use cache_account::CacheAccount;
 pub use changes::{PlainStateReverts, PlainStorageChangeset, PlainStorageRevert, StateChangeset};
 pub use plain_account::{PlainAccount, StorageWithOriginalValues};
 pub use reverts::{AccountRevert, RevertToSlot};
-pub use state::{State, StateDBBox};
+pub use state::{DBBox, State, StateDBBox};
 pub use state_builder::StateBuilder;
 pub use transition_account::TransitionAccount;
 pub use transition_state::TransitionState;

--- a/crates/revm/src/db/states.rs
+++ b/crates/revm/src/db/states.rs
@@ -20,7 +20,7 @@ pub use cache_account::CacheAccount;
 pub use changes::{PlainStateReverts, PlainStorageChangeset, PlainStorageRevert, StateChangeset};
 pub use plain_account::{PlainAccount, StorageWithOriginalValues};
 pub use reverts::{AccountRevert, RevertToSlot};
-pub use state::State;
+pub use state::{State, StateDBBox};
 pub use state_builder::StateBuilder;
 pub use transition_account::TransitionAccount;
 pub use transition_state::TransitionState;

--- a/crates/revm/src/db/states/bundle_state.rs
+++ b/crates/revm/src/db/states/bundle_state.rs
@@ -27,6 +27,25 @@ pub struct BundleBuilder {
     contracts: HashMap<B256, Bytecode>,
 }
 
+/// Option for [`BundleState`] when converting it to the plain state.
+pub enum OriginalValuesKnown {
+    /// Check changed with original values that [BundleState] has
+    /// If we dont expect parent blocks to be committed or unwinded from database
+    /// this option should be used.
+    Yes,
+    /// Dont check original values, see CheckOriginalValues for more info.
+    /// If Bundle can be split or extended we would not be sure about
+    /// original values so this option should be used.
+    No,
+}
+
+impl OriginalValuesKnown {
+    /// Original value is not known for sure.
+    pub fn is_not_known(&self) -> bool {
+        matches!(self, Self::No)
+    }
+}
+
 impl Default for BundleBuilder {
     fn default() -> Self {
         BundleBuilder {
@@ -403,11 +422,7 @@ impl BundleState {
     }
 
     /// Consume the bundle state and return sorted plain state.
-    ///
-    /// `omit_changed_check` does not check if account is same as
-    /// original state, this assumption can't be made in cases when
-    /// we split the bundle state and commit parts of it.
-    pub fn into_plain_state_sorted(self, omit_changed_check: bool) -> StateChangeset {
+    pub fn into_plain_state_sorted(self, is_value_known: OriginalValuesKnown) -> StateChangeset {
         // pessimistically pre-allocate assuming _all_ accounts changed.
         let state_len = self.state.len();
         let mut accounts = Vec::with_capacity(state_len);
@@ -416,7 +431,7 @@ impl BundleState {
         for (address, account) in self.state {
             // append account info if it is changed.
             let was_destroyed = account.was_destroyed();
-            if omit_changed_check || account.is_info_changed() {
+            if is_value_known.is_not_known() || account.is_info_changed() {
                 let info = account.info.map(AccountInfo::without_code);
                 accounts.push((address, info));
             }
@@ -436,7 +451,10 @@ impl BundleState {
                 // so we can update it.
                 let not_destroyed_and_changed = !was_destroyed && slot.is_changed();
 
-                if omit_changed_check || destroyed_and_not_zero || not_destroyed_and_changed {
+                if is_value_known.is_not_known()
+                    || destroyed_and_not_zero
+                    || not_destroyed_and_changed
+                {
                     account_storage_changed.push((key, slot.present_value));
                 }
             }
@@ -472,10 +490,10 @@ impl BundleState {
     /// Consume the bundle state and split it into reverts and plain state.
     pub fn into_sorted_plain_state_and_reverts(
         mut self,
-        omit_changed_check: bool,
+        is_value_known: OriginalValuesKnown,
     ) -> (StateChangeset, PlainStateReverts) {
         let reverts = self.take_all_reverts();
-        let plain_state = self.into_plain_state_sorted(omit_changed_check);
+        let plain_state = self.into_plain_state_sorted(is_value_known);
         (plain_state, reverts.into_plain_state_reverts())
     }
 

--- a/crates/revm/src/db/states/state.rs
+++ b/crates/revm/src/db/states/state.rs
@@ -2,17 +2,20 @@ use super::{
     bundle_state::BundleRetention, cache::CacheState, plain_account::PlainStorage, BundleState,
     CacheAccount, TransitionState,
 };
-use crate::TransitionAccount;
+use crate::{db::EmptyDB, StateBuilder, TransitionAccount};
 use alloc::collections::{btree_map, BTreeMap};
 use revm_interpreter::primitives::{
     db::{Database, DatabaseCommit},
     hash_map, Account, AccountInfo, Bytecode, HashMap, B160, B256, BLOCK_HASH_HISTORY, U256,
 };
 
+/// Database boxed with a lifetime and Send.
+pub type DBBox<'a, E> = Box<dyn Database<Error = E> + Send + 'a>;
+
 /// More constrained version of State that uses Boxed database with a lifetime.
 ///
 /// This is used to make it easier to use State.
-pub type StateDBBox<'a, DBError> = State<Box<dyn Database<Error = DBError> + Send + 'a>>;
+pub type StateDBBox<'a, E> = State<DBBox<'a, E>>;
 
 /// State of blockchain.
 ///
@@ -49,6 +52,14 @@ pub struct State<DB: Database> {
     /// This map can be used to give different values for block hashes if in case
     /// The fork block is different or some blocks are not saved inside database.
     pub block_hashes: BTreeMap<u64, B256>,
+}
+
+// Have ability to call State::builder without having to specify the type.
+impl State<EmptyDB> {
+    /// Return the builder that build the State.
+    pub fn builder() -> StateBuilder<EmptyDB> {
+        StateBuilder::default()
+    }
 }
 
 impl<DB: Database> State<DB> {
@@ -269,18 +280,15 @@ impl<DB: Database> DatabaseCommit for State<DB> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        db::{
-            states::reverts::AccountInfoRevert, AccountRevert, AccountStatus, BundleAccount,
-            RevertToSlot,
-        },
-        StateBuilder,
+    use crate::db::{
+        states::reverts::AccountInfoRevert, AccountRevert, AccountStatus, BundleAccount,
+        RevertToSlot,
     };
     use revm_interpreter::primitives::{keccak256, StorageSlot};
 
     #[test]
     fn block_hash_cache() {
-        let mut state = StateBuilder::default().build();
+        let mut state = State::builder().build();
         state.block_hash(U256::from(1)).unwrap();
         state.block_hash(U256::from(2)).unwrap();
 
@@ -310,7 +318,7 @@ mod tests {
     /// state of the account before the block.
     #[test]
     fn reverts_preserve_old_values() {
-        let mut state = StateBuilder::default().with_bundle_update().build();
+        let mut state = State::builder().with_bundle_update().build();
 
         let (slot1, slot2, slot3) = (U256::from(1), U256::from(2), U256::from(3));
 
@@ -555,7 +563,7 @@ mod tests {
     /// Checks that the accounts and storages that are changed within the block and reverted to their previous state do not appear in the reverts.
     #[test]
     fn bundle_scoped_reverts_collapse() {
-        let mut state = StateBuilder::default().with_bundle_update().build();
+        let mut state = State::builder().with_bundle_update().build();
 
         // Non-existing account.
         let new_account_address = B160::from_slice(&[0x1; 20]);
@@ -721,7 +729,7 @@ mod tests {
     /// Checks that the behavior of selfdestruct within the block is correct.
     #[test]
     fn selfdestruct_state_and_reverts() {
-        let mut state = StateBuilder::default().with_bundle_update().build();
+        let mut state = State::builder().with_bundle_update().build();
 
         // Existing account.
         let existing_account_address = B160::from_slice(&[0x1; 20]);

--- a/crates/revm/src/db/states/state_builder.rs
+++ b/crates/revm/src/db/states/state_builder.rs
@@ -1,7 +1,10 @@
-use super::{cache::CacheState, BundleState, State, TransitionState};
+use super::{cache::CacheState, state::DBBox, BundleState, State, TransitionState};
 use crate::db::EmptyDB;
 use alloc::collections::BTreeMap;
-use revm_interpreter::primitives::{db::Database, B256};
+use revm_interpreter::primitives::{
+    db::{Database, DatabaseRef, WrapDatabaseRef},
+    B256,
+};
 
 /// Allows building of State and initializing it with different options.
 pub struct StateBuilder<DB> {
@@ -12,7 +15,7 @@ pub struct StateBuilder<DB> {
     /// return not existing account and storage.
     ///
     /// Note: It is marked as Send so database can be shared between threads.
-    database: DB, //Box<dyn Database<Error = DBError> + Send + 'a>,
+    database: DB,
     /// if there is prestate that we want to use.
     /// This would mean that we have additional state layer between evm and disk/database.
     with_bundle_prestate: Option<BundleState>,
@@ -29,11 +32,11 @@ pub struct StateBuilder<DB> {
     with_block_hashes: BTreeMap<u64, B256>,
 }
 
-impl Default for StateBuilder<Box<EmptyDB>> {
+impl Default for StateBuilder<EmptyDB> {
     fn default() -> Self {
         Self {
             with_state_clear: true,
-            database: Box::<EmptyDB>::default(),
+            database: EmptyDB::default(),
             with_cache_prestate: None,
             with_bundle_prestate: None,
             with_bundle_update: false,
@@ -45,14 +48,12 @@ impl Default for StateBuilder<Box<EmptyDB>> {
 
 impl<DB: Database> StateBuilder<DB> {
     /// Create default instance of builder.
-    pub fn new() -> StateBuilder<Box<EmptyDB>> {
-        StateBuilder::<Box<EmptyDB>>::default()
+    pub fn new() -> StateBuilder<EmptyDB> {
+        StateBuilder::default()
     }
 
-    pub fn with_database_boxed<'a, NewDBError>(
-        self,
-        database: Box<dyn Database<Error = NewDBError> + Send + 'a>,
-    ) -> StateBuilder<Box<dyn Database<Error = NewDBError> + Send + 'a>> {
+    /// With generic database.
+    pub fn with_database<ODB: Database>(self, database: ODB) -> StateBuilder<ODB> {
         // cast to the different database,
         // Note that we return different type depending of the database NewDBError.
         StateBuilder {
@@ -64,6 +65,22 @@ impl<DB: Database> StateBuilder<DB> {
             with_background_transition_merge: self.with_background_transition_merge,
             with_block_hashes: self.with_block_hashes,
         }
+    }
+
+    /// Takes [DatabaseRef] and wraps [WrapDatabaseRef] around it.
+    pub fn with_database_ref<ODB: DatabaseRef>(
+        self,
+        database: ODB,
+    ) -> StateBuilder<WrapDatabaseRef<ODB>> {
+        self.with_database(WrapDatabaseRef(database))
+    }
+
+    /// With boxed version of database.
+    pub fn with_database_boxed<Error>(
+        self,
+        database: DBBox<'_, Error>,
+    ) -> StateBuilder<DBBox<'_, Error>> {
+        self.with_database(database)
     }
 
     /// By default state clear flag is enabled but for initial sync on mainnet

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -17,9 +17,11 @@ pub(crate) const USE_GAS: bool = !cfg!(feature = "no_gas_measuring");
 pub type DummyStateDB = InMemoryDB;
 
 #[cfg(feature = "std")]
-pub use db::{CacheState, StateBuilder, TransitionAccount, TransitionState};
+pub use db::{
+    CacheState, DBBox, State, StateBuilder, StateDBBox, TransitionAccount, TransitionState,
+};
 
-pub use db::{Database, DatabaseCommit, InMemoryDB, State};
+pub use db::{Database, DatabaseCommit, InMemoryDB};
 pub use evm::{evm_inner, new, to_precompile_id, EVM};
 pub use evm_impl::{EVMData, EVMImpl, Transact};
 pub use journaled_state::{is_precompile, JournalCheckpoint, JournalEntry, JournaledState};


### PR DESCRIPTION
Introduce `OriginalValueKnown` enum that replaces a boolean used as a flag.

Add `State::builder()` that allows better usage of StateBuilder.