### PR TITLE
  EIP-6780: SELFDESTRUCT only in same transaction

### DIFF
--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -7,9 +7,7 @@ use crate::journaled_state::{is_precompile, JournalCheckpoint};
 use crate::primitives::{
     create2_address, create_address, keccak256, Account, AnalysisKind, Bytecode, Bytes, EVMError,
     EVMResult, Env, ExecutionResult, HashMap, InvalidTransaction, Log, Output, ResultAndState,
-    Spec,
-    SpecId::{self, *},
-    TransactTo, B160, B256, U256,
+    Spec, SpecId::*, TransactTo, B160, B256, U256,
 };
 use crate::{db::Database, journaled_state::JournaledState, precompile, Inspector};
 use alloc::boxed::Box;
@@ -267,11 +265,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
         inspector: &'a mut dyn Inspector<DB>,
         precompiles: Precompiles,
     ) -> Self {
-        let journaled_state = if GSPEC::enabled(SpecId::SPURIOUS_DRAGON) {
-            JournaledState::new(precompiles.len())
-        } else {
-            JournaledState::new_legacy(precompiles.len())
-        };
+        let journaled_state = JournaledState::new(precompiles.len(), GSPEC::SPEC_ID);
         Self {
             data: EVMData {
                 env,

--- a/crates/revm/src/journaled_state.rs
+++ b/crates/revm/src/journaled_state.rs
@@ -509,6 +509,10 @@ impl JournaledState {
                 balance,
             })
         } else {
+            // State is not changed:
+            // * if we are after Cancun upgrade and
+            // * Selfdestruct account that is created in the same transaction and
+            // * Specify the target is same as selfdestructed account. The balance stays unchanged.
             None
         };
 

--- a/crates/revm/src/journaled_state.rs
+++ b/crates/revm/src/journaled_state.rs
@@ -479,6 +479,8 @@ impl JournaledState {
         let (is_cold, target_exists) = self.load_account_exist(target, db)?;
 
         let acc = if address != target {
+            // Both accounts are loaded before this point, `address` as we execute its contract.
+            // and `target` at the beginning of the function.
             let [acc, target_account] = self.state.get_many_mut([&address, &target]).unwrap();
             Self::touch_account(self.journal.last_mut().unwrap(), &target, target_account);
             target_account.info.balance += acc.info.balance;


### PR DESCRIPTION
Closes #524. Reading the [EIP](https://eips.ethereum.org/EIPS/eip-6780), when the contract is not created in the same tx, `SELFDESTRUCT` simply becomes a transfer, while keeping the gas cost of the opcode. As such, I tried to modify only the `JournaledState` to reflect that.