### PR TITLE
feat(interpreter): OpCode struct constants

### DIFF
--- a/crates/interpreter/src/instructions/opcode.rs
+++ b/crates/interpreter/src/instructions/opcode.rs
@@ -99,6 +99,10 @@ macro_rules! opcodes {
             #[doc = concat!("The `", stringify!($val), "` (\"", stringify!($name),"\") opcode.")]
             pub const $name: u8 = $val;
         )*
+        impl OpCode {$(
+            #[doc = concat!("The `", stringify!($val), "` (\"", stringify!($name),"\") opcode.")]
+            pub const $name: Self = Self($val);
+        )*}
 
         /// Maps each opcode to its name.
         pub const OPCODE_JUMPMAP: [Option<&'static str>; 256] = {


### PR DESCRIPTION
Currently the only way to instantiate an OpCode at compile time is by using unsafe or matching on the Option returned by `new` (unwrap is not stable). This PR adds the same `u8` opcode constants to the `OpCode` struct as well.