### PR TITLE
feat: add serde derives for `CacheDB` under "serde" flag

### DIFF
--- a/crates/revm/src/db/emptydb.rs
+++ b/crates/revm/src/db/emptydb.rs
@@ -10,6 +10,7 @@ pub type EmptyDB = EmptyDBTyped<Infallible>;
 /// An empty database that always returns default values when queried.
 ///
 /// This is generic over a type which is used as the database error type.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EmptyDBTyped<E> {
     _phantom: PhantomData<E>,
 }

--- a/crates/revm/src/db/in_memory_db.rs
+++ b/crates/revm/src/db/in_memory_db.rs
@@ -456,4 +456,28 @@ mod tests {
         assert_eq!(new_state.storage(account, key0), Ok(U256::ZERO));
         assert_eq!(new_state.storage(account, key1), Ok(value1));
     }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serialize_deserialize_cachedb() {
+        let account = Address::with_last_byte(69);
+        let nonce = 420;
+        let mut init_state = CacheDB::new(EmptyDB::default());
+        init_state.insert_account_info(
+            account,
+            AccountInfo {
+                nonce,
+                ..Default::default()
+            },
+        );
+
+        let serialized = serde_json::to_string(&init_state).unwrap();
+        let deserialized: CacheDB<EmptyDB> = serde_json::from_str(&serialized).unwrap();
+
+        assert!(deserialized.accounts.get(&account).is_some());
+        assert_eq!(
+            deserialized.accounts.get(&account).unwrap().info.nonce,
+            nonce
+        );
+    }
 }

--- a/crates/revm/src/db/in_memory_db.rs
+++ b/crates/revm/src/db/in_memory_db.rs
@@ -18,6 +18,7 @@ pub type InMemoryDB = CacheDB<EmptyDB>;
 /// whereas contracts are identified by their code hash, and are stored in the `contracts` map.
 /// The [DbAccount] holds the code hash of the contract, which is used to look up the contract in the `contracts` map.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CacheDB<ExtDB: DatabaseRef> {
     /// Account info where None means it is not existing. Not existing state is needed for Pre TANGERINE forks.
     /// `code` is always `None`, and bytecode can be found in `contracts`.
@@ -288,6 +289,7 @@ impl<ExtDB: DatabaseRef> DatabaseRef for CacheDB<ExtDB> {
 }
 
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DbAccount {
     pub info: AccountInfo,
     /// If account is selfdestructed or newly created, storage will be cleared.
@@ -330,6 +332,7 @@ impl From<AccountInfo> for DbAccount {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AccountState {
     /// Before Spurious Dragon hardfork there was a difference between empty and not existing.
     /// And we are flagging it here.


### PR DESCRIPTION
## Idea
In order to be able to take a snapshot of a `CacheDB` that can then be shared in many ways, having the `Serialize + Serialize` added is helpful. 

## Feedback
Change is minimal and is not set as default. Wrote simple unit test to check that this works. If this change is not wanted upstream, that is okay. Perhaps it can be under its own separate flag then, if need be. Please let me know!