### PR TITLE
feat(inspector): Share call/create inputs in Inspector call_end/create_end

### DIFF
--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -94,9 +94,11 @@ pub trait Inspector<DB: Database> {
     fn call_end(
         &mut self,
         context: &mut EvmContext<DB>,
+        inputs: &CallInputs,
         result: InterpreterResult,
     ) -> InterpreterResult {
         let _ = context;
+        let _ = inputs;
         result
     }
 
@@ -122,10 +124,12 @@ pub trait Inspector<DB: Database> {
     fn create_end(
         &mut self,
         context: &mut EvmContext<DB>,
+        inputs: &CreateInputs,
         result: InterpreterResult,
         address: Option<Address>,
     ) -> CreateOutcome {
         let _ = context;
+        let _ = inputs;
         CreateOutcome::new(result, address)
     }
 

--- a/crates/revm/src/inspector/customprinter.rs
+++ b/crates/revm/src/inspector/customprinter.rs
@@ -64,18 +64,21 @@ impl<DB: Database> Inspector<DB> for CustomPrintTracer {
     fn call_end(
         &mut self,
         context: &mut EvmContext<DB>,
+        inputs: &CallInputs,
         result: InterpreterResult,
     ) -> InterpreterResult {
-        self.gas_inspector.call_end(context, result)
+        self.gas_inspector.call_end(context, inputs, result)
     }
 
     fn create_end(
         &mut self,
         context: &mut EvmContext<DB>,
+        inputs: &CreateInputs,
         result: InterpreterResult,
         address: Option<Address>,
     ) -> CreateOutcome {
-        self.gas_inspector.create_end(context, result, address)
+        self.gas_inspector
+            .create_end(context, inputs, result, address)
     }
 
     fn call(

--- a/crates/revm/src/inspector/eip3155.rs
+++ b/crates/revm/src/inspector/eip3155.rs
@@ -98,9 +98,10 @@ impl<DB: Database> Inspector<DB> for TracerEip3155 {
     fn call_end(
         &mut self,
         context: &mut EvmContext<DB>,
+        inputs: &CallInputs,
         result: InterpreterResult,
     ) -> InterpreterResult {
-        let result = self.gas_inspector.call_end(context, result);
+        let result = self.gas_inspector.call_end(context, inputs, result);
         if context.journaled_state.depth() == 0 {
             let log_line = json!({
                 //stateroot
@@ -127,10 +128,12 @@ impl<DB: Database> Inspector<DB> for TracerEip3155 {
     fn create_end(
         &mut self,
         context: &mut EvmContext<DB>,
+        inputs: &CreateInputs,
         result: InterpreterResult,
         address: Option<Address>,
     ) -> CreateOutcome {
-        self.gas_inspector.create_end(context, result, address)
+        self.gas_inspector
+            .create_end(context, inputs, result, address)
     }
 }
 

--- a/crates/revm/src/inspector/gas.rs
+++ b/crates/revm/src/inspector/gas.rs
@@ -5,7 +5,7 @@ use revm_interpreter::{CallInputs, CreateInputs, CreateOutcome};
 use crate::{
     interpreter::InterpreterResult,
     primitives::{db::Database, Address},
-    EvmContext, Inspector,
+    EvmContext, GetInspector, Inspector,
 };
 
 /// Helper [Inspector] that keeps track of gas.
@@ -23,6 +23,12 @@ impl GasInspector {
 
     pub fn last_gas_cost(&self) -> u64 {
         self.last_gas_cost
+    }
+}
+
+impl<DB: Database> GetInspector<'_, DB> for GasInspector {
+    fn get_inspector(&mut self) -> &mut dyn Inspector<DB> {
+        self
     }
 }
 

--- a/crates/revm/src/inspector/gas.rs
+++ b/crates/revm/src/inspector/gas.rs
@@ -1,6 +1,6 @@
 //! GasIspector. Helper Inspector to calculate gas for others.
 
-use revm_interpreter::CreateOutcome;
+use revm_interpreter::{CallInputs, CreateInputs, CreateOutcome};
 
 use crate::{
     interpreter::InterpreterResult,
@@ -47,6 +47,7 @@ impl<DB: Database> Inspector<DB> for GasInspector {
     fn call_end(
         &mut self,
         _context: &mut EvmContext<DB>,
+        _inputs: &CallInputs,
         mut result: InterpreterResult,
     ) -> InterpreterResult {
         if result.result.is_error() {
@@ -59,6 +60,7 @@ impl<DB: Database> Inspector<DB> for GasInspector {
     fn create_end(
         &mut self,
         _context: &mut EvmContext<DB>,
+        _inputs: &CreateInputs,
         result: InterpreterResult,
         address: Option<Address>,
     ) -> CreateOutcome {
@@ -123,9 +125,10 @@ mod tests {
         fn call_end(
             &mut self,
             context: &mut EvmContext<DB>,
+            inputs: &CallInputs,
             result: InterpreterResult,
         ) -> InterpreterResult {
-            self.gas_inspector.call_end(context, result)
+            self.gas_inspector.call_end(context, inputs, result)
         }
 
         fn create(
@@ -140,10 +143,12 @@ mod tests {
         fn create_end(
             &mut self,
             context: &mut EvmContext<DB>,
+            inputs: &CreateInputs,
             result: InterpreterResult,
             address: Option<Address>,
         ) -> CreateOutcome {
-            self.gas_inspector.create_end(context, result, address)
+            self.gas_inspector
+                .create_end(context, inputs, result, address)
         }
     }
 

--- a/crates/revm/src/inspector/handler_register.rs
+++ b/crates/revm/src/inspector/handler_register.rs
@@ -1,3 +1,5 @@
+use core::cell::RefCell;
+
 use crate::{
     db::Database,
     handler::register::{EvmHandler, EvmInstructionTables},
@@ -8,7 +10,7 @@ use crate::{
     primitives::TransactTo,
     CallStackFrame, Evm, FrameData, FrameOrResult, Inspector, JournalEntry,
 };
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, rc::Rc, sync::Arc, vec::Vec};
 use revm_interpreter::{CallOutcome, CreateInputs};
 
 pub trait GetInspector<'a, DB: Database> {
@@ -93,6 +95,14 @@ pub fn inspector_handle_register<'a, DB: Database, EXT: GetInspector<'a, DB>>(
     inspect_log(opcode::LOG3);
     inspect_log(opcode::LOG4);
 
+    // call and create input stack shared between handlers. They are used to share
+    // inputs in *_end Inspector calls. 
+    let call_input_stack = Rc::<RefCell<Vec<_>>>::new(RefCell::new(Vec::new()));
+    let create_input_stack = Rc::<RefCell<Vec<_>>>::new(RefCell::new(Vec::new()));
+
+    let create_input_stack_inner = create_input_stack.clone();
+    let call_input_stack_inner = call_input_stack.clone();
+
     // wrap first frame create and main frame return.
     handler.execution_loop.create_first_frame =
         Arc::new(move |context, gas_limit| -> FrameOrResult {
@@ -109,7 +119,11 @@ pub fn inspector_handle_register<'a, DB: Database, EXT: GetInspector<'a, DB>>(
                         return FrameOrResult::Result(output.interpreter_result);
                     }
                     // first call frame does not have return range.
-                    context.evm.make_call_frame(&call_inputs, 0..0)
+                    let out = context.evm.make_call_frame(&call_inputs, 0..0);
+                    call_input_stack_inner
+                        .borrow_mut()
+                        .push(Box::new(call_inputs));
+                    out
                 }
                 TransactTo::Create(_) => {
                     let mut create_inputs =
@@ -121,7 +135,11 @@ pub fn inspector_handle_register<'a, DB: Database, EXT: GetInspector<'a, DB>>(
                     {
                         return FrameOrResult::Result(output.result);
                     };
-                    context.evm.make_create_frame(spec_id, &create_inputs)
+                    let out = context.evm.make_create_frame(spec_id, &create_inputs);
+                    create_input_stack_inner
+                        .borrow_mut()
+                        .push(Box::new(create_inputs));
+                    out
                 }
             };
 
@@ -174,6 +192,7 @@ pub fn inspector_handle_register<'a, DB: Database, EXT: GetInspector<'a, DB>>(
     ));
 
     // handle sub create
+    let create_input_stack_inner = create_input_stack.clone();
     handler.execution_loop.sub_create = Arc::new(
         move |context, frame, mut inputs| -> Option<Box<CallStackFrame>> {
             let inspector = context.external.get_inspector();
@@ -185,11 +204,16 @@ pub fn inspector_handle_register<'a, DB: Database, EXT: GetInspector<'a, DB>>(
             match context.evm.make_create_frame(spec_id, &inputs) {
                 FrameOrResult::Frame(mut new_frame) => {
                     inspector.initialize_interp(&mut new_frame.interpreter, &mut context.evm);
+                    create_input_stack_inner.borrow_mut().push(inputs);
                     Some(new_frame)
                 }
                 FrameOrResult::Result(result) => {
-                    let create_outcome =
-                        inspector.create_end(&mut context.evm, result, frame.created_address());
+                    let create_outcome = inspector.create_end(
+                        &mut context.evm,
+                        &inputs,
+                        result,
+                        frame.created_address(),
+                    );
                     // insert result of the failed creation of create CallStackFrame.
                     frame.interpreter.insert_create_outcome(create_outcome);
                     None
@@ -199,6 +223,7 @@ pub fn inspector_handle_register<'a, DB: Database, EXT: GetInspector<'a, DB>>(
     );
 
     // handle sub call
+    let call_input_stack_inner = call_input_stack.clone();
     handler.execution_loop.sub_call = Arc::new(
         move |context, mut inputs, frame, memory, return_memory_offset| -> Option<Box<_>> {
             // inspector handle
@@ -213,11 +238,12 @@ pub fn inspector_handle_register<'a, DB: Database, EXT: GetInspector<'a, DB>>(
             {
                 FrameOrResult::Frame(mut new_frame) => {
                     inspector.initialize_interp(&mut new_frame.interpreter, &mut context.evm);
+                    call_input_stack_inner.borrow_mut().push(inputs);
                     Some(new_frame)
                 }
                 FrameOrResult::Result(result) => {
                     // inspector handle
-                    let result = inspector.call_end(&mut context.evm, result);
+                    let result = inspector.call_end(&mut context.evm, &inputs, result);
                     let call_outcome = CallOutcome::new(result, return_memory_offset);
                     frame.interpreter.insert_call_outcome(memory, call_outcome);
                     None
@@ -233,8 +259,10 @@ pub fn inspector_handle_register<'a, DB: Database, EXT: GetInspector<'a, DB>>(
             let inspector = &mut context.external.get_inspector();
             result = match &mut child.frame_data {
                 FrameData::Create { created_address } => {
+                    let create_input = create_input_stack.borrow_mut().pop().unwrap();
                     let create_outcome = inspector.create_end(
                         &mut context.evm,
+                        &create_input,
                         result.clone(),
                         Some(*created_address),
                     );
@@ -243,7 +271,10 @@ pub fn inspector_handle_register<'a, DB: Database, EXT: GetInspector<'a, DB>>(
                     }
                     result
                 }
-                FrameData::Call { .. } => inspector.call_end(&mut context.evm, result),
+                FrameData::Call { .. } => {
+                    let call_input = call_input_stack.borrow_mut().pop().unwrap();
+                    inspector.call_end(&mut context.evm, &call_input, result)
+                }
             };
             old_handle(context, child, parent, memory, result)
         },
@@ -359,6 +390,7 @@ mod tests {
         fn call_end(
             &mut self,
             _context: &mut EvmContext<DB>,
+            _inputs: &CallInputs,
             result: InterpreterResult,
         ) -> InterpreterResult {
             if self.call_end {
@@ -379,6 +411,7 @@ mod tests {
         fn create_end(
             &mut self,
             _context: &mut EvmContext<DB>,
+            _inputs: &CreateInputs,
             result: InterpreterResult,
             address: Option<Address>,
         ) -> CreateOutcome {

--- a/crates/revm/src/inspector/handler_register.rs
+++ b/crates/revm/src/inspector/handler_register.rs
@@ -96,7 +96,7 @@ pub fn inspector_handle_register<'a, DB: Database, EXT: GetInspector<'a, DB>>(
     inspect_log(opcode::LOG4);
 
     // call and create input stack shared between handlers. They are used to share
-    // inputs in *_end Inspector calls. 
+    // inputs in *_end Inspector calls.
     let call_input_stack = Rc::<RefCell<Vec<_>>>::new(RefCell::new(Vec::new()));
     let create_input_stack = Rc::<RefCell<Vec<_>>>::new(RefCell::new(Vec::new()));
 


### PR DESCRIPTION
Added `Rc<RefCell<>>` to call/create inspector handler so we can share inputs stack.

This functionality was removed with a call loop as the input is discarded after the frame is created and not available in *_end Inspector function, this removal became a problem for downstream libraries that use Inspector.