### PR TITLE
feat: use `impl` instead of `dyn` in `GetInspector`

### DIFF
--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -115,7 +115,7 @@ fn check_evm_execution<EXT>(
     evm: &Evm<'_, EXT, &mut State<EmptyDB>>,
     print_json_outcome: bool,
 ) -> Result<(), TestError> {
-    let logs_root = log_rlp_hash(&exec_result.as_ref().map(|r| r.logs()).unwrap_or_default());
+    let logs_root = log_rlp_hash(exec_result.as_ref().map(|r| r.logs()).unwrap_or_default());
     let state_root = state_merkle_trie_root(evm.context.evm.db.cache.trie_account());
 
     let print_json_output = |error: Option<String>| {

--- a/crates/interpreter/src/instructions/i256.rs
+++ b/crates/interpreter/src/instructions/i256.rs
@@ -136,10 +136,8 @@ mod tests {
         let one = U256::from(1);
         let one_hundred = U256::from(100);
         let fifty = U256::from(50);
-        let _fifty_sign = Sign::Plus;
         let two = U256::from(2);
         let neg_one_hundred = U256::from(100);
-        let _neg_one_hundred_sign = Sign::Minus;
         let minus_one = U256::from(1);
         let max_value = U256::from(2).pow(U256::from(255)) - U256::from(1);
         let neg_max_value = U256::from(2).pow(U256::from(255)) - U256::from(1);

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -5,7 +5,7 @@ mod stack;
 
 pub use analysis::BytecodeLocked;
 pub use contract::Contract;
-pub use shared_memory::{next_multiple_of_32, SharedMemory};
+pub use shared_memory::{next_multiple_of_32, SharedMemory, EMPTY_SHARED_MEMORY};
 pub use stack::{Stack, STACK_LIMIT};
 
 use crate::{
@@ -16,8 +16,6 @@ use core::cmp::min;
 use revm_primitives::U256;
 use std::borrow::ToOwned;
 use std::boxed::Box;
-
-pub use self::shared_memory::EMPTY_SHARED_MEMORY;
 
 #[derive(Debug)]
 pub struct Interpreter {

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -52,14 +52,6 @@ impl ExecutionResult {
         matches!(self, Self::Halt { .. })
     }
 
-    /// Return logs, if execution is not successful, function will return empty vec.
-    pub fn logs(&self) -> Vec<Log> {
-        match self {
-            Self::Success { logs, .. } => logs.clone(),
-            _ => Vec::new(),
-        }
-    }
-
     /// Returns the output data of the execution.
     ///
     /// Returns `None` if the execution was halted.
@@ -82,7 +74,15 @@ impl ExecutionResult {
         }
     }
 
-    /// Consumes the type and returns logs, if execution is not successful, function will return empty vec.
+    /// Returns the logs if execution is successful, or an empty list otherwise.
+    pub fn logs(&self) -> &[Log] {
+        match self {
+            Self::Success { logs, .. } => logs,
+            _ => &[],
+        }
+    }
+
+    /// Consumes `self` and returns the logs if execution is successful, or an empty list otherwise.
     pub fn into_logs(self) -> Vec<Log> {
         match self {
             Self::Success { logs, .. } => logs,
@@ -90,12 +90,13 @@ impl ExecutionResult {
         }
     }
 
+    /// Returns the gas used.
     pub fn gas_used(&self) -> u64 {
-        let (Self::Success { gas_used, .. }
-        | Self::Revert { gas_used, .. }
-        | Self::Halt { gas_used, .. }) = self;
-
-        *gas_used
+        match *self {
+            Self::Success { gas_used, .. }
+            | Self::Revert { gas_used, .. }
+            | Self::Halt { gas_used, .. } => gas_used,
+        }
     }
 }
 
@@ -121,6 +122,14 @@ impl Output {
         match self {
             Output::Call(data) => data,
             Output::Create(data, _) => data,
+        }
+    }
+
+    /// Returns the created address, if any.
+    pub fn address(&self) -> Option<&Address> {
+        match self {
+            Output::Call(_) => None,
+            Output::Create(_, address) => address.as_ref(),
         }
     }
 }

--- a/crates/revm/src/builder.rs
+++ b/crates/revm/src/builder.rs
@@ -497,10 +497,9 @@ mod test {
             .build();
 
         let Context {
-            external,
-            evm: EvmContext { db, .. },
+            external: _,
+            evm: EvmContext { db: _, .. },
         } = evm.into_context();
-        let _ = (external, db);
     }
 
     #[test]

--- a/crates/revm/src/db/in_memory_db.rs
+++ b/crates/revm/src/db/in_memory_db.rs
@@ -428,7 +428,9 @@ mod tests {
 
         let (key, value) = (U256::from(123), U256::from(456));
         let mut new_state = CacheDB::new(init_state);
-        let _ = new_state.insert_account_storage(account, key, value);
+        new_state
+            .insert_account_storage(account, key, value)
+            .unwrap();
 
         assert_eq!(new_state.basic(account).unwrap().unwrap().nonce, nonce);
         assert_eq!(new_state.storage(account, key), Ok(value));
@@ -449,10 +451,14 @@ mod tests {
 
         let (key0, value0) = (U256::from(123), U256::from(456));
         let (key1, value1) = (U256::from(789), U256::from(999));
-        let _ = init_state.insert_account_storage(account, key0, value0);
+        init_state
+            .insert_account_storage(account, key0, value0)
+            .unwrap();
 
         let mut new_state = CacheDB::new(init_state);
-        let _ = new_state.replace_account_storage(account, [(key1, value1)].into());
+        new_state
+            .replace_account_storage(account, [(key1, value1)].into())
+            .unwrap();
 
         assert_eq!(new_state.basic(account).unwrap().unwrap().nonce, nonce);
         assert_eq!(new_state.storage(account, key0), Ok(U256::ZERO));

--- a/crates/revm/src/frame.rs
+++ b/crates/revm/src/frame.rs
@@ -110,10 +110,9 @@ impl FrameResult {
 
 /// Contains either a frame or a result.
 pub enum FrameOrResult {
-    /// Boxed call frame,
+    /// Boxed call or create frame.
     Frame(Frame),
-    /// Boxed create frame
-    /// Interpreter result
+    /// Call or create result.
     Result(FrameResult),
 }
 
@@ -186,6 +185,16 @@ impl Frame {
             Self::Call(call_frame) => &mut call_frame.frame_data,
             Self::Create(create_frame) => &mut create_frame.frame_data,
         }
+    }
+
+    /// Returns a reference to the interpreter.
+    pub fn interpreter(&self) -> &Interpreter {
+        &self.frame_data().interpreter
+    }
+
+    /// Returns a mutable reference to the interpreter.
+    pub fn interpreter_mut(&mut self) -> &mut Interpreter {
+        &mut self.frame_data_mut().interpreter
     }
 }
 

--- a/crates/revm/src/handler/mainnet/execution.rs
+++ b/crates/revm/src/handler/mainnet/execution.rs
@@ -37,14 +37,15 @@ pub fn frame_return_with_refund_flag<SPEC: Spec>(
         }
         _ => {}
     }
+
     // Calculate gas refund for transaction.
     // If config is set to disable gas refund, it will return 0.
     // If spec is set to london, it will decrease the maximum refund amount to 5th part of
     // gas spend. (Before london it was 2th part of gas spend)
     if refund_enabled {
         // EIP-3529: Reduction in refunds
-        gas.set_final_refund::<SPEC>()
-    };
+        gas.set_final_refund::<SPEC>();
+    }
 }
 
 /// Handle output of the transaction

--- a/crates/revm/src/handler/mainnet/post_execution.rs
+++ b/crates/revm/src/handler/mainnet/post_execution.rs
@@ -1,7 +1,7 @@
 use crate::{
     interpreter::{Gas, SuccessOrHalt},
     primitives::{
-        db::Database, EVMError, ExecutionResult, Output, ResultAndState, Spec, SpecId::LONDON, U256,
+        db::Database, EVMError, ExecutionResult, ResultAndState, Spec, SpecId::LONDON, U256,
     },
     Context, FrameResult,
 };
@@ -94,10 +94,7 @@ pub fn output<EXT, DB: Database>(
         },
         SuccessOrHalt::Revert => ExecutionResult::Revert {
             gas_used: final_gas_used,
-            output: match output {
-                Output::Call(return_value) => return_value,
-                Output::Create(return_value, _) => return_value,
-            },
+            output: output.into_data(),
         },
         SuccessOrHalt::Halt(reason) => ExecutionResult::Halt {
             reason,


### PR DESCRIPTION
Increases minimum Rust version to 1.75