### PR TITLE
Run the Ethereum tests both in debug and release mode

### DIFF
--- a/.github/workflows/ethereum-tests.yml
+++ b/.github/workflows/ethereum-tests.yml
@@ -29,9 +29,18 @@ jobs:
         with:
           cache-on-failure: true
 
-      - name: Run Ethereum tests
+      - name: Run Ethereum tests (Debug mode)
         run: |
           cargo run --profile ethtests -p revme -- \
+          statetest \
+          ethtests/GeneralStateTests/ \
+          ethtests/LegacyTests/Constantinople/GeneralStateTests/ \
+          tests/EIPTests/StateTests/stEIP5656-MCOPY/ \
+          tests/EIPTests/StateTests/stEIP1153-transientStorage/
+
+      - name: Run Ethereum tests (Release mode)
+        run: |
+          cargo run --release -p revme -- \
           statetest \
           ethtests/GeneralStateTests/ \
           ethtests/LegacyTests/Constantinople/GeneralStateTests/ \

--- a/.github/workflows/ethereum-tests.yml
+++ b/.github/workflows/ethereum-tests.yml
@@ -11,6 +11,9 @@ jobs:
     name: Ethereum Tests (Stable)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      matrix:
+        profile: [ethtests, release]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -29,18 +32,9 @@ jobs:
         with:
           cache-on-failure: true
 
-      - name: Run Ethereum tests (Debug mode)
+      - name: Run Ethereum tests
         run: |
-          cargo run --profile ethtests -p revme -- \
-          statetest \
-          ethtests/GeneralStateTests/ \
-          ethtests/LegacyTests/Constantinople/GeneralStateTests/ \
-          tests/EIPTests/StateTests/stEIP5656-MCOPY/ \
-          tests/EIPTests/StateTests/stEIP1153-transientStorage/
-
-      - name: Run Ethereum tests (Release mode)
-        run: |
-          cargo run --release -p revme -- \
+          cargo run --profile ${{ matrix.profile }} -p revme -- \
           statetest \
           ethtests/GeneralStateTests/ \
           ethtests/LegacyTests/Constantinople/GeneralStateTests/ \


### PR DESCRIPTION
In debug mode the tests are checking for additional things like unsigned int arithmetic overflows. In release mode they are checking for things like proper stack utilization (ex. in release mode the tests are running with the default thread stack limit).