### PR TITLE
feat(precompile): add a bool to bytes32 helper function

### DIFF
--- a/crates/precompile/src/bn128.rs
+++ b/crates/precompile/src/bn128.rs
@@ -1,5 +1,6 @@
 use crate::{
-    utilities::right_pad, Address, Error, Precompile, PrecompileResult, PrecompileWithAddress,
+    utilities::{bool_to_bytes32, right_pad},
+    Address, Error, Precompile, PrecompileResult, PrecompileWithAddress,
 };
 use bn::{AffineG1, AffineG2, Fq, Fq2, Group, Gt, G1, G2};
 use revm_primitives::Bytes;
@@ -222,10 +223,7 @@ fn run_pair(
 
         mul == Gt::one()
     };
-
-    let mut out = [0u8; 32];
-    out[31] = success as u8;
-    Ok((gas_used, out.into()))
+    Ok((gas_used, bool_to_bytes32(success)))
 }
 
 /*

--- a/crates/precompile/src/utilities.rs
+++ b/crates/precompile/src/utilities.rs
@@ -1,9 +1,10 @@
+use revm_primitives::{b256, Bytes, B256};
 use std::borrow::Cow;
 
 /// Right-pads the given slice at `offset` with zeroes until `LEN`.
 ///
 /// Returns the first `LEN` bytes if it does not need padding.
-#[inline(always)]
+#[inline]
 pub fn right_pad_with_offset<const LEN: usize>(data: &[u8], offset: usize) -> Cow<'_, [u8; LEN]> {
     right_pad(data.get(offset..).unwrap_or_default())
 }
@@ -11,7 +12,7 @@ pub fn right_pad_with_offset<const LEN: usize>(data: &[u8], offset: usize) -> Co
 /// Right-pads the given slice at `offset` with zeroes until `len`.
 ///
 /// Returns the first `len` bytes if it does not need padding.
-#[inline(always)]
+#[inline]
 pub fn right_pad_with_offset_vec(data: &[u8], offset: usize, len: usize) -> Cow<'_, [u8]> {
     right_pad_vec(data.get(offset..).unwrap_or_default(), len)
 }
@@ -19,7 +20,7 @@ pub fn right_pad_with_offset_vec(data: &[u8], offset: usize, len: usize) -> Cow<
 /// Right-pads the given slice with zeroes until `LEN`.
 ///
 /// Returns the first `LEN` bytes if it does not need padding.
-#[inline(always)]
+#[inline]
 pub fn right_pad<const LEN: usize>(data: &[u8]) -> Cow<'_, [u8; LEN]> {
     if let Some(data) = data.get(..LEN) {
         Cow::Borrowed(data.try_into().unwrap())
@@ -33,7 +34,7 @@ pub fn right_pad<const LEN: usize>(data: &[u8]) -> Cow<'_, [u8; LEN]> {
 /// Right-pads the given slice with zeroes until `len`.
 ///
 /// Returns the first `len` bytes if it does not need padding.
-#[inline(always)]
+#[inline]
 pub fn right_pad_vec(data: &[u8], len: usize) -> Cow<'_, [u8]> {
     if let Some(data) = data.get(..len) {
         Cow::Borrowed(data)
@@ -47,7 +48,7 @@ pub fn right_pad_vec(data: &[u8], len: usize) -> Cow<'_, [u8]> {
 /// Left-pads the given slice with zeroes until `LEN`.
 ///
 /// Returns the first `LEN` bytes if it does not need padding.
-#[inline(always)]
+#[inline]
 pub fn left_pad<const LEN: usize>(data: &[u8]) -> Cow<'_, [u8; LEN]> {
     if let Some(data) = data.get(..LEN) {
         Cow::Borrowed(data.try_into().unwrap())
@@ -61,7 +62,7 @@ pub fn left_pad<const LEN: usize>(data: &[u8]) -> Cow<'_, [u8; LEN]> {
 /// Left-pads the given slice with zeroes until `len`.
 ///
 /// Returns the first `len` bytes if it does not need padding.
-#[inline(always)]
+#[inline]
 pub fn left_pad_vec(data: &[u8], len: usize) -> Cow<'_, [u8]> {
     if let Some(data) = data.get(..len) {
         Cow::Borrowed(data)
@@ -69,6 +70,28 @@ pub fn left_pad_vec(data: &[u8], len: usize) -> Cow<'_, [u8]> {
         let mut padded = vec![0; len];
         padded[len - data.len()..].copy_from_slice(data);
         Cow::Owned(padded)
+    }
+}
+
+/// Converts a boolean to a left-padded 32-byte `Bytes` value.
+///
+/// This is optimized to not allocate at runtime by using 2 static arrays.
+#[inline]
+pub const fn bool_to_bytes32(value: bool) -> Bytes {
+    Bytes::from_static(&bool_to_b256(value).0)
+}
+
+/// Converts a boolean to a left-padded `B256` value.
+///
+/// This is optimized to not allocate at runtime by using 2 static arrays.
+#[inline]
+pub const fn bool_to_b256(value: bool) -> &'static B256 {
+    const TRUE: &B256 = &b256!("0000000000000000000000000000000000000000000000000000000000000001");
+    const FALSE: &B256 = &b256!("0000000000000000000000000000000000000000000000000000000000000000");
+    if value {
+        TRUE
+    } else {
+        FALSE
     }
 }
 
@@ -139,5 +162,15 @@ mod tests {
         let padded = left_pad_vec(&data, 8);
         assert!(matches!(padded, Cow::Borrowed(_)));
         assert_eq!(padded[..], [1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn bool2bytes() {
+        let f = bool_to_bytes32(false);
+        assert_eq!(f[..], [0; 32]);
+        let t = bool_to_bytes32(true);
+        assert_eq!(t.len(), 32);
+        assert_eq!(t[..31], [0; 31]);
+        assert_eq!(t[31], 1);
     }
 }


### PR DESCRIPTION
Useful for precompiles that return `bool` padded to 32 bytes.