### PR TITLE
refactor(interpreter): improve enum naming

### DIFF
--- a/crates/interpreter/src/instruction_result.rs
+++ b/crates/interpreter/src/instruction_result.rs
@@ -1,4 +1,4 @@
-use crate::primitives::{Eval, Halt, OutOfGasError};
+use crate::primitives::{HaltReason, OutOfGasError, SuccessReason};
 
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
@@ -49,44 +49,44 @@ pub enum InstructionResult {
     FatalExternalError,
 }
 
-impl From<Eval> for InstructionResult {
-    fn from(value: Eval) -> Self {
+impl From<SuccessReason> for InstructionResult {
+    fn from(value: SuccessReason) -> Self {
         match value {
-            Eval::Return => InstructionResult::Return,
-            Eval::Stop => InstructionResult::Stop,
-            Eval::SelfDestruct => InstructionResult::SelfDestruct,
+            SuccessReason::Return => InstructionResult::Return,
+            SuccessReason::Stop => InstructionResult::Stop,
+            SuccessReason::SelfDestruct => InstructionResult::SelfDestruct,
         }
     }
 }
 
-impl From<Halt> for InstructionResult {
-    fn from(value: Halt) -> Self {
+impl From<HaltReason> for InstructionResult {
+    fn from(value: HaltReason) -> Self {
         match value {
-            Halt::OutOfGas(OutOfGasError::BasicOutOfGas) => Self::OutOfGas,
-            Halt::OutOfGas(OutOfGasError::InvalidOperand) => Self::InvalidOperandOOG,
-            Halt::OutOfGas(OutOfGasError::Memory) => Self::MemoryOOG,
-            Halt::OutOfGas(OutOfGasError::MemoryLimit) => Self::MemoryLimitOOG,
-            Halt::OutOfGas(OutOfGasError::Precompile) => Self::PrecompileOOG,
-            Halt::OpcodeNotFound => Self::OpcodeNotFound,
-            Halt::InvalidFEOpcode => Self::InvalidFEOpcode,
-            Halt::InvalidJump => Self::InvalidJump,
-            Halt::NotActivated => Self::NotActivated,
-            Halt::StackOverflow => Self::StackOverflow,
-            Halt::StackUnderflow => Self::StackUnderflow,
-            Halt::OutOfOffset => Self::OutOfOffset,
-            Halt::CreateCollision => Self::CreateCollision,
-            Halt::PrecompileError => Self::PrecompileError,
-            Halt::NonceOverflow => Self::NonceOverflow,
-            Halt::CreateContractSizeLimit => Self::CreateContractSizeLimit,
-            Halt::CreateContractStartingWithEF => Self::CreateContractStartingWithEF,
-            Halt::CreateInitCodeSizeLimit => Self::CreateInitCodeSizeLimit,
-            Halt::OverflowPayment => Self::OverflowPayment,
-            Halt::StateChangeDuringStaticCall => Self::StateChangeDuringStaticCall,
-            Halt::CallNotAllowedInsideStatic => Self::CallNotAllowedInsideStatic,
-            Halt::OutOfFund => Self::OutOfFund,
-            Halt::CallTooDeep => Self::CallTooDeep,
+            HaltReason::OutOfGas(OutOfGasError::BasicOutOfGas) => Self::OutOfGas,
+            HaltReason::OutOfGas(OutOfGasError::InvalidOperand) => Self::InvalidOperandOOG,
+            HaltReason::OutOfGas(OutOfGasError::Memory) => Self::MemoryOOG,
+            HaltReason::OutOfGas(OutOfGasError::MemoryLimit) => Self::MemoryLimitOOG,
+            HaltReason::OutOfGas(OutOfGasError::Precompile) => Self::PrecompileOOG,
+            HaltReason::OpcodeNotFound => Self::OpcodeNotFound,
+            HaltReason::InvalidFEOpcode => Self::InvalidFEOpcode,
+            HaltReason::InvalidJump => Self::InvalidJump,
+            HaltReason::NotActivated => Self::NotActivated,
+            HaltReason::StackOverflow => Self::StackOverflow,
+            HaltReason::StackUnderflow => Self::StackUnderflow,
+            HaltReason::OutOfOffset => Self::OutOfOffset,
+            HaltReason::CreateCollision => Self::CreateCollision,
+            HaltReason::PrecompileError => Self::PrecompileError,
+            HaltReason::NonceOverflow => Self::NonceOverflow,
+            HaltReason::CreateContractSizeLimit => Self::CreateContractSizeLimit,
+            HaltReason::CreateContractStartingWithEF => Self::CreateContractStartingWithEF,
+            HaltReason::CreateInitCodeSizeLimit => Self::CreateInitCodeSizeLimit,
+            HaltReason::OverflowPayment => Self::OverflowPayment,
+            HaltReason::StateChangeDuringStaticCall => Self::StateChangeDuringStaticCall,
+            HaltReason::CallNotAllowedInsideStatic => Self::CallNotAllowedInsideStatic,
+            HaltReason::OutOfFund => Self::OutOfFund,
+            HaltReason::CallTooDeep => Self::CallTooDeep,
             #[cfg(feature = "optimism")]
-            Halt::FailedDeposit => Self::FatalExternalError,
+            HaltReason::FailedDeposit => Self::FatalExternalError,
         }
     }
 }
@@ -158,9 +158,9 @@ impl InstructionResult {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SuccessOrHalt {
-    Success(Eval),
+    Success(SuccessReason),
     Revert,
-    Halt(Halt),
+    Halt(HaltReason),
     FatalExternalError,
     /// Internal instruction that signals Interpreter should continue running.
     InternalContinue,
@@ -175,11 +175,11 @@ impl SuccessOrHalt {
         matches!(self, SuccessOrHalt::Success(_))
     }
 
-    /// Returns the [Eval] value if this a successful result
+    /// Returns the [SuccessReason] value if this a successful result
     #[inline]
-    pub fn to_success(self) -> Option<Eval> {
+    pub fn to_success(self) -> Option<SuccessReason> {
         match self {
-            SuccessOrHalt::Success(eval) => Some(eval),
+            SuccessOrHalt::Success(reason) => Some(reason),
             _ => None,
         }
     }
@@ -196,11 +196,11 @@ impl SuccessOrHalt {
         matches!(self, SuccessOrHalt::Halt(_))
     }
 
-    /// Returns the [Halt] value the EVM has experienced an exceptional halt
+    /// Returns the [HaltReason] value the EVM has experienced an exceptional halt
     #[inline]
-    pub fn to_halt(self) -> Option<Halt> {
+    pub fn to_halt(self) -> Option<HaltReason> {
         match self {
-            SuccessOrHalt::Halt(halt) => Some(halt),
+            SuccessOrHalt::Halt(reason) => Some(reason),
             _ => None,
         }
     }
@@ -210,50 +210,52 @@ impl From<InstructionResult> for SuccessOrHalt {
     fn from(result: InstructionResult) -> Self {
         match result {
             InstructionResult::Continue => Self::InternalContinue, // used only in interpreter loop
-            InstructionResult::Stop => Self::Success(Eval::Stop),
-            InstructionResult::Return => Self::Success(Eval::Return),
-            InstructionResult::SelfDestruct => Self::Success(Eval::SelfDestruct),
+            InstructionResult::Stop => Self::Success(SuccessReason::Stop),
+            InstructionResult::Return => Self::Success(SuccessReason::Return),
+            InstructionResult::SelfDestruct => Self::Success(SuccessReason::SelfDestruct),
             InstructionResult::Revert => Self::Revert,
             InstructionResult::CallOrCreate => Self::InternalCallOrCreate, // used only in interpreter loop
-            InstructionResult::CallTooDeep => Self::Halt(Halt::CallTooDeep), // not gonna happen for first call
-            InstructionResult::OutOfFund => Self::Halt(Halt::OutOfFund), // Check for first call is done separately.
-            InstructionResult::OutOfGas => Self::Halt(Halt::OutOfGas(
+            InstructionResult::CallTooDeep => Self::Halt(HaltReason::CallTooDeep), // not gonna happen for first call
+            InstructionResult::OutOfFund => Self::Halt(HaltReason::OutOfFund), // Check for first call is done separately.
+            InstructionResult::OutOfGas => Self::Halt(HaltReason::OutOfGas(
                 revm_primitives::OutOfGasError::BasicOutOfGas,
             )),
-            InstructionResult::MemoryLimitOOG => {
-                Self::Halt(Halt::OutOfGas(revm_primitives::OutOfGasError::MemoryLimit))
-            }
+            InstructionResult::MemoryLimitOOG => Self::Halt(HaltReason::OutOfGas(
+                revm_primitives::OutOfGasError::MemoryLimit,
+            )),
             InstructionResult::MemoryOOG => {
-                Self::Halt(Halt::OutOfGas(revm_primitives::OutOfGasError::Memory))
+                Self::Halt(HaltReason::OutOfGas(revm_primitives::OutOfGasError::Memory))
             }
-            InstructionResult::PrecompileOOG => {
-                Self::Halt(Halt::OutOfGas(revm_primitives::OutOfGasError::Precompile))
-            }
-            InstructionResult::InvalidOperandOOG => Self::Halt(Halt::OutOfGas(
+            InstructionResult::PrecompileOOG => Self::Halt(HaltReason::OutOfGas(
+                revm_primitives::OutOfGasError::Precompile,
+            )),
+            InstructionResult::InvalidOperandOOG => Self::Halt(HaltReason::OutOfGas(
                 revm_primitives::OutOfGasError::InvalidOperand,
             )),
-            InstructionResult::OpcodeNotFound => Self::Halt(Halt::OpcodeNotFound),
+            InstructionResult::OpcodeNotFound => Self::Halt(HaltReason::OpcodeNotFound),
             InstructionResult::CallNotAllowedInsideStatic => {
-                Self::Halt(Halt::CallNotAllowedInsideStatic)
+                Self::Halt(HaltReason::CallNotAllowedInsideStatic)
             } // first call is not static call
             InstructionResult::StateChangeDuringStaticCall => {
-                Self::Halt(Halt::StateChangeDuringStaticCall)
+                Self::Halt(HaltReason::StateChangeDuringStaticCall)
             }
-            InstructionResult::InvalidFEOpcode => Self::Halt(Halt::InvalidFEOpcode),
-            InstructionResult::InvalidJump => Self::Halt(Halt::InvalidJump),
-            InstructionResult::NotActivated => Self::Halt(Halt::NotActivated),
-            InstructionResult::StackUnderflow => Self::Halt(Halt::StackUnderflow),
-            InstructionResult::StackOverflow => Self::Halt(Halt::StackOverflow),
-            InstructionResult::OutOfOffset => Self::Halt(Halt::OutOfOffset),
-            InstructionResult::CreateCollision => Self::Halt(Halt::CreateCollision),
-            InstructionResult::OverflowPayment => Self::Halt(Halt::OverflowPayment), // Check for first call is done separately.
-            InstructionResult::PrecompileError => Self::Halt(Halt::PrecompileError),
-            InstructionResult::NonceOverflow => Self::Halt(Halt::NonceOverflow),
+            InstructionResult::InvalidFEOpcode => Self::Halt(HaltReason::InvalidFEOpcode),
+            InstructionResult::InvalidJump => Self::Halt(HaltReason::InvalidJump),
+            InstructionResult::NotActivated => Self::Halt(HaltReason::NotActivated),
+            InstructionResult::StackUnderflow => Self::Halt(HaltReason::StackUnderflow),
+            InstructionResult::StackOverflow => Self::Halt(HaltReason::StackOverflow),
+            InstructionResult::OutOfOffset => Self::Halt(HaltReason::OutOfOffset),
+            InstructionResult::CreateCollision => Self::Halt(HaltReason::CreateCollision),
+            InstructionResult::OverflowPayment => Self::Halt(HaltReason::OverflowPayment), // Check for first call is done separately.
+            InstructionResult::PrecompileError => Self::Halt(HaltReason::PrecompileError),
+            InstructionResult::NonceOverflow => Self::Halt(HaltReason::NonceOverflow),
             InstructionResult::CreateContractSizeLimit
             | InstructionResult::CreateContractStartingWithEF => {
-                Self::Halt(Halt::CreateContractSizeLimit)
+                Self::Halt(HaltReason::CreateContractSizeLimit)
             }
-            InstructionResult::CreateInitCodeSizeLimit => Self::Halt(Halt::CreateInitCodeSizeLimit),
+            InstructionResult::CreateInitCodeSizeLimit => {
+                Self::Halt(HaltReason::CreateInitCodeSizeLimit)
+            }
             InstructionResult::FatalExternalError => Self::FatalExternalError,
         }
     }

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -23,7 +23,7 @@ pub struct ResultAndState {
 pub enum ExecutionResult {
     /// Returned successfully
     Success {
-        reason: Eval,
+        reason: SuccessReason,
         gas_used: u64,
         gas_refunded: u64,
         logs: Vec<Log>,
@@ -33,7 +33,7 @@ pub enum ExecutionResult {
     Revert { gas_used: u64, output: Bytes },
     /// Reverted for various reasons and spend all gas.
     Halt {
-        reason: Halt,
+        reason: HaltReason,
         /// Halting will spend all the gas, and will be equal to gas_limit.
         gas_used: u64,
     },
@@ -223,28 +223,28 @@ pub enum InvalidTransaction {
     /// was deprecated in the Regolith hardfork, and this error is thrown if a `Deposit` transaction
     /// is found with this field set to `true` after the hardfork activation.
     ///
-    /// In addition, this error is internal, and bubbles up into a [Halt::FailedDeposit] error
+    /// In addition, this error is internal, and bubbles up into a [HaltReason::FailedDeposit] error
     /// in the `revm` handler for the consumer to easily handle. This is due to a state transition
     /// rule on OP Stack chains where, if for any reason a deposit transaction fails, the transaction
     /// must still be included in the block, the sender nonce is bumped, the `mint` value persists, and
     /// special gas accounting rules are applied. Normally on L1, [EVMError::Transaction] errors
-    /// are cause for non-inclusion, so a special [Halt] variant was introduced to handle this
+    /// are cause for non-inclusion, so a special [HaltReason] variant was introduced to handle this
     /// case for failed deposit transactions.
     #[cfg(feature = "optimism")]
     DepositSystemTxPostRegolith,
     /// Deposit transaction haults bubble up to the global main return handler, wiping state and
     /// only increasing the nonce + persisting the mint value.
     ///
-    /// This is a catch-all error for any deposit transaction that is results in a [Halt] error
+    /// This is a catch-all error for any deposit transaction that is results in a [HaltReason] error
     /// post-regolith hardfork. This allows for a consumer to easily handle special cases where
     /// a deposit transaction fails during validation, but must still be included in the block.
     ///
-    /// In addition, this error is internal, and bubbles up into a [Halt::FailedDeposit] error
+    /// In addition, this error is internal, and bubbles up into a [HaltReason::FailedDeposit] error
     /// in the `revm` handler for the consumer to easily handle. This is due to a state transition
     /// rule on OP Stack chains where, if for any reason a deposit transaction fails, the transaction
     /// must still be included in the block, the sender nonce is bumped, the `mint` value persists, and
     /// special gas accounting rules are applied. Normally on L1, [EVMError::Transaction] errors
-    /// are cause for non-inclusion, so a special [Halt] variant was introduced to handle this
+    /// are cause for non-inclusion, so a special [HaltReason] variant was introduced to handle this
     /// case for failed deposit transactions.
     #[cfg(feature = "optimism")]
     HaltedDepositPostRegolith,
@@ -355,7 +355,7 @@ impl fmt::Display for InvalidHeader {
 /// Reason a transaction successfully completed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum Eval {
+pub enum SuccessReason {
     Stop,
     Return,
     SelfDestruct,
@@ -365,7 +365,7 @@ pub enum Eval {
 /// immediately end with all gas being consumed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum Halt {
+pub enum HaltReason {
     OutOfGas(OutOfGasError),
     OpcodeNotFound,
     InvalidFEOpcode,

--- a/crates/revm/src/handler/optimism.rs
+++ b/crates/revm/src/handler/optimism.rs
@@ -5,8 +5,8 @@ use crate::{
     interpreter::{return_ok, return_revert, Gas, InstructionResult},
     optimism,
     primitives::{
-        db::Database, Account, EVMError, Env, ExecutionResult, Halt, HashMap, InvalidTransaction,
-        Output, ResultAndState, Spec, SpecId::REGOLITH, U256,
+        db::Database, Account, EVMError, Env, ExecutionResult, HaltReason, HashMap,
+        InvalidTransaction, Output, ResultAndState, Spec, SpecId::REGOLITH, U256,
     },
     EvmContext,
 };
@@ -225,7 +225,7 @@ pub fn end_handle<SPEC: Spec, DB: Database>(
 
             Ok(ResultAndState {
                 result: ExecutionResult::Halt {
-                    reason: Halt::FailedDeposit,
+                    reason: HaltReason::FailedDeposit,
                     gas_used,
                 },
                 state,


### PR DESCRIPTION
The new names are more suggestive of what the enums represent, in my opinion.