### PR TITLE
fix(Interpreter): is_revert should call is_revert

### DIFF
--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -315,7 +315,7 @@ impl InterpreterResult {
     /// Returns whether the instruction result is a revert.
     #[inline]
     pub const fn is_revert(&self) -> bool {
-        self.result.is_ok()
+        self.result.is_revert()
     }
 
     /// Returns whether the instruction result is an error.


### PR DESCRIPTION
From comment here: https://github.com/bluealloy/revm/pull/1002/files#r1461978421

Introduced yesterday