### PR TITLE
fix: optimism compilation

### DIFF
--- a/crates/primitives/src/env/handler_cfg.rs
+++ b/crates/primitives/src/env/handler_cfg.rs
@@ -20,7 +20,7 @@ impl HandlerCfg {
         cfg_if::cfg_if! {
             if #[cfg(all(feature = "optimism_default_handler",
                 not(feature = "negate_optimism_default_handler")))] {
-                    let is_optimism: true;
+                    let is_optimism = true;
             } else if #[cfg(feature = "optimism")] {
                 let is_optimism = false;
             }

--- a/crates/revm/src/builder.rs
+++ b/crates/revm/src/builder.rs
@@ -34,7 +34,7 @@ impl<'a> Default for EvmBuilder<'a, SetGenericStage, (), EmptyDB> {
             if #[cfg(all(feature = "optimism_default_handler",
                 not(feature = "negate_optimism_default_handler")))] {
                     let mut handler_cfg = HandlerCfg::new(SpecId::LATEST);
-                    /// set is_optimism to true by default.
+                    // set is_optimism to true by default.
                     handler_cfg.is_optimism = true;
 
             } else {


### PR DESCRIPTION
Fixes compilation when `optimism_default_handler` is enabled.

There is still an issue this PR doesn't fix: the flag `optimism_default_handler` doesn't seem to be passed down to `revm-primitives` when enabled in `revm`. As it requires some refactoring in the Cargo.tomls/imports, I think it's better if I let you handle that.