### PR TITLE
chore: use keccak256 for blockhash

### DIFF
--- a/crates/revm/src/db/emptydb.rs
+++ b/crates/revm/src/db/emptydb.rs
@@ -1,7 +1,7 @@
 use core::{convert::Infallible, fmt, marker::PhantomData};
 use revm_interpreter::primitives::{
     db::{Database, DatabaseRef},
-    AccountInfo, Address, Bytecode, B256, U256,
+    keccak256, AccountInfo, Address, Bytecode, B256, U256,
 };
 
 /// An empty database that always returns default values when queried.
@@ -101,6 +101,6 @@ impl<E> DatabaseRef for EmptyDBTyped<E> {
 
     #[inline]
     fn block_hash_ref(&self, number: U256) -> Result<B256, Self::Error> {
-        Ok(number.to_be_bytes().into())
+        Ok(keccak256(number.to_be_bytes::<{ U256::BYTES }>()))
     }
 }

--- a/crates/revm/src/db/states/state.rs
+++ b/crates/revm/src/db/states/state.rs
@@ -305,7 +305,7 @@ mod tests {
         states::reverts::AccountInfoRevert, AccountRevert, AccountStatus, BundleAccount,
         RevertToSlot,
     };
-    use revm_interpreter::primitives::StorageSlot;
+    use revm_interpreter::primitives::{keccak256, StorageSlot};
 
     #[test]
     fn block_hash_cache() {
@@ -315,9 +315,9 @@ mod tests {
 
         let test_number = BLOCK_HASH_HISTORY as u64 + 2;
 
-        let block1_hash = B256::from(U256::from(1).to_be_bytes());
-        let block2_hash = B256::from(U256::from(2).to_be_bytes());
-        let block_test_hash = B256::from(U256::from(test_number).to_be_bytes());
+        let block1_hash = keccak256(&U256::from(1).to_be_bytes::<{ U256::BYTES }>());
+        let block2_hash = keccak256(&U256::from(2).to_be_bytes::<{ U256::BYTES }>());
+        let block_test_hash = keccak256(&U256::from(test_number).to_be_bytes::<{ U256::BYTES }>());
 
         assert_eq!(
             state.block_hashes,


### PR DESCRIPTION
As the discussion in https://github.com/foundry-rs/foundry/issues/6235 , currently, `blockhash(number)` returns `number`, but I think we should use `keccak256` for `blockhash`.

The main reason is:

>`blockhash`, even though it's a 256-bit value, can be represented by a much smaller number of bits  from a security point of view.
>For example, if a contract has a bug that the upper bits of the `blockhash` value are missing in inline-assembly or something, the bug would not be detected in tests.

This PR used it as we have done so before https://github.com/bluealloy/revm/pull/691 .

@DaniPopes This is a minor change and mds1 agreed that so I've sent this PR to facilitate it before I get your reply. :)