### PR TITLE
feat: expose builder stages

### DIFF
--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -28,7 +28,7 @@ pub mod optimism;
 
 // Export items.
 
-pub use builder::EvmBuilder;
+pub use builder::{EvmBuilder, HandlerStage, SetGenericStage};
 pub use context::{Context, ContextWithHandlerCfg, EvmContext};
 #[cfg(feature = "std")]
 pub use db::{


### PR DESCRIPTION
Exposes builder stages so we can write functions that return a builder type at a specific stage, for example:
```rust
    /// Returns new EVM builder
    fn evm(&self) -> EvmBuilder<'static, SetGenericStage, (), EmptyDB> {
        Default::default()
    }
```