### PR TITLE
feat(revm): implement DatabaseRef trait for EthersDB

### DIFF
--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -26,7 +26,7 @@ pub use db::{
     CacheState, DBBox, State, StateBuilder, StateDBBox, TransitionAccount, TransitionState,
 };
 
-pub use db::{Database, DatabaseCommit, InMemoryDB};
+pub use db::{Database, DatabaseCommit, DatabaseRef, InMemoryDB};
 pub use evm::{evm_inner, new, EVM};
 pub use evm_impl::{EVMData, EVMImpl, Transact};
 pub use journaled_state::{is_precompile, JournalCheckpoint, JournalEntry, JournaledState};


### PR DESCRIPTION
Provides a concrete implementation for the `DatabaseRef` trait instead of the `Database` trait. Implementation for the Database trait is simply a wrapper.