### PR TITLE
fix: rename and pass optimism-default-handler to revm-primitives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: ["stable", "beta", "nightly"]
-        flags: ["--no-default-features", "", "--all-features"]
+        flags: ["--no-default-features", "--all-features"]
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: ["stable", "beta", "nightly"]
-        flags: ["--no-default-features", "--all-features"]
+        flags: ["--no-default-features", "", "--all-features"]
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -17,7 +17,10 @@ rustdoc-args = ["--cfg", "docsrs"]
 revm-primitives = { path = "../primitives", version = "2.0.0", default-features = false }
 
 # optional
-serde = { version = "1.0", default-features = false, features = ["derive", "rc"], optional = true }
+serde = { version = "1.0", default-features = false, features = [
+    "derive",
+    "rc",
+], optional = true }
 
 [features]
 default = ["std"]
@@ -27,6 +30,14 @@ arbitrary = ["std", "revm-primitives/arbitrary"]
 asm-keccak = ["revm-primitives/asm-keccak"]
 
 optimism = ["revm-primitives/optimism"]
+# Optimism default handler enabled Optimism handler register by default in EvmBuilder.
+optimism-default-handler = [
+    "optimism",
+    "revm-primitives/optimism-default-handler",
+]
+negate-optimism-default-handler = [
+    "revm-primitives/negate-optimism-default-handler",
+]
 
 dev = [
     "memory_limit",

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -49,6 +49,14 @@ std = [
 asm-keccak = ["revm-primitives/asm-keccak"]
 
 optimism = ["revm-primitives/optimism"]
+# Optimism default handler enabled Optimism handler register by default in EvmBuilder.
+optimism-default-handler = [
+    "optimism",
+    "revm-primitives/optimism-default-handler",
+]
+negate-optimism-default-handler = [
+    "revm-primitives/negate-optimism-default-handler",
+]
 
 # These libraries may not work on all no_std platforms as they depend on C.
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -67,6 +67,9 @@ arbitrary = ["std", "alloy-primitives/arbitrary", "bitflags/arbitrary"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
 
 optimism = []
+# Optimism default handler enabled Optimism handler register by default in EvmBuilder.
+optimism-default-handler = ["optimism"]
+negate-optimism-default-handler = []
 
 dev = [
     "memory_limit",
@@ -87,4 +90,10 @@ optional_beneficiary_reward = []
 
 # See comments in `revm-precompile`
 # TODO: remove `blst` dep when `c-kzg` has a portable feature
-c-kzg = ["dep:c-kzg", "dep:once_cell", "dep:derive_more", "dep:blst", "blst?/portable"]
+c-kzg = [
+    "dep:c-kzg",
+    "dep:once_cell",
+    "dep:derive_more",
+    "dep:blst",
+    "blst?/portable",
+]

--- a/crates/primitives/src/env/handler_cfg.rs
+++ b/crates/primitives/src/env/handler_cfg.rs
@@ -18,8 +18,8 @@ impl HandlerCfg {
     /// Creates new `HandlerCfg` instance.
     pub fn new(spec_id: SpecId) -> Self {
         cfg_if::cfg_if! {
-            if #[cfg(all(feature = "optimism_default_handler",
-                not(feature = "negate_optimism_default_handler")))] {
+            if #[cfg(all(feature = "optimism-default-handler",
+                not(feature = "negate-optimism-default-handler")))] {
                     let is_optimism = true;
             } else if #[cfg(feature = "optimism")] {
                 let is_optimism = false;
@@ -73,7 +73,7 @@ impl CfgEnvWithHandlerCfg {
 
     /// Returns new `CfgEnvWithHandlerCfg` instance with the chain spec id.
     ///
-    /// is_optimism will be set to default value depending on `optimism_default_handler` feature.
+    /// is_optimism will be set to default value depending on `optimism-default-handler` feature.
     pub fn new_with_spec_id(cfg_env: CfgEnv, spec_id: SpecId) -> Self {
         Self::new(cfg_env, HandlerCfg::new(spec_id))
     }
@@ -116,7 +116,7 @@ impl EnvWithHandlerCfg {
 
     /// Returns new `EnvWithHandlerCfg` instance with the chain spec id.
     ///
-    /// is_optimism will be set to default value depending on `optimism_default_handler` feature.
+    /// is_optimism will be set to default value depending on `optimism-default-handler` feature.
     pub fn new_with_spec_id(env: Box<Env>, spec_id: SpecId) -> Self {
         Self::new(env, HandlerCfg::new(spec_id))
     }

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -63,8 +63,15 @@ test-utils = []
 
 optimism = ["revm-interpreter/optimism", "revm-precompile/optimism"]
 # Optimism default handler enabled Optimism handler register by default in EvmBuilder.
-optimism_default_handler = ["optimism"]
-negate_optimism_default_handler = []
+optimism-default-handler = [
+    "optimism",
+    "revm-precompile/optimism-default-handler",
+    "revm-interpreter/optimism-default-handler",
+]
+negate-optimism-default-handler = [
+    "revm-precompile/negate-optimism-default-handler",
+    "revm-interpreter/negate-optimism-default-handler",
+]
 
 
 ethersdb = [

--- a/crates/revm/src/builder.rs
+++ b/crates/revm/src/builder.rs
@@ -31,8 +31,8 @@ pub struct HandlerStage;
 impl<'a> Default for EvmBuilder<'a, SetGenericStage, (), EmptyDB> {
     fn default() -> Self {
         cfg_if::cfg_if! {
-            if #[cfg(all(feature = "optimism_default_handler",
-                not(feature = "negate_optimism_default_handler")))] {
+            if #[cfg(all(feature = "optimism-default-handler",
+                not(feature = "negate-optimism-default-handler")))] {
                     let mut handler_cfg = HandlerCfg::new(SpecId::LATEST);
                     // set is_optimism to true by default.
                     handler_cfg.is_optimism = true;
@@ -157,7 +157,7 @@ impl<'a, EXT, DB: Database> EvmBuilder<'a, SetGenericStage, EXT, DB> {
 
     /// Sets the Optimism handler with latest spec.
     ///
-    /// If `optimism_default_handler` feature is enabled this is not needed.
+    /// If `optimism-default-handler` feature is enabled this is not needed.
     #[cfg(feature = "optimism")]
     pub fn optimism(mut self) -> EvmBuilder<'a, HandlerStage, EXT, DB> {
         self.handler = Handler::optimism_with_spec(self.handler.cfg.spec_id);
@@ -170,8 +170,8 @@ impl<'a, EXT, DB: Database> EvmBuilder<'a, SetGenericStage, EXT, DB> {
 
     /// Sets the mainnet handler with latest spec.
     ///
-    /// Enabled only with `optimism_default_handler` feature.
-    #[cfg(feature = "optimism_default_handler")]
+    /// Enabled only with `optimism-default-handler` feature.
+    #[cfg(feature = "optimism-default-handler")]
     pub fn mainnet(mut self) -> EvmBuilder<'a, HandlerStage, EXT, DB> {
         self.handler = Handler::mainnet_with_spec(self.handler.cfg.spec_id);
         EvmBuilder {
@@ -209,8 +209,8 @@ impl<'a, EXT, DB: Database> EvmBuilder<'a, HandlerStage, EXT, DB> {
 
     /// Resets the [`Handler`] and sets base mainnet handler.
     ///
-    /// Enabled only with `optimism_default_handler` feature.
-    #[cfg(feature = "optimism_default_handler")]
+    /// Enabled only with `optimism-default-handler` feature.
+    #[cfg(feature = "optimism-default-handler")]
     pub fn reset_handler_with_mainnet(mut self) -> EvmBuilder<'a, HandlerStage, EXT, DB> {
         self.handler = Handler::mainnet_with_spec(self.handler.cfg.spec_id);
         EvmBuilder {


### PR DESCRIPTION
Follow up to this PR: https://github.com/bluealloy/revm/pull/1091