### PR TITLE
ci(cachegrind): pass action always

### DIFF
--- a/.github/workflows/cachegrind.yml
+++ b/.github/workflows/cachegrind.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   valgrind:
     runs-on: ubuntu-latest
-    environment: ci-cachegrind
     permissions: write-all
 
     steps:
@@ -38,7 +37,7 @@ jobs:
 
       - name: Comment on PR
         env:
-          GH_TOKEN: ${{ secrets.PAT_COMMENT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Try to edit the last comment
           if gh pr comment ${{ github.event.pull_request.number }} --edit-last --body-file results.md; then
@@ -46,5 +45,8 @@ jobs:
           else
             echo "Failed to edit last comment. Trying to add a new comment instead!"
             # If editing last comment fails, try to add a new comment
-            gh pr comment ${{ github.event.pull_request.number }} --body-file results.md
+            if ! gh pr comment ${{ github.event.pull_request.number }} --body-file results.md; then
+              echo "Comment failed to be made, printing out results here:"
+              cat results.md
+            fi
           fi


### PR DESCRIPTION
Always pass action as GITHUB_TOKEN is giving only read access from forked repositories: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#changing-the-permissions-in-a-forked-repository
