### PR TITLE
fix: use maximum possible data fee for 4844 balance checks

### DIFF
--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -47,6 +47,19 @@ impl Env {
         })
     }
 
+    /// Calculates the maximum [EIP-4844] `data_fee` of the transaction.
+    ///
+    /// This is used for ensuring that the user has at least enough funds to pay the
+    /// `max_fee_per_blob_gas * total_blob_gas`, on top of regular gas costs.
+    ///
+    /// See EIP-4844:
+    /// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4844.md#execution-layer-validation
+    pub fn calc_max_data_fee(&self) -> Option<U256> {
+        self.tx.max_fee_per_blob_gas.map(|max_fee_per_blob_gas| {
+            max_fee_per_blob_gas.saturating_mul(U256::from(self.tx.get_total_blob_gas()))
+        })
+    }
+
     /// Validate the block environment.
     #[inline]
     pub fn validate_block_env<SPEC: Spec>(&self) -> Result<(), InvalidHeader> {
@@ -560,7 +573,7 @@ pub struct TxEnv {
 }
 
 impl TxEnv {
-    /// See [EIP-4844] and [`Env::calc_data_fee`].
+    /// See [EIP-4844], [`Env::calc_data_fee`], and [`Env::calc_max_data_fee`].
     ///
     /// [EIP-4844]: https://eips.ethereum.org/EIPS/eip-4844
     #[inline]

--- a/crates/revm/src/handler/mainnet/pre_execution.rs
+++ b/crates/revm/src/handler/mainnet/pre_execution.rs
@@ -60,7 +60,7 @@ pub fn deduct_caller_inner<SPEC: Spec>(caller_account: &mut Account, env: &Env) 
 
     // EIP-4844
     if SPEC::enabled(CANCUN) {
-        let data_fee = env.calc_data_fee().expect("already checked");
+        let data_fee = env.calc_max_data_fee().expect("already checked");
         gas_cost = gas_cost.saturating_add(data_fee);
     }
 


### PR DESCRIPTION
ref https://github.com/paradigmxyz/reth/issues/6077

The balance checks shown in EIP-4844 use the maximum possible blob fee:
```python
        # modify the check for sufficient balance
        max_total_fee = tx.gas * tx.max_fee_per_gas
        if get_tx_type(tx) == BLOB_TX_TYPE:
            max_total_fee += get_total_blob_gas(tx) * tx.max_fee_per_blob_gas
        assert signer(tx).balance >= max_total_fee
```

This implements what is written in the spec, introducing a new method `calc_max_data_fee` to calculate `get_total_blob_gas(tx) * tx.max_fee_per_blob_gas`