### PR TITLE
feat: add more `auto_impl`s to revm traits

### DIFF
--- a/crates/primitives/src/db/components/block_hash.rs
+++ b/crates/primitives/src/db/components/block_hash.rs
@@ -6,7 +6,7 @@ use alloc::sync::Arc;
 use auto_impl::auto_impl;
 use core::ops::Deref;
 
-#[auto_impl(& mut, Box)]
+#[auto_impl(&mut, Box)]
 pub trait BlockHash {
     type Error;
 
@@ -14,7 +14,7 @@ pub trait BlockHash {
     fn block_hash(&mut self, number: U256) -> Result<B256, Self::Error>;
 }
 
-#[auto_impl(&, Box, Arc)]
+#[auto_impl(&, &mut, Box, Rc, Arc)]
 pub trait BlockHashRef {
     type Error;
 

--- a/crates/primitives/src/db/components/state.rs
+++ b/crates/primitives/src/db/components/state.rs
@@ -6,7 +6,7 @@ use alloc::sync::Arc;
 use auto_impl::auto_impl;
 use core::ops::Deref;
 
-#[auto_impl(& mut, Box)]
+#[auto_impl(&mut, Box)]
 pub trait State {
     type Error;
 
@@ -20,7 +20,7 @@ pub trait State {
     fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error>;
 }
 
-#[auto_impl(&, Box, Arc)]
+#[auto_impl(&, &mut, Box, Rc, Arc)]
 pub trait StateRef {
     type Error;
 

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -14,6 +14,7 @@ use crate::{db::Database, journaled_state::JournaledState, precompile, Inspector
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
+use auto_impl::auto_impl;
 use core::fmt;
 use core::marker::PhantomData;
 use revm_interpreter::opcode::make_boxed_instruction_table;
@@ -89,6 +90,8 @@ struct CallResult {
     return_value: Bytes,
 }
 
+/// EVM transaction interface.
+#[auto_impl(&mut, Box)]
 pub trait Transact<DBError> {
     /// Run checks that could make transaction fail before call/create.
     fn preverify_transaction(&mut self) -> Result<(), EVMError<DBError>>;
@@ -100,7 +103,7 @@ pub trait Transact<DBError> {
     #[inline]
     fn transact(&mut self) -> EVMResult<DBError> {
         self.preverify_transaction()
-            .and_then(|_| self.transact_preverified())
+            .and_then(|()| self.transact_preverified())
     }
 }
 


### PR DESCRIPTION
Ref traits with `&self` can have all of `&, &mut, Box, Rc, Arc`
Traits with `&mut self` can only have `&mut, Box`