### PR TITLE
fix(op): Base Goerli `op-reth` sync patches

### DIFF
--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -215,6 +215,10 @@ pub enum InvalidTransaction {
     /// post-regolith hardfork.
     #[cfg(feature = "optimism")]
     DepositSystemTxPostRegolith,
+    /// Deposit transaction haults bubble up to the global main return handler,
+    /// wiping state and only increasing the nonce + persisting the mint value.
+    #[cfg(feature = "optimism")]
+    HaltedDepositPostRegolith,
 }
 
 #[cfg(feature = "std")]
@@ -278,6 +282,13 @@ impl fmt::Display for InvalidTransaction {
                 write!(
                     f,
                     "Deposit system transactions post regolith hardfork are not supported"
+                )
+            }
+            #[cfg(feature = "optimism")]
+            InvalidTransaction::HaltedDepositPostRegolith => {
+                write!(
+                    f,
+                    "Deposit transaction halted post-regolith. Error will be bubbled up to main return handler."
                 )
             }
         }

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -350,6 +350,10 @@ pub enum Halt {
     CallNotAllowedInsideStatic,
     OutOfFund,
     CallTooDeep,
+
+    /* Optimism errors */
+    #[cfg(feature = "optimism")]
+    FailedDeposit,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -69,7 +69,7 @@ impl<DB: Database> Handler<DB> {
             reimburse_caller: mainnet::handle_reimburse_caller::<SPEC, DB>,
             calculate_gas_refund: optimism::calculate_gas_refund::<SPEC>,
             reward_beneficiary: optimism::reward_beneficiary::<SPEC, DB>,
-            main_return: mainnet::main_return::<DB>,
+            main_return: optimism::main_return::<SPEC, DB>,
         }
     }
 

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -43,7 +43,7 @@ pub struct Handler<DB: Database> {
     /// Calculate gas refund for transaction.
     /// Some chains have it disabled.
     pub calculate_gas_refund: CalculateGasRefundHandle,
-    /// Main return handle, returns the output of the transaction.
+    /// Main return handle, returns the output of the transact.
     pub main_return: MainReturnHandle<DB>,
 }
 

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -2,11 +2,11 @@ pub mod mainnet;
 #[cfg(feature = "optimism")]
 pub mod optimism;
 
-use crate::interpreter::{Gas, InstructionResult};
-use crate::primitives::{Env, Output, ResultAndState, Spec};
-use crate::EVMData;
-use revm_interpreter::primitives::db::Database;
-use revm_interpreter::primitives::{EVMError, EVMResultGeneric};
+use crate::{
+    interpreter::{Gas, InstructionResult},
+    primitives::{db::Database, EVMError, EVMResultGeneric, Env, Output, ResultAndState, Spec},
+    EVMData,
+};
 
 /// Handle call return and return final gas value.
 type CallReturnHandle = fn(&Env, InstructionResult, Gas) -> Gas;
@@ -43,7 +43,7 @@ pub struct Handler<DB: Database> {
     /// Calculate gas refund for transaction.
     /// Some chains have it disabled.
     pub calculate_gas_refund: CalculateGasRefundHandle,
-    /// Main return handle this handle output of the transact.
+    /// Main return handle, returns the output of the transaction.
     pub main_return: MainReturnHandle<DB>,
 }
 

--- a/crates/revm/src/handler/mainnet.rs
+++ b/crates/revm/src/handler/mainnet.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 /// Handle output of the transaction
+#[inline]
 pub fn handle_call_return<SPEC: Spec>(
     env: &Env,
     call_result: InstructionResult,
@@ -103,6 +104,8 @@ pub fn calculate_gas_refund<SPEC: Spec>(env: &Env, gas: &Gas) -> u64 {
     }
 }
 
+/// Main return handle this handle output of the transact.
+#[inline]
 pub fn main_return<DB: Database>(
     data: &mut EVMData<'_, DB>,
     call_result: InstructionResult,

--- a/crates/revm/src/handler/optimism.rs
+++ b/crates/revm/src/handler/optimism.rs
@@ -175,9 +175,9 @@ pub fn end_handle<SPEC: Spec, DB: Database>(
     evm_output: Result<ResultAndState, EVMError<DB::Error>>,
 ) -> Result<ResultAndState, EVMError<DB::Error>> {
     evm_output.or_else(|err| {
-        if matches!(EVMError::Transaction(_), err)
-            && evm.env().cfg.optimism
-            && evm.env().tx.optimism.source_hash.is_some()
+        if matches!(err, EVMError::Transaction(_))
+            && data.env().cfg.optimism
+            && data.env().tx.optimism.source_hash.is_some()
         {
             // If the transaction is a deposit transaction and it failed
             // for any reason, the caller nonce must be bumped, and the


### PR DESCRIPTION
## Overview

Contains several fixes for the Optimism state transition code.

### Context

After hooking up the OP execution changes to `op-reth` and performing a sync test on the Base Goerli network, a few bugs were found.

### Patches

1. The Optimism EL has a critical invariant that _deposit transactions may never fail_. This implies that even upon a total failure of the state transition, for any reason, the `mint` value should be persisted to the sender account's balance to prevent loss of funds, and the sender's nonce should be bumped as well.
    1. **Solution**: Pull out the default implementation of the `transact` function in the `Transact` trait, and define a catch-all failure handler that persists the `mint` value to and bumps the nonce of the caller account before returning a special `Halt` variant.
1. When a deposit `Halt`s, a few special rules apply. These happen to be identical to the logic in the above catch-all.
    1. **Solution**: Wipe the state of the journal and fall back to the catch-all that persists the mint value and bumps the nonce of the caller. This will return a `Halt::FailedDeposit` status.

Reference Branch (cherry-picked #781 onto `3.5.0` for integrating w/ `op-reth`: https://github.com/anton-rs/op-revm/tree/cl/patch-op) 