### PR TITLE
Never inline the prepare functions

### DIFF
--- a/bins/revme/src/statetest/runner.rs
+++ b/bins/revme/src/statetest/runner.rs
@@ -365,12 +365,7 @@ pub fn run(
         let console_bar = console_bar.clone();
         let elapsed = elapsed.clone();
 
-        let mut thread = std::thread::Builder::new();
-
-        // Allow bigger stack in debug mode to prevent stack overflow errors
-        //if cfg!(debug_assertions) {
-        thread = thread.stack_size(4 * 1024 * 1024);
-        //}
+        let thread: std::thread::Builder = std::thread::Builder::new();
 
         joins.push(
             thread

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -239,6 +239,7 @@ pub fn selfdestruct<SPEC: Spec>(interpreter: &mut Interpreter, host: &mut dyn Ho
     interpreter.instruction_result = InstructionResult::SelfDestruct;
 }
 
+#[inline(never)]
 pub fn prepare_create_inputs<const IS_CREATE2: bool, SPEC: Spec>(
     interpreter: &mut Interpreter,
     host: &mut dyn Host,
@@ -368,6 +369,7 @@ pub fn static_call<SPEC: Spec>(interpreter: &mut Interpreter, host: &mut dyn Hos
     call_inner::<SPEC>(interpreter, CallScheme::StaticCall, host);
 }
 
+#[inline(never)]
 fn prepare_call_inputs<SPEC: Spec>(
     interpreter: &mut Interpreter,
     scheme: CallScheme,

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -340,6 +340,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
         (new_state, logs, gas_used, gas_refunded)
     }
 
+    #[inline(never)]
     fn prepare_create(&mut self, inputs: &CreateInputs) -> Result<PreparedCreate, CreateResult> {
         let gas = Gas::new(inputs.gas_limit);
 
@@ -629,6 +630,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
         }
     }
 
+    #[inline(never)]
     fn prepare_call(&mut self, inputs: &CallInputs) -> Result<PreparedCall, CallResult> {
         let gas = Gas::new(inputs.gas_limit);
         let account = match self


### PR DESCRIPTION
These functions are used for keeping the stack memory clean on the host recursive code paths. EVM supports up to 1024 levels of recursion, so if one is not careful with the stack memory allocations, the stack memory can blow up.

Benchmarks show dramatic stack memory improvements when ont inlining these functions. A recursive bomb uses around 1.1MB of stack when these functions are not inlined. If inlined the recursive bombs blow up the stack.

Fixes #589 
