### PR TITLE
feat: Add boxed precompile trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,6 +827,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2367,6 +2373,7 @@ dependencies = [
  "c-kzg",
  "cfg-if",
  "derive_more",
+ "dyn-clone",
  "enumn",
  "hashbrown",
  "hex",

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -20,7 +20,7 @@ mod modexp;
 mod secp256k1;
 pub mod utilities;
 
-use core::{fmt, hash::Hash};
+use core::hash::Hash;
 use once_cell::race::OnceBox;
 #[doc(hidden)]
 pub use revm_primitives as primitives;
@@ -200,21 +200,6 @@ impl Precompiles {
     /// Other precompiles with overwrite existing precompiles.
     pub fn extend(&mut self, other: impl IntoIterator<Item = PrecompileWithAddress>) {
         self.inner.extend(other.into_iter().map(Into::into));
-    }
-}
-
-#[derive(Clone)]
-pub enum Precompile {
-    Standard(StandardPrecompileFn),
-    Env(EnvPrecompileFn),
-}
-
-impl fmt::Debug for Precompile {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Precompile::Standard(_) => f.write_str("Standard"),
-            Precompile::Env(_) => f.write_str("Env"),
-        }
     }
 }
 

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -181,8 +181,14 @@ impl Precompiles {
 
     /// Returns the precompile for the given address.
     #[inline]
-    pub fn get(&self, address: &Address) -> Option<Precompile> {
-        self.inner.get(address).cloned()
+    pub fn get(&self, address: &Address) -> Option<&Precompile> {
+        self.inner.get(address)
+    }
+
+    /// Returns the precompile for the given address.
+    #[inline]
+    pub fn get_mut(&mut self, address: &Address) -> Option<&mut Precompile> {
+        self.inner.get_mut(address)
     }
 
     /// Is the precompiles list empty.

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -33,6 +33,7 @@ once_cell = { version = "1.19", default-features = false, optional = true }
 enumn = "0.1"
 derive_more = { version = "0.99", optional = true }
 cfg-if = "1"
+dyn-clone = "1.0"
 
 # optional
 serde = { version = "1.0", default-features = false, features = [

--- a/crates/primitives/src/precompile.rs
+++ b/crates/primitives/src/precompile.rs
@@ -1,6 +1,7 @@
 use crate::{Bytes, Env};
 use core::fmt;
 use dyn_clone::DynClone;
+use std::boxed::Box;
 
 /// A precompile operation result.
 ///

--- a/crates/revm/src/context.rs
+++ b/crates/revm/src/context.rs
@@ -453,6 +453,7 @@ impl<DB: Database> EvmContext<DB> {
         let out = match precompile {
             Precompile::Standard(fun) => fun(input_data, gas.limit()),
             Precompile::Env(fun) => fun(input_data, gas.limit(), self.env()),
+            Precompile::BoxedEnv(fun) => fun.call(input_data, gas.limit(), self.env()),
         };
 
         let mut result = InterpreterResult {

--- a/crates/revm/src/context.rs
+++ b/crates/revm/src/context.rs
@@ -411,8 +411,8 @@ impl<DB: Database> EvmContext<DB> {
             return return_result(result);
         }
 
-        if let Some(precompile) = self.precompiles.get(&inputs.contract) {
-            let result = self.call_precompile(precompile, inputs, gas);
+        if let Some(precompile) = self.precompiles.get_mut(&inputs.contract) {
+            let result = Self::call_precompile(precompile, &inputs.input, gas, &self.env);
             if matches!(result.result, return_ok!()) {
                 self.journaled_state.checkpoint_commit();
             } else {
@@ -444,17 +444,12 @@ impl<DB: Database> EvmContext<DB> {
     /// Call precompile contract
     #[inline]
     fn call_precompile(
-        &mut self,
-        precompile: Precompile,
-        inputs: &CallInputs,
+        precompile: &mut Precompile,
+        input_data: &Bytes,
         gas: Gas,
+        env: &Env,
     ) -> InterpreterResult {
-        let input_data = &inputs.input;
-        let out = match precompile {
-            Precompile::Standard(fun) => fun(input_data, gas.limit()),
-            Precompile::Env(fun) => fun(input_data, gas.limit(), self.env()),
-            Precompile::BoxedEnv(fun) => fun.call(input_data, gas.limit(), self.env()),
-        };
+        let out = precompile.call(input_data, gas.limit(), env);
 
         let mut result = InterpreterResult {
             result: InstructionResult::Return,


### PR DESCRIPTION
closes: #798 

Box is over the trait that has a `call` function. Trait is sync/send so it can be stored inside OnceBox.
And DynClone is added so precompiles can be cloned.