### PR TITLE
Add `clone` method to `ContextWithHandlerCfg`

### DIFF
--- a/crates/revm/src/context.rs
+++ b/crates/revm/src/context.rs
@@ -90,7 +90,7 @@ where
     fn clone(&self) -> Self {
         Self {
             context: self.context.clone(),
-            cfg: self.cfg.clone(),
+            cfg: self.cfg,
         }
     }
 }

--- a/crates/revm/src/context.rs
+++ b/crates/revm/src/context.rs
@@ -83,6 +83,18 @@ impl<EXT, DB: Database> ContextWithHandlerCfg<EXT, DB> {
     }
 }
 
+impl<EXT: Clone, DB: Database + Clone> Clone for ContextWithHandlerCfg<EXT, DB>
+where
+    DB::Error: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            context: self.context.clone(),
+            cfg: self.cfg.clone(),
+        }
+    }
+}
+
 /// EVM contexts contains data that EVM needs for execution.
 #[derive(Debug)]
 pub struct EvmContext<DB: Database> {


### PR DESCRIPTION
Add `clone` method to `ContextWithHandlerCfg`.

Pullrequest created for: #1126

So instead of
```rust
let cfg = ContextWithHandlerCfg::new(self.ctx_with_handler.context.clone(), self.ctx_with_handler.cfg.clone());
Evm::builder().with_context_with_handler_cfg(cfg).build();
```

Now:
```rust
Evm::builder().with_context_with_handler_cfg(self.ctx_with_handler.clone()).build();
```