### PR TITLE
refactor(interpreter): consistency in all_results_are_covered()

### DIFF
--- a/crates/interpreter/src/instruction_result.rs
+++ b/crates/interpreter/src/instruction_result.rs
@@ -108,6 +108,7 @@ macro_rules! return_revert {
     };
 }
 
+#[macro_export]
 macro_rules! return_error {
     () => {
         InstructionResult::OutOfGas
@@ -248,8 +249,8 @@ impl From<InstructionResult> for SuccessOrHalt {
             InstructionResult::OverflowPayment => Self::Halt(Halt::OverflowPayment), // Check for first call is done separately.
             InstructionResult::PrecompileError => Self::Halt(Halt::PrecompileError),
             InstructionResult::NonceOverflow => Self::Halt(Halt::NonceOverflow),
-            InstructionResult::CreateContractSizeLimit => Self::Halt(Halt::CreateContractSizeLimit),
-            InstructionResult::CreateContractStartingWithEF => {
+            InstructionResult::CreateContractSizeLimit
+            | InstructionResult::CreateContractStartingWithEF => {
                 Self::Halt(Halt::CreateContractSizeLimit)
             }
             InstructionResult::CreateInitCodeSizeLimit => Self::Halt(Halt::CreateInitCodeSizeLimit),
@@ -264,12 +265,11 @@ mod tests {
 
     #[test]
     fn all_results_are_covered() {
-        let result = InstructionResult::Continue;
-        match result {
+        match InstructionResult::Continue {
             return_error!() => {}
-            return_revert!() => (),
+            return_revert!() => {}
             return_ok!() => {}
-            InstructionResult::CallOrCreate => (),
+            InstructionResult::CallOrCreate => {}
         }
     }
 


### PR DESCRIPTION
While any of the 2 could've been used to achieve consistency, `{ }` has been chosen because, as far as I've read, it doesn't lead to any memory being allocated (being just a code block), while `( )`, representing the "unit type", does occupy some memory.

The latter isn't as important in the context of a test function, of course, but given that this would be the better option (over `( )`), in general, don't see why it wouldn't also be used throughout the test functions (to maintain the consistency with the production codebase functions).

Curious about your take on this, @rakita