### PR TITLE
chore(Interpreter): Split calls to separate functions

### DIFF
--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -349,7 +349,6 @@ pub fn execute_test_suite(
                     .build();
 
                 // do the deed
-                let timer = Instant::now();
                 let (e, exec_result) = if trace {
                     let mut evm = evm
                         .modify()
@@ -360,7 +359,10 @@ pub fn execute_test_suite(
                         ))
                         .append_handler_register(inspector_handle_register)
                         .build();
+
+                    let timer = Instant::now();
                     let res = evm.transact_commit();
+                    *elapsed.lock().unwrap() += timer.elapsed();
 
                     let Err(e) = check_evm_execution(
                         &test,
@@ -375,7 +377,9 @@ pub fn execute_test_suite(
                     // reset external context
                     (e, res)
                 } else {
+                    let timer = Instant::now();
                     let res = evm.transact_commit();
+                    *elapsed.lock().unwrap() += timer.elapsed();
 
                     // dump state and traces if test failed
                     let output = check_evm_execution(
@@ -391,7 +395,6 @@ pub fn execute_test_suite(
                     };
                     (e, res)
                 };
-                *elapsed.lock().unwrap() += timer.elapsed();
 
                 // print only once or
                 // if we are already in trace mode, just return error

--- a/crates/interpreter/src/gas/calc.rs
+++ b/crates/interpreter/src/gas/calc.rs
@@ -271,14 +271,8 @@ pub fn selfdestruct_cost<SPEC: Spec>(res: SelfDestructResult) -> u64 {
     gas
 }
 
-pub fn call_cost<SPEC: Spec>(
-    transfers_value: bool,
-    is_new: bool,
-    is_cold: bool,
-    is_call_or_callcode: bool,
-    is_call_or_staticcall: bool,
-) -> u64 {
-    let call_gas = if SPEC::enabled(BERLIN) {
+pub fn call_gas<SPEC: Spec>(is_cold: bool) -> u64 {
+    if SPEC::enabled(BERLIN) {
         if is_cold {
             COLD_ACCOUNT_ACCESS_COST
         } else {
@@ -289,9 +283,17 @@ pub fn call_cost<SPEC: Spec>(
         700
     } else {
         40
-    };
+    }
+}
 
-    call_gas
+pub fn call_cost<SPEC: Spec>(
+    transfers_value: bool,
+    is_new: bool,
+    is_cold: bool,
+    is_call_or_callcode: bool,
+    is_call_or_staticcall: bool,
+) -> u64 {
+    call_gas::<SPEC>(is_cold)
         + xfer_cost(is_call_or_callcode, transfers_value)
         + new_cost::<SPEC>(is_call_or_staticcall, is_new, transfers_value)
 }

--- a/crates/interpreter/src/instructions/host/call_helpers.rs
+++ b/crates/interpreter/src/instructions/host/call_helpers.rs
@@ -1,0 +1,72 @@
+use crate::{
+    gas::{self},
+    interpreter::Interpreter,
+    primitives::{Address, Bytes, Spec, SpecId::*},
+    Host, InstructionResult,
+};
+use core::{cmp::min, ops::Range};
+
+#[inline]
+pub fn get_memory_input_and_out_ranges(
+    interpreter: &mut Interpreter,
+) -> Option<(Bytes, Range<usize>)> {
+    pop_ret!(interpreter, in_offset, in_len, out_offset, out_len, None);
+
+    let in_len = as_usize_or_fail_ret!(interpreter, in_len, None);
+    let input = if in_len != 0 {
+        let in_offset = as_usize_or_fail_ret!(interpreter, in_offset, None);
+        shared_memory_resize!(interpreter, in_offset, in_len, None);
+        Bytes::copy_from_slice(interpreter.shared_memory.slice(in_offset, in_len))
+    } else {
+        Bytes::new()
+    };
+
+    let out_len = as_usize_or_fail_ret!(interpreter, out_len, None);
+    let out_offset = if out_len != 0 {
+        let out_offset = as_usize_or_fail_ret!(interpreter, out_offset, None);
+        shared_memory_resize!(interpreter, out_offset, out_len, None);
+        out_offset
+    } else {
+        usize::MAX //unrealistic value so we are sure it is not used
+    };
+
+    Some((input, out_offset..out_offset + out_len))
+}
+
+#[inline]
+pub fn calc_call_gas<H: Host, SPEC: Spec>(
+    interpreter: &mut Interpreter,
+    host: &mut H,
+    to: Address,
+    has_transfer: bool,
+    local_gas_limit: u64,
+    is_call_or_callcode: bool,
+    is_call_or_staticcall: bool,
+) -> Option<u64> {
+    let Some((is_cold, exist)) = host.load_account(to) else {
+        interpreter.instruction_result = InstructionResult::FatalExternalError;
+        return None;
+    };
+    let is_new = !exist;
+
+    let call_cost = gas::call_cost::<SPEC>(
+        has_transfer,
+        is_new,
+        is_cold,
+        is_call_or_callcode,
+        is_call_or_staticcall,
+    );
+
+    gas!(interpreter, call_cost, None);
+
+    // EIP-150: Gas cost changes for IO-heavy operations
+    let gas_limit = if SPEC::enabled(TANGERINE) {
+        let gas = interpreter.gas().remaining();
+        // take l64 part of gas_limit
+        min(gas - gas / 64, local_gas_limit)
+    } else {
+        local_gas_limit
+    };
+
+    Some(gas_limit)
+}


### PR DESCRIPTION
Split calls to separate functions.

Calls are now very rigid and it is hard to add custom calls to create a new frame. This is first step towards introducing Generics on calls (not sure on the final form that would encompass both creates and calls)