### PR TITLE
docs: document non-zero amounts in State::increment_balances

### DIFF
--- a/crates/revm/src/db/states/cache_account.rs
+++ b/crates/revm/src/db/states/cache_account.rs
@@ -296,6 +296,7 @@ impl CacheAccount {
     /// Note: to skip some edge cases we assume that additional balance is never zero.
     /// And as increment is always related to block fee/reward and withdrawals this is correct.
     pub fn increment_balance(&mut self, balance: u128) -> TransitionAccount {
+        debug_assert!(balance > 0, "Balance is assumed to be positive");
         self.account_info_change(|info| {
             info.balance += U256::from(balance);
         })

--- a/crates/revm/src/db/states/cache_account.rs
+++ b/crates/revm/src/db/states/cache_account.rs
@@ -293,14 +293,15 @@ impl CacheAccount {
     /// Increment balance by `balance` amount. Assume that balance will not
     /// overflow or be zero.
     ///
-    /// Note: to skip some edge cases we assume that additional balance is never zero.
-    /// And as increment is always related to block fee/reward and withdrawals this is correct.
-    pub fn increment_balance(&mut self, balance: u128) -> TransitionAccount {
-        debug_assert!(balance > 0, "Balance is assumed to be positive");
-        self.account_info_change(|info| {
-            info.balance += U256::from(balance);
-        })
-        .1
+    /// Note: only if balance is zero we would return None as no transition would be made.
+    pub fn increment_balance(&mut self, balance: u128) -> Option<TransitionAccount> {
+        if balance == 0 {
+            return None;
+        }
+        let (_, transition) = self.account_info_change(|info| {
+            info.balance = info.balance.saturating_add(U256::from(balance));
+        });
+        Some(transition)
     }
 
     fn account_info_change<T, F: FnOnce(&mut AccountInfo) -> T>(

--- a/crates/revm/src/db/states/state.rs
+++ b/crates/revm/src/db/states/state.rs
@@ -93,8 +93,16 @@ impl<DB: Database> State<DB> {
         // make transition and update cache state
         let mut transitions = Vec::new();
         for (address, balance) in balances {
+            if balance == 0 {
+                continue;
+            }
             let original_account = self.load_cache_account(address)?;
-            transitions.push((address, original_account.increment_balance(balance)))
+            transitions.push((
+                address,
+                original_account
+                    .increment_balance(balance)
+                    .expect("Balance is not zero"),
+            ))
         }
         // append transition
         if let Some(s) = self.transition_state.as_mut() {

--- a/crates/revm/src/db/states/state.rs
+++ b/crates/revm/src/db/states/state.rs
@@ -82,6 +82,10 @@ impl<DB: Database> State<DB> {
     /// If account is not found inside cache state it will be loaded from database.
     ///
     /// Update will create transitions for all accounts that are updated.
+    ///
+    /// Like [CacheAccount::increment_balance], this assumes that incremented balances are not
+    /// zero, and will not overflow once incremented. If using this to implement withdrawals, zero
+    /// balances must be filtered out before calling this function.
     pub fn increment_balances(
         &mut self,
         balances: impl IntoIterator<Item = (B160, u128)>,


### PR DESCRIPTION
Thought this would be good to add after debugging https://github.com/paradigmxyz/reth/pull/4840. This documents the same assumptions in `CacheAccount::increment_balance`, but in `State::increment_balances` as well. A `debug_assert` is added in `increment_balance`, to cause it to panic if the assumption is violated in tests.