### PR TITLE
fix: gas cost calculation

### DIFF
--- a/crates/revm/src/inspector/gas.rs
+++ b/crates/revm/src/inspector/gas.rs
@@ -41,7 +41,7 @@ impl<DB: Database> Inspector<DB> for GasInspector {
         _context: &mut EvmContext<DB>,
     ) {
         let last_gas = core::mem::replace(&mut self.gas_remaining, interp.gas.remaining());
-        self.last_gas_cost = last_gas.saturating_sub(self.last_gas_cost);
+        self.last_gas_cost = last_gas.saturating_sub(self.gas_remaining);
     }
 
     fn call_end(

--- a/crates/revm/src/inspector/gas.rs
+++ b/crates/revm/src/inspector/gas.rs
@@ -40,7 +40,8 @@ impl<DB: Database> Inspector<DB> for GasInspector {
         interp: &mut crate::interpreter::Interpreter,
         _context: &mut EvmContext<DB>,
     ) {
-        let last_gas_remaining = core::mem::replace(&mut self.gas_remaining, interp.gas.remaining());
+        let last_gas_remaining =
+            core::mem::replace(&mut self.gas_remaining, interp.gas.remaining());
         self.last_gas_cost = last_gas_remaining.saturating_sub(self.gas_remaining);
     }
 

--- a/crates/revm/src/inspector/gas.rs
+++ b/crates/revm/src/inspector/gas.rs
@@ -41,7 +41,7 @@ impl<DB: Database> Inspector<DB> for GasInspector {
         _context: &mut EvmContext<DB>,
     ) {
         let last_gas = core::mem::replace(&mut self.gas_remaining, interp.gas.remaining());
-        self.last_gas_cost = last_gas.saturating_sub(self.gas_remaining);
+        self.last_gas_cost = last_gas_remaining.saturating_sub(self.gas_remaining);
     }
 
     fn call_end(

--- a/crates/revm/src/inspector/gas.rs
+++ b/crates/revm/src/inspector/gas.rs
@@ -40,7 +40,7 @@ impl<DB: Database> Inspector<DB> for GasInspector {
         interp: &mut crate::interpreter::Interpreter,
         _context: &mut EvmContext<DB>,
     ) {
-        let last_gas = core::mem::replace(&mut self.gas_remaining, interp.gas.remaining());
+        let last_gas_remaining = core::mem::replace(&mut self.gas_remaining, interp.gas.remaining());
         self.last_gas_cost = last_gas_remaining.saturating_sub(self.gas_remaining);
     }
 


### PR DESCRIPTION
A bug was introduced in the last gas cost calculation in [this commit](https://github.com/bluealloy/revm/commit/8418558b808f87a251ae1d97a80b985d0039988e#diff-bc5de00072f218e23e10d28db011fdb048e16fac459147e7c9a1a1bdce56c621L55). This PR fixes it.

