### PR TITLE
chore(primitives): Precompile Error Display + Error Trait Implementations

### DIFF
--- a/crates/primitives/src/precompile.rs
+++ b/crates/primitives/src/precompile.rs
@@ -1,5 +1,6 @@
 use crate::Env;
 use alloc::vec::Vec;
+use core::fmt;
 
 /// A precompile operation result.
 ///
@@ -31,4 +32,34 @@ pub enum PrecompileError {
     BlobMismatchedVersion,
     /// The proof verification failed.
     BlobVerifyKzgProofFailed,
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for PrecompileError {}
+
+impl fmt::Display for PrecompileError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            PrecompileError::OutOfGas => write!(f, "out of gas"),
+            PrecompileError::Blake2WrongLength => write!(f, "wrong input length for blake2"),
+            PrecompileError::Blake2WrongFinalIndicatorFlag => {
+                write!(f, "wrong final indicator flag for blake2")
+            }
+            PrecompileError::ModexpExpOverflow => write!(f, "modexp exp overflow"),
+            PrecompileError::ModexpBaseOverflow => write!(f, "modexp base overflow"),
+            PrecompileError::ModexpModOverflow => write!(f, "modexp mod overflow"),
+            PrecompileError::Bn128FieldPointNotAMember => {
+                write!(f, "field point not a member of bn128 curve")
+            }
+            PrecompileError::Bn128AffineGFailedToCreate => {
+                write!(f, "failed to create affine g point for bn128 curve")
+            }
+            PrecompileError::Bn128PairLength => write!(f, "bn128 invalid pair length"),
+            PrecompileError::BlobInvalidInputLength => write!(f, "invalid blob input length"),
+            PrecompileError::BlobMismatchedVersion => write!(f, "mismatched blob version"),
+            PrecompileError::BlobVerifyKzgProofFailed => {
+                write!(f, "verifying blob kzg proof failed")
+            }
+        }
+    }
 }


### PR DESCRIPTION
**Description**

Implements the `std::error::Error` and `core::fmt::Display` traits for the `PrecompileError` enum.