### PR TITLE
perf(interpreter): evaluate instruction table constructor at compile time

### DIFF
--- a/crates/primitives/src/env/handler_cfg.rs
+++ b/crates/primitives/src/env/handler_cfg.rs
@@ -41,7 +41,7 @@ impl HandlerCfg {
         }
     }
 
-    /// Returns true if the optimism feature is enabled and flag is set to true.
+    /// Returns `true` if the optimism feature is enabled and flag is set to `true`.
     pub fn is_optimism(&self) -> bool {
         cfg_if::cfg_if! {
             if #[cfg(feature = "optimism")] {

--- a/crates/primitives/src/specification.rs
+++ b/crates/primitives/src/specification.rs
@@ -110,7 +110,7 @@ impl From<&str> for SpecId {
     }
 }
 
-pub trait Spec: Sized {
+pub trait Spec: Sized + 'static {
     /// The specification ID.
     const SPEC_ID: SpecId;
 

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -8,10 +8,7 @@ pub use handle_types::*;
 
 // Includes.
 use crate::{
-    interpreter::{
-        opcode::{make_instruction_table, InstructionTables},
-        Host,
-    },
+    interpreter::{opcode::InstructionTables, Host},
     primitives::{db::Database, spec_to_generic, HandlerCfg, Spec, SpecId},
     Evm,
 };
@@ -58,14 +55,12 @@ impl<'a, EXT, DB: Database> EvmHandler<'a, EXT, DB> {
             }
         }
     }
-    /// Handler for the mainnet
-    pub fn mainnet<SPEC: Spec + 'static>() -> Self {
+
+    /// Default handler for Ethereum mainnet.
+    pub fn mainnet<SPEC: Spec>() -> Self {
         Self {
             cfg: HandlerCfg::new(SPEC::SPEC_ID),
-            instruction_table: Some(InstructionTables::Plain(make_instruction_table::<
-                Evm<'a, EXT, DB>,
-                SPEC,
-            >())),
+            instruction_table: Some(InstructionTables::new_plain::<SPEC>()),
             registers: Vec::new(),
             validation: ValidationHandler::new::<SPEC>(),
             pre_execution: PreExecutionHandler::new::<SPEC>(),
@@ -74,14 +69,14 @@ impl<'a, EXT, DB: Database> EvmHandler<'a, EXT, DB> {
         }
     }
 
-    /// Is optimism enabled.
+    /// Returns `true` if the optimism feature is enabled and flag is set to `true`.
     pub fn is_optimism(&self) -> bool {
         self.cfg.is_optimism()
     }
 
     /// Handler for optimism
     #[cfg(feature = "optimism")]
-    pub fn optimism<SPEC: Spec + 'static>() -> Self {
+    pub fn optimism<SPEC: Spec>() -> Self {
         let mut handler = Self::mainnet::<SPEC>();
         handler.cfg.is_optimism = true;
         handler.append_handler_register(HandleRegisters::Plain(
@@ -171,7 +166,7 @@ impl<'a, EXT, DB: Database> EvmHandler<'a, EXT, DB> {
     }
 
     /// Creates the Handler with Generic Spec.
-    pub fn create_handle_generic<SPEC: Spec + 'static>(&mut self) -> EvmHandler<'a, EXT, DB> {
+    pub fn create_handle_generic<SPEC: Spec>(&mut self) -> EvmHandler<'a, EXT, DB> {
         let registers = core::mem::take(&mut self.registers);
         let mut base_handler = Handler::mainnet::<SPEC>();
         // apply all registers to default handeler and raw mainnet instruction table.


### PR DESCRIPTION
Ideally this would also return `&'static` but since `InstructionTable` is generic over `H`, `&'static InstructionTable<H>` requires `H: 'static`, for which I haven't yet found a work-around.