### PR TITLE
feat(op): Ecotone hardfork

### DIFF
--- a/crates/interpreter/src/instructions/opcode.rs
+++ b/crates/interpreter/src/instructions/opcode.rs
@@ -872,6 +872,11 @@ pub const fn spec_opcode_gas(spec_id: SpecId) -> &'static [OpInfo; 256] {
                     const TABLE: &[OpInfo;256] = &make_gas_table(SpecId::CANYON);
                     TABLE
                 }
+                #[cfg(feature = "optimism")]
+                SpecId::ECOTONE => {
+                    const TABLE: &[OpInfo;256] = &make_gas_table(SpecId::ECOTONE);
+                    TABLE
+                }
             }
         };
     }

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -258,6 +258,8 @@ impl PrecompileSpecId {
             LATEST => Self::LATEST,
             #[cfg(feature = "optimism")]
             BEDROCK | REGOLITH | CANYON => Self::BERLIN,
+            #[cfg(feature = "optimism")]
+            ECOTONE => Self::CANCUN,
         }
     }
 }

--- a/crates/primitives/src/specification.rs
+++ b/crates/primitives/src/specification.rs
@@ -60,6 +60,7 @@ pub enum SpecId {
     SHANGHAI = 18,
     CANYON = 19,
     CANCUN = 20,
+    ECOTONE = 21,
     LATEST = u8::MAX,
 }
 
@@ -102,6 +103,8 @@ impl From<&str> for SpecId {
             "Regolith" => SpecId::REGOLITH,
             #[cfg(feature = "optimism")]
             "Canyon" => SpecId::CANYON,
+            #[cfg(feature = "optimism")]
+            "Ecotone" => SpecId::ECOTONE,
             _ => Self::LATEST,
         }
     }
@@ -157,6 +160,8 @@ spec!(BEDROCK, BedrockSpec);
 spec!(REGOLITH, RegolithSpec);
 #[cfg(feature = "optimism")]
 spec!(CANYON, CanyonSpec);
+#[cfg(feature = "optimism")]
+spec!(ECOTONE, EcotoneSpec);
 
 #[macro_export]
 macro_rules! spec_to_generic {
@@ -230,6 +235,11 @@ macro_rules! spec_to_generic {
             #[cfg(feature = "optimism")]
             $crate::SpecId::CANYON => {
                 use $crate::CanyonSpec as SPEC;
+                $e
+            }
+            #[cfg(feature = "optimism")]
+            $crate::SpecId::ECOTONE => {
+                use $crate::EcotoneSpec as SPEC;
                 $e
             }
         }
@@ -337,5 +347,29 @@ mod optimism_tests {
         assert!(SpecId::enabled(SpecId::CANYON, SpecId::BEDROCK));
         assert!(SpecId::enabled(SpecId::CANYON, SpecId::REGOLITH));
         assert!(SpecId::enabled(SpecId::CANYON, SpecId::CANYON));
+    }
+
+    #[test]
+    fn test_ecotone_post_merge_hardforks() {
+        assert!(EcotoneSpec::enabled(SpecId::MERGE));
+        assert!(EcotoneSpec::enabled(SpecId::SHANGHAI));
+        assert!(EcotoneSpec::enabled(SpecId::CANCUN));
+        assert!(!EcotoneSpec::enabled(SpecId::LATEST));
+        assert!(EcotoneSpec::enabled(SpecId::BEDROCK));
+        assert!(EcotoneSpec::enabled(SpecId::REGOLITH));
+        assert!(EcotoneSpec::enabled(SpecId::CANYON));
+        assert!(EcotoneSpec::enabled(SpecId::ECOTONE));
+    }
+
+    #[test]
+    fn test_ecotone_post_merge_hardforks_spec_id() {
+        assert!(SpecId::enabled(SpecId::ECOTONE, SpecId::MERGE));
+        assert!(SpecId::enabled(SpecId::ECOTONE, SpecId::SHANGHAI));
+        assert!(SpecId::enabled(SpecId::ECOTONE, SpecId::CANCUN));
+        assert!(!SpecId::enabled(SpecId::ECOTONE, SpecId::LATEST));
+        assert!(SpecId::enabled(SpecId::ECOTONE, SpecId::BEDROCK));
+        assert!(SpecId::enabled(SpecId::ECOTONE, SpecId::REGOLITH));
+        assert!(SpecId::enabled(SpecId::ECOTONE, SpecId::CANYON));
+        assert!(SpecId::enabled(SpecId::ECOTONE, SpecId::ECOTONE));
     }
 }

--- a/crates/revm/src/handler/mainnet/pre_execution.rs
+++ b/crates/revm/src/handler/mainnet/pre_execution.rs
@@ -30,8 +30,9 @@ pub fn load<SPEC: Spec, EXT, DB: Database>(
     // the L1-cost fee is only computed for Optimism non-deposit transactions.
     #[cfg(feature = "optimism")]
     if context.evm.env.cfg.optimism && context.evm.env.tx.optimism.source_hash.is_none() {
-        let l1_block_info = crate::optimism::L1BlockInfo::try_fetch(&mut context.evm.db)
-            .map_err(EVMError::Database)?;
+        let l1_block_info =
+            crate::optimism::L1BlockInfo::try_fetch(&mut context.evm.db, SPEC::SPEC_ID)
+                .map_err(EVMError::Database)?;
 
         // storage l1 block info for later use.
         context.evm.l1_block_info = Some(l1_block_info);

--- a/crates/revm/src/optimism/handler_register.rs
+++ b/crates/revm/src/optimism/handler_register.rs
@@ -409,8 +409,9 @@ mod tests {
         let mut context: Context<(), InMemoryDB> = Context::new_with_db(db);
         context.evm.l1_block_info = Some(L1BlockInfo {
             l1_base_fee: U256::from(1_000),
-            l1_fee_overhead: U256::from(1_000),
-            l1_fee_scalar: U256::from(1_000),
+            l1_fee_overhead: Some(U256::from(1_000)),
+            l1_base_fee_scalar: U256::from(1_000),
+            ..Default::default()
         });
         // Enveloped needs to be some but it will deduce zero fee.
         context.evm.env.tx.optimism.enveloped_tx = Some(bytes!(""));
@@ -442,8 +443,9 @@ mod tests {
         let mut context: Context<(), InMemoryDB> = Context::new_with_db(db);
         context.evm.l1_block_info = Some(L1BlockInfo {
             l1_base_fee: U256::from(1_000),
-            l1_fee_overhead: U256::from(1_000),
-            l1_fee_scalar: U256::from(1_000),
+            l1_fee_overhead: Some(U256::from(1_000)),
+            l1_base_fee_scalar: U256::from(1_000),
+            ..Default::default()
         });
         // l1block cost is 1048 fee.
         context.evm.env.tx.optimism.enveloped_tx = Some(bytes!("FACADE"));
@@ -478,8 +480,9 @@ mod tests {
         let mut context: Context<(), InMemoryDB> = Context::new_with_db(db);
         context.evm.l1_block_info = Some(L1BlockInfo {
             l1_base_fee: U256::from(1_000),
-            l1_fee_overhead: U256::from(1_000),
-            l1_fee_scalar: U256::from(1_000),
+            l1_fee_overhead: Some(U256::from(1_000)),
+            l1_base_fee_scalar: U256::from(1_000),
+            ..Default::default()
         });
         // l1block cost is 1048 fee.
         context.evm.env.tx.optimism.enveloped_tx = Some(bytes!("FACADE"));
@@ -508,8 +511,9 @@ mod tests {
         let mut context: Context<(), InMemoryDB> = Context::new_with_db(db);
         context.evm.l1_block_info = Some(L1BlockInfo {
             l1_base_fee: U256::from(1_000),
-            l1_fee_overhead: U256::from(1_000),
-            l1_fee_scalar: U256::from(1_000),
+            l1_fee_overhead: Some(U256::from(1_000)),
+            l1_base_fee_scalar: U256::from(1_000),
+            ..Default::default()
         });
         // l1block cost is 1048 fee.
         context.evm.env.tx.optimism.enveloped_tx = Some(bytes!("FACADE"));

--- a/examples/generate_block_traces.rs
+++ b/examples/generate_block_traces.rs
@@ -153,7 +153,11 @@ async fn main() -> anyhow::Result<()> {
         // Construct the file writer to write the trace to
         let tx_number = tx.transaction_index.unwrap().0[0];
         let file_name = format!("traces/{}.json", tx_number);
-        let write = OpenOptions::new().write(true).create(true).open(file_name);
+        let write = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(file_name);
         let inner = Arc::new(Mutex::new(BufWriter::new(
             write.expect("Failed to open file"),
         )));


### PR DESCRIPTION
## Overview

Adds definitions and support for the upcoming Ecotone hardfork on Optimism.

### Details

The `Ecotone` hardfork is activated alongside `Cancun`, with few execution layer modifications of our own. The rollup will now be using 4844 DA, which involves some changes to the L1 fee calculation.

1. `Ecotone` L1 fee specifications: https://github.com/ethereum-optimism/specs/blob/main/specs/exec-engine.md#ecotone-l1-cost-fee-changes-eip-4844-da
2. `Ecotone` L1 fee reference implementation: https://github.com/ethereum-optimism/op-geth/blob/a4e85ec465e2de3f962d757d8f9b561b5461f861/core/types/rollup_cost.go