### PR TITLE
feat: add asm-keccak feature

### DIFF
--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -24,6 +24,7 @@ default = ["std"]
 std = ["revm-primitives/std"]
 serde = ["dep:serde", "revm-primitives/serde"]
 arbitrary = ["std", "revm-primitives/arbitrary"]
+asm-keccak = ["revm-primitives/asm-keccak"]
 
 optimism = ["revm-primitives/optimism"]
 

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -43,6 +43,7 @@ std = [
     "c-kzg?/std",
     "secp256k1?/std",
 ]
+asm-keccak = ["revm-primitives/asm-keccak"]
 
 optimism = ["revm-primitives/optimism"]
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -59,6 +59,7 @@ serde = [
     "c-kzg?/serde",
 ]
 arbitrary = ["std", "alloy-primitives/arbitrary", "bitflags/arbitrary"]
+asm-keccak = ["alloy-primitives/asm-keccak"]
 
 optimism = []
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -44,6 +44,7 @@ default = ["std", "c-kzg", "secp256k1"]
 std = ["revm-interpreter/std", "revm-precompile/std"]
 serde = ["dep:serde", "dep:serde_json", "revm-interpreter/serde"]
 arbitrary = ["revm-interpreter/arbitrary"]
+asm-keccak = ["revm-interpreter/asm-keccak", "revm-precompile/asm-keccak"]
 
 test-utils = []
 


### PR DESCRIPTION
Adds a feature to each crate, `asm-keccak`, which enables the same feature from alloy-primitives.

This can show performance improvements for keccak on some machines:
https://github.com/alloy-rs/core/pull/466