### PR TITLE
chore: Make Instruction fn const

### DIFF
--- a/crates/interpreter/src/instructions/opcode.rs
+++ b/crates/interpreter/src/instructions/opcode.rs
@@ -64,7 +64,7 @@ macro_rules! opcodes {
         };
 
         /// Return the instruction function for the given opcode and spec.
-        pub fn instruction<H:Host, SPEC:Spec>(opcode: u8) -> Instruction<H> {
+        pub const fn instruction<H:Host, SPEC:Spec>(opcode: u8) -> Instruction<H> {
             match opcode {
                 $($name => $f,)*
                 _ => control::not_found,
@@ -75,9 +75,8 @@ macro_rules! opcodes {
 }
 
 /// Make instruction table.
-pub fn make_instruction_table<SPEC: Spec, H: Host>() -> InstructionTable<H> {
-    let mut table: InstructionTable<H> =
-        core::array::from_fn(|_| control::not_found::<H> as Instruction<H>);
+pub const fn make_instruction_table<SPEC: Spec, H: Host>() -> InstructionTable<H> {
+    let mut table: InstructionTable<H> = [control::not_found::<H> as Instruction<H>; 256];
     let mut i = 0;
     while i < 256 {
         table[i] = instruction::<H, SPEC>(i as u8);
@@ -85,6 +84,7 @@ pub fn make_instruction_table<SPEC: Spec, H: Host>() -> InstructionTable<H> {
     }
     table
 }
+
 
 /// Make boxed instruction table that calls `outer` closure for every instruction.
 pub fn make_boxed_instruction_table<'a, SPEC: Spec + 'static, H: Host + 'a, FN>(


### PR DESCRIPTION
After merging [this PR](https://github.com/rust-lang/rust/issues/114994) some constraints got relaxed and we are able to create a const Instruction that contains `&mut` in its signature.

Currently, this works in the nightly version: `cargo 1.75.0-nightly (6fa6fdc76 2023-10-10)` and we should wait until this is in stable before merging.