### PR TITLE
feat: Convert optimism panic into graceful error

### DIFF
--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -1,5 +1,5 @@
 use crate::{Address, Bytes, Log, State, U256};
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, string::String, vec::Vec};
 use core::fmt;
 
 /// Result of EVM execution.

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -137,8 +137,7 @@ pub enum EVMError<DBError> {
     Database(DBError),
     /// Custom error.
     ///
-    /// Currently implemented for the Optimism handler. This is an interim solution pending
-    /// the development of a more generic error mechanism for integration with custom handlers.
+    /// Useful for handler registers where custom logic would want to return their own custom error.
     Custom(String),
 }
 

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -135,6 +135,11 @@ pub enum EVMError<DBError> {
     Header(InvalidHeader),
     /// Database error.
     Database(DBError),
+    /// Custom error.
+    ///
+    /// Currently implemented for the Optimism handler. This is an interim solution pending
+    /// the development of a more generic error mechanism for integration with custom handlers.
+    Custom(String),
 }
 
 #[cfg(feature = "std")]
@@ -146,6 +151,7 @@ impl<DBError: fmt::Display> fmt::Display for EVMError<DBError> {
             EVMError::Transaction(e) => write!(f, "Transaction error: {e:?}"),
             EVMError::Header(e) => write!(f, "Header error: {e:?}"),
             EVMError::Database(e) => write!(f, "Database error: {e}"),
+            EVMError::Custom(e) => write!(f, "Custom error: {e}"),
         }
     }
 }

--- a/crates/revm/src/optimism/handler_register.rs
+++ b/crates/revm/src/optimism/handler_register.rs
@@ -125,7 +125,9 @@ pub fn deduct_caller<SPEC: Spec, EXT, DB: Database>(
     if context.evm.env.tx.optimism.source_hash.is_none() {
         // get envelope
         let Some(enveloped_tx) = context.evm.env.tx.optimism.enveloped_tx.clone() else {
-            panic!("[OPTIMISM] Failed to load enveloped transaction.");
+            return Err(EVMError::Custom(
+                "[OPTIMISM] Failed to load enveloped transaction.".to_string(),
+            ));
         };
 
         let tx_l1_cost = context
@@ -166,11 +168,15 @@ pub fn reward_beneficiary<SPEC: Spec, EXT, DB: Database>(
         // If the transaction is not a deposit transaction, fees are paid out
         // to both the Base Fee Vault as well as the L1 Fee Vault.
         let Some(l1_block_info) = context.evm.l1_block_info.clone() else {
-            panic!("[OPTIMISM] Failed to load L1 block information.");
+            return Err(EVMError::Custom(
+                "[OPTIMISM] Failed to load L1 block information.".to_string(),
+            ));
         };
 
         let Some(enveloped_tx) = &context.evm.env.tx.optimism.enveloped_tx else {
-            panic!("[OPTIMISM] Failed to load enveloped transaction.");
+            return Err(EVMError::Custom(
+                "[OPTIMISM] Failed to load enveloped transaction.".to_string(),
+            ));
         };
 
         let l1_cost = l1_block_info.calculate_tx_l1_cost(enveloped_tx, SPEC::SPEC_ID);
@@ -181,7 +187,9 @@ pub fn reward_beneficiary<SPEC: Spec, EXT, DB: Database>(
             .journaled_state
             .load_account(optimism::L1_FEE_RECIPIENT, &mut context.evm.db)
         else {
-            panic!("[OPTIMISM] Failed to load L1 Fee Vault account");
+            return Err(EVMError::Custom(
+                "[OPTIMISM] Failed to load L1 Fee Vault account.".to_string(),
+            ));
         };
         l1_fee_vault_account.mark_touch();
         l1_fee_vault_account.info.balance += l1_cost;
@@ -192,7 +200,9 @@ pub fn reward_beneficiary<SPEC: Spec, EXT, DB: Database>(
             .journaled_state
             .load_account(optimism::BASE_FEE_RECIPIENT, &mut context.evm.db)
         else {
-            panic!("[OPTIMISM] Failed to load Base Fee Vault account");
+            return Err(EVMError::Custom(
+                "[OPTIMISM] Failed to load Base Fee Vault account.".to_string(),
+            ));
         };
         base_fee_vault_account.mark_touch();
         base_fee_vault_account.info.balance += context


### PR DESCRIPTION
In #967 there is described a temporary solution for a panic in optimism handler code.
So far, it is a simple extension for the `EVMError` enum, containing error explanation as a String.
All related panics are replaced with the code returning this error.

This is my first quick issue here, looking forward for feedback.