### PR TITLE
chore(precompiles): Make PrecompileWithAddress field public, from impl

### DIFF
--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -242,7 +242,13 @@ impl fmt::Debug for Precompile {
 }
 
 #[derive(Clone, Debug)]
-pub struct PrecompileWithAddress(Address, Precompile);
+pub struct PrecompileWithAddress(pub Address, pub Precompile);
+
+impl From<(Address, Precompile)> for PrecompileWithAddress {
+    fn from(value: (Address, Precompile)) -> Self {
+        PrecompileWithAddress(value.0, value.1)
+    }
+}
 
 impl From<PrecompileWithAddress> for (Address, Precompile) {
     fn from(value: PrecompileWithAddress) -> Self {

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -101,7 +101,13 @@ impl fmt::Debug for Precompile {
 }
 
 #[derive(Clone, Debug)]
-pub struct PrecompileWithAddress(Address, Precompile);
+pub struct PrecompileWithAddress(pub Address, pub Precompile);
+
+impl From<(Address, Precompile)> for PrecompileWithAddress {
+    fn from(value: (Address, Precompile)) -> Self {
+        PrecompileWithAddress(value.0, value.1)
+    }
+}
 
 impl From<PrecompileWithAddress> for (Address, Precompile) {
     fn from(value: PrecompileWithAddress) -> Self {


### PR DESCRIPTION
Make `PrecompileWithAddress` fields public so they can be accessible and add `From` impl for (address,precompile) tuple.