### PR TITLE
chore: expose InstructionResult getters in Interpreter result

### DIFF
--- a/crates/interpreter/src/instruction_result.rs
+++ b/crates/interpreter/src/instruction_result.rs
@@ -141,19 +141,19 @@ macro_rules! return_error {
 impl InstructionResult {
     /// Returns whether the result is a success.
     #[inline]
-    pub fn is_ok(self) -> bool {
+    pub const fn is_ok(self) -> bool {
         matches!(self, crate::return_ok!())
     }
 
     /// Returns whether the result is a revert.
     #[inline]
-    pub fn is_revert(self) -> bool {
+    pub const fn is_revert(self) -> bool {
         matches!(self, crate::return_revert!())
     }
 
     /// Returns whether the result is an error.
     #[inline]
-    pub fn is_error(self) -> bool {
+    pub const fn is_error(self) -> bool {
         matches!(self, return_error!())
     }
 }

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -53,6 +53,35 @@ pub struct Interpreter {
     pub next_action: Option<InterpreterAction>,
 }
 
+/// The result of an interpreter operation.
+#[derive(Debug, Clone)]
+pub struct InterpreterResult {
+    /// The result of the instruction execution.
+    pub result: InstructionResult,
+    /// The output of the instruction execution.
+    pub output: Bytes,
+    /// The gas usage information.
+    pub gas: Gas,
+}
+
+#[derive(Debug, Clone)]
+pub enum InterpreterAction {
+    SubCall {
+        /// Call inputs
+        inputs: Box<CallInputs>,
+        /// The offset into `self.memory` of the return data.
+        ///
+        /// This value must be ignored if `self.return_len` is 0.
+        return_memory_offset: Range<usize>,
+    },
+    Create {
+        inputs: Box<CreateInputs>,
+    },
+    Return {
+        result: InterpreterResult,
+    },
+}
+
 impl Interpreter {
     /// Create new interpreter
     pub fn new(contract: Box<Contract>, gas_limit: u64, is_static: bool) -> Self {
@@ -276,17 +305,6 @@ impl Interpreter {
     }
 }
 
-/// The result of an interpreter operation.
-#[derive(Debug, Clone)]
-pub struct InterpreterResult {
-    /// The result of the instruction execution.
-    pub result: InstructionResult,
-    /// The output of the instruction execution.
-    pub output: Bytes,
-    /// The gas usage information.
-    pub gas: Gas,
-}
-
 impl InterpreterResult {
     /// Returns whether the instruction result is a success.
     #[inline]
@@ -305,22 +323,4 @@ impl InterpreterResult {
     pub const fn is_error(&self) -> bool {
         self.result.is_error()
     }
-}
-
-#[derive(Debug, Clone)]
-pub enum InterpreterAction {
-    SubCall {
-        /// Call inputs
-        inputs: Box<CallInputs>,
-        /// The offset into `self.memory` of the return data.
-        ///
-        /// This value must be ignored if `self.return_len` is 0.
-        return_memory_offset: Range<usize>,
-    },
-    Create {
-        inputs: Box<CreateInputs>,
-    },
-    Return {
-        result: InterpreterResult,
-    },
 }

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -53,31 +53,6 @@ pub struct Interpreter {
     pub next_action: Option<InterpreterAction>,
 }
 
-#[derive(Debug, Clone)]
-pub struct InterpreterResult {
-    pub result: InstructionResult,
-    pub output: Bytes,
-    pub gas: Gas,
-}
-
-#[derive(Debug, Clone)]
-pub enum InterpreterAction {
-    SubCall {
-        /// Call inputs
-        inputs: Box<CallInputs>,
-        /// The offset into `self.memory` of the return data.
-        ///
-        /// This value must be ignored if `self.return_len` is 0.
-        return_memory_offset: Range<usize>,
-    },
-    Create {
-        inputs: Box<CreateInputs>,
-    },
-    Return {
-        result: InterpreterResult,
-    },
-}
-
 impl Interpreter {
     /// Create new interpreter
     pub fn new(contract: Box<Contract>, gas_limit: u64, is_static: bool) -> Self {
@@ -299,4 +274,53 @@ impl Interpreter {
             },
         }
     }
+}
+
+/// The result of an interpreter operation.
+#[derive(Debug, Clone)]
+pub struct InterpreterResult {
+    /// The result of the instruction execution.
+    pub result: InstructionResult,
+    /// The output of the instruction execution.
+    pub output: Bytes,
+    /// The gas usage information.
+    pub gas: Gas,
+}
+
+impl InterpreterResult {
+    /// Returns whether the instruction result is a success.
+    #[inline]
+    pub const fn is_ok(&self) -> bool {
+        self.result.is_ok()
+    }
+
+    /// Returns whether the instruction result is a revert.
+    #[inline]
+    pub const fn is_revert(&self) -> bool {
+        self.result.is_ok()
+    }
+
+    /// Returns whether the instruction result is an error.
+    #[inline]
+    pub const fn is_error(&self) -> bool {
+        self.result.is_error()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum InterpreterAction {
+    SubCall {
+        /// Call inputs
+        inputs: Box<CallInputs>,
+        /// The offset into `self.memory` of the return data.
+        ///
+        /// This value must be ignored if `self.return_len` is 0.
+        return_memory_offset: Range<usize>,
+    },
+    Create {
+        inputs: Box<CreateInputs>,
+    },
+    Return {
+        result: InterpreterResult,
+    },
 }


### PR DESCRIPTION
The `InterpreterResult` wraps an `InstructionResult`

This also exposes the `is_{error,success}` functions on the `InterpreterResult`

moves struct defs around and makes calls const.