### PR TITLE
feat: return wiped inside storage changeset

### DIFF
--- a/crates/revm/src/db/states/bundle_account.rs
+++ b/crates/revm/src/db/states/bundle_account.rs
@@ -216,6 +216,7 @@ impl BundleAccount {
                 None
             }
             AccountStatus::Destroyed => {
+                // clear this storage and move it to the Revert.
                 let this_storage = self.storage.drain().collect();
                 let ret = match self.status {
                     AccountStatus::InMemoryChange | AccountStatus::Changed | AccountStatus::Loaded | AccountStatus::LoadedEmptyEIP161 => {

--- a/crates/revm/src/db/states/bundle_state.rs
+++ b/crates/revm/src/db/states/bundle_state.rs
@@ -476,11 +476,12 @@ impl BundleState {
                 }
             }
 
-            if !account_storage_changed.is_empty() {
+            if !account_storage_changed.is_empty() || was_destroyed {
                 account_storage_changed.sort_by(|a, b| a.0.cmp(&b.0));
                 // append storage changes to account.
                 storage.push(PlainStorageChangeset {
                     address,
+                    wipe_storage: was_destroyed,
                     storage: account_storage_changed,
                 });
             }

--- a/crates/revm/src/db/states/changes.rs
+++ b/crates/revm/src/db/states/changes.rs
@@ -21,6 +21,8 @@ pub struct StateChangeset {
 pub struct PlainStorageChangeset {
     /// Address of account
     pub address: B160,
+    /// Wipe storage,
+    pub wipe_storage: bool,
     /// Storage key value pairs.
     pub storage: Vec<(U256, U256)>,
 }


### PR DESCRIPTION
If we prune `Reverts` the wiped flag would be lost so we should return it inside `StorageChangeSet`