### PR TITLE
docs(interpreter): fix the name of the macro referenced by record_memory()

### DIFF
--- a/crates/interpreter/src/gas.rs
+++ b/crates/interpreter/src/gas.rs
@@ -100,7 +100,7 @@ impl Gas {
         true
     }
 
-    /// used in memory_resize! macro to record gas used for memory expansion.
+    /// used in shared_memory_resize! macro to record gas used for memory expansion.
     #[inline]
     pub fn record_memory(&mut self, gas_memory: u64) -> bool {
         if gas_memory > self.memory {


### PR DESCRIPTION
`shared_memory_resize!` was the only macro I've found that calls the `record_memory()` function.