### PR TITLE
perf: optimize gas overflow check

### DIFF
--- a/crates/interpreter/src/gas.rs
+++ b/crates/interpreter/src/gas.rs
@@ -90,11 +90,10 @@ impl Gas {
     /// Returns `false` if the gas limit is exceeded.
     #[inline(always)]
     pub fn record_cost(&mut self, cost: u64) -> bool {
-        let all_used_gas = self.all_used_gas.saturating_add(cost);
-        if self.limit < all_used_gas {
+        let (all_used_gas, overflow) = self.all_used_gas.overflowing_add(cost);
+        if overflow | (self.limit < all_used_gas) {
             return false;
         }
-
         self.used += cost;
         self.all_used_gas = all_used_gas;
         true
@@ -104,8 +103,8 @@ impl Gas {
     #[inline]
     pub fn record_memory(&mut self, gas_memory: u64) -> bool {
         if gas_memory > self.memory {
-            let all_used_gas = self.used.saturating_add(gas_memory);
-            if self.limit < all_used_gas {
+            let (all_used_gas, overflow) = self.used.overflowing_add(gas_memory);
+            if overflow | (self.limit < all_used_gas) {
                 return false;
             }
             self.memory = gas_memory;


### PR DESCRIPTION
Partly reverts #592. Saturating add incurs more cost than just overflow check because we always branch if there is an overflow.

We can optimize the overflow check by using a bitwise or instead of logical one, so there is only one branch, although the compiler usually does this anyway.

Benches:
- Cachegrind: 430,444,571 to 421,462,297
- [Godbolt](https://godbolt.org/z/o5fvo33KW)

Note: I will be maintaining [a `cachegrind` branch](https://github.com/DaniPopes/revm/tree/cachegrind) on my fork where I will do these tests