### PR TITLE
fix(ci): Workflow Touchups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,65 +10,105 @@ on:
   pull_request:
     branches: [main, "release/**"]
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
-  tests-stable:
-    name: Tests (Stable)
+  test:
+    name: test ${{ matrix.rust }} ${{ matrix.flags }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: ["stable", "beta", "nightly", "1.65"]
+        flags: ["--no-default-features", "", "--all-features"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - uses: Swatinem/rust-cache@v2
+      # Only run tests on latest stable and above
+      - name: check
+        if: ${{ matrix.rust == '1.65' }} # MSRV
+        run: cargo check --workspace ${{ matrix.flags }}
+      - name: test
+        if: ${{ matrix.rust != '1.65' }} # MSRV
+        run: cargo test --workspace ${{ matrix.flags }}
+
+  test-no-std:
+    name: test no_std
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
           targets: riscv32imac-unknown-none-elf
+      - run: cargo check --target riscv32imac-unknown-none-elf --no-default-features
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-
-      - name: cargo test
-        run: cargo test --workspace
-
-      - name: cargo test all features
-        run: cargo test --workspace --all-features
-      
-      - name: cargo check no_std
-        run: cargo check --target riscv32imac-unknown-none-elf --no-default-features
-
-  lint:
-    name: Lint
+  check-no-default-features:
+    name: check no-default-features
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustfmt, clippy
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-
-      - name: cargo fmt
-        run: cargo +nightly fmt --all -- --check
-
-      - name: cargo clippy
-        run: cargo +nightly clippy --workspace --all-features -- -D warnings
-
-      - name: cargo check no-default-features
-        run: |
+      - uses: actions/checkout@v3
+      - run: |
           cd crates/revm
           cargo check --no-default-features
-      - name: cargo check serde
-        run: |
+  
+  check-serde:
+    name: check serde
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
           cd crates/revm
           cargo check --no-default-features --features serde
-      - name: cargo check std
-        run: |
+
+  check-std:
+    name: check std
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
           cd crates/revm
           cargo check --no-default-features --features std
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@clippy
+      - run: cargo +nightly clippy --workspace --all-targets --all-features
+        env:
+          RUSTFLAGS: -Dwarnings
+
+  docs:
+    name: docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rust-docs
+      - run: cargo doc --workspace --all-features --no-deps --document-private-items
+        env:
+          RUSTDOCFLAGS: "--cfg docsrs -D warnings"
+
+  fmt:
+    name: fmt
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - run: cargo +nightly fmt --all --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ["stable", "beta", "nightly", "1.65"]
+        rust: ["stable", "beta", "nightly"]
         flags: ["--no-default-features", "", "--all-features"]
     steps:
       - uses: actions/checkout@v3
@@ -29,13 +29,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - uses: Swatinem/rust-cache@v2
-      # Only run tests on latest stable and above
-      - name: check
-        if: ${{ matrix.rust == '1.65' }} # MSRV
-        run: cargo check --workspace ${{ matrix.flags }}
-      - name: test
-        if: ${{ matrix.rust != '1.65' }} # MSRV
-        run: cargo test --workspace ${{ matrix.flags }}
+      - run: cargo test --workspace ${{ matrix.flags }}
 
   test-no-std:
     name: test no_std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ resolver = "2"
 members = ["bins/*", "crates/*"]
 default-members = ["crates/revm"]
 
+[workspace.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/bluealloy/revm"
 version = "1.3.0"
 readme = "../../README.md"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 revm-primitives = { path = "../primitives", version = "1.3.0", default-features = false }
 

--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -21,7 +21,7 @@ pub struct SharedMemory {
     checkpoints: Vec<usize>,
     /// Invariant: equals `self.checkpoints.last()`
     last_checkpoint: usize,
-    /// Memory limit. See [`crate::CfgEnv`].
+    /// Memory limit. See [`CfgEnv`](revm_primitives::CfgEnv).
     #[cfg(feature = "memory_limit")]
     memory_limit: u64,
 }

--- a/crates/interpreter/src/lib.rs
+++ b/crates/interpreter/src/lib.rs
@@ -1,6 +1,7 @@
 //! # revm-interpreter
 //!
 //! REVM Interpreter.
+#![warn(rustdoc::all)]
 #![warn(unreachable_pub, unused_crate_dependencies)]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -8,6 +8,10 @@ name = "revm-precompile"
 repository = "https://github.com/bluealloy/revm"
 version = "2.2.0"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 revm-primitives = { path = "../primitives", version = "1.3.0", default-features = false }
 bn = { package = "substrate-bn", version = "0.6", default-features = false }

--- a/crates/precompile/src/blake2.rs
+++ b/crates/precompile/src/blake2.rs
@@ -9,7 +9,7 @@ pub const FUN: PrecompileWithAddress = PrecompileWithAddress(
     Precompile::Standard(run as StandardPrecompileFn),
 );
 
-/// reference: https://eips.ethereum.org/EIPS/eip-152
+/// reference: <https://eips.ethereum.org/EIPS/eip-152>
 /// input format:
 /// [4 bytes for rounds][64 bytes for h][128 bytes for m][8 bytes for t_0][8 bytes for t_1][1 byte for f]
 fn run(input: &[u8], gas_limit: u64) -> PrecompileResult {
@@ -55,7 +55,7 @@ fn run(input: &[u8], gas_limit: u64) -> PrecompileResult {
 }
 
 mod algo {
-    /// SIGMA from spec: https://datatracker.ietf.org/doc/html/rfc7693#section-2.7
+    /// SIGMA from spec: <https://datatracker.ietf.org/doc/html/rfc7693#section-2.7>
     const SIGMA: [[usize; 16]; 10] = [
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
         [14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3],
@@ -69,7 +69,7 @@ mod algo {
         [10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0],
     ];
 
-    /// got IV from: https://en.wikipedia.org/wiki/BLAKE_(hash_function)
+    /// got IV from: <https://en.wikipedia.org/wiki/BLAKE_(hash_function)>
     const IV: [u64; 8] = [
         0x6a09e667f3bcc908,
         0xbb67ae8584caa73b,
@@ -83,7 +83,7 @@ mod algo {
 
     #[inline(always)]
     #[allow(clippy::many_single_char_names)]
-    /// G function: https://tools.ietf.org/html/rfc7693#section-3.1
+    /// G function: <https://tools.ietf.org/html/rfc7693#section-3.1>
     fn g(v: &mut [u64], a: usize, b: usize, c: usize, d: usize, x: u64, y: u64) {
         v[a] = v[a].wrapping_add(v[b]).wrapping_add(x);
         v[d] = (v[d] ^ v[a]).rotate_right(32);

--- a/crates/precompile/src/hash.rs
+++ b/crates/precompile/src/hash.rs
@@ -11,9 +11,9 @@ pub const RIPEMD160: PrecompileWithAddress = PrecompileWithAddress(
     Precompile::Standard(ripemd160_run as StandardPrecompileFn),
 );
 
-/// See: https://ethereum.github.io/yellowpaper/paper.pdf
-/// See: https://docs.soliditylang.org/en/develop/units-and-global-variables.html#mathematical-and-cryptographic-functions
-/// See: https://etherscan.io/address/0000000000000000000000000000000000000002
+/// See: <https://ethereum.github.io/yellowpaper/paper.pdf>
+/// See: <https://docs.soliditylang.org/en/develop/units-and-global-variables.html#mathematical-and-cryptographic-functions>
+/// See: <https://etherscan.io/address/0000000000000000000000000000000000000002>
 fn sha256_run(input: &[u8], gas_limit: u64) -> PrecompileResult {
     let cost = calc_linear_cost_u32(input.len(), 60, 12);
     if cost > gas_limit {
@@ -24,9 +24,9 @@ fn sha256_run(input: &[u8], gas_limit: u64) -> PrecompileResult {
     }
 }
 
-/// See: https://ethereum.github.io/yellowpaper/paper.pdf
-/// See: https://docs.soliditylang.org/en/develop/units-and-global-variables.html#mathematical-and-cryptographic-functions
-/// See: https://etherscan.io/address/0000000000000000000000000000000000000003
+/// See: <https://ethereum.github.io/yellowpaper/paper.pdf>
+/// See: <https://docs.soliditylang.org/en/develop/units-and-global-variables.html#mathematical-and-cryptographic-functions>
+/// See: <https://etherscan.io/address/0000000000000000000000000000000000000003>
 fn ripemd160_run(input: &[u8], gas_limit: u64) -> PrecompileResult {
     let gas_used = calc_linear_cost_u32(input.len(), 600, 120);
     if gas_used > gas_limit {

--- a/crates/precompile/src/identity.rs
+++ b/crates/precompile/src/identity.rs
@@ -13,8 +13,8 @@ const IDENTITY_PER_WORD: u64 = 3;
 
 /// Takes the input bytes, copies them, and returns it as the output.
 ///
-/// See: https://ethereum.github.io/yellowpaper/paper.pdf
-/// See: https://etherscan.io/address/0000000000000000000000000000000000000004
+/// See: <https://ethereum.github.io/yellowpaper/paper.pdf>
+/// See: <https://etherscan.io/address/0000000000000000000000000000000000000004>
 fn identity_run(input: &[u8], gas_limit: u64) -> PrecompileResult {
     let gas_used = calc_linear_cost_u32(input.len(), IDENTITY_BASE, IDENTITY_PER_WORD);
     if gas_used > gas_limit {

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -1,6 +1,7 @@
 //! # revm-precompile
 //!
 //! Implementations of EVM precompiled contracts.
+#![warn(rustdoc::all)]
 #![warn(unused_crate_dependencies)]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/crates/precompile/src/modexp.rs
+++ b/crates/precompile/src/modexp.rs
@@ -17,8 +17,8 @@ pub const BERLIN: PrecompileWithAddress = PrecompileWithAddress(
     Precompile::Standard(berlin_run as StandardPrecompileFn),
 );
 
-/// See: https://eips.ethereum.org/EIPS/eip-198
-/// See: https://etherscan.io/address/0000000000000000000000000000000000000005
+/// See: <https://eips.ethereum.org/EIPS/eip-198>
+/// See: <https://etherscan.io/address/0000000000000000000000000000000000000005>
 fn byzantium_run(input: &[u8], gas_limit: u64) -> PrecompileResult {
     run_inner(input, gas_limit, 0, |a, b, c, d| {
         byzantium_gas_calc(a, b, c, d)

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -12,6 +12,10 @@ readme = "../../README.md"
 # Don't need to run build script outside of this repo
 exclude = ["build.rs", "src/kzg/*.txt"]
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 alloy-primitives = { version = "0.5", default-features = false, features = [
     "rlp",

--- a/crates/primitives/src/db/components/block_hash.rs
+++ b/crates/primitives/src/db/components/block_hash.rs
@@ -1,5 +1,5 @@
 //! BlockHash database component from [`crate::db::Database`]
-//! it is used inside [crate::db::DatabaseComponents`]
+//! it is used inside [`crate::db::DatabaseComponents`]
 
 use crate::{B256, U256};
 use alloc::sync::Arc;

--- a/crates/primitives/src/db/components/state.rs
+++ b/crates/primitives/src/db/components/state.rs
@@ -1,5 +1,5 @@
 //! State database component from [`crate::db::Database`]
-//! it is used inside [crate::db::DatabaseComponents`]
+//! it is used inside [`crate::db::DatabaseComponents`]
 
 use crate::{AccountInfo, Address, Bytecode, B256, U256};
 use alloc::sync::Arc;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -1,6 +1,7 @@
 //! # revm-primitives
 //!
 //! EVM primitive types.
+#![warn(rustdoc::all)]
 #![warn(unreachable_pub, unused_crate_dependencies)]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/bluealloy/revm"
 version = "3.5.0"
 readme = "../../README.md"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 revm-interpreter = { path = "../interpreter", version = "1.3.0", default-features = false }
 revm-precompile = { path = "../precompile", version = "2.2.0", default-features = false }

--- a/crates/revm/src/evm_context.rs
+++ b/crates/revm/src/evm_context.rs
@@ -111,7 +111,7 @@ impl<'a, DB: Database> EvmContext<'a, DB> {
             .ok()
     }
 
-    /// Storage change of storage slot, before storing `sload`` will be called for that slot.
+    /// Storage change of storage slot, before storing `sload` will be called for that slot.
     pub fn sstore(
         &mut self,
         address: Address,

--- a/crates/revm/src/journaled_state.rs
+++ b/crates/revm/src/journaled_state.rs
@@ -548,7 +548,7 @@ impl JournaledState {
 
     /// Load account from database to JournaledState.
     ///
-    /// Return boolean pair where first is `is_cold`` second bool `is_exists`.
+    /// Return boolean pair where first is `is_cold` second bool `is_exists`.
     #[inline]
     pub fn load_account_exist<DB: Database>(
         &mut self,

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -1,4 +1,6 @@
-#![warn(unreachable_pub)]
+#![doc = include_str!("../../../README.md")]
+#![warn(rustdoc::all, unreachable_pub)]
+#![allow(rustdoc::bare_urls)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(unused_must_use, rust_2018_idioms)]


### PR DESCRIPTION
**Description**

Breaks up the github `ci.yml` workflows to mirror [alloy](https://github.com/alloy-rs/core/blob/0c21fcc48eab0b52c20d3e98c739bac862aad8ff/.github/workflows/ci.yml).

Adds warnings to all crates for `rustdoc::all`. Fixes #742