### PR TITLE
chore: add helper function for spec id

### DIFF
--- a/crates/primitives/src/env/handler_cfg.rs
+++ b/crates/primitives/src/env/handler_cfg.rs
@@ -139,6 +139,11 @@ impl EnvWithHandlerCfg {
         }
     }
 
+    /// Returns the specification id.
+    pub const fn spec_id(&self) -> SpecId {
+        self.handler_cfg.spec_id
+    }
+
     /// Enables the optimism handle register.
     #[cfg(feature = "optimism")]
     pub fn enable_optimism(&mut self) {


### PR DESCRIPTION
make it easier to access spec id