### PR TITLE
Fix error message for LackOfFundForMaxFee

### DIFF
--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -227,7 +227,7 @@ impl Env {
                 account.info.balance = balance_check;
             } else {
                 return Err(InvalidTransaction::LackOfFundForMaxFee {
-                    fee: self.tx.gas_limit,
+                    fee: balance_check,
                     balance: account.info.balance,
                 });
             }

--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -227,8 +227,8 @@ impl Env {
                 account.info.balance = balance_check;
             } else {
                 return Err(InvalidTransaction::LackOfFundForMaxFee {
-                    fee: balance_check,
-                    balance: account.info.balance,
+                    fee: Box::new(balance_check),
+                    balance: Box::new(account.info.balance),
                 });
             }
         }

--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -3,6 +3,7 @@ use crate::{
     InvalidTransaction, Spec, SpecId, B256, GAS_PER_BLOB, KECCAK_EMPTY, MAX_BLOB_NUMBER_PER_BLOCK,
     MAX_INITCODE_SIZE, U256, VERSIONED_HASH_VERSION_KZG,
 };
+use alloc::boxed::Box;
 use core::cmp::{min, Ordering};
 
 /// EVM environment configuration.

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -180,7 +180,7 @@ pub enum InvalidTransaction {
     RejectCallerWithCode,
     /// Transaction account does not have enough amount of ether to cover transferred value and gas_limit*gas_price.
     LackOfFundForMaxFee {
-        fee: u64,
+        fee: U256,
         balance: U256,
     },
     /// Overflow payment in transaction.

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -1,5 +1,5 @@
 use crate::{Address, Bytes, Log, State, U256};
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 
 /// Result of EVM execution.

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -126,7 +126,7 @@ impl Output {
 }
 
 /// Main EVM error.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum EVMError<DBError> {
     /// Transaction validation error.
@@ -157,7 +157,7 @@ impl<DBError> From<InvalidTransaction> for EVMError<DBError> {
 }
 
 /// Transaction validation error.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum InvalidTransaction {
     /// When using the EIP-1559 fee model introduced in the London upgrade, transactions specify two primary fee fields:
@@ -180,8 +180,8 @@ pub enum InvalidTransaction {
     RejectCallerWithCode,
     /// Transaction account does not have enough amount of ether to cover transferred value and gas_limit*gas_price.
     LackOfFundForMaxFee {
-        fee: U256,
-        balance: U256,
+        fee: Box<U256>,
+        balance: Box<U256>,
     },
     /// Overflow payment in transaction.
     OverflowPaymentInTransaction,

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -66,15 +66,10 @@ impl<'a, SPEC: Spec, DB: Database> EVMImpl<'a, SPEC, DB> {
             .map_err(EVMError::Database)?
             .0;
         if l1_cost.gt(&acc.info.balance) {
-            let u64_cost = if U256::from(u64::MAX).lt(&l1_cost) {
-                u64::MAX
-            } else {
-                l1_cost.as_limbs()[0]
-            };
             return Err(EVMError::Transaction(
                 InvalidTransaction::LackOfFundForMaxFee {
-                    fee: U256::from(u64_cost),
-                    balance: acc.info.balance,
+                    fee: Box::new(l1_cost),
+                    balance: Box::new(acc.info.balance),
                 },
             ));
         }

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -822,8 +822,8 @@ mod tests {
             ),
             Err(EVMError::Transaction(
                 InvalidTransaction::LackOfFundForMaxFee {
-                    fee: U256::from(101),
-                    balance: U256::from(100),
+                    fee: Box::new(U256::from(101)),
+                    balance: Box::new(U256::from(100)),
                 },
             ))
         );

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -73,7 +73,7 @@ impl<'a, SPEC: Spec, DB: Database> EVMImpl<'a, SPEC, DB> {
             };
             return Err(EVMError::Transaction(
                 InvalidTransaction::LackOfFundForMaxFee {
-                    fee: u64_cost,
+                    fee: U256::from(u64_cost),
                     balance: acc.info.balance,
                 },
             ));
@@ -827,7 +827,7 @@ mod tests {
             ),
             Err(EVMError::Transaction(
                 InvalidTransaction::LackOfFundForMaxFee {
-                    fee: 101u64,
+                    fee: U256::from(101),
                     balance: U256::from(100),
                 },
             ))


### PR DESCRIPTION
Instead of returning the fee for a transaction, the LackOfFundForMaxFee error currently returns gas_limit. This PR fixes that.