### PR TITLE
Add `ahash`'s `RandomState` for HashDoS prevention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
+ "const-random",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -662,6 +663,26 @@ name = "const-oid"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+
+[[package]]
+name = "const-random"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaf16c9c2c612020bcfd042e170f6e32de9b9d75adb5277cdbbd2e2c8c8299a"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "convert_case"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,11 +19,12 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -2467,6 +2468,7 @@ dependencies = [
 name = "revm-primitives"
 version = "1.3.0"
 dependencies = [
+ "ahash",
  "alloy-primitives",
  "auto_impl",
  "bitflags 2.4.2",
@@ -3893,18 +3895,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.26"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.26"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
- "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -21,7 +21,7 @@ alloy-primitives = { version = "0.6", default-features = false, features = [
     "rlp",
 ] }
 hashbrown = "0.14"
-ahash = { version = "0.8.7", default-features = false, features = [ "runtime-rng" ] }
+ahash = { version = "0.8.7", default-features = false }
 auto_impl = "1.1"
 bitvec = { version = "1", default-features = false, features = ["alloc"] }
 bitflags = { version = "2.4.2", default-features = false }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -21,7 +21,7 @@ alloy-primitives = { version = "0.6", default-features = false, features = [
     "rlp",
 ] }
 hashbrown = "0.14"
-ahash = { version = "0.8.7", default-features = false }
+ahash = { version = "0.8.7", default-features = false, features = [ "compile-time-rng" ] }
 auto_impl = "1.1"
 bitvec = { version = "1", default-features = false, features = ["alloc"] }
 bitflags = { version = "2.4.2", default-features = false }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -21,6 +21,7 @@ alloy-primitives = { version = "0.6", default-features = false, features = [
     "rlp",
 ] }
 hashbrown = "0.14"
+ahash = "0.8.7"
 auto_impl = "1.1"
 bitvec = { version = "1", default-features = false, features = ["alloc"] }
 bitflags = { version = "2.4.2", default-features = false }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -21,7 +21,7 @@ alloy-primitives = { version = "0.6", default-features = false, features = [
     "rlp",
 ] }
 hashbrown = "0.14"
-ahash = "0.8.7"
+ahash = { version = "0.8.7", default-features = false, features = [ "runtime-rng" ] }
 auto_impl = "1.1"
 bitvec = { version = "1", default-features = false, features = ["alloc"] }
 bitflags = { version = "2.4.2", default-features = false }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -21,6 +21,7 @@ pub mod specification;
 pub mod state;
 pub mod utilities;
 
+pub use ahash::RandomState;
 pub use alloy_primitives::{
     self, address, b256, bytes, fixed_bytes, hex, hex_literal, ruint, uint, Address, Bytes,
     FixedBytes, Log, LogData, B256, I256, U256,
@@ -30,7 +31,6 @@ pub use bytecode::*;
 pub use constants::*;
 pub use env::*;
 pub use hashbrown::{hash_map, hash_set, HashMap, HashSet};
-pub use ahash::RandomState;
 #[cfg(feature = "c-kzg")]
 pub use kzg::{EnvKzgSettings, KzgSettings};
 pub use precompile::*;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -30,6 +30,7 @@ pub use bytecode::*;
 pub use constants::*;
 pub use env::*;
 pub use hashbrown::{hash_map, hash_set, HashMap, HashSet};
+pub use ahash::RandomState;
 #[cfg(feature = "c-kzg")]
 pub use kzg::{EnvKzgSettings, KzgSettings};
 pub use precompile::*;

--- a/crates/primitives/src/state.rs
+++ b/crates/primitives/src/state.rs
@@ -2,12 +2,13 @@ use crate::{Address, Bytecode, B256, KECCAK_EMPTY, U256};
 use bitflags::bitflags;
 use core::hash::{Hash, Hasher};
 use hashbrown::HashMap;
+use ahash::RandomState;
 
 /// EVM State is a mapping from addresses to accounts.
 pub type State = HashMap<Address, Account>;
 
 /// Structure used for EIP-1153 transient storage.
-pub type TransientStorage = HashMap<(Address, U256), U256>;
+pub type TransientStorage = HashMap<(Address, U256), U256, RandomState>;
 
 /// An account's Storage is a mapping from 256-bit integer keys to [StorageSlot]s.
 pub type Storage = HashMap<U256, StorageSlot>;

--- a/crates/primitives/src/state.rs
+++ b/crates/primitives/src/state.rs
@@ -1,8 +1,8 @@
 use crate::{Address, Bytecode, B256, KECCAK_EMPTY, U256};
+use ahash::RandomState;
 use bitflags::bitflags;
 use core::hash::{Hash, Hasher};
 use hashbrown::HashMap;
-use ahash::RandomState;
 
 /// EVM State is a mapping from addresses to accounts.
 pub type State = HashMap<Address, Account>;

--- a/crates/revm/src/journaled_state.rs
+++ b/crates/revm/src/journaled_state.rs
@@ -1,10 +1,10 @@
 use crate::interpreter::{InstructionResult, SelfDestructResult};
 use crate::primitives::{
-    db::Database, hash_map::Entry, Account, Address, Bytecode, HashMap, HashSet, Log, SpecId::*,
+    db::Database, hash_map::Entry, Account, Address, Bytecode, HashMap, HashSet, RandomState, Log, SpecId::*,
     State, StorageSlot, TransientStorage, KECCAK_EMPTY, PRECOMPILE3, U256,
 };
 use alloc::vec::Vec;
-use core::mem;
+use core::{mem, hash::BuildHasher};
 use revm_interpreter::primitives::SpecId;
 
 /// JournalState is internal EVM state that is used to contain state and track changes to that state.
@@ -50,7 +50,7 @@ impl JournaledState {
     pub fn new(spec: SpecId, warm_preloaded_addresses: HashSet<Address>) -> JournaledState {
         Self {
             state: HashMap::new(),
-            transient_storage: TransientStorage::default(),
+            transient_storage: TransientStorage::with_hasher(RandomState::new()),
             logs: Vec::new(),
             journal: vec![vec![]],
             depth: 0,

--- a/crates/revm/src/journaled_state.rs
+++ b/crates/revm/src/journaled_state.rs
@@ -1,10 +1,10 @@
 use crate::interpreter::{InstructionResult, SelfDestructResult};
 use crate::primitives::{
-    db::Database, hash_map::Entry, Account, Address, Bytecode, HashMap, HashSet, RandomState, Log, SpecId::*,
-    State, StorageSlot, TransientStorage, KECCAK_EMPTY, PRECOMPILE3, U256,
+    db::Database, hash_map::Entry, Account, Address, Bytecode, HashMap, HashSet, Log, RandomState,
+    SpecId::*, State, StorageSlot, TransientStorage, KECCAK_EMPTY, PRECOMPILE3, U256,
 };
 use alloc::vec::Vec;
-use core::{mem, hash::BuildHasher};
+use core::{hash::BuildHasher, mem};
 use revm_interpreter::primitives::SpecId;
 
 /// JournalState is internal EVM state that is used to contain state and track changes to that state.

--- a/crates/revm/src/journaled_state.rs
+++ b/crates/revm/src/journaled_state.rs
@@ -4,7 +4,7 @@ use crate::primitives::{
     SpecId::*, State, StorageSlot, TransientStorage, KECCAK_EMPTY, PRECOMPILE3, U256,
 };
 use alloc::vec::Vec;
-use core::{hash::BuildHasher, mem};
+use core::mem;
 use revm_interpreter::primitives::SpecId;
 
 /// JournalState is internal EVM state that is used to contain state and track changes to that state.


### PR DESCRIPTION
Adds `ahash` crate to `primitives`, exports `RandomState` from `primtives`, and adds `RandomState` to `TransientStorage` definition and instantiation.

This prevents HashDoS as documented in the [hashbrown crate](https://docs.rs/hashbrown/latest/hashbrown/struct.HashMap.html#method.with_hasher).