### PR TITLE
chore(docs): Binary Readme Touchup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ target
 .idea
 pkg/
 
-
+tests
 bins/revme/temp_folder
 bins/revme/tests
 ethereumjs-util.js

--- a/bins/revme/README.md
+++ b/bins/revme/README.md
@@ -1,4 +1,26 @@
 # Rust EVM executor or short REVME
 
-This is binary crate that executed evm multiple ways. Currently it is used to run ethereum tests:
-* statetest: takes path to folder where ethereum statetest json can be found. It recursively searches for all json files and execute them. This is how i run all https://github.com/ethereum/tests to check if revm is compliant. Example `revme statests test/GenericEvmTest/`
+`revme` is a binary crate to execute the evm in multiple ways.
+
+Currently it is mainly used to run ethereum tests with the `statetest` subcommand.
+
+## State Tests
+
+`statetest` takes a path to the directory where ethereum statetest json can be found.
+It recursively parses all json files in the specified directory and executes them.
+
+Running all [ethereum tests][et] checks that revm is compliant to the ethereum specs.
+
+To run [ethereum tests][et] locally, clone the [tests][et] repository and provide the
+test directory. Below, we clone the repo and execute the `GeneralStateTests` suite of
+tests.
+
+```shell
+git clone https://github.com/ethereum/tests
+cargo run -p revme statetest tests/GeneralStateTests
+```
+
+*Notice, in the [`.gitignore`](../../.gitignore), the `bins/revme/tests` directory
+is ignored so it won't be checked into git.*
+
+[et]: https://github.com/ethereum/tests


### PR DESCRIPTION
**Description**

Updates the `revme` readme to provide working instructions for running ethereum tests locally using the `revme statetest` subcommand.