### PR TITLE
Fix feature name for generate_block_traces example

### DIFF
--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -112,7 +112,7 @@ required-features = ["ethersdb"]
 [[example]]
 name = "generate_block_traces"
 path = "../../examples/generate_block_traces.rs"
-required-features = ["std", "serde", "ethersdb"]
+required-features = ["std", "serde-json", "ethersdb"]
 
 [[bench]]
 name = "bench"


### PR DESCRIPTION
This PR fixes name of feature used by one of the examples. It looks like this feature is now renamed: 

https://github.com/bluealloy/revm/blob/2d4fb0605585477add6478b9495022816a7d965c/crates/revm/src/inspector.rs#L10