### PR TITLE
fix: reset tstorage on finalize

### DIFF
--- a/crates/revm/src/journaled_state.rs
+++ b/crates/revm/src/journaled_state.rs
@@ -93,7 +93,7 @@ impl JournaledState {
 
     /// Does cleanup and returns modified state.
     ///
-    /// This resets the [JournalState] to its initial state in [Self::new]
+    /// This resets the [JournaledState] to its initial state in [Self::new]
     #[inline]
     pub fn finalize(&mut self) -> (State, Vec<Log>) {
         let Self {

--- a/crates/revm/src/journaled_state.rs
+++ b/crates/revm/src/journaled_state.rs
@@ -15,7 +15,7 @@ use std::vec::Vec;
 pub struct JournaledState {
     /// Current state.
     pub state: State,
-    /// EIP 1153 transient storage
+    /// [EIP-1153[(https://eips.ethereum.org/EIPS/eip-1153) transient storage that is discarded after every transactions
     pub transient_storage: TransientStorage,
     /// logs
     pub logs: Vec<Log>,
@@ -92,10 +92,13 @@ impl JournaledState {
     }
 
     /// Does cleanup and returns modified state.
+    ///
+    /// This resets the [JournalState] to its initial state in [Self::new]
     #[inline]
     pub fn finalize(&mut self) -> (State, Vec<Log>) {
         let state = mem::take(&mut self.state);
         let logs = mem::take(&mut self.logs);
+        self.transient_storage = TransientStorage::default();
         self.journal = vec![vec![]];
         self.depth = 0;
         (state, logs)

--- a/crates/revm/src/journaled_state.rs
+++ b/crates/revm/src/journaled_state.rs
@@ -107,11 +107,12 @@ impl JournaledState {
             warm_preloaded_addresses: _,
         } = self;
 
-        let state = mem::take(state);
-        let logs = mem::take(logs);
         *transient_storage = TransientStorage::default();
         *journal = vec![vec![]];
         *depth = 0;
+        let state = mem::take(state);
+        let logs = mem::take(logs);
+
         (state, logs)
     }
 

--- a/crates/revm/src/journaled_state.rs
+++ b/crates/revm/src/journaled_state.rs
@@ -96,11 +96,22 @@ impl JournaledState {
     /// This resets the [JournalState] to its initial state in [Self::new]
     #[inline]
     pub fn finalize(&mut self) -> (State, Vec<Log>) {
-        let state = mem::take(&mut self.state);
-        let logs = mem::take(&mut self.logs);
-        self.transient_storage = TransientStorage::default();
-        self.journal = vec![vec![]];
-        self.depth = 0;
+        let Self {
+            state,
+            transient_storage,
+            logs,
+            depth,
+            journal,
+            // kept, see [Self::new]
+            spec: _,
+            warm_preloaded_addresses: _,
+        } = self;
+
+        let state = mem::take(state);
+        let logs = mem::take(logs);
+        *transient_storage = TransientStorage::default();
+        *journal = vec![vec![]];
+        *depth = 0;
         (state, logs)
     }
 


### PR DESCRIPTION
finalize is called via the output handler and is supposed to reset the journaledstate.

this ensures the transient storage is also cleared, restoring the initial state of JournaledState