### PR TITLE
refactor: say "warm" instead of "hot"

### DIFF
--- a/crates/interpreter/src/gas/calc.rs
+++ b/crates/interpreter/src/gas/calc.rs
@@ -290,7 +290,7 @@ pub fn call_cost<SPEC: Spec>(
 }
 
 #[inline]
-pub fn hot_cold_cost<SPEC: Spec>(is_cold: bool, regular_value: u64) -> u64 {
+pub fn warm_cold_cost<SPEC: Spec>(is_cold: bool, regular_value: u64) -> u64 {
     if SPEC::enabled(BERLIN) {
         if is_cold {
             COLD_ACCOUNT_ACCESS_COST

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -75,7 +75,7 @@ pub trait Transact<DBError> {
 impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, INSPECT> {
     /// Load access list for berlin hardfork.
     ///
-    /// Loading of accounts/storages is needed to make them hot.
+    /// Loading of accounts/storages is needed to make them warm.
     #[inline]
     fn load_access_list(&mut self) -> Result<(), EVMError<DB::Error>> {
         for (address, slots) in self.data.env.tx.access_list.iter() {
@@ -396,7 +396,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
             CreateScheme::Create2 { salt } => create2_address(inputs.caller, code_hash, salt),
         };
 
-        // Load account so it needs to be marked as hot for access list.
+        // Load account so it needs to be marked as warm for access list.
         if self
             .data
             .journaled_state
@@ -815,7 +815,7 @@ impl<'a, GSPEC: Spec, DB: Database + 'a, const INSPECT: bool> Host
     }
 
     fn sload(&mut self, address: B160, index: U256) -> Option<(U256, bool)> {
-        // account is always hot. reference on that statement https://eips.ethereum.org/EIPS/eip-2929 see `Note 2:`
+        // account is always warm. reference on that statement https://eips.ethereum.org/EIPS/eip-2929 see `Note 2:`
         self.data
             .journaled_state
             .sload(address, index, self.data.db)

--- a/crates/revm/src/journaled_state.rs
+++ b/crates/revm/src/journaled_state.rs
@@ -32,7 +32,7 @@ pub struct JournaledState {
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum JournalEntry {
-    /// Used to mark account that is hot inside EVM in regards to EIP-2929 AccessList.
+    /// Used to mark account that is warm inside EVM in regards to EIP-2929 AccessList.
     /// Action: We will add Account to state.
     /// Revert: we will remove account from state.
     AccountLoaded { address: B160 },
@@ -64,9 +64,9 @@ pub enum JournalEntry {
     /// Actions: Mark account as created
     /// Revert: Unmart account as created and reset nonce to zero.
     AccountCreated { address: B160 },
-    /// It is used to track both storage change and hot load of storage slot. For hot load in regard
+    /// It is used to track both storage change and warm load of storage slot. For warm load in regard
     /// to EIP-2929 AccessList had_value will be None
-    /// Action: Storage change or hot load
+    /// Action: Storage change or warm load
     /// Revert: Revert to previous value or remove slot from storage
     StorageChange {
         address: B160,
@@ -153,8 +153,8 @@ impl JournaledState {
         self.depth as u64
     }
 
-    /// use it only if you know that acc is hot
-    /// Assume account is hot
+    /// use it only if you know that acc is warm
+    /// Assume account is warm
     pub fn set_code(&mut self, address: B160, code: Bytecode) {
         let account = self.state.get_mut(&address).unwrap();
         Self::touch_account(self.journal.last_mut().unwrap(), &address, account);
@@ -231,7 +231,7 @@ impl JournaledState {
     /// Create account or return false if collision is detected.
     ///
     /// There are few steps done:
-    /// 1. Make created account hot loaded (AccessList) and this should
+    /// 1. Make created account warm loaded (AccessList) and this should
     ///     be done before subroutine checkpoint is created.
     /// 2. Check if there is collision of newly created account with existing one.
     /// 3. Mark created account as created.
@@ -574,7 +574,7 @@ impl JournaledState {
         Ok(account)
     }
 
-    /// load account into memory. return if it is cold or hot accessed
+    /// load account into memory. return if it is cold or warm accessed
     pub fn load_account<DB: Database>(
         &mut self,
         address: B160,
@@ -595,7 +595,7 @@ impl JournaledState {
                     .unwrap()
                     .push(JournalEntry::AccountLoaded { address });
 
-                // precompiles are hot loaded so we need to take that into account
+                // precompiles are warm loaded so we need to take that into account
                 let is_cold = !is_precompile(address, self.num_of_precompiles);
 
                 (vac.insert(account), is_cold)
@@ -647,7 +647,7 @@ impl JournaledState {
         key: U256,
         db: &mut DB,
     ) -> Result<(U256, bool), DB::Error> {
-        let account = self.state.get_mut(&address).unwrap(); // assume acc is hot
+        let account = self.state.get_mut(&address).unwrap(); // assume acc is warm
                                                              // only if account is created in this tx we can assume that storage is empty.
         let is_newly_created = account.is_created();
         let load = match account.storage.entry(key) {

--- a/documentation/src/crates/revm/journaled_state.md
+++ b/documentation/src/crates/revm/journaled_state.md
@@ -45,12 +45,12 @@ This module is built around the `JournaledState` structure, which encapsulates t
 - `load_account`
 
     This method loads an account's information into memory and returns whether the account was
-    cold or hot accessed.
+    cold or warm accessed.
 
 - `load_account_exist`
 
     This method checks whether an account exists or not. It returns whether the account was
-    cold or hot accessed and whether it exists.
+    cold or warm accessed and whether it exists.
 
 - `load_code`
 


### PR DESCRIPTION
[EIP-2919](https://eips.ethereum.org/EIPS/eip-2929) does not make any reference to "hot". It only says "warm".

There's no need to introduce another term to refer to the same concept.

There are other references on the Internet, such as [EVM codes](https://www.evm.codes/about#accesssets), which also use only the "warm" terminology.