### PR TITLE
fix(primitives): Error Primitive Display + Error Implementations

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -4,7 +4,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(unused_crate_dependencies)]
-#![feature(error_in_core)]
 
 extern crate alloc;
 

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -4,6 +4,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(unused_crate_dependencies)]
+#![feature(error_in_core)]
 
 extern crate alloc;
 

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -217,6 +217,68 @@ pub enum InvalidTransaction {
     DepositSystemTxPostRegolith,
 }
 
+impl std::error::Error for InvalidTransaction {}
+
+impl fmt::Display for InvalidTransaction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            InvalidTransaction::PriorityFeeGreaterThanMaxFee => {
+                write!(f, "Priority fee is greater than max fee")
+            }
+            InvalidTransaction::GasPriceLessThanBasefee => {
+                write!(f, "Gas price is less than basefee")
+            }
+            InvalidTransaction::CallerGasLimitMoreThanBlock => {
+                write!(f, "Caller gas limit exceeds the block gas limit")
+            }
+            InvalidTransaction::CallGasCostMoreThanGasLimit => {
+                write!(f, "Call gas cost exceeds the gas limit")
+            }
+            InvalidTransaction::RejectCallerWithCode => {
+                write!(f, "Reject transactions from senders with deployed code")
+            }
+            InvalidTransaction::LackOfFundForMaxFee { .. } => {
+                write!(f, "Lack of funds for max fee",)
+            }
+            InvalidTransaction::OverflowPaymentInTransaction => {
+                write!(f, "Overflow payment in transaction")
+            }
+            InvalidTransaction::NonceOverflowInTransaction => {
+                write!(f, "Nonce overflow in transaction")
+            }
+            InvalidTransaction::NonceTooHigh { .. } => write!(f, "Nonce too high"),
+            InvalidTransaction::NonceTooLow { .. } => write!(f, "Nonce too low"),
+            InvalidTransaction::CreateInitcodeSizeLimit => {
+                write!(f, "Create initcode size limit")
+            }
+            InvalidTransaction::InvalidChainId => write!(f, "Invalid chain id"),
+            InvalidTransaction::AccessListNotSupported => {
+                write!(f, "Access list not supported")
+            }
+            InvalidTransaction::MaxFeePerBlobGasNotSupported => {
+                write!(f, "Max fee per blob gas not supported")
+            }
+            InvalidTransaction::BlobVersionedHashesNotSupported => {
+                write!(f, "Blob versioned hashes not supported")
+            }
+            InvalidTransaction::BlobGasPriceGreaterThanMax => {
+                write!(f, "Blob gas price is greater than max fee per blob gas")
+            }
+            InvalidTransaction::EmptyBlobs => write!(f, "Empty blobs"),
+            InvalidTransaction::BlobCreateTransaction => write!(f, "Blob create transaction"),
+            InvalidTransaction::TooManyBlobs => write!(f, "Too many blobs"),
+            InvalidTransaction::BlobVersionNotSupported => write!(f, "Blob version not supported"),
+            #[cfg(feature = "optimism")]
+            InvalidTransaction::DepositSystemTxPostRegolith => {
+                write!(
+                    f,
+                    "Deposit system transactions post regolith hardfork are not supported"
+                )
+            }
+        }
+    }
+}
+
 impl<DBError> From<InvalidHeader> for EVMError<DBError> {
     fn from(invalid: InvalidHeader) -> Self {
         EVMError::Header(invalid)
@@ -231,6 +293,17 @@ pub enum InvalidHeader {
     PrevrandaoNotSet,
     /// `excess_blob_gas` is not set for Cancun and above.
     ExcessBlobGasNotSet,
+}
+
+impl std::error::Error for InvalidHeader {}
+
+impl fmt::Display for InvalidHeader {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            InvalidHeader::PrevrandaoNotSet => write!(f, "Prevrandao not set"),
+            InvalidHeader::ExcessBlobGasNotSet => write!(f, "Excess blob gas not set"),
+        }
+    }
 }
 
 /// Reason a transaction successfully completed.

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -1,5 +1,6 @@
 use crate::{Address, Bytes, Log, State, U256};
 use alloc::vec::Vec;
+use core::error;
 use core::fmt;
 
 /// Result of EVM execution.
@@ -217,7 +218,7 @@ pub enum InvalidTransaction {
     DepositSystemTxPostRegolith,
 }
 
-impl std::error::Error for InvalidTransaction {}
+impl error::Error for InvalidTransaction {}
 
 impl fmt::Display for InvalidTransaction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -295,7 +296,7 @@ pub enum InvalidHeader {
     ExcessBlobGasNotSet,
 }
 
-impl std::error::Error for InvalidHeader {}
+impl error::Error for InvalidHeader {}
 
 impl fmt::Display for InvalidHeader {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -1,6 +1,5 @@
 use crate::{Address, Bytes, Log, State, U256};
 use alloc::vec::Vec;
-use core::error;
 use core::fmt;
 
 /// Result of EVM execution.
@@ -218,7 +217,8 @@ pub enum InvalidTransaction {
     DepositSystemTxPostRegolith,
 }
 
-impl error::Error for InvalidTransaction {}
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidTransaction {}
 
 impl fmt::Display for InvalidTransaction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -238,8 +238,8 @@ impl fmt::Display for InvalidTransaction {
             InvalidTransaction::RejectCallerWithCode => {
                 write!(f, "Reject transactions from senders with deployed code")
             }
-            InvalidTransaction::LackOfFundForMaxFee { .. } => {
-                write!(f, "Lack of funds for max fee",)
+            InvalidTransaction::LackOfFundForMaxFee { fee, balance } => {
+                write!(f, "Lack of funds {} for max fee {}", balance, fee)
             }
             InvalidTransaction::OverflowPaymentInTransaction => {
                 write!(f, "Overflow payment in transaction")
@@ -247,8 +247,12 @@ impl fmt::Display for InvalidTransaction {
             InvalidTransaction::NonceOverflowInTransaction => {
                 write!(f, "Nonce overflow in transaction")
             }
-            InvalidTransaction::NonceTooHigh { .. } => write!(f, "Nonce too high"),
-            InvalidTransaction::NonceTooLow { .. } => write!(f, "Nonce too low"),
+            InvalidTransaction::NonceTooHigh { tx, state } => {
+                write!(f, "Nonce too high {}, expected {}", tx, state)
+            }
+            InvalidTransaction::NonceTooLow { tx, state } => {
+                write!(f, "Nonce {} too low, expected {}", tx, state)
+            }
             InvalidTransaction::CreateInitcodeSizeLimit => {
                 write!(f, "Create initcode size limit")
             }
@@ -296,7 +300,8 @@ pub enum InvalidHeader {
     ExcessBlobGasNotSet,
 }
 
-impl error::Error for InvalidHeader {}
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidHeader {}
 
 impl fmt::Display for InvalidHeader {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
**Description**

Addresses #740 

Implements `std::error::Error + std::fmt::Display` for `InvalidTransaction` and `InvalidHeader`. If there are others that should be implemented, happy to do in this pr cc @DaniPopes 