### PR TITLE
feat: split off serde_json dependency to its own feature

### DIFF
--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -7,7 +7,6 @@ license = "MIT"
 repository = "https://github.com/bluealloy/revm"
 description = "Rust Ethereum Virtual Machine Executable"
 version = "0.2.1"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 hash-db = "0.15"
@@ -17,7 +16,7 @@ plain_hasher = "0.2"
 revm = { path = "../../crates/revm", version = "6.0.0", default-features = false, features = [
     "ethersdb",
     "std",
-    "json",
+    "serde-json",
     "c-kzg",
 ] }
 alloy-rlp = { version = "0.3", default-features = false, features = [

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -17,7 +17,7 @@ plain_hasher = "0.2"
 revm = { path = "../../crates/revm", version = "6.0.0", default-features = false, features = [
     "ethersdb",
     "std",
-    "serde",
+    "json",
     "c-kzg",
 ] }
 alloy-rlp = { version = "0.3", default-features = false, features = [

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -55,7 +55,8 @@ std = [
     "revm-interpreter/std",
     "revm-precompile/std",
 ]
-serde = ["dep:serde", "dep:serde_json", "revm-interpreter/serde"]
+serde = ["dep:serde", "revm-interpreter/serde"]
+json = ["serde", "dep:serde_json"]
 arbitrary = ["revm-interpreter/arbitrary"]
 asm-keccak = ["revm-interpreter/asm-keccak", "revm-precompile/asm-keccak"]
 
@@ -72,7 +73,6 @@ negate-optimism-default-handler = [
     "revm-precompile/negate-optimism-default-handler",
     "revm-interpreter/negate-optimism-default-handler",
 ]
-
 
 ethersdb = [
     "std",

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -56,7 +56,7 @@ std = [
     "revm-precompile/std",
 ]
 serde = ["dep:serde", "revm-interpreter/serde"]
-json = ["serde", "dep:serde_json"]
+serde-json = ["serde", "dep:serde_json"]
 arbitrary = ["revm-interpreter/arbitrary"]
 asm-keccak = ["revm-interpreter/asm-keccak", "revm-precompile/asm-keccak"]
 

--- a/crates/revm/src/db/in_memory_db.rs
+++ b/crates/revm/src/db/in_memory_db.rs
@@ -457,7 +457,7 @@ mod tests {
         assert_eq!(new_state.storage(account, key1), Ok(value1));
     }
 
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "json")]
     #[test]
     fn test_serialize_deserialize_cachedb() {
         let account = Address::with_last_byte(69);

--- a/crates/revm/src/db/in_memory_db.rs
+++ b/crates/revm/src/db/in_memory_db.rs
@@ -457,7 +457,7 @@ mod tests {
         assert_eq!(new_state.storage(account, key1), Ok(value1));
     }
 
-    #[cfg(feature = "json")]
+    #[cfg(feature = "serde-json")]
     #[test]
     fn test_serialize_deserialize_cachedb() {
         let account = Address::with_last_byte(69);

--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -7,7 +7,7 @@ use auto_impl::auto_impl;
 
 #[cfg(feature = "std")]
 mod customprinter;
-#[cfg(all(feature = "std", feature = "serde"))]
+#[cfg(all(feature = "std", feature = "json"))]
 mod eip3155;
 mod gas;
 mod handler_register;
@@ -22,7 +22,7 @@ use revm_interpreter::{CallOutcome, CreateOutcome};
 pub mod inspectors {
     #[cfg(feature = "std")]
     pub use super::customprinter::CustomPrintTracer;
-    #[cfg(all(feature = "std", feature = "serde"))]
+    #[cfg(all(feature = "std", feature = "json"))]
     pub use super::eip3155::TracerEip3155;
     pub use super::gas::GasInspector;
     pub use super::noop::NoOpInspector;

--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -7,7 +7,7 @@ use auto_impl::auto_impl;
 
 #[cfg(feature = "std")]
 mod customprinter;
-#[cfg(all(feature = "std", feature = "json"))]
+#[cfg(all(feature = "std", feature = "serde-json"))]
 mod eip3155;
 mod gas;
 mod handler_register;
@@ -22,7 +22,7 @@ use revm_interpreter::{CallOutcome, CreateOutcome};
 pub mod inspectors {
     #[cfg(feature = "std")]
     pub use super::customprinter::CustomPrintTracer;
-    #[cfg(all(feature = "std", feature = "json"))]
+    #[cfg(all(feature = "std", feature = "serde-json"))]
     pub use super::eip3155::TracerEip3155;
     pub use super::gas::GasInspector;
     pub use super::noop::NoOpInspector;


### PR DESCRIPTION
`serde_json` is not necessarily wanted when enabling `serde` impls.

Technically a breaking change.