### PR TITLE
chore: for now support 1.69 rust compiler

### DIFF
--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -59,7 +59,7 @@ impl PrecompileOutput {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub struct Precompiles {
     pub fun: HashMap<Address, Precompile>,
 }
@@ -70,7 +70,7 @@ impl Default for Precompiles {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone)]
 pub enum Precompile {
     Standard(StandardPrecompileFn),
     Env(EnvPrecompileFn),
@@ -85,7 +85,7 @@ impl fmt::Debug for Precompile {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug)]
 pub struct PrecompileAddress(Address, Precompile);
 
 impl From<PrecompileAddress> for (Address, Precompile) {

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -25,9 +25,8 @@ type CalculateGasRefundHandle = fn(&Env, &Gas) -> u64;
 /// Handler acts as a proxy and allow to define different behavior for different
 /// sections of the code. This allows nice integration of different chains or
 /// to disable some mainnet behavior.
-#[derive(Debug)]
 pub struct Handler<DB: Database> {
-    // Uses env, call resul and returned gas from the call to determine the gas
+    // Uses env, call result and returned gas from the call to determine the gas
     // that is returned from transaction execution..
     pub call_return: CallReturnHandle,
     pub reimburse_caller: ReimburseCallerHandle<DB>,


### PR DESCRIPTION
Reversing some changes so we can support the older rust compiler, there was a request for this as llvm bump broke downstream project.

From chat: `This has nothing to do with Rust specifically, but with the RISC-V LLVM backend used: There seems to be a bug in LLVM, introduced somewhere between 1.69 and 1.70, that generates invalid riscv32 instructions.`

For note: `rust 1.70` added `llvm 16.0.2` while `rust 1.73` added `llvm 17.0.2`.