### PR TITLE
Check runtime dynamically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2324,7 +2324,6 @@ dependencies = [
  "ethers-contract",
  "ethers-core",
  "ethers-providers",
- "futures",
  "indicatif",
  "revm-interpreter",
  "revm-precompile",

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -38,7 +38,6 @@ tokio = { version = "1.36", features = [
 ], optional = true }
 ethers-providers = { version = "2.0", optional = true }
 ethers-core = { version = "2.0", optional = true }
-futures = { version = "0.3.30", optional = true }
 
 [dev-dependencies]
 ethers-contract = { version = "2.0.13", default-features = false }
@@ -78,7 +77,6 @@ negate-optimism-default-handler = [
 ethersdb = [
     "std",
     "tokio",
-    "futures",
     "ethers-providers",
     "ethers-core",
 ] # Negate optimism default handler

--- a/crates/revm/src/db/ethersdb.rs
+++ b/crates/revm/src/db/ethersdb.rs
@@ -34,7 +34,11 @@ impl<M: Middleware> EthersDB<M> {
     /// internal utility function to call tokio feature and wait for output
     fn block_on<F: core::future::Future>(&self, f: F) -> F::Output {
         match Handle::try_current() {
-            Ok(handle) => handle.block_on(f),
+            Ok(handle) => {
+                tokio::task::block_in_place(move || {
+                    handle.block_on(f)
+                })
+            }
             Err(_) => Builder::new_current_thread()
                 .enable_all()
                 .build()

--- a/crates/revm/src/db/ethersdb.rs
+++ b/crates/revm/src/db/ethersdb.rs
@@ -39,6 +39,8 @@ impl<M: Middleware> EthersDB<M> {
     {
         match Handle::try_current() {
             Ok(handle) => match handle.runtime_flavor() {
+                // This essentially equals to tokio::task::spawn_blocking because tokio doesn't
+                // allow current_thread runtime to block_in_place
                 RuntimeFlavor::CurrentThread => std::thread::scope(move |s| {
                     s.spawn(move || {
                         Builder::new_current_thread()

--- a/crates/revm/src/db/ethersdb.rs
+++ b/crates/revm/src/db/ethersdb.rs
@@ -67,7 +67,7 @@ impl<M: Middleware> DatabaseRef for EthersDB<M> {
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         let add = eH160::from(address.0 .0);
 
-        let f = async move {
+        let f = async {
             let nonce = self.client.get_transaction_count(add, self.block_number);
             let balance = self.client.get_balance(add, self.block_number);
             let code = self.client.get_code(add, self.block_number);

--- a/crates/revm/src/db/ethersdb.rs
+++ b/crates/revm/src/db/ethersdb.rs
@@ -3,27 +3,20 @@ use crate::{Database, DatabaseRef};
 use ethers_core::types::{BlockId, H160 as eH160, H256, U64 as eU64};
 use ethers_providers::Middleware;
 use std::sync::Arc;
-use tokio::runtime::{Handle, Runtime};
+use tokio::runtime::{Builder, Handle};
 
 #[derive(Debug)]
 pub struct EthersDB<M: Middleware> {
     client: Arc<M>,
-    runtime: Option<Runtime>,
     block_number: Option<BlockId>,
 }
 
 impl<M: Middleware> EthersDB<M> {
     /// create ethers db connector inputs are url and block on what we are basing our database (None for latest)
     pub fn new(client: Arc<M>, block_number: Option<BlockId>) -> Option<Self> {
-        let runtime = Handle::try_current()
-            .is_err()
-            .then(|| Runtime::new().unwrap());
-
         let client = client;
-
         let mut out = Self {
             client,
-            runtime,
             block_number: None,
         };
 
@@ -40,9 +33,13 @@ impl<M: Middleware> EthersDB<M> {
 
     /// internal utility function to call tokio feature and wait for output
     fn block_on<F: core::future::Future>(&self, f: F) -> F::Output {
-        match &self.runtime {
-            Some(runtime) => runtime.block_on(f),
-            None => futures::executor::block_on(f),
+        match Handle::try_current() {
+            Ok(handle) => handle.block_on(f),
+            Err(_) => Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("Fail to build current_thread runtime")
+                .block_on(f),
         }
     }
 }

--- a/crates/revm/src/db/ethersdb.rs
+++ b/crates/revm/src/db/ethersdb.rs
@@ -5,7 +5,7 @@ use ethers_providers::Middleware;
 use std::sync::Arc;
 use tokio::runtime::{Builder, Handle, RuntimeFlavor};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EthersDB<M: Middleware> {
     client: Arc<M>,
     block_number: Option<BlockId>,

--- a/crates/revm/src/db/ethersdb.rs
+++ b/crates/revm/src/db/ethersdb.rs
@@ -34,11 +34,7 @@ impl<M: Middleware> EthersDB<M> {
     /// internal utility function to call tokio feature and wait for output
     fn block_on<F: core::future::Future>(&self, f: F) -> F::Output {
         match Handle::try_current() {
-            Ok(handle) => {
-                tokio::task::block_in_place(move || {
-                    handle.block_on(f)
-                })
-            }
+            Ok(handle) => tokio::task::block_in_place(move || handle.block_on(f)),
             Err(_) => Builder::new_current_thread()
                 .enable_all()
                 .build()


### PR DESCRIPTION
This PR removes the improper initialization of the runtime.

Explanation:

- Initializing a runtime when creating the struct doesn't make sense.

Users may create an `EthersDB` in a sync context but later use it in an async environment and vice versa. In this case, two runtimes will conflict. In addition, the current code, by default, creates a multithreaded runtime, which could be unexpected for users. For example, users may want to run many instances in parallel with separate cores pinned but the runtime created could interfere with this design.

Therefore, reasonable behavior is always checking if we are in an `async` environment by `Handle::try_current.` If we are in  `async`, we will pick the runtime created by users. Or else, we simply create a `current_thread` runtime to get things done. Note this is the recommended way by [tokio docs](https://tokio.rs/tokio/topics/bridging).

For `current_thread` runtime, a new thread is spawned to complete the futures as `tokio` doesn't allow us to `block_in_place`, which essentially does `spawn_blocking`. This could be removed once we have a `async` equivalent trait.

- Does it make things slower?

No. Because the current implementation only has __concurrency__ but not __parallelism__. Specifically, see:

```
        let f = async {
            let nonce = self.client.get_transaction_count(add, self.block_number);
            let balance = self.client.get_balance(add, self.block_number);
            let code = self.client.get_code(add, self.block_number);
            tokio::join!(nonce, balance, code)
        };
       let (nonce, balance, code) = self.block_on(f);
```

Either a `current_thread` or a `multi_thread` runtime will execute the three rpc calls one by one. Refer to [tokio::join!](https://docs.rs/tokio/latest/tokio/macro.join.html) documents for details.

- Any breaking changes?

No, as explained above.