### PR TITLE
fix: typo on internal append_handle_register methods

### DIFF
--- a/crates/revm/src/builder.rs
+++ b/crates/revm/src/builder.rs
@@ -285,7 +285,7 @@ impl<'a, BuilderStage, EXT, DB: Database> EvmBuilder<'a, BuilderStage, EXT, DB> 
         handle_register: register::HandleRegister<'a, EXT, DB>,
     ) -> EvmBuilder<'_, HandlerStage, EXT, DB> {
         self.handler
-            .append_handled_register(register::HandleRegisters::Plain(handle_register));
+            .append_handle_register(register::HandleRegisters::Plain(handle_register));
         EvmBuilder {
             evm: self.evm,
             external: self.external,
@@ -304,7 +304,7 @@ impl<'a, BuilderStage, EXT, DB: Database> EvmBuilder<'a, BuilderStage, EXT, DB> 
         handle_register: register::HandleRegisterBox<'a, EXT, DB>,
     ) -> EvmBuilder<'_, HandlerStage, EXT, DB> {
         self.handler
-            .append_handled_register(register::HandleRegisters::Box(handle_register));
+            .append_handle_register(register::HandleRegisters::Box(handle_register));
         EvmBuilder {
             evm: self.evm,
             external: self.external,

--- a/crates/revm/src/builder.rs
+++ b/crates/revm/src/builder.rs
@@ -285,7 +285,7 @@ impl<'a, BuilderStage, EXT, DB: Database> EvmBuilder<'a, BuilderStage, EXT, DB> 
         handle_register: register::HandleRegister<'a, EXT, DB>,
     ) -> EvmBuilder<'_, HandlerStage, EXT, DB> {
         self.handler
-            .append_handle_register(register::HandleRegisters::Plain(handle_register));
+            .append_handler_register(register::HandleRegisters::Plain(handle_register));
         EvmBuilder {
             evm: self.evm,
             external: self.external,
@@ -304,7 +304,7 @@ impl<'a, BuilderStage, EXT, DB: Database> EvmBuilder<'a, BuilderStage, EXT, DB> 
         handle_register: register::HandleRegisterBox<'a, EXT, DB>,
     ) -> EvmBuilder<'_, HandlerStage, EXT, DB> {
         self.handler
-            .append_handle_register(register::HandleRegisters::Box(handle_register));
+            .append_handler_register(register::HandleRegisters::Box(handle_register));
         EvmBuilder {
             evm: self.evm,
             external: self.external,

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -138,7 +138,7 @@ impl<'a, EXT, DB: Database> EvmHandler<'a, EXT, DB> {
     }
 
     /// Append handle register.
-    pub fn append_handled_register(&mut self, register: HandleRegisters<'a, EXT, DB>) {
+    pub fn append_handle_register(&mut self, register: HandleRegisters<'a, EXT, DB>) {
         register.register(self);
         self.registers.push(register);
     }
@@ -163,7 +163,7 @@ impl<'a, EXT, DB: Database> EvmHandler<'a, EXT, DB> {
             let mut base_handler = Handler::mainnet_with_spec(self.cfg.spec_id);
             // apply all registers to default handeler and raw mainnet instruction table.
             for register in registers {
-                base_handler.append_handled_register(register)
+                base_handler.append_handle_register(register)
             }
             *self = base_handler;
         }
@@ -176,7 +176,7 @@ impl<'a, EXT, DB: Database> EvmHandler<'a, EXT, DB> {
         let mut base_handler = Handler::mainnet::<SPEC>();
         // apply all registers to default handeler and raw mainnet instruction table.
         for register in registers {
-            base_handler.append_handled_register(register)
+            base_handler.append_handle_register(register)
         }
         base_handler
     }
@@ -192,7 +192,7 @@ impl<'a, EXT, DB: Database> EvmHandler<'a, EXT, DB> {
         let mut handler = Handler::mainnet_with_spec(spec_id);
         // apply all registers to default handeler and raw mainnet instruction table.
         for register in registers {
-            handler.append_handled_register(register)
+            handler.append_handle_register(register)
         }
         handler.cfg = self.cfg();
         *self = handler;

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -84,7 +84,7 @@ impl<'a, EXT, DB: Database> EvmHandler<'a, EXT, DB> {
     pub fn optimism<SPEC: Spec + 'static>() -> Self {
         let mut handler = Self::mainnet::<SPEC>();
         handler.cfg.is_optimism = true;
-        handler.append_handled_register(HandleRegisters::Plain(
+        handler.append_handler_register(HandleRegisters::Plain(
             crate::optimism::optimism_handle_register::<DB, EXT>,
         ));
         handler
@@ -138,7 +138,7 @@ impl<'a, EXT, DB: Database> EvmHandler<'a, EXT, DB> {
     }
 
     /// Append handle register.
-    pub fn append_handle_register(&mut self, register: HandleRegisters<'a, EXT, DB>) {
+    pub fn append_handler_register(&mut self, register: HandleRegisters<'a, EXT, DB>) {
         register.register(self);
         self.registers.push(register);
     }
@@ -163,7 +163,7 @@ impl<'a, EXT, DB: Database> EvmHandler<'a, EXT, DB> {
             let mut base_handler = Handler::mainnet_with_spec(self.cfg.spec_id);
             // apply all registers to default handeler and raw mainnet instruction table.
             for register in registers {
-                base_handler.append_handle_register(register)
+                base_handler.append_handler_register(register)
             }
             *self = base_handler;
         }
@@ -176,7 +176,7 @@ impl<'a, EXT, DB: Database> EvmHandler<'a, EXT, DB> {
         let mut base_handler = Handler::mainnet::<SPEC>();
         // apply all registers to default handeler and raw mainnet instruction table.
         for register in registers {
-            base_handler.append_handle_register(register)
+            base_handler.append_handler_register(register)
         }
         base_handler
     }
@@ -192,7 +192,7 @@ impl<'a, EXT, DB: Database> EvmHandler<'a, EXT, DB> {
         let mut handler = Handler::mainnet_with_spec(spec_id);
         // apply all registers to default handeler and raw mainnet instruction table.
         for register in registers {
-            handler.append_handle_register(register)
+            handler.append_handler_register(register)
         }
         handler.cfg = self.cfg();
         *self = handler;


### PR DESCRIPTION
Docs said `append handle register` so I just did a quick rename