### PR TITLE
fix: unused `step` and `step_end` results

### DIFF
--- a/crates/revm/src/inspector/instruction.rs
+++ b/crates/revm/src/inspector/instruction.rs
@@ -21,7 +21,9 @@ pub fn inspector_instruction<'a, SPEC: Spec + 'static, DB: Database>(
                 interpreter.instruction_pointer = interpreter.instruction_pointer.sub(1);
             }
             if let Some(inspector) = host.inspector.as_mut() {
-                if inspector.step(interpreter, data) != InstructionResult::Continue {
+                let result = inspector.step(interpreter, data);
+                if result != InstructionResult::Continue {
+                    interpreter.instruction_result = result;
                     return;
                 }
             }
@@ -37,7 +39,10 @@ pub fn inspector_instruction<'a, SPEC: Spec + 'static, DB: Database>(
             // step ends
             let data = &mut host.data;
             if let Some(inspector) = host.inspector.as_mut() {
-                inspector.step_end(interpreter, data);
+                let result = inspector.step_end(interpreter, data);
+                if result != InstructionResult::Continue {
+                    interpreter.instruction_result = result;
+                }
             }
         },
     );


### PR DESCRIPTION
This PR fixes a bug introduced by #759:
- The result of `step` is read but not written to the interpreter result. If the function returns something other than `Continue`, it will lead to an infinite loop in the interpreter.
- The result of `step_end` is not being read at all, which means the execution cannot be halted by the inspector from this function.