### PR TITLE
chore: bump c-kzg to create lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,8 +442,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "0.1.0"
-source = "git+https://github.com/ethereum/c-kzg-4844#fbef59a3f9e8fa998bdb5069d212daf83d586aa5"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac926d808fb72fe09ebf471a091d6d72918876ccf0b4989766093d2d0d24a0ef"
 dependencies = [
  "bindgen",
  "blst",

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -24,7 +24,7 @@ secp256k1 = { version = "0.27.0", default-features = false, features = [
 ], optional = true }
 sha2 = { version = "0.10.8", default-features = false }
 sha3 = { version = "0.10.7", default-features = false }
-c-kzg = { git = "https://github.com/ethereum/c-kzg-4844", default-features = false, optional = true }
+c-kzg = { version="0.1.1", default-features = false, optional = true }
 
 [dev-dependencies]
 hex = "0.4"

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -23,7 +23,7 @@ bitvec = { version = "1", default-features = false, features = ["alloc"] }
 bitflags = { version = "2.4.0", default-features = false }
 
 # For setting the CfgEnv KZGSettings. Enabled by std flag.
-c-kzg = { git = "https://github.com/ethereum/c-kzg-4844", default-features = false, optional = true }
+c-kzg = { version = "0.1.1", default-features = false, optional = true }
 
 # bits B256 B160 crate
 fixed-hash = { version = "0.8", default-features = false, features = [


### PR DESCRIPTION
Bump to unofficial c-kzg lib.

c-kzg 0.1.1 is based on fbef59a3f9e8fa998bdb5069d212daf83d586aa5 commit from [ethereum/c-kzg-4844](https://github.com/ethereum/c-kzg-4844) repo.

It does not support `minimal-spec` feature.