### PR TITLE
chore: Fix rustdoc warnings

### DIFF
--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use core::cmp::{min, Ordering};
 
+
 /// EVM environment configuration.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -256,7 +257,7 @@ pub struct CfgEnv {
     /// If some it will effects EIP-170: Contract code size limit. Useful to increase this because of tests.
     /// By default it is 0x6000 (~25kb).
     pub limit_contract_code_size: Option<usize>,
-    /// A hard memory limit in bytes beyond which [Memory] cannot be resized.
+    /// A hard memory limit in bytes beyond which [crate::result::OutOfGasError::Memory] cannot be resized.
     ///
     /// In cases where the gas limit may be extraordinarily high, it is recommended to set this to
     /// a sane value to prevent memory allocation panics. Defaults to `2^32 - 1` bytes per
@@ -433,8 +434,8 @@ pub struct BlockEnv {
     /// [EIP-4399]: https://eips.ethereum.org/EIPS/eip-4399
     pub prevrandao: Option<B256>,
     /// Excess blob gas and blob gasprice.
-    /// See also [`calc_excess_blob_gas`](crate::calc_excess_blob_gas)
-    /// and [`calc_blob_gasprice`](crate::calc_blob_gasprice).
+    /// See also [`crate::calc_excess_blob_gas`]
+    /// and [`calc_blob_gasprice`].
     ///
     /// Incorporated as part of the Cancun upgrade via [EIP-4844].
     ///
@@ -444,7 +445,7 @@ pub struct BlockEnv {
 
 impl BlockEnv {
     /// Takes `blob_excess_gas` saves it inside env
-    /// and calculates `blob_fee` with [`BlobGasAndFee`].
+    /// and calculates `blob_fee` with [`BlobExcessGasAndPrice`].
     pub fn set_blob_excess_gas_and_price(&mut self, excess_blob_gas: u64) {
         self.blob_excess_gas_and_price = Some(BlobExcessGasAndPrice::new(excess_blob_gas));
     }

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -3,7 +3,6 @@ use alloc::vec::Vec;
 use core::fmt;
 
 
-
 /// Result of EVM execution.
 pub type EVMResult<DBError> = EVMResultGeneric<ResultAndState, DBError>;
 

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -2,6 +2,8 @@ use crate::{Address, Bytes, Log, State, U256};
 use alloc::vec::Vec;
 use core::fmt;
 
+
+
 /// Result of EVM execution.
 pub type EVMResult<DBError> = EVMResultGeneric<ResultAndState, DBError>;
 
@@ -306,7 +308,7 @@ impl<DBError> From<InvalidHeader> for EVMError<DBError> {
     }
 }
 
-/// Errors related to misconfiguration of a [`BlockEnv`].
+/// Errors related to misconfiguration of a [`crate::env::BlockEnv`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum InvalidHeader {

--- a/crates/primitives/src/utilities.rs
+++ b/crates/primitives/src/utilities.rs
@@ -9,7 +9,7 @@ pub const KECCAK_EMPTY: B256 =
 
 /// Calculates the `excess_blob_gas` from the parent header's `blob_gas_used` and `excess_blob_gas`.
 ///
-/// See also [the EIP-4844 helpers](https://eips.ethereum.org/EIPS/eip-4844#helpers
+/// See also [the EIP-4844 helpers]<https://eips.ethereum.org/EIPS/eip-4844#helpers>
 /// (`calc_excess_blob_gas`).
 #[inline]
 pub fn calc_excess_blob_gas(parent_excess_blob_gas: u64, parent_blob_gas_used: u64) -> u64 {

--- a/crates/revm/src/db/states/changes.rs
+++ b/crates/revm/src/db/states/changes.rs
@@ -58,7 +58,7 @@ pub struct PlainStateReverts {
 }
 
 impl PlainStateReverts {
-    /// Constructs new [StateReverts] with pre-allocated capacity.
+    /// Constructs new [PlainStateReverts] with pre-allocated capacity.
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             accounts: Vec::with_capacity(capacity),

--- a/crates/revm/src/db/states/state.rs
+++ b/crates/revm/src/db/states/state.rs
@@ -204,7 +204,7 @@ impl<DB: Database> State<DB> {
     /// NOTE: If either:
     /// * The [State] has not been built with [StateBuilder::with_bundle_update], or
     /// * The [State] has a [TransitionState] set to `None` when
-    /// [TransitionState::merge_transitions] is called,
+    /// [State::merge_transitions] is called,
     ///
     /// this will panic.
     pub fn take_bundle(&mut self) -> BundleState {

--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -32,7 +32,7 @@ pub mod inspectors {
 pub trait Inspector<DB: Database> {
     /// Called before the interpreter is initialized.
     ///
-    /// If `interp.instruction_result` is set to anything other than [InstructionResult::Continue] then the execution of the interpreter
+    /// If `interp.instruction_result` is set to anything other than [crate::interpreter::InstructionResult::Continue] then the execution of the interpreter
     /// is skipped.
     #[inline]
     fn initialize_interp(&mut self, interp: &mut Interpreter, context: &mut EvmContext<'_, DB>) {
@@ -71,7 +71,7 @@ pub trait Inspector<DB: Database> {
 
     /// Called after `step` when the instruction has been executed.
     ///
-    /// Setting `interp.instruction_result` to anything other than [InstructionResult::Continue] alters the execution
+    /// Setting `interp.instruction_result` to anything other than [crate::interpreter::InstructionResult::Continue] alters the execution
     /// of the interpreter.
     #[inline]
     fn step_end(&mut self, interp: &mut Interpreter, context: &mut EvmContext<'_, DB>) {
@@ -81,7 +81,7 @@ pub trait Inspector<DB: Database> {
 
     /// Called whenever a call to a contract is about to start.
     ///
-    /// InstructionResulting anything other than [InstructionResult::Continue] overrides the result of the call.
+    /// InstructionResulting anything other than [crate::interpreter::InstructionResult::Continue] overrides the result of the call.
     #[inline]
     fn call(
         &mut self,
@@ -109,7 +109,7 @@ pub trait Inspector<DB: Database> {
 
     /// Called when a contract is about to be created.
     ///
-    /// InstructionResulting anything other than [InstructionResult::Continue] overrides the result of the creation.
+    /// InstructionResulting anything other than [crate::interpreter::InstructionResult::Continue] overrides the result of the creation.
     #[inline]
     fn create(
         &mut self,

--- a/crates/revm/src/journaled_state.rs
+++ b/crates/revm/src/journaled_state.rs
@@ -420,14 +420,14 @@ impl JournaledState {
     /// Performans selfdestruct action.
     /// Transfers balance from address to target. Check if target exist/is_cold
     ///
-    /// Note: balance will be lost if [address] and [target] are the same BUT when
-    /// current spec enables Cancun, this happens only when the account associated to [address]
+    /// Note: balance will be lost if address and target are the same BUT when
+    /// current spec enables Cancun, this happens only when the account associated to address
     /// is created in the same tx
     ///
     /// references:
-    ///  * https://github.com/ethereum/go-ethereum/blob/141cd425310b503c5678e674a8c3872cf46b7086/core/vm/instructions.go#L832-L833
-    ///  * https://github.com/ethereum/go-ethereum/blob/141cd425310b503c5678e674a8c3872cf46b7086/core/state/statedb.go#L449
-    ///  * https://eips.ethereum.org/EIPS/eip-6780
+    ///  * <https://github.com/ethereum/go-ethereum/blob/141cd425310b503c5678e674a8c3872cf46b7086/core/vm/instructions.go#L832-L833>
+    ///  * <https://github.com/ethereum/go-ethereum/blob/141cd425310b503c5678e674a8c3872cf46b7086/core/state/statedb.go#L449>
+    ///  * <https://eips.ethereum.org/EIPS/eip-6780>
     #[inline]
     pub fn selfdestruct<DB: Database>(
         &mut self,


### PR DESCRIPTION
Solved rust doc warnings since the issue was open since september.
One part I was uncertain was
 _/// Takes `blob_excess_gas` saves it inside env
    /// and calculates `blob_fee` with [`BlobGasAndFee`]._
Because there's no mention of BlobGasAndFee in the code. I assumed it to be BlobExcessGasAndPrice that is what is used in the code below it