### PR TITLE
chore: remove unused EvmInstructionTables type alias

### DIFF
--- a/crates/revm/src/handler/register.rs
+++ b/crates/revm/src/handler/register.rs
@@ -1,11 +1,8 @@
-use crate::{db::Database, handler::Handler, interpreter::opcode::InstructionTables, Evm};
+use crate::{db::Database, handler::Handler, Evm};
 use std::boxed::Box;
 
 /// EVM Handler
 pub type EvmHandler<'a, EXT, DB> = Handler<'a, Evm<'a, EXT, DB>, EXT, DB>;
-
-/// EVM Instruction Tables
-pub type EvmInstructionTables<'a, EXT, DB> = InstructionTables<'a, Evm<'a, EXT, DB>>;
 
 // Handle register
 pub type HandleRegister<'a, EXT, DB> = fn(&mut EvmHandler<'a, EXT, DB>);

--- a/crates/revm/src/inspector/handler_register.rs
+++ b/crates/revm/src/inspector/handler_register.rs
@@ -1,12 +1,12 @@
-use core::cell::RefCell;
-
 use crate::{
     db::Database,
-    handler::register::{EvmHandler, EvmInstructionTables},
+    handler::register::EvmHandler,
     interpreter::{opcode, opcode::BoxedInstruction, InstructionResult, Interpreter},
     primitives::EVMError,
     Evm, FrameOrResult, FrameResult, Inspector, JournalEntry,
 };
+use core::cell::RefCell;
+use revm_interpreter::opcode::InstructionTables;
 use std::{boxed::Box, rc::Rc, sync::Arc, vec::Vec};
 
 /// Provides access to an `Inspector` instance.
@@ -41,11 +41,11 @@ pub fn inspector_handle_register<'a, DB: Database, EXT: GetInspector<DB>>(
         .take()
         .expect("Handler must have instruction table");
     let mut table = match table {
-        EvmInstructionTables::Plain(table) => table
+        InstructionTables::Plain(table) => table
             .into_iter()
             .map(|i| inspector_instruction(i))
             .collect::<Vec<_>>(),
-        EvmInstructionTables::Boxed(table) => table
+        InstructionTables::Boxed(table) => table
             .into_iter()
             .map(|i| inspector_instruction(i))
             .collect::<Vec<_>>(),
@@ -123,7 +123,7 @@ pub fn inspector_handle_register<'a, DB: Database, EXT: GetInspector<DB>>(
     }
 
     // cast vector to array.
-    handler.instruction_table = Some(EvmInstructionTables::Boxed(
+    handler.instruction_table = Some(InstructionTables::Boxed(
         table.try_into().unwrap_or_else(|_| unreachable!()),
     ));
 


### PR DESCRIPTION
Noticed that this type alias was not really used, and could be replaced with InstructionTables, so I removed it