### PR TITLE
chore: rm nonexhaustive for error

### DIFF
--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -122,7 +122,6 @@ impl Output {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[non_exhaustive]
 pub enum EVMError<DBError> {
     Transaction(InvalidTransaction),
     /// `prevrandao` is not set for Merge and above.


### PR DESCRIPTION
having non-exhaustive on an error forces this clippy error:

```
126 | pub enum EVMError<DBError> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: the matched value is of type `EVMError<T>`
    = note: `EVMError<T>` is marked as non-exhaustive, so a wildcard `_` is necessary to match exhaustively
help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
192 ~             EVMError::Database(err) => err.into(),
193 ~             _ => todo!(),
    |

```

this forces a wildcard handling which can introduce bugs if a new evmerror variant is added