### PR TITLE
feat: add Stack empty

### DIFF
--- a/crates/interpreter/src/interpreter/stack.rs
+++ b/crates/interpreter/src/interpreter/stack.rs
@@ -46,6 +46,12 @@ impl Stack {
         }
     }
 
+    /// Instantiate a new stack without pre-allocating any memory.
+    #[inline]
+    pub fn empty() -> Self {
+        Self { data: Vec::new() }
+    }
+
     /// Returns the length of the stack in words.
     #[inline]
     pub fn len(&self) -> usize {


### PR DESCRIPTION
Adds a helper function to get an empty Stack.

this can be beneficial during tracing where stack capturing is optional, and working with `Stack` over `Option<Stack>` is preferred

ref https://github.com/paradigmxyz/reth/pull/5521