### PR TITLE
feat: bump c-kzg, add portable feature, make it default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d8c306be83ec04bf5f73710badd8edf56dea23f2f0d8b7f9fe4644d371c758"
+checksum = "94a4bc5367b6284358d2a6a6a1dc2d92ec4b86034561c3b9d3341909752fd848"
 dependencies = [
  "blst",
  "cc",
@@ -2346,7 +2346,6 @@ name = "revm-precompile"
 version = "4.0.1"
 dependencies = [
  "aurora-engine-modexp",
- "blst",
  "c-kzg",
  "k256",
  "once_cell",
@@ -2365,7 +2364,6 @@ dependencies = [
  "auto_impl",
  "bitflags 2.4.2",
  "bitvec",
- "blst",
  "c-kzg",
  "cfg-if",
  "derive_more",

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -28,6 +28,7 @@ std = ["serde?/std", "revm-primitives/std"]
 serde = ["dep:serde", "revm-primitives/serde"]
 arbitrary = ["std", "revm-primitives/arbitrary"]
 asm-keccak = ["revm-primitives/asm-keccak"]
+portable = ["revm-primitives/portable"]
 
 optimism = ["revm-primitives/optimism"]
 # Optimism default handler enabled Optimism handler register by default in EvmBuilder.

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -22,10 +22,7 @@ sha2 = { version = "0.10", default-features = false }
 aurora-engine-modexp = { version = "1.0", default-features = false }
 
 # Optional KZG point evaluation precompile
-c-kzg = { version = "0.4.1", default-features = false, optional = true }
-
-# TODO: make specific feature for this in c-kzg-4844
-blst = { version = "0.3.11", default-features = false, optional = true }
+c-kzg = { version = "0.4.2", default-features = false, optional = true }
 
 # ecRecover precompile
 k256 = { version = "0.13.3", default-features = false, features = ["ecdsa"] }
@@ -36,7 +33,7 @@ secp256k1 = { version = "0.28.2", default-features = false, features = [
 
 
 [features]
-default = ["std", "c-kzg", "secp256k1"]
+default = ["std", "c-kzg", "secp256k1", "portable"]
 std = [
     "revm-primitives/std",
     "k256/std",
@@ -61,8 +58,8 @@ negate-optimism-default-handler = [
 # These libraries may not work on all no_std platforms as they depend on C.
 
 # Enables the KZG point evaluation precompile.
-# TODO: remove `blst` dep when `c-kzg` has a portable feature
-c-kzg = ["dep:c-kzg", "revm-primitives/c-kzg", "dep:blst", "blst?/portable"]
+c-kzg = ["dep:c-kzg", "revm-primitives/c-kzg"]
+portable = ["revm-primitives/portable", "c-kzg?/portable"]
 
 # Use `secp256k1` as a faster alternative to `k256`.
 # The problem that `secp256k1` has is it fails to build for `wasm` target on Windows and Mac as it is c lib.

--- a/crates/precompile/src/kzg_point_evaluation.rs
+++ b/crates/precompile/src/kzg_point_evaluation.rs
@@ -3,9 +3,6 @@ use c_kzg::{Bytes32, Bytes48, KzgProof, KzgSettings};
 use revm_primitives::{hex_literal::hex, Bytes, Env};
 use sha2::{Digest, Sha256};
 
-// TODO: remove when we have `portable` feature in `c-kzg`
-use blst as _;
-
 pub const POINT_EVALUATION: PrecompileWithAddress =
     PrecompileWithAddress(ADDRESS, Precompile::Env(run));
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -26,10 +26,8 @@ bitvec = { version = "1", default-features = false, features = ["alloc"] }
 bitflags = { version = "2.4.2", default-features = false }
 
 # For setting the CfgEnv KZGSettings. Enabled by c-kzg flag.
-c-kzg = { version = "0.4.1", default-features = false, optional = true }
+c-kzg = { version = "0.4.2", default-features = false, optional = true }
 once_cell = { version = "1.19", default-features = false, optional = true }
-# TODO: make specific feature for this in c-kzg-4844
-blst = { version = "0.3.11", default-features = false, optional = true }
 
 # utility
 enumn = "0.1"
@@ -46,7 +44,7 @@ serde = { version = "1.0", default-features = false, features = [
 hex = { version = "0.4", default-features = false }
 
 [features]
-default = ["std", "c-kzg"]
+default = ["std", "c-kzg", "portable"]
 std = [
     "serde?/std",
     "alloy-primitives/std",
@@ -65,6 +63,7 @@ serde = [
 ]
 arbitrary = ["std", "alloy-primitives/arbitrary", "bitflags/arbitrary"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
+portable = ["c-kzg?/portable"]
 
 optimism = []
 # Optimism default handler enabled Optimism handler register by default in EvmBuilder.
@@ -89,11 +88,8 @@ optional_no_base_fee = []
 optional_beneficiary_reward = []
 
 # See comments in `revm-precompile`
-# TODO: remove `blst` dep when `c-kzg` has a portable feature
 c-kzg = [
     "dep:c-kzg",
     "dep:once_cell",
     "dep:derive_more",
-    "dep:blst",
-    "blst?/portable",
 ]

--- a/crates/primitives/src/kzg.rs
+++ b/crates/primitives/src/kzg.rs
@@ -1,9 +1,6 @@
 mod env_settings;
 mod trusted_setup_points;
 
-// TODO: remove when we have `portable` feature in `c-kzg`
-use blst as _;
-
 pub use c_kzg::KzgSettings;
 pub use env_settings::EnvKzgSettings;
 pub use trusted_setup_points::{

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -47,7 +47,7 @@ criterion = "0.5"
 indicatif = "0.17"
 
 [features]
-default = ["std", "c-kzg", "secp256k1"]
+default = ["std", "c-kzg", "secp256k1", "portable"]
 std = [
     "serde?/std",
     "serde_json?/std",
@@ -59,6 +59,7 @@ serde = ["dep:serde", "revm-interpreter/serde"]
 serde-json = ["serde", "dep:serde_json"]
 arbitrary = ["revm-interpreter/arbitrary"]
 asm-keccak = ["revm-interpreter/asm-keccak", "revm-precompile/asm-keccak"]
+portable = ["revm-precompile/portable", "revm-interpreter/portable"]
 
 test-utils = []
 


### PR DESCRIPTION
This uses the new `portable` feature, enabled by default, for c-kzg. Also bumps c-kzg version. Removes the need to do:
```rust
// TODO: remove when we have `portable` feature in `c-kzg`
use blst as _;
```
and
```toml
# TODO: remove `blst` dep when `c-kzg` has a portable feature
c-kzg = ["dep:c-kzg", "revm-primitives/c-kzg", "dep:blst", "blst?/portable"]
```