### PR TITLE
fix EthersDB deadlock

### DIFF
--- a/crates/revm/src/db/ethersdb.rs
+++ b/crates/revm/src/db/ethersdb.rs
@@ -3,36 +3,31 @@ use crate::{Database, DatabaseRef};
 use ethers_core::types::{BlockId, H160 as eH160, H256, U64 as eU64};
 use ethers_providers::Middleware;
 use std::sync::Arc;
-use tokio::runtime::{Handle, Runtime};
 
 #[derive(Debug)]
 pub struct EthersDB<M: Middleware> {
     client: Arc<M>,
-    runtime: Option<Runtime>,
     block_number: Option<BlockId>,
 }
 
 impl<M: Middleware> EthersDB<M> {
     /// create ethers db connector inputs are url and block on what we are basing our database (None for latest)
     pub fn new(client: Arc<M>, block_number: Option<BlockId>) -> Option<Self> {
-        let runtime = Handle::try_current()
-            .is_err()
-            .then(|| Runtime::new().unwrap());
-
         let client = client;
 
         let mut out = Self {
             client,
-            runtime,
             block_number: None,
         };
 
-        out.block_number = if block_number.is_some() {
-            block_number
+        out.block_number = if let Some(bn) = block_number {
+            Some(bn)
         } else {
-            Some(BlockId::from(
-                out.block_on(out.client.get_block_number()).ok()?,
-            ))
+            let current_block_number = tokio::runtime::Handle::current()
+                .block_on(out.client.get_block_number())
+                .ok()?;
+
+            Some(BlockId::from(current_block_number))
         };
 
         Some(out)
@@ -40,10 +35,7 @@ impl<M: Middleware> EthersDB<M> {
 
     /// internal utility function to call tokio feature and wait for output
     fn block_on<F: core::future::Future>(&self, f: F) -> F::Output {
-        match &self.runtime {
-            Some(runtime) => runtime.block_on(f),
-            None => futures::executor::block_on(f),
-        }
+        tokio::runtime::Handle::current().block_on(f)
     }
 }
 

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -34,7 +34,6 @@ pub use context::{Context, ContextWithHandlerCfg, EvmContext};
 pub use db::{
     CacheState, DBBox, State, StateBuilder, StateDBBox, TransitionAccount, TransitionState,
 };
-use futures as _;
 pub use db::{Database, DatabaseCommit, DatabaseRef, InMemoryDB};
 pub use evm::{Evm, CALL_STACK_LIMIT};
 pub use frame::{CallFrame, CreateFrame, Frame, FrameData, FrameOrResult, FrameResult};

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -34,6 +34,7 @@ pub use context::{Context, ContextWithHandlerCfg, EvmContext};
 pub use db::{
     CacheState, DBBox, State, StateBuilder, StateDBBox, TransitionAccount, TransitionState,
 };
+use futures as _;
 pub use db::{Database, DatabaseCommit, DatabaseRef, InMemoryDB};
 pub use evm::{Evm, CALL_STACK_LIMIT};
 pub use frame::{CallFrame, CreateFrame, Frame, FrameData, FrameOrResult, FrameResult};


### PR DESCRIPTION
related with https://github.com/bluealloy/revm/issues/1056

actually removing the way we use futures::executor::block_on with tokio async 

we're using now Handle::block_on instead of (futures::executor::block_on) so we can have futures executed in same context of tokio runtime and we can then avoid deadlocks


@rakita do you suggest me i allow unused crates to fix clippy error ?