### PR TITLE
fix: use u128 for calc_blob_gasprice

### DIFF
--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -63,7 +63,7 @@ pub struct BlockEnv {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BlobExcessGasAndPrice {
     pub excess_blob_gas: u64,
-    pub blob_gasprice: u64,
+    pub blob_gasprice: u128,
 }
 
 impl BlobExcessGasAndPrice {
@@ -106,7 +106,7 @@ impl BlockEnv {
     ///
     /// [EIP-4844]: https://eips.ethereum.org/EIPS/eip-4844
     #[inline]
-    pub fn get_blob_gasprice(&self) -> Option<u64> {
+    pub fn get_blob_gasprice(&self) -> Option<u128> {
         self.blob_excess_gas_and_price
             .as_ref()
             .map(|a| a.blob_gasprice)

--- a/crates/primitives/src/utilities.rs
+++ b/crates/primitives/src/utilities.rs
@@ -45,7 +45,7 @@ pub fn calc_excess_blob_gas(parent_excess_blob_gas: u64, parent_blob_gas_used: u
 ///
 /// See also [the EIP-4844 helpers](https://eips.ethereum.org/EIPS/eip-4844#helpers).
 #[inline]
-pub fn calc_blob_gasprice(excess_blob_gas: u64) -> u64 {
+pub fn calc_blob_gasprice(excess_blob_gas: u64) -> u128 {
     fake_exponential(
         MIN_BLOB_GASPRICE,
         excess_blob_gas,
@@ -63,7 +63,7 @@ pub fn calc_blob_gasprice(excess_blob_gas: u64) -> u64 {
 ///
 /// Panics if `denominator` is zero.
 #[inline]
-pub fn fake_exponential(factor: u64, numerator: u64, denominator: u64) -> u64 {
+pub fn fake_exponential(factor: u64, numerator: u64, denominator: u64) -> u128 {
     assert_ne!(denominator, 0, "attempt to divide by zero");
     let factor = factor as u128;
     let numerator = numerator as u128;
@@ -79,7 +79,7 @@ pub fn fake_exponential(factor: u64, numerator: u64, denominator: u64) -> u64 {
         numerator_accum = (numerator_accum * numerator) / (denominator * i);
         i += 1;
     }
-    (output / denominator) as u64
+    output / denominator
 }
 
 /// Serde functions to serde as [bytes::Bytes] hex string
@@ -173,7 +173,17 @@ mod tests {
     // https://github.com/ethereum/go-ethereum/blob/28857080d732857030eda80c69b9ba2c8926f221/consensus/misc/eip4844/eip4844_test.go#L60
     #[test]
     fn test_calc_blob_fee() {
-        for &(excess, expected) in &[(0, 1), (2314057, 1), (2314058, 2), (10 * 1024 * 1024, 23)] {
+        let blob_fee_vectors = &[
+            (0, 1),
+            (2314057, 1),
+            (2314058, 2),
+            (10 * 1024 * 1024, 23),
+            (148099578, 18446739238971471609), // output is just below the overflow
+            (148099579, 18446744762204311910), // output is just after the overflow
+            (161087488, 902580055246494526580),
+        ];
+
+        for &(excess, expected) in blob_fee_vectors {
             let actual = calc_blob_gasprice(excess);
             assert_eq!(actual, expected, "test: {excess}");
         }
@@ -183,7 +193,7 @@ mod tests {
     #[test]
     fn fake_exp() {
         for t @ &(factor, numerator, denominator, expected) in &[
-            (1u64, 0u64, 1u64, 1u64),
+            (1u64, 0u64, 1u64, 1u128),
             (38493, 0, 1000, 38493),
             (0, 1234, 2345, 0),
             (1, 2, 1, 6), // approximate 7.389

--- a/crates/primitives/src/utilities.rs
+++ b/crates/primitives/src/utilities.rs
@@ -178,6 +178,11 @@ mod tests {
             (2314057, 1),
             (2314058, 2),
             (10 * 1024 * 1024, 23),
+            // calc_blob_gasprice approximates `e ** (excess_blob_gas / BLOB_GASPRICE_UPDATE_FRACTION)` using Taylor expansion
+            //
+            // to roughly find where boundaries will be hit:
+            // 2 ** bits = e ** (excess_blob_gas / BLOB_GASPRICE_UPDATE_FRACTION)
+            // excess_blob_gas = ln(2 ** bits) * BLOB_GASPRICE_UPDATE_FRACTION
             (148099578, 18446739238971471609), // output is just below the overflow
             (148099579, 18446744762204311910), // output is just after the overflow
             (161087488, 902580055246494526580),


### PR DESCRIPTION
This uses `u128` for `calc_blob_gasprice` and `fake_exponential`. This solves an issue where an `excess_blob_gas` value of `161087488` in hive tests should produce a value over 128 bits, but did not because of the following cast:
https://github.com/bluealloy/revm/blob/ef2f21b6e2b507c18b7edcdd005c5aaddb63df0f/crates/primitives/src/utilities.rs#L82