### PR TITLE
Refactored logic in sstore_cost

### DIFF
--- a/crates/interpreter/src/gas/calc.rs
+++ b/crates/interpreter/src/gas/calc.rs
@@ -205,7 +205,7 @@ pub fn sstore_cost<SPEC: Spec>(
     };
 
     let gas_cost = if SPEC::enabled(ISTANBUL) {
-        calculate_istanbul_gas_cost(original, current, new, gas_sload, gas_sstore_reset)
+        istanbul_sstore_cost(original, current, new, gas_sload, gas_sstore_reset)
     } else {
         calculate_non_istanbul_gas_cost(current, new, gas_sstore_reset)
     };
@@ -217,7 +217,8 @@ pub fn sstore_cost<SPEC: Spec>(
     }
 }
 
-fn calculate_istanbul_gas_cost(
+#[inline(always)]
+fn istanbul_sstore_cost(
     original: U256,
     current: U256,
     new: U256,

--- a/crates/interpreter/src/gas/calc.rs
+++ b/crates/interpreter/src/gas/calc.rs
@@ -205,18 +205,18 @@ pub fn sstore_cost<SPEC: Spec>(
         let gas_cost = istanbul_sstore_cost(original, current, new, gas_sload, gas_sstore_reset);
         
         if is_cold {
-            return Some(gas_cost + COLD_SLOAD_COST);
+            Some(gas_cost + COLD_SLOAD_COST)
         } else {
-            return Some(gas_cost);
+            Some(gas_cost)
         }
     } else if SPEC::enabled(ISTANBUL) {
         // Istanbul logic
         let (gas_sload, gas_sstore_reset) = (sload_cost::<SPEC>(is_cold), SSTORE_RESET);
-        return Some(istanbul_sstore_cost(original, current, new, gas_sload, gas_sstore_reset));
+        Some(istanbul_sstore_cost(original, current, new, gas_sload, gas_sstore_reset))
     } else {
         // Non-Berlin and non-Istanbul logic
         let gas_sstore_reset = SSTORE_RESET;
-        return Some(non_istanbul_sstore_cost(current, new, gas_sstore_reset));
+        Some(non_istanbul_sstore_cost(current, new, gas_sstore_reset))
     }
 }
 


### PR DESCRIPTION
Refactored the sstore_cost function to be more readable and maintainable as mentioned in #830. Broke it down into smaller functions and removed the nesting by using return statements.