### PR TITLE
feat: implement DatabaseCommit for DatabaseComponents

### DIFF
--- a/crates/primitives/src/db.rs
+++ b/crates/primitives/src/db.rs
@@ -91,6 +91,13 @@ impl<T: DatabaseRef> Database for WrapDatabaseRef<T> {
     }
 }
 
+impl<T: DatabaseRef + DatabaseCommit> DatabaseCommit for WrapDatabaseRef<T> {
+    #[inline]
+    fn commit(&mut self, changes: HashMap<Address, Account>) {
+        self.0.commit(changes)
+    }
+}
+
 /// Wraps a `dyn DatabaseRef` to provide a [`Database`] implementation.
 #[doc(hidden)]
 #[deprecated = "use `WrapDatabaseRef` instead"]

--- a/crates/primitives/src/db/components.rs
+++ b/crates/primitives/src/db/components.rs
@@ -3,12 +3,15 @@ pub mod block_hash;
 pub mod state;
 
 pub use block_hash::{BlockHash, BlockHashRef};
+use hashbrown::HashMap;
 pub use state::{State, StateRef};
 
 use crate::{
     db::{Database, DatabaseRef},
-    AccountInfo, Address, Bytecode, B256, U256,
+    Account, AccountInfo, Address, Bytecode, B256, U256,
 };
+
+use super::DatabaseCommit;
 
 #[derive(Debug)]
 pub struct DatabaseComponents<S, BH> {
@@ -71,5 +74,11 @@ impl<S: StateRef, BH: BlockHashRef> DatabaseRef for DatabaseComponents<S, BH> {
         self.block_hash
             .block_hash(number)
             .map_err(Self::Error::BlockHash)
+    }
+}
+
+impl<S: DatabaseCommit, BH: BlockHashRef> DatabaseCommit for DatabaseComponents<S, BH> {
+    fn commit(&mut self, changes: HashMap<Address, Account>) {
+        self.state.commit(changes);
     }
 }


### PR DESCRIPTION
These implementations were missing when working with a type that implements `DatabaseRef` instead of `Database`