### PR TITLE
fix: add ToString for no_std add exports some types in no_std

### DIFF
--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -30,7 +30,6 @@ pub mod optimism;
 
 pub use builder::EvmBuilder;
 pub use context::{Context, ContextWithHandlerCfg, EvmContext};
-#[cfg(feature = "std")]
 pub use db::{
     CacheState, DBBox, State, StateBuilder, StateDBBox, TransitionAccount, TransitionState,
 };

--- a/crates/revm/src/optimism/handler_register.rs
+++ b/crates/revm/src/optimism/handler_register.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 use core::ops::Mul;
 use std::sync::Arc;
+use std::string::ToString;
 
 pub fn optimism_handle_register<DB: Database, EXT>(handler: &mut EvmHandler<'_, EXT, DB>) {
     spec_to_generic!(handler.cfg.spec_id, {

--- a/crates/revm/src/optimism/handler_register.rs
+++ b/crates/revm/src/optimism/handler_register.rs
@@ -14,8 +14,8 @@ use crate::{
     Context, FrameResult,
 };
 use core::ops::Mul;
-use std::sync::Arc;
 use std::string::ToString;
+use std::sync::Arc;
 
 pub fn optimism_handle_register<DB: Database, EXT>(handler: &mut EvmHandler<'_, EXT, DB>) {
     spec_to_generic!(handler.cfg.spec_id, {


### PR DESCRIPTION

Seems some versions of rust need this. 

```
error[E0599]: no method named `to_string` found for reference `&'static str` in the current scope
   --> /Users/yjhmelody/.cargo/registry/src/index.crates.io-6f17d22bba15001f/revm-6.1.0/src/optimism/handler_register.rs:187:68
    |
187 |                 "[OPTIMISM] Failed to load enveloped transaction.".to_string(),
    |                                                                    ^^^^^^^^^ method not found in `&str`
    |
    = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
3   + use crate::std::string::ToString;
    |

error[E0599]: no method named `to_string` found for reference `&'static str` in the current scope
   --> /Users/yjhmelody/.cargo/registry/src/index.crates.io-6f17d22bba15001f/revm-6.1.0/src/optimism/handler_register.rs:228:67
    |
228 |                 "[OPTIMISM] Failed to load L1 block information.".to_string(),
    |                                                                   ^^^^^^^^^ method not found in `&str`
    |
    = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
3   + use crate::std::string::ToString;
    |

error[E0599]: no method named `to_string` found for reference `&'static str` in the current scope
   --> /Users/yjhmelody/.cargo/registry/src/index.crates.io-6f17d22bba15001f/revm-6.1.0/src/optimism/handler_register.rs:234:68
    |
234 |                 "[OPTIMISM] Failed to load enveloped transaction.".to_string(),
    |                                                                    ^^^^^^^^^ method not found in `&str`
    |
    = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
3   + use crate::std::string::ToString;
    |

error[E0599]: no method named `to_string` found for reference `&'static str` in the current scope
   --> /Users/yjhmelody/.cargo/registry/src/index.crates.io-6f17d22bba15001f/revm-6.1.0/src/optimism/handler_register.rs:247:67
    |
247 |                 "[OPTIMISM] Failed to load L1 Fee Vault account.".to_string(),
    |                                                                   ^^^^^^^^^ method not found in `&str`
    |
    = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
3   + use crate::std::string::ToString;
    |

error[E0599]: no method named `to_string` found for reference `&'static str` in the current scope
   --> /Users/yjhmelody/.cargo/registry/src/index.crates.io-6f17d22bba15001f/revm-6.1.0/src/optimism/handler_register.rs:260:69
    |
260 |                 "[OPTIMISM] Failed to load Base Fee Vault account.".to_string(),
    |                                                                     ^^^^^^^^^ method not found in `&str`
    |
    = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
3   + use crate::std::string::ToString;
    |

For more information about this error, try `rustc --explain E0599`.
error: could not compile `revm` (lib) due to 5 previous errors
warning: build failed, waiting for other jobs to finish...

```

And some types should also work in no_std.