### PR TITLE
chore(state): make bundle state non-optional

### DIFF
--- a/crates/revm/src/db/states/state_builder.rs
+++ b/crates/revm/src/db/states/state_builder.rs
@@ -162,7 +162,7 @@ impl<DB: Database> StateBuilder<DB> {
                 .with_cache_prestate
                 .unwrap_or_else(|| CacheState::new(self.with_state_clear)),
             database: self.database,
-            transition_state: self.with_bundle_update.then(|| TransitionState::default()),
+            transition_state: self.with_bundle_update.then(TransitionState::default),
             bundle_state: self.with_bundle_prestate.unwrap_or_default(),
             use_preloaded_bundle,
             block_hashes: self.with_block_hashes,

--- a/crates/revm/src/db/states/state_builder.rs
+++ b/crates/revm/src/db/states/state_builder.rs
@@ -162,12 +162,8 @@ impl<DB: Database> StateBuilder<DB> {
                 .with_cache_prestate
                 .unwrap_or_else(|| CacheState::new(self.with_state_clear)),
             database: self.database,
-            transition_state: if self.with_bundle_update {
-                Some(TransitionState::default())
-            } else {
-                None
-            },
-            bundle_state: self.with_bundle_prestate,
+            transition_state: self.with_bundle_update.then(|| TransitionState::default()),
+            bundle_state: self.with_bundle_prestate.unwrap_or_default(),
             use_preloaded_bundle,
             block_hashes: self.with_block_hashes,
         }


### PR DESCRIPTION
## Description

There is no good reason to put `BundleState` in an `Option`. In the case of a missing pre-loaded bundle, the default can be used instead. 