### PR TITLE
perf(primitives): optimize AccountInfo.is_empty()

### DIFF
--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -352,12 +352,12 @@ impl CfgEnv {
         false
     }
 
-    #[cfg(feaure = "optional_beneficiary_reward")]
+    #[cfg(feature = "optional_beneficiary_reward")]
     pub fn is_beneficiary_reward_disabled(&self) -> bool {
         self.disable_beneficiary_reward
     }
 
-    #[cfg(not(feaure = "optional_beneficiary_reward"))]
+    #[cfg(not(feature = "optional_beneficiary_reward"))]
     pub fn is_beneficiary_reward_disabled(&self) -> bool {
         false
     }

--- a/crates/primitives/src/state.rs
+++ b/crates/primitives/src/state.rs
@@ -239,7 +239,7 @@ impl AccountInfo {
     /// - nonce is zero
     pub fn is_empty(&self) -> bool {
         let code_empty = self.is_empty_code_hash() || self.code_hash == B256::ZERO;
-        self.balance == U256::ZERO && self.nonce == 0 && code_empty
+        code_empty && self.balance == U256::ZERO && self.nonce == 0
     }
 
     /// Returns `true` if the account is not empty.


### PR DESCRIPTION
This is a small optimization for AccountInfo.is_empty() with regards to the short-circuiting of bool operators in Rust.