### PR TITLE
fix(crates): Package Manifest Lint Reporting Levels

### DIFF
--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -9,6 +9,12 @@ repository = "https://github.com/bluealloy/revm"
 version = "1.3.0"
 readme = "../../README.md"
 
+[lints.rust]
+unreachable_pub = "warn"
+unused_crate_dependencies = "warn"
+unused_must_use = "deny"
+rust_2018_idioms = "deny"
+
 [dependencies]
 revm-primitives = { path = "../primitives", version = "1.3.0", default-features = false }
 

--- a/crates/interpreter/src/lib.rs
+++ b/crates/interpreter/src/lib.rs
@@ -1,8 +1,6 @@
 //! # revm-interpreter
 //!
 //! REVM Interpreter.
-#![warn(unreachable_pub, unused_crate_dependencies)]
-#![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -8,6 +8,11 @@ name = "revm-precompile"
 repository = "https://github.com/bluealloy/revm"
 version = "2.2.0"
 
+[lints.rust]
+unused_crate_dependencies = "warn"
+unused_must_use = "deny"
+rust_2018_idioms = "deny"
+
 [dependencies]
 revm-primitives = { path = "../primitives", version = "1.3.0", default-features = false }
 bn = { package = "substrate-bn", version = "0.6", default-features = false }

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -1,8 +1,6 @@
 //! # revm-precompile
 //!
 //! Implementations of EVM precompiled contracts.
-#![warn(unused_crate_dependencies)]
-#![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -12,6 +12,12 @@ readme = "../../README.md"
 # Don't need to run build script outside of this repo
 exclude = ["build.rs", "src/kzg/*.txt"]
 
+[lints.rust]
+unreachable_pub = "warn"
+unused_crate_dependencies = "warn"
+unused_must_use = "deny"
+rust_2018_idioms = "deny"
+
 [dependencies]
 alloy-primitives = { version = "0.5", default-features = false, features = [
     "rlp",

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -1,8 +1,6 @@
 //! # revm-primitives
 //!
 //! EVM primitive types.
-#![warn(unreachable_pub, unused_crate_dependencies)]
-#![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -9,6 +9,11 @@ repository = "https://github.com/bluealloy/revm"
 version = "3.5.0"
 readme = "../../README.md"
 
+[lints.rust]
+unreachable_pub = "warn"
+unused_must_use = "deny"
+rust_2018_idioms = "deny"
+
 [dependencies]
 revm-interpreter = { path = "../interpreter", version = "1.3.0", default-features = false }
 revm-precompile = { path = "../precompile", version = "2.2.0", default-features = false }

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -1,7 +1,5 @@
-#![warn(unreachable_pub)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-#![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(all(feature = "with-serde", not(feature = "serde")))]


### PR DESCRIPTION
**Description**

Fixes #887 

Moves inline lint reporting levels to each crates' package manifest under the `[lints]` table.