### PR TITLE
chore(`perf`): only recalc code hash if its the default

### DIFF
--- a/crates/revm/src/db/in_memory_db.rs
+++ b/crates/revm/src/db/in_memory_db.rs
@@ -61,7 +61,9 @@ impl<ExtDB: DatabaseRef> CacheDB<ExtDB> {
     pub fn insert_contract(&mut self, account: &mut AccountInfo) {
         if let Some(code) = &account.code {
             if !code.is_empty() {
-                account.code_hash = code.hash_slow();
+                if account.code_hash == KECCAK_EMPTY {
+                    account.code_hash = code.hash_slow();
+                }
                 self.contracts
                     .entry(account.code_hash)
                     .or_insert_with(|| code.clone());


### PR DESCRIPTION
Stems from https://github.com/foundry-rs/foundry/issues/5730#issuecomment-1700458447

Only recalculate the code hash when inserting if it's the default