### PR TITLE
chore(opcodes): new_or_invalid helper

### DIFF
--- a/crates/interpreter/src/instructions/opcode.rs
+++ b/crates/interpreter/src/instructions/opcode.rs
@@ -393,6 +393,17 @@ impl OpCode {
         }
     }
 
+    /// Instantiate a new opcode from a u8 or return
+    /// the `INVALID` opcode if missing from `OPCODE_JUMPMAP`
+    #[inline]
+    pub const fn new_or_invalid(opcode: u8) -> Self {
+        if let Some(op) = Self::new(opcode) {
+            op
+        } else {
+            Self(0xFE)
+        }
+    }
+
     /// Instantiate a new opcode from a u8 without checking if it is valid.
     ///
     /// # Safety


### PR DESCRIPTION
While doing an issue on reth (https://github.com/paradigmxyz/reth/issues/5067) I've found it can be helpful to have this method that simply converts to `INVALID` any unknown opcode, instead of having to do pattern matching