### PR TITLE
feat(`deps`): Make `c-kzg` optional

### DIFF
--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -36,7 +36,8 @@ hex = "0.4"
 default = ["secp256k1", "std"]
 # Used to disable kzg lib as i couldn't make it compile for wasm target
 # at least not on mac.
-std = ["dep:c-kzg"]
+std = []
+c_kzg = ["dep:c-kzg", "revm-primitives/c_kzg"]
 # secp256k1 is used as faster alternative to k256 lib. And in most cases should be default.
 # Only problem that it has, it fails to build for wasm target on windows and mac as it is c lib.
 # If you dont require wasm on win/mac, i would recommend its usage.

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -7,7 +7,7 @@ mod blake2;
 mod bn128;
 mod hash;
 mod identity;
-#[cfg(feature = "std")]
+#[cfg(feature = "c_kzg")]
 pub mod kzg_point_evaluation;
 mod modexp;
 mod secp256k1;
@@ -197,7 +197,7 @@ impl Precompiles {
         static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
         INSTANCE.get_or_init(|| {
             // Don't include KZG point evaluation precompile in no_std builds.
-            #[cfg(feature = "std")]
+            #[cfg(feature = "c_kzg")]
             {
                 let mut precompiles = Box::new(Self::berlin().clone());
                 precompiles.fun.extend(
@@ -210,7 +210,7 @@ impl Precompiles {
                 );
                 precompiles
             }
-            #[cfg(not(feature = "std"))]
+            #[cfg(not(feature = "c_kzg"))]
             {
                 Box::new(Self::berlin().clone())
             }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -22,7 +22,7 @@ auto_impl = "1.1"
 bitvec = { version = "1", default-features = false, features = ["alloc"] }
 bitflags = { version = "2.4.0", default-features = false }
 
-# For setting the CfgEnv KZGSettings. Enabled by std flag.
+# For setting the CfgEnv KZGSettings. Enabled by the c_kzg flag.
 c-kzg = { git = "https://github.com/ethereum/c-kzg-4844", default-features = false, optional = true }
 
 # bits B256 B160 crate
@@ -77,7 +77,8 @@ optional_block_gas_limit = []
 optional_eip3607 = []
 optional_gas_refund = []
 optional_no_base_fee = []
-std = ["bytes/std", "rlp/std", "hex/std", "bitvec/std", "bitflags/std", "dep:c-kzg"]
+std = ["bytes/std", "rlp/std", "hex/std", "bitvec/std", "bitflags/std"]
+c_kzg = ["std", "dep:c-kzg"]
 serde = [
     "dep:serde",
     "hex/serde",

--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -238,7 +238,7 @@ pub struct CfgEnv {
     pub spec_id: SpecId,
     /// KZG Settings for point evaluation precompile. By default, this is loaded from the ethereum mainnet trusted setup.
     #[cfg_attr(feature = "serde", serde(skip))]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "c_kzg")]
     pub kzg_settings: crate::kzg::EnvKzgSettings,
     /// Bytecode that is created with CREATE/CREATE2 is by default analysed and jumptable is created.
     /// This is very beneficial for testing and speeds up execution of that bytecode if called multiple times.
@@ -355,7 +355,7 @@ impl Default for CfgEnv {
             perf_analyse_created_bytecodes: AnalysisKind::default(),
             limit_contract_code_size: None,
             disable_coinbase_tip: false,
-            #[cfg(feature = "std")]
+            #[cfg(feature = "c_kzg")]
             kzg_settings: crate::kzg::EnvKzgSettings::Default,
             #[cfg(feature = "memory_limit")]
             memory_limit: (1 << 32) - 1,

--- a/crates/primitives/src/kzg.rs
+++ b/crates/primitives/src/kzg.rs
@@ -2,8 +2,11 @@ mod env_settings;
 #[rustfmt::skip]
 mod generated;
 
+#[cfg(feature = "c_kzg")]
 pub use c_kzg::KzgSettings;
+#[cfg(feature = "c_kzg")]
 pub use env_settings::EnvKzgSettings;
+#[cfg(feature = "c_kzg")]
 pub use generated::{
     BYTES_PER_G1_POINT, BYTES_PER_G2_POINT, G1_POINTS, G2_POINTS, NUM_G1_POINTS, NUM_G2_POINTS,
 };

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -7,7 +7,7 @@ pub mod bytecode;
 pub mod constants;
 pub mod db;
 pub mod env;
-#[cfg(feature = "std")]
+#[cfg(feature = "c_kzg")]
 pub mod kzg;
 pub mod log;
 pub mod precompile;
@@ -27,7 +27,7 @@ pub use env::*;
 pub use hashbrown::{hash_map, hash_set, HashMap, HashSet};
 pub use hex;
 pub use hex_literal;
-#[cfg(feature = "std")]
+#[cfg(feature = "c_kzg")]
 pub use kzg::{EnvKzgSettings, KzgSettings};
 pub use log::Log;
 pub use precompile::*;

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -58,6 +58,7 @@ optional_no_base_fee = ["revm-interpreter/optional_no_base_fee"]
 std = ["revm-interpreter/std", "revm-precompile/std"]
 ethersdb = ["std", "tokio", "futures", "ethers-providers", "ethers-core"]
 serde = ["dep:serde", "dep:serde_json", "revm-interpreter/serde"]
+c_kzg = ["revm-precompile/c_kzg"]
 arbitrary = ["revm-interpreter/arbitrary"]
 # deprecated feature
 web3db = []


### PR DESCRIPTION
There are some `c-kzg` binding snafus which mess with [foundry's docker build process](https://github.com/foundry-rs/foundry/actions/runs/6302981610/job/17111278694). While this gets solved, making `c-kzg` an optional dep/feature that can be enabled can also solve this issue.