### PR TITLE
chore(interpreter): conditionally enable `optional_beneficiary_reward`

### DIFF
--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -34,6 +34,7 @@ dev = [
     "optional_eip3607",
     "optional_gas_refund",
     "optional_no_base_fee",
+    "optional_beneficiary_reward",
 ]
 memory_limit = ["revm-primitives/memory_limit"]
 optional_balance_check = ["revm-primitives/optional_balance_check"]


### PR DESCRIPTION
- enable the `optional_beneficiary_reward` feature automatically when the `dev` feature is enabled.

This modification seemed reasonable, being in line with how the `dev` features of the `primitives` and `revm` crates are defined.