### PR TITLE
chore: error type for block header

### DIFF
--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -1,5 +1,5 @@
 use crate::{
-    alloc::vec::Vec, calc_blob_fee, Account, EVMError, InvalidTransaction, Spec, SpecId, B160,
+    alloc::vec::Vec, calc_blob_fee, Account, InvalidHeader, InvalidTransaction, Spec, SpecId, B160,
     B256, GAS_PER_BLOB, KECCAK_EMPTY, MAX_BLOB_NUMBER_PER_BLOCK, MAX_INITCODE_SIZE, U256,
     VERSIONED_HASH_VERSION_KZG,
 };

--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -391,14 +391,14 @@ impl Env {
 
     /// Validate the block environment.
     #[inline]
-    pub fn validate_block_env<SPEC: Spec, T>(&self) -> Result<(), EVMError<T>> {
+    pub fn validate_block_env<SPEC: Spec>(&self) -> Result<(), InvalidHeader> {
         // `prevrandao` is required for the merge
         if SPEC::enabled(SpecId::MERGE) && self.block.prevrandao.is_none() {
-            return Err(EVMError::PrevrandaoNotSet);
+            return Err(InvalidHeader::PrevrandaoNotSet);
         }
         // `excess_blob_gas` is required for Cancun
         if SPEC::enabled(SpecId::CANCUN) && self.block.excess_blob_gas.is_none() {
-            return Err(EVMError::ExcessBlobGasNotSet);
+            return Err(InvalidHeader::ExcessBlobGasNotSet);
         }
         Ok(())
     }

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -124,10 +124,7 @@ impl Output {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum EVMError<DBError> {
     Transaction(InvalidTransaction),
-    /// `prevrandao` is not set for Merge and above.
-    PrevrandaoNotSet,
-    /// `excess_blob_gas` is not set for Cancun and above.
-    ExcessBlobGasNotSet,
+    Header(InvalidHeader),
     Database(DBError),
 }
 
@@ -138,8 +135,7 @@ impl<DBError: fmt::Display> fmt::Display for EVMError<DBError> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             EVMError::Transaction(e) => write!(f, "Transaction error: {e:?}"),
-            EVMError::PrevrandaoNotSet => f.write_str("`prevrandao` not set"),
-            EVMError::ExcessBlobGasNotSet => f.write_str("`excess_blob_gas` not set"),
+            EVMError::Header(e) => write!(f, "Header error: {e:?}"),
             EVMError::Database(e) => write!(f, "Database error: {e}"),
         }
     }
@@ -210,6 +206,21 @@ pub enum InvalidTransaction {
     TooManyBlobs,
     /// Blob transaction contains a versioned hash with an incorrect version
     BlobVersionNotSupported,
+}
+
+impl<DBError> From<InvalidHeader> for EVMError<DBError> {
+    fn from(invalid: InvalidHeader) -> Self {
+        EVMError::Header(invalid)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum InvalidHeader {
+    /// `prevrandao` is not set for Merge and above.
+    PrevrandaoNotSet,
+    /// `excess_blob_gas` is not set for Cancun and above.
+    ExcessBlobGasNotSet,
 }
 
 /// Reason a transaction successfully completed.

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -214,6 +214,7 @@ impl<DBError> From<InvalidHeader> for EVMError<DBError> {
     }
 }
 
+/// Errors related to misconfiguration of the  `BlockEnv`
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum InvalidHeader {

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -97,7 +97,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact<DB::Error>
         let env = self.env();
 
         // Important: validate block before tx.
-        env.validate_block_env::<GSPEC, DB::Error>()?;
+        env.validate_block_env::<GSPEC>()?;
         env.validate_tx::<GSPEC>()?;
 
         let initial_gas_spend = initial_tx_gas::<GSPEC>(


### PR DESCRIPTION
should close #685 

I have used enum name as header since env names such as `BlockEnv`, `CfgEnv` & `Env` are already used as type, let me know if prefer EnvError over this and I can quickly make that change.