### PR TITLE
ci: concurrency for github actions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,4 +1,9 @@
 name: book
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{github.workflow}}-${{github.ref}}
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: Tests
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{github.workflow}}-${{github.ref}}
+
 on:
   push:
     branches: [main, "release/**"]

--- a/.github/workflows/ethereum-tests.yml
+++ b/.github/workflows/ethereum-tests.yml
@@ -1,10 +1,15 @@
+name: Ethereum Tests
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{github.workflow}}-${{github.ref}}
+
 on:
   push:
     branches: [main, "release/**"]
   pull_request:
     branches: [main, "release/**"]
 
-name: Ethereum Tests
 
 jobs:
   tests-stable:


### PR DESCRIPTION
The goal is to ensure that only a single job or workflow using the same concurrency group will run at a time.

E.g. if someone force pushes, CI won't run twice. The first workflow run will be stopped.