### PR TITLE
fix(State): Preserve original values on delete revert

### DIFF
--- a/crates/revm/src/db/states/bundle_account.rs
+++ b/crates/revm/src/db/states/bundle_account.rs
@@ -93,7 +93,15 @@ impl BundleAccount {
             AccountInfoRevert::DeleteIt => {
                 self.info = None;
                 self.storage = HashMap::new();
-                return true;
+                if self.original_info.is_none() {
+                    return true;
+                } else {
+                    // set all storage to zero but   preserve original values.
+                    self.storage.iter_mut().for_each(|(_, v)| {
+                        v.present_value = U256::ZERO;
+                    });
+                    return false;
+                }
             }
             AccountInfoRevert::RevertTo(info) => self.info = Some(info),
         };

--- a/crates/revm/src/db/states/bundle_account.rs
+++ b/crates/revm/src/db/states/bundle_account.rs
@@ -92,11 +92,11 @@ impl BundleAccount {
             AccountInfoRevert::DoNothing => (),
             AccountInfoRevert::DeleteIt => {
                 self.info = None;
-                self.storage = HashMap::new();
                 if self.original_info.is_none() {
+                    self.storage = HashMap::new();
                     return true;
                 } else {
-                    // set all storage to zero but   preserve original values.
+                    // set all storage to zero but preserve original values.
                     self.storage.iter_mut().for_each(|(_, v)| {
                         v.present_value = U256::ZERO;
                     });


### PR DESCRIPTION
Delete an account from bundle state only if the original value is None, if we delete non original value we will lose this information.

Original account `None` means that account din't exist.

On revert if we want to revert on non existing account this means that it is not existing, so we revert on non existing account.
