### PR TITLE
feat(revm): implement DatabaseRef trait for EthersDB

### DIFF
--- a/crates/revm/src/db/ethersdb.rs
+++ b/crates/revm/src/db/ethersdb.rs
@@ -1,5 +1,5 @@
 use crate::primitives::{AccountInfo, Address, Bytecode, B256, KECCAK_EMPTY, U256};
-use crate::Database;
+use crate::{Database, DatabaseRef};
 use ethers_core::types::{BlockId, H160 as eH160, H256, U64 as eU64};
 use ethers_providers::Middleware;
 use std::sync::Arc;
@@ -10,6 +10,7 @@ pub struct EthersDB<M: Middleware> {
     runtime: Option<Runtime>,
     block_number: Option<BlockId>,
 }
+
 
 impl<M: Middleware> EthersDB<M> {
     /// create ethers db connector inputs are url and block on what we are basing our database (None for latest)
@@ -46,10 +47,10 @@ impl<M: Middleware> EthersDB<M> {
     }
 }
 
-impl<M: Middleware> Database for EthersDB<M> {
+impl<M: Middleware> DatabaseRef for EthersDB<M> {
     type Error = ();
 
-    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+    fn basic(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         let add = eH160::from(address.0 .0);
 
         let f = async {
@@ -77,12 +78,12 @@ impl<M: Middleware> Database for EthersDB<M> {
         )))
     }
 
-    fn code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+    fn code_by_hash(&self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
         panic!("Should not be called. Code is already loaded");
         // not needed because we already load code with basic info
     }
 
-    fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
+    fn storage(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
         let add = eH160::from(address.0 .0);
         let index = H256::from(index.to_be_bytes());
         let f = async {
@@ -96,7 +97,7 @@ impl<M: Middleware> Database for EthersDB<M> {
         Ok(self.block_on(f))
     }
 
-    fn block_hash(&mut self, number: U256) -> Result<B256, Self::Error> {
+    fn block_hash(&self, number: U256) -> Result<B256, Self::Error> {
         // saturate usize
         if number > U256::from(u64::MAX) {
             return Ok(KECCAK_EMPTY);
@@ -110,6 +111,30 @@ impl<M: Middleware> Database for EthersDB<M> {
                 .flatten()
         };
         Ok(B256::new(self.block_on(f).unwrap().hash.unwrap().0))
+    }
+}
+
+impl<M: Middleware> Database for EthersDB<M> {
+    type Error = ();
+
+    #[inline]
+    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        <Self as DatabaseRef>::basic(self, address)
+    }
+
+    #[inline]
+    fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        <Self as DatabaseRef>::code_by_hash(self, code_hash)
+    }
+
+    #[inline]
+    fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        <Self as DatabaseRef>::storage(self, address, index)
+    }
+
+    #[inline]
+    fn block_hash(&mut self, number: U256) -> Result<B256, Self::Error> {
+        <Self as DatabaseRef>::block_hash(self, number)
     }
 }
 

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -26,7 +26,7 @@ pub use db::{
     CacheState, DBBox, State, StateBuilder, StateDBBox, TransitionAccount, TransitionState,
 };
 
-pub use db::{Database, DatabaseCommit, InMemoryDB};
+pub use db::{Database, DatabaseCommit, DatabaseRef, InMemoryDB};
 pub use evm::{evm_inner, new, EVM};
 pub use evm_impl::{EVMData, EVMImpl, Transact};
 pub use journaled_state::{is_precompile, JournalCheckpoint, JournalEntry, JournaledState};


### PR DESCRIPTION
Provides a concrete implementation for the `DatabaseRef` trait instead of the `Database` trait. Implementation for the Database trait is simply a wrapper.