### PR TITLE
chore: add getter for specId

### DIFF
--- a/crates/revm/src/context.rs
+++ b/crates/revm/src/context.rs
@@ -99,6 +99,11 @@ impl<DB: Database> EvmContext<DB> {
         }
     }
 
+    /// Returns the configured EVM spec ID.
+    pub const fn spec_id(&self) -> SpecId {
+        self.journaled_state.spec
+    }
+
     /// Sets precompiles
     pub fn set_precompiles(&mut self, precompiles: Precompiles) {
         self.journaled_state.warm_preloaded_addresses =


### PR DESCRIPTION
CfgEnv no longer has the specId. this is now in the journaledstate

This adds a getter to the EmvContext, though it's not obvious to me where the SpecId in the journaledState is properly set, in the new functions this is always, latest.

if the EvmContext has access to the spec id then it's not clear why it gets it as argument:

https://github.com/bluealloy/revm/blob/main/crates/revm/src/context.rs#L214-L214

so I'm not 100% about this getter, but it's definitely useful the get access to the evm's specid during inspection.