### PR TITLE
fix(primitives): Use Upstream Alloy Create Implementations

### DIFF
--- a/crates/primitives/src/utilities.rs
+++ b/crates/primitives/src/utilities.rs
@@ -1,24 +1,11 @@
 use crate::{
-    b256, Address, B256, BLOB_GASPRICE_UPDATE_FRACTION, MIN_BLOB_GASPRICE,
-    TARGET_BLOB_GAS_PER_BLOCK, U256,
+    b256, B256, BLOB_GASPRICE_UPDATE_FRACTION, MIN_BLOB_GASPRICE, TARGET_BLOB_GAS_PER_BLOCK,
 };
 pub use alloy_primitives::keccak256;
 
 /// The Keccak-256 hash of the empty string `""`.
 pub const KECCAK_EMPTY: B256 =
     b256!("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");
-
-/// Returns the address for the legacy `CREATE` scheme: [`CreateScheme::Create`]
-#[inline]
-pub fn create_address(caller: Address, nonce: u64) -> Address {
-    caller.create(nonce)
-}
-
-/// Returns the address for the `CREATE2` scheme: [`CreateScheme::Create2`]
-#[inline]
-pub fn create2_address(caller: Address, code_hash: B256, salt: U256) -> Address {
-    caller.create2(salt.to_be_bytes::<32>(), code_hash)
-}
 
 /// Calculates the `excess_blob_gas` from the parent header's `blob_gas_used` and `excess_blob_gas`.
 ///

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -6,9 +6,8 @@ use crate::interpreter::{
 };
 use crate::journaled_state::{is_precompile, JournalCheckpoint};
 use crate::primitives::{
-    create2_address, create_address, keccak256, Address, AnalysisKind, Bytecode, Bytes, EVMError,
-    EVMResult, Env, ExecutionResult, InvalidTransaction, Log, Output, ResultAndState, Spec,
-    SpecId::*, TransactTo, B256, U256,
+    keccak256, Address, AnalysisKind, Bytecode, Bytes, EVMError, EVMResult, Env, ExecutionResult,
+    InvalidTransaction, Log, Output, ResultAndState, Spec, SpecId::*, TransactTo, B256, U256,
 };
 use crate::{db::Database, journaled_state::JournaledState, precompile, Inspector};
 use alloc::boxed::Box;
@@ -471,8 +470,8 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
         // Create address
         let code_hash = keccak256(&inputs.init_code);
         let created_address = match inputs.scheme {
-            CreateScheme::Create => create_address(inputs.caller, old_nonce),
-            CreateScheme::Create2 { salt } => create2_address(inputs.caller, code_hash, salt),
+            CreateScheme::Create => inputs.caller.create(old_nonce),
+            CreateScheme::Create2 { salt } => inputs.caller.create2(B256::from(salt), code_hash),
         };
 
         // Load account so it needs to be marked as warm for access list.

--- a/documentation/src/crates/primitives/utils.md
+++ b/documentation/src/crates/primitives/utils.md
@@ -5,7 +5,3 @@ This Rust module provides utility functions and constants for handling Keccak ha
 The `KECCAK_EMPTY` constant represents the Keccak-256 hash of an empty input.
 
 The `keccak256` function takes a byte slice input and returns its Keccak-256 hash as a `B256` value.
-
-`create_address` function implements the address calculation for the Ethereum `CREATE` operation. It takes as parameters the address of the caller (`caller`) and a nonce (`nonce`). The function serializes these inputs using Recursive Length Prefix (RLP) encoding, calculates the Keccak-256 hash of the result, and returns the last 20 bytes of this hash as the created address.
-
-`create2_address` function implements the address calculation for the Ethereum `CREATE2` operation. It takes as parameters the address of the caller (`caller`), a hash of the initializing code (`code_hash`), and a "salt" value (`salt`). The function hashes these inputs together in a specific way, as per the Ethereum `CREATE2` rules, and returns the last 20 bytes of the result as the created address.


### PR DESCRIPTION
**Description**

Since `create` and `create2_address` are used internally and external implementations can just use the methods directly on the re-exported `Address` type, this PR removes the utility methods and inlines the upstream alloy creation function calls.