### PR TITLE
feat: Restrict ContextPrecompiles only to EvmContext

### DIFF
--- a/crates/revm/src/builder.rs
+++ b/crates/revm/src/builder.rs
@@ -446,7 +446,7 @@ mod test {
         primitives::{
             address, AccountInfo, Address, Bytecode, Bytes, PrecompileResult, TransactTo, U256,
         },
-        Context, ContextPrecompile, ContextStatefulPrecompile, Evm, EvmContext, InMemoryDB,
+        Context, ContextPrecompile, ContextStatefulPrecompile, Evm, InMemoryDB, InnerEvmContext,
     };
     use revm_interpreter::{Host, Interpreter};
     use std::sync::Arc;
@@ -557,12 +557,12 @@ mod test {
     fn build_custom_precompile() {
         struct CustomPrecompile;
 
-        impl ContextStatefulPrecompile<EvmContext<EmptyDB>> for CustomPrecompile {
+        impl ContextStatefulPrecompile<EmptyDB> for CustomPrecompile {
             fn call(
                 &self,
                 _input: &Bytes,
                 _gas_price: u64,
-                _context: &mut EvmContext<EmptyDB>,
+                _context: &mut InnerEvmContext<EmptyDB>,
             ) -> PrecompileResult {
                 Ok((10, Bytes::new()))
             }

--- a/crates/revm/src/builder.rs
+++ b/crates/revm/src/builder.rs
@@ -534,11 +534,7 @@ mod test {
             // .with_db(..)
             .build();
 
-        let Context {
-            external: _,
-            evm: EvmContext { db: _, .. },
-            ..
-        } = evm.into_context();
+        let Context { external: _, .. } = evm.into_context();
     }
 
     #[test]
@@ -561,13 +557,12 @@ mod test {
     fn build_custom_precompile() {
         struct CustomPrecompile;
 
-        impl ContextStatefulPrecompile<EvmContext<EmptyDB>, ()> for CustomPrecompile {
+        impl ContextStatefulPrecompile<EvmContext<EmptyDB>> for CustomPrecompile {
             fn call(
                 &self,
                 _input: &Bytes,
                 _gas_price: u64,
                 _context: &mut EvmContext<EmptyDB>,
-                _extctx: &mut (),
             ) -> PrecompileResult {
                 Ok((10, Bytes::new()))
             }

--- a/crates/revm/src/context.rs
+++ b/crates/revm/src/context.rs
@@ -1,19 +1,17 @@
 mod context_precompiles;
-mod evm_context;
+pub(crate) mod evm_context;
+mod inner_evm_context;
 
 pub use context_precompiles::{
     ContextPrecompile, ContextPrecompiles, ContextStatefulPrecompile, ContextStatefulPrecompileArc,
     ContextStatefulPrecompileBox, ContextStatefulPrecompileMut,
 };
 pub use evm_context::EvmContext;
+pub use inner_evm_context::InnerEvmContext;
 
 use crate::{
     db::{Database, EmptyDB},
-    interpreter::{
-        return_ok, CallInputs, Contract, Gas, InstructionResult, Interpreter, InterpreterResult,
-    },
-    primitives::{Address, Bytes, EVMError, HandlerCfg, HashSet, U256},
-    FrameOrResult, CALL_STACK_LIMIT,
+    primitives::HandlerCfg,
 };
 use std::boxed::Box;
 
@@ -23,8 +21,6 @@ pub struct Context<EXT, DB: Database> {
     pub evm: EvmContext<DB>,
     /// External contexts.
     pub external: EXT,
-    /// Precompiles that are available for evm.
-    pub precompiles: ContextPrecompiles<DB>,
 }
 
 impl<EXT: Clone, DB: Database + Clone> Clone for Context<EXT, DB>
@@ -35,7 +31,6 @@ where
         Self {
             evm: self.evm.clone(),
             external: self.external.clone(),
-            precompiles: self.precompiles.clone(),
         }
     }
 }
@@ -52,7 +47,6 @@ impl Context<(), EmptyDB> {
         Context {
             evm: EvmContext::new(EmptyDB::new()),
             external: (),
-            precompiles: ContextPrecompiles::default(),
         }
     }
 }
@@ -63,7 +57,6 @@ impl<DB: Database> Context<(), DB> {
         Context {
             evm: EvmContext::new_with_env(db, Box::default()),
             external: (),
-            precompiles: ContextPrecompiles::default(),
         }
     }
 }
@@ -71,139 +64,7 @@ impl<DB: Database> Context<(), DB> {
 impl<EXT, DB: Database> Context<EXT, DB> {
     /// Creates new context with external and database.
     pub fn new(evm: EvmContext<DB>, external: EXT) -> Context<EXT, DB> {
-        Context {
-            evm,
-            external,
-            precompiles: ContextPrecompiles::default(),
-        }
-    }
-
-    /// Sets precompiles
-    #[inline]
-    pub fn set_precompiles(&mut self, precompiles: ContextPrecompiles<DB>) {
-        // set warm loaded addresses.
-        self.evm.journaled_state.warm_preloaded_addresses =
-            precompiles.addresses().copied().collect::<HashSet<_>>();
-        self.precompiles = precompiles;
-    }
-
-    /// Call precompile contract
-    #[inline]
-    fn call_precompile(
-        &mut self,
-        address: Address,
-        input_data: &Bytes,
-        gas: Gas,
-    ) -> Option<InterpreterResult> {
-        let out = self
-            .precompiles
-            .call(address, input_data, gas.limit(), &mut self.evm)?;
-
-        let mut result = InterpreterResult {
-            result: InstructionResult::Return,
-            gas,
-            output: Bytes::new(),
-        };
-
-        match out {
-            Ok((gas_used, data)) => {
-                if result.gas.record_cost(gas_used) {
-                    result.result = InstructionResult::Return;
-                    result.output = data;
-                } else {
-                    result.result = InstructionResult::PrecompileOOG;
-                }
-            }
-            Err(e) => {
-                result.result = if e == crate::precompile::Error::OutOfGas {
-                    InstructionResult::PrecompileOOG
-                } else {
-                    InstructionResult::PrecompileError
-                };
-            }
-        }
-        Some(result)
-    }
-
-    /// Make call frame
-    #[inline]
-    pub fn make_call_frame(
-        &mut self,
-        inputs: &CallInputs,
-    ) -> Result<FrameOrResult, EVMError<DB::Error>> {
-        let gas = Gas::new(inputs.gas_limit);
-
-        let return_result = |instruction_result: InstructionResult| {
-            Ok(FrameOrResult::new_call_result(
-                InterpreterResult {
-                    result: instruction_result,
-                    gas,
-                    output: Bytes::new(),
-                },
-                inputs.return_memory_offset.clone(),
-            ))
-        };
-
-        // Check depth
-        if self.evm.journaled_state.depth() > CALL_STACK_LIMIT {
-            return return_result(InstructionResult::CallTooDeep);
-        }
-
-        let (account, _) = self
-            .evm
-            .inner
-            .journaled_state
-            .load_code(inputs.contract, &mut self.evm.inner.db)?;
-        let code_hash = account.info.code_hash();
-        let bytecode = account.info.code.clone().unwrap_or_default();
-
-        // Create subroutine checkpoint
-        let checkpoint = self.evm.journaled_state.checkpoint();
-
-        // Touch address. For "EIP-158 State Clear", this will erase empty accounts.
-        if inputs.transfer.value == U256::ZERO {
-            self.evm.load_account(inputs.context.address)?;
-            self.evm.journaled_state.touch(&inputs.context.address);
-        }
-
-        // Transfer value from caller to called account
-        if let Some(result) = self.evm.inner.journaled_state.transfer(
-            &inputs.transfer.source,
-            &inputs.transfer.target,
-            inputs.transfer.value,
-            &mut self.evm.inner.db,
-        )? {
-            self.evm.journaled_state.checkpoint_revert(checkpoint);
-            return return_result(result);
-        }
-
-        if let Some(result) = self.call_precompile(inputs.contract, &inputs.input, gas) {
-            if matches!(result.result, return_ok!()) {
-                self.evm.journaled_state.checkpoint_commit();
-            } else {
-                self.evm.journaled_state.checkpoint_revert(checkpoint);
-            }
-            Ok(FrameOrResult::new_call_result(
-                result,
-                inputs.return_memory_offset.clone(),
-            ))
-        } else if !bytecode.is_empty() {
-            let contract = Box::new(Contract::new_with_context(
-                inputs.input.clone(),
-                bytecode,
-                code_hash,
-                &inputs.context,
-            ));
-            // Create interpreter and executes call and push new CallStackFrame.
-            Ok(FrameOrResult::new_call_frame(
-                inputs.return_memory_offset.clone(),
-                checkpoint,
-                Interpreter::new(contract, gas.limit(), inputs.is_static),
-            ))
-        } else {
-            self.evm.journaled_state.checkpoint_commit();
-            return_result(InstructionResult::Stop)
-        }
+        Context { evm, external }
     }
 }
 
@@ -231,203 +92,5 @@ where
             context: self.context.clone(),
             cfg: self.cfg,
         }
-    }
-}
-
-/// Test utilities for the [`EvmContext`].
-#[cfg(any(test, feature = "test-utils"))]
-pub(crate) mod test_utils {
-    use self::evm_context::InnerEvmContext;
-
-    use super::*;
-    use crate::{
-        db::{CacheDB, EmptyDB},
-        journaled_state::JournaledState,
-        primitives::{address, Address, Bytes, Env, HashSet, SpecId, B256, U256},
-    };
-    use std::boxed::Box;
-
-    /// Mock caller address.
-    pub const MOCK_CALLER: Address = address!("0000000000000000000000000000000000000000");
-
-    /// Creates `CallInputs` that calls a provided contract address from the mock caller.
-    pub fn create_mock_call_inputs(to: Address) -> CallInputs {
-        CallInputs {
-            contract: to,
-            transfer: revm_interpreter::Transfer {
-                source: MOCK_CALLER,
-                target: to,
-                value: U256::ZERO,
-            },
-            input: Bytes::new(),
-            gas_limit: 0,
-            context: revm_interpreter::CallContext {
-                address: MOCK_CALLER,
-                caller: MOCK_CALLER,
-                code_address: MOCK_CALLER,
-                apparent_value: U256::ZERO,
-                scheme: revm_interpreter::CallScheme::Call,
-            },
-            is_static: false,
-            return_memory_offset: 0..0,
-        }
-    }
-
-    /// Creates an evm context with a cache db backend.
-    /// Additionally loads the mock caller account into the db,
-    /// and sets the balance to the provided U256 value.
-    pub fn create_cache_db_evm_context_with_balance(
-        env: Box<Env>,
-        mut db: CacheDB<EmptyDB>,
-        balance: U256,
-    ) -> Context<(), CacheDB<EmptyDB>> {
-        db.insert_account_info(
-            test_utils::MOCK_CALLER,
-            crate::primitives::AccountInfo {
-                nonce: 0,
-                balance,
-                code_hash: B256::default(),
-                code: None,
-            },
-        );
-        create_cache_db_evm_context(env, db)
-    }
-
-    /// Creates a cached db evm context.
-    pub fn create_cache_db_evm_context(
-        env: Box<Env>,
-        db: CacheDB<EmptyDB>,
-    ) -> Context<(), CacheDB<EmptyDB>> {
-        Context {
-            evm: EvmContext {
-                inner: InnerEvmContext {
-                    env,
-                    journaled_state: JournaledState::new(SpecId::CANCUN, HashSet::new()),
-                    db,
-                    error: Ok(()),
-                    #[cfg(feature = "optimism")]
-                    l1_block_info: None,
-                },
-                precompiles: (),
-            },
-            external: (),
-            precompiles: ContextPrecompiles::default(),
-        }
-    }
-
-    /// Returns a new `EvmContext` with an empty journaled state.
-    pub fn create_empty_evm_context(env: Box<Env>, db: EmptyDB) -> Context<(), EmptyDB> {
-        Context::new(
-            EvmContext {
-                inner: InnerEvmContext {
-                    env,
-                    journaled_state: JournaledState::new(SpecId::CANCUN, HashSet::new()),
-                    db,
-                    error: Ok(()),
-                    #[cfg(feature = "optimism")]
-                    l1_block_info: None,
-                },
-                precompiles: (),
-            },
-            (),
-        )
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use test_utils::*;
-
-    use crate::{
-        db::{CacheDB, EmptyDB},
-        interpreter::InstructionResult,
-        primitives::{address, Bytecode, Bytes, Env, U256},
-        Frame, FrameOrResult, JournalEntry,
-    };
-    use std::boxed::Box;
-
-    // Tests that the `EVMContext::make_call_frame` function returns an error if the
-    // call stack is too deep.
-    #[test]
-    fn test_make_call_frame_stack_too_deep() {
-        let env = Env::default();
-        let db = EmptyDB::default();
-        let mut context = test_utils::create_empty_evm_context(Box::new(env), db);
-        context.evm.journaled_state.depth = CALL_STACK_LIMIT as usize + 1;
-        let contract = address!("dead10000000000000000000000000000001dead");
-        let call_inputs = test_utils::create_mock_call_inputs(contract);
-        let res = context.make_call_frame(&call_inputs);
-        let Ok(FrameOrResult::Result(err)) = res else {
-            panic!("Expected FrameOrResult::Result");
-        };
-        assert_eq!(
-            err.interpreter_result().result,
-            InstructionResult::CallTooDeep
-        );
-    }
-
-    // Tests that the `EVMContext::make_call_frame` function returns an error if the
-    // transfer fails on the journaled state. It also verifies that the revert was
-    // checkpointed on the journaled state correctly.
-    #[test]
-    fn test_make_call_frame_transfer_revert() {
-        let env = Env::default();
-        let db = EmptyDB::default();
-        let mut evm_context = test_utils::create_empty_evm_context(Box::new(env), db);
-        let contract = address!("dead10000000000000000000000000000001dead");
-        let mut call_inputs = test_utils::create_mock_call_inputs(contract);
-        call_inputs.transfer.value = U256::from(1);
-        let res = evm_context.make_call_frame(&call_inputs);
-        let Ok(FrameOrResult::Result(result)) = res else {
-            panic!("Expected FrameOrResult::Result");
-        };
-        assert_eq!(
-            result.interpreter_result().result,
-            InstructionResult::OutOfFunds
-        );
-        let checkpointed = vec![vec![JournalEntry::AccountLoaded { address: contract }]];
-        assert_eq!(evm_context.evm.journaled_state.journal, checkpointed);
-        assert_eq!(evm_context.evm.journaled_state.depth, 0);
-    }
-
-    #[test]
-    fn test_make_call_frame_missing_code_context() {
-        let env = Env::default();
-        let cdb = CacheDB::new(EmptyDB::default());
-        let bal = U256::from(3_000_000_000_u128);
-        let mut context = create_cache_db_evm_context_with_balance(Box::new(env), cdb, bal);
-        let contract = address!("dead10000000000000000000000000000001dead");
-        let call_inputs = test_utils::create_mock_call_inputs(contract);
-        let res = context.make_call_frame(&call_inputs);
-        let Ok(FrameOrResult::Result(result)) = res else {
-            panic!("Expected FrameOrResult::Result");
-        };
-        assert_eq!(result.interpreter_result().result, InstructionResult::Stop);
-    }
-
-    #[test]
-    fn test_make_call_frame_succeeds() {
-        let env = Env::default();
-        let mut cdb = CacheDB::new(EmptyDB::default());
-        let bal = U256::from(3_000_000_000_u128);
-        let by = Bytecode::new_raw(Bytes::from(vec![0x60, 0x00, 0x60, 0x00]));
-        let contract = address!("dead10000000000000000000000000000001dead");
-        cdb.insert_account_info(
-            contract,
-            crate::primitives::AccountInfo {
-                nonce: 0,
-                balance: bal,
-                code_hash: by.clone().hash_slow(),
-                code: Some(by),
-            },
-        );
-        let mut evm_context = create_cache_db_evm_context_with_balance(Box::new(env), cdb, bal);
-        let call_inputs = test_utils::create_mock_call_inputs(contract);
-        let res = evm_context.make_call_frame(&call_inputs);
-        let Ok(FrameOrResult::Frame(Frame::Call(call_frame))) = res else {
-            panic!("Expected FrameOrResult::Frame(Frame::Call(..))");
-        };
-        assert_eq!(call_frame.return_memory_range, 0..0,);
     }
 }

--- a/crates/revm/src/context.rs
+++ b/crates/revm/src/context.rs
@@ -1,19 +1,20 @@
+mod context_precompiles;
+mod evm_context;
+
+pub use context_precompiles::{
+    ContextPrecompile, ContextPrecompiles, ContextStatefulPrecompile, ContextStatefulPrecompileArc,
+    ContextStatefulPrecompileBox, ContextStatefulPrecompileMut,
+};
+pub use evm_context::EvmContext;
+
 use crate::{
     db::{Database, EmptyDB},
     interpreter::{
-        analysis::to_analysed, gas, return_ok, CallInputs, Contract, CreateInputs, Gas,
-        InstructionResult, Interpreter, InterpreterResult, MAX_CODE_SIZE,
+        return_ok, CallInputs, Contract, Gas, InstructionResult, Interpreter, InterpreterResult,
     },
-    journaled_state::JournaledState,
-    primitives::{
-        keccak256, Account, Address, AnalysisKind, Bytecode, Bytes, CreateScheme, EVMError, Env,
-        HandlerCfg, HashSet, Spec,
-        SpecId::{self, *},
-        B256, U256,
-    },
-    ContextPrecompiles, FrameOrResult, JournalCheckpoint, CALL_STACK_LIMIT,
+    primitives::{Address, Bytes, EVMError, HandlerCfg, HashSet, U256},
+    FrameOrResult, CALL_STACK_LIMIT,
 };
-use revm_interpreter::{SStoreResult, SelfDestructResult};
 use std::boxed::Box;
 
 /// Main Context structure that contains both EvmContext and External context.
@@ -23,7 +24,7 @@ pub struct Context<EXT, DB: Database> {
     /// External contexts.
     pub external: EXT,
     /// Precompiles that are available for evm.
-    pub precompiles: ContextPrecompiles<DB, EXT>,
+    pub precompiles: ContextPrecompiles<DB>,
 }
 
 impl<EXT: Clone, DB: Database + Clone> Clone for Context<EXT, DB>
@@ -79,7 +80,7 @@ impl<EXT, DB: Database> Context<EXT, DB> {
 
     /// Sets precompiles
     #[inline]
-    pub fn set_precompiles(&mut self, precompiles: ContextPrecompiles<DB, EXT>) {
+    pub fn set_precompiles(&mut self, precompiles: ContextPrecompiles<DB>) {
         // set warm loaded addresses.
         self.evm.journaled_state.warm_preloaded_addresses =
             precompiles.addresses().copied().collect::<HashSet<_>>();
@@ -94,13 +95,9 @@ impl<EXT, DB: Database> Context<EXT, DB> {
         input_data: &Bytes,
         gas: Gas,
     ) -> Option<InterpreterResult> {
-        let out = self.precompiles.call(
-            address,
-            input_data,
-            gas.limit(),
-            &mut self.evm,
-            &mut self.external,
-        )?;
+        let out = self
+            .precompiles
+            .call(address, input_data, gas.limit(), &mut self.evm)?;
 
         let mut result = InterpreterResult {
             result: InstructionResult::Return,
@@ -154,8 +151,9 @@ impl<EXT, DB: Database> Context<EXT, DB> {
 
         let (account, _) = self
             .evm
+            .inner
             .journaled_state
-            .load_code(inputs.contract, &mut self.evm.db)?;
+            .load_code(inputs.contract, &mut self.evm.inner.db)?;
         let code_hash = account.info.code_hash();
         let bytecode = account.info.code.clone().unwrap_or_default();
 
@@ -169,11 +167,11 @@ impl<EXT, DB: Database> Context<EXT, DB> {
         }
 
         // Transfer value from caller to called account
-        if let Some(result) = self.evm.journaled_state.transfer(
+        if let Some(result) = self.evm.inner.journaled_state.transfer(
             &inputs.transfer.source,
             &inputs.transfer.target,
             inputs.transfer.value,
-            &mut self.evm.db,
+            &mut self.evm.inner.db,
         )? {
             self.evm.journaled_state.checkpoint_revert(checkpoint);
             return return_result(result);
@@ -236,392 +234,18 @@ where
     }
 }
 
-/// EVM contexts contains data that EVM needs for execution.
-#[derive(Debug)]
-pub struct EvmContext<DB: Database> {
-    /// EVM Environment contains all the information about config, block and transaction that
-    /// evm needs.
-    pub env: Box<Env>,
-    /// EVM State with journaling support.
-    pub journaled_state: JournaledState,
-    /// Database to load data from.
-    pub db: DB,
-    /// Error that happened during execution.
-    pub error: Result<(), EVMError<DB::Error>>,
-    /// Used as temporary value holder to store L1 block info.
-    #[cfg(feature = "optimism")]
-    pub l1_block_info: Option<crate::optimism::L1BlockInfo>,
-}
-
-impl<DB: Database + Clone> Clone for EvmContext<DB>
-where
-    DB::Error: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            env: self.env.clone(),
-            journaled_state: self.journaled_state.clone(),
-            db: self.db.clone(),
-            error: self.error.clone(),
-            #[cfg(feature = "optimism")]
-            l1_block_info: self.l1_block_info.clone(),
-        }
-    }
-}
-
-impl<DB: Database> EvmContext<DB> {
-    pub fn new(db: DB) -> Self {
-        Self {
-            env: Box::default(),
-            journaled_state: JournaledState::new(SpecId::LATEST, HashSet::new()),
-            db,
-            error: Ok(()),
-            #[cfg(feature = "optimism")]
-            l1_block_info: None,
-        }
-    }
-
-    /// Creates a new context with the given environment and database.
-    #[inline]
-    pub fn new_with_env(db: DB, env: Box<Env>) -> Self {
-        Self {
-            env,
-            journaled_state: JournaledState::new(SpecId::LATEST, HashSet::new()),
-            db,
-            error: Ok(()),
-            #[cfg(feature = "optimism")]
-            l1_block_info: None,
-        }
-    }
-
-    /// Sets the database.
-    ///
-    /// Note that this will ignore the previous `error` if set.
-    #[inline]
-    pub fn with_db<ODB: Database>(self, db: ODB) -> EvmContext<ODB> {
-        EvmContext {
-            env: self.env,
-            journaled_state: self.journaled_state,
-            db,
-            error: Ok(()),
-            #[cfg(feature = "optimism")]
-            l1_block_info: self.l1_block_info,
-        }
-    }
-
-    /// Returns the configured EVM spec ID.
-    #[inline]
-    pub const fn spec_id(&self) -> SpecId {
-        self.journaled_state.spec
-    }
-
-    /// Load access list for berlin hard fork.
-    ///
-    /// Loading of accounts/storages is needed to make them warm.
-    #[inline]
-    pub fn load_access_list(&mut self) -> Result<(), EVMError<DB::Error>> {
-        for (address, slots) in self.env.tx.access_list.iter() {
-            self.journaled_state
-                .initial_account_load(*address, slots, &mut self.db)?;
-        }
-        Ok(())
-    }
-
-    /// Return environment.
-    #[inline]
-    pub fn env(&mut self) -> &mut Env {
-        &mut self.env
-    }
-
-    /// Fetch block hash from database.
-    #[inline]
-    pub fn block_hash(&mut self, number: U256) -> Result<B256, EVMError<DB::Error>> {
-        self.db.block_hash(number).map_err(EVMError::Database)
-    }
-
-    /// Mark account as touched as only touched accounts will be added to state.
-    #[inline]
-    pub fn touch(&mut self, address: &Address) {
-        self.journaled_state.touch(address);
-    }
-
-    /// Loads an account into memory. Returns `true` if it is cold accessed.
-    #[inline]
-    pub fn load_account(
-        &mut self,
-        address: Address,
-    ) -> Result<(&mut Account, bool), EVMError<DB::Error>> {
-        self.journaled_state.load_account(address, &mut self.db)
-    }
-
-    /// Load account from database to JournaledState.
-    ///
-    /// Return boolean pair where first is `is_cold` second bool `exists`.
-    #[inline]
-    pub fn load_account_exist(
-        &mut self,
-        address: Address,
-    ) -> Result<(bool, bool), EVMError<DB::Error>> {
-        self.journaled_state
-            .load_account_exist(address, &mut self.db)
-    }
-
-    /// Return account balance and is_cold flag.
-    #[inline]
-    pub fn balance(&mut self, address: Address) -> Result<(U256, bool), EVMError<DB::Error>> {
-        self.journaled_state
-            .load_account(address, &mut self.db)
-            .map(|(acc, is_cold)| (acc.info.balance, is_cold))
-    }
-
-    /// Return account code and if address is cold loaded.
-    #[inline]
-    pub fn code(&mut self, address: Address) -> Result<(Bytecode, bool), EVMError<DB::Error>> {
-        self.journaled_state
-            .load_code(address, &mut self.db)
-            .map(|(a, is_cold)| (a.info.code.clone().unwrap(), is_cold))
-    }
-
-    /// Get code hash of address.
-    #[inline]
-    pub fn code_hash(&mut self, address: Address) -> Result<(B256, bool), EVMError<DB::Error>> {
-        let (acc, is_cold) = self.journaled_state.load_code(address, &mut self.db)?;
-        if acc.is_empty() {
-            return Ok((B256::ZERO, is_cold));
-        }
-        Ok((acc.info.code_hash, is_cold))
-    }
-
-    /// Load storage slot, if storage is not present inside the account then it will be loaded from database.
-    #[inline]
-    pub fn sload(
-        &mut self,
-        address: Address,
-        index: U256,
-    ) -> Result<(U256, bool), EVMError<DB::Error>> {
-        // account is always warm. reference on that statement https://eips.ethereum.org/EIPS/eip-2929 see `Note 2:`
-        self.journaled_state.sload(address, index, &mut self.db)
-    }
-
-    /// Storage change of storage slot, before storing `sload` will be called for that slot.
-    #[inline]
-    pub fn sstore(
-        &mut self,
-        address: Address,
-        index: U256,
-        value: U256,
-    ) -> Result<SStoreResult, EVMError<DB::Error>> {
-        self.journaled_state
-            .sstore(address, index, value, &mut self.db)
-    }
-
-    /// Returns transient storage value.
-    #[inline]
-    pub fn tload(&mut self, address: Address, index: U256) -> U256 {
-        self.journaled_state.tload(address, index)
-    }
-
-    /// Stores transient storage value.
-    #[inline]
-    pub fn tstore(&mut self, address: Address, index: U256, value: U256) {
-        self.journaled_state.tstore(address, index, value)
-    }
-
-    /// Selfdestructs the account.
-    #[inline]
-    pub fn selfdestruct(
-        &mut self,
-        address: Address,
-        target: Address,
-    ) -> Result<SelfDestructResult, EVMError<DB::Error>> {
-        self.journaled_state
-            .selfdestruct(address, target, &mut self.db)
-    }
-
-    /// Make create frame.
-    #[inline]
-    pub fn make_create_frame(
-        &mut self,
-        spec_id: SpecId,
-        inputs: &CreateInputs,
-    ) -> Result<FrameOrResult, EVMError<DB::Error>> {
-        // Prepare crate.
-        let gas = Gas::new(inputs.gas_limit);
-
-        let return_error = |e| {
-            Ok(FrameOrResult::new_create_result(
-                InterpreterResult {
-                    result: e,
-                    gas,
-                    output: Bytes::new(),
-                },
-                None,
-            ))
-        };
-
-        // Check depth
-        if self.journaled_state.depth() > CALL_STACK_LIMIT {
-            return return_error(InstructionResult::CallTooDeep);
-        }
-
-        // Fetch balance of caller.
-        let (caller_balance, _) = self.balance(inputs.caller)?;
-
-        // Check if caller has enough balance to send to the created contract.
-        if caller_balance < inputs.value {
-            return return_error(InstructionResult::OutOfFunds);
-        }
-
-        // Increase nonce of caller and check if it overflows
-        let old_nonce;
-        if let Some(nonce) = self.journaled_state.inc_nonce(inputs.caller) {
-            old_nonce = nonce - 1;
-        } else {
-            return return_error(InstructionResult::Return);
-        }
-
-        // Create address
-        let mut init_code_hash = B256::ZERO;
-        let created_address = match inputs.scheme {
-            CreateScheme::Create => inputs.caller.create(old_nonce),
-            CreateScheme::Create2 { salt } => {
-                init_code_hash = keccak256(&inputs.init_code);
-                inputs.caller.create2(salt.to_be_bytes(), init_code_hash)
-            }
-        };
-
-        // Load account so it needs to be marked as warm for access list.
-        self.journaled_state
-            .load_account(created_address, &mut self.db)?;
-
-        // create account, transfer funds and make the journal checkpoint.
-        let checkpoint = match self.journaled_state.create_account_checkpoint(
-            inputs.caller,
-            created_address,
-            inputs.value,
-            spec_id,
-        ) {
-            Ok(checkpoint) => checkpoint,
-            Err(e) => {
-                return return_error(e);
-            }
-        };
-
-        let bytecode = Bytecode::new_raw(inputs.init_code.clone());
-
-        let contract = Box::new(Contract::new(
-            Bytes::new(),
-            bytecode,
-            init_code_hash,
-            created_address,
-            inputs.caller,
-            inputs.value,
-        ));
-
-        Ok(FrameOrResult::new_create_frame(
-            created_address,
-            checkpoint,
-            Interpreter::new(contract, gas.limit(), false),
-        ))
-    }
-
-    /// Handles call return.
-    #[inline]
-    pub fn call_return(
-        &mut self,
-        interpreter_result: &InterpreterResult,
-        journal_checkpoint: JournalCheckpoint,
-    ) {
-        // revert changes or not.
-        if matches!(interpreter_result.result, return_ok!()) {
-            self.journaled_state.checkpoint_commit();
-        } else {
-            self.journaled_state.checkpoint_revert(journal_checkpoint);
-        }
-    }
-
-    /// Handles create return.
-    #[inline]
-    pub fn create_return<SPEC: Spec>(
-        &mut self,
-        interpreter_result: &mut InterpreterResult,
-        address: Address,
-        journal_checkpoint: JournalCheckpoint,
-    ) {
-        // if return is not ok revert and return.
-        if !matches!(interpreter_result.result, return_ok!()) {
-            self.journaled_state.checkpoint_revert(journal_checkpoint);
-            return;
-        }
-        // Host error if present on execution
-        // if ok, check contract creation limit and calculate gas deduction on output len.
-        //
-        // EIP-3541: Reject new contract code starting with the 0xEF byte
-        if SPEC::enabled(LONDON)
-            && !interpreter_result.output.is_empty()
-            && interpreter_result.output.first() == Some(&0xEF)
-        {
-            self.journaled_state.checkpoint_revert(journal_checkpoint);
-            interpreter_result.result = InstructionResult::CreateContractStartingWithEF;
-            return;
-        }
-
-        // EIP-170: Contract code size limit
-        // By default limit is 0x6000 (~25kb)
-        if SPEC::enabled(SPURIOUS_DRAGON)
-            && interpreter_result.output.len()
-                > self
-                    .env
-                    .cfg
-                    .limit_contract_code_size
-                    .unwrap_or(MAX_CODE_SIZE)
-        {
-            self.journaled_state.checkpoint_revert(journal_checkpoint);
-            interpreter_result.result = InstructionResult::CreateContractSizeLimit;
-            return;
-        }
-        let gas_for_code = interpreter_result.output.len() as u64 * gas::CODEDEPOSIT;
-        if !interpreter_result.gas.record_cost(gas_for_code) {
-            // record code deposit gas cost and check if we are out of gas.
-            // EIP-2 point 3: If contract creation does not have enough gas to pay for the
-            // final gas fee for adding the contract code to the state, the contract
-            //  creation fails (i.e. goes out-of-gas) rather than leaving an empty contract.
-            if SPEC::enabled(HOMESTEAD) {
-                self.journaled_state.checkpoint_revert(journal_checkpoint);
-                interpreter_result.result = InstructionResult::OutOfGas;
-                return;
-            } else {
-                interpreter_result.output = Bytes::new();
-            }
-        }
-        // if we have enough gas we can commit changes.
-        self.journaled_state.checkpoint_commit();
-
-        // Do analysis of bytecode straight away.
-        let bytecode = match self.env.cfg.perf_analyse_created_bytecodes {
-            AnalysisKind::Raw => Bytecode::new_raw(interpreter_result.output.clone()),
-            AnalysisKind::Check => {
-                Bytecode::new_raw(interpreter_result.output.clone()).to_checked()
-            }
-            AnalysisKind::Analyse => {
-                to_analysed(Bytecode::new_raw(interpreter_result.output.clone()))
-            }
-        };
-
-        // set code
-        self.journaled_state.set_code(address, bytecode);
-
-        interpreter_result.result = InstructionResult::Return;
-    }
-}
 /// Test utilities for the [`EvmContext`].
 #[cfg(any(test, feature = "test-utils"))]
 pub(crate) mod test_utils {
+    use self::evm_context::InnerEvmContext;
+
     use super::*;
-    use crate::db::CacheDB;
-    use crate::db::EmptyDB;
-    use crate::primitives::address;
-    use crate::primitives::SpecId;
+    use crate::{
+        db::{CacheDB, EmptyDB},
+        journaled_state::JournaledState,
+        primitives::{address, Address, Bytes, Env, HashSet, SpecId, B256, U256},
+    };
+    use std::boxed::Box;
 
     /// Mock caller address.
     pub const MOCK_CALLER: Address = address!("0000000000000000000000000000000000000000");
@@ -676,12 +300,15 @@ pub(crate) mod test_utils {
     ) -> Context<(), CacheDB<EmptyDB>> {
         Context {
             evm: EvmContext {
-                env,
-                journaled_state: JournaledState::new(SpecId::CANCUN, HashSet::new()),
-                db,
-                error: Ok(()),
-                #[cfg(feature = "optimism")]
-                l1_block_info: None,
+                inner: InnerEvmContext {
+                    env,
+                    journaled_state: JournaledState::new(SpecId::CANCUN, HashSet::new()),
+                    db,
+                    error: Ok(()),
+                    #[cfg(feature = "optimism")]
+                    l1_block_info: None,
+                },
+                precompiles: (),
             },
             external: (),
             precompiles: ContextPrecompiles::default(),
@@ -692,12 +319,15 @@ pub(crate) mod test_utils {
     pub fn create_empty_evm_context(env: Box<Env>, db: EmptyDB) -> Context<(), EmptyDB> {
         Context::new(
             EvmContext {
-                env,
-                journaled_state: JournaledState::new(SpecId::CANCUN, HashSet::new()),
-                db,
-                error: Ok(()),
-                #[cfg(feature = "optimism")]
-                l1_block_info: None,
+                inner: InnerEvmContext {
+                    env,
+                    journaled_state: JournaledState::new(SpecId::CANCUN, HashSet::new()),
+                    db,
+                    error: Ok(()),
+                    #[cfg(feature = "optimism")]
+                    l1_block_info: None,
+                },
+                precompiles: (),
             },
             (),
         )
@@ -707,10 +337,15 @@ pub(crate) mod test_utils {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::{CacheDB, EmptyDB};
-    use crate::primitives::address;
-    use crate::{Frame, JournalEntry};
     use test_utils::*;
+
+    use crate::{
+        db::{CacheDB, EmptyDB},
+        interpreter::InstructionResult,
+        primitives::{address, Bytecode, Bytes, Env, U256},
+        Frame, FrameOrResult, JournalEntry,
+    };
+    use std::boxed::Box;
 
     // Tests that the `EVMContext::make_call_frame` function returns an error if the
     // call stack is too deep.

--- a/crates/revm/src/context/context_precompiles.rs
+++ b/crates/revm/src/context/context_precompiles.rs
@@ -9,18 +9,18 @@ use revm_precompile::Precompiles;
 use std::{boxed::Box, sync::Arc};
 
 /// Precompile and its handlers.
-pub enum ContextPrecompile<DB: Database, EXTCTX> {
+pub enum ContextPrecompile<DB: Database> {
     /// Ordinary precompiles
     Ordinary(Precompile),
     /// Stateful precompile that is Arc over [`ContextStatefulPrecompile`] trait.
     /// It takes a reference to input, gas limit and Context.
-    ContextStateful(ContextStatefulPrecompileArc<EvmContext<DB>, EXTCTX>),
+    ContextStateful(ContextStatefulPrecompileArc<EvmContext<DB>>),
     /// Mutable stateful precompile that is Box over [`ContextStatefulPrecompileMut`] trait.
     /// It takes a reference to input, gas limit and context.
-    ContextStatefulMut(ContextStatefulPrecompileBox<EvmContext<DB>, EXTCTX>),
+    ContextStatefulMut(ContextStatefulPrecompileBox<EvmContext<DB>>),
 }
 
-impl<DB: Database, EXTCTX> Clone for ContextPrecompile<DB, EXTCTX> {
+impl<DB: Database> Clone for ContextPrecompile<DB> {
     fn clone(&self) -> Self {
         match self {
             Self::Ordinary(arg0) => Self::Ordinary(arg0.clone()),
@@ -31,11 +31,11 @@ impl<DB: Database, EXTCTX> Clone for ContextPrecompile<DB, EXTCTX> {
 }
 
 #[derive(Clone)]
-pub struct ContextPrecompiles<DB: Database, EXTCTX> {
-    inner: HashMap<Address, ContextPrecompile<DB, EXTCTX>>,
+pub struct ContextPrecompiles<DB: Database> {
+    inner: HashMap<Address, ContextPrecompile<DB>>,
 }
 
-impl<DB: Database, EXTCTX> ContextPrecompiles<DB, EXTCTX> {
+impl<DB: Database> ContextPrecompiles<DB> {
     /// Returns precompiles addresses.
     #[inline]
     pub fn addresses(&self) -> impl Iterator<Item = &Address> {
@@ -48,7 +48,7 @@ impl<DB: Database, EXTCTX> ContextPrecompiles<DB, EXTCTX> {
     #[inline]
     pub fn extend(
         &mut self,
-        other: impl IntoIterator<Item = impl Into<(Address, ContextPrecompile<DB, EXTCTX>)>>,
+        other: impl IntoIterator<Item = impl Into<(Address, ContextPrecompile<DB>)>>,
     ) {
         self.inner.extend(other.into_iter().map(Into::into));
     }
@@ -62,21 +62,18 @@ impl<DB: Database, EXTCTX> ContextPrecompiles<DB, EXTCTX> {
         bytes: &Bytes,
         gas_price: u64,
         evmctx: &mut EvmContext<DB>,
-        extctx: &mut EXTCTX,
     ) -> Option<PrecompileResult> {
         let precompile = self.inner.get_mut(&addess)?;
 
         match precompile {
             ContextPrecompile::Ordinary(p) => Some(p.call(bytes, gas_price, &evmctx.env)),
-            ContextPrecompile::ContextStatefulMut(p) => {
-                Some(p.call_mut(bytes, gas_price, evmctx, extctx))
-            }
-            ContextPrecompile::ContextStateful(p) => Some(p.call(bytes, gas_price, evmctx, extctx)),
+            ContextPrecompile::ContextStatefulMut(p) => Some(p.call_mut(bytes, gas_price, evmctx)),
+            ContextPrecompile::ContextStateful(p) => Some(p.call(bytes, gas_price, evmctx)),
         }
     }
 }
 
-impl<DB: Database, EXTCTX> Default for ContextPrecompiles<DB, EXTCTX> {
+impl<DB: Database> Default for ContextPrecompiles<DB> {
     fn default() -> Self {
         Self {
             inner: Default::default(),
@@ -84,15 +81,15 @@ impl<DB: Database, EXTCTX> Default for ContextPrecompiles<DB, EXTCTX> {
     }
 }
 
-impl<DB: Database, EXTCTX> Deref for ContextPrecompiles<DB, EXTCTX> {
-    type Target = HashMap<Address, ContextPrecompile<DB, EXTCTX>>;
+impl<DB: Database> Deref for ContextPrecompiles<DB> {
+    type Target = HashMap<Address, ContextPrecompile<DB>>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
 
-impl<DB: Database, EXTCTX> DerefMut for ContextPrecompiles<DB, EXTCTX> {
+impl<DB: Database> DerefMut for ContextPrecompiles<DB> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
@@ -100,45 +97,31 @@ impl<DB: Database, EXTCTX> DerefMut for ContextPrecompiles<DB, EXTCTX> {
 
 /// Context aware stateful precompile trait. It is used to create
 /// a arc precompile in [`ContextPrecompile`].
-pub trait ContextStatefulPrecompile<EVMCTX, EXTCTX>: Sync + Send {
-    fn call(
-        &self,
-        bytes: &Bytes,
-        gas_price: u64,
-        evmctx: &mut EVMCTX,
-        extctx: &mut EXTCTX,
-    ) -> PrecompileResult;
+pub trait ContextStatefulPrecompile<EVMCTX>: Sync + Send {
+    fn call(&self, bytes: &Bytes, gas_price: u64, evmctx: &mut EVMCTX) -> PrecompileResult;
 }
 
 /// Context aware mutable stateful precompile trait. It is used to create
 /// a boxed precompile in [`ContextPrecompile`].
-pub trait ContextStatefulPrecompileMut<EVMCTX, EXTCTX>: DynClone + Send + Sync {
-    fn call_mut(
-        &mut self,
-        bytes: &Bytes,
-        gas_price: u64,
-        evmctx: &mut EVMCTX,
-        extctx: &mut EXTCTX,
-    ) -> PrecompileResult;
+pub trait ContextStatefulPrecompileMut<EVMCTX>: DynClone + Send + Sync {
+    fn call_mut(&mut self, bytes: &Bytes, gas_price: u64, evmctx: &mut EVMCTX) -> PrecompileResult;
 }
 
-dyn_clone::clone_trait_object!(<EVMCTX, EXTCTX> ContextStatefulPrecompileMut<EVMCTX, EXTCTX>);
+dyn_clone::clone_trait_object!(<EVMCTX> ContextStatefulPrecompileMut<EVMCTX>);
 
 /// Arc over context stateful precompile.
-pub type ContextStatefulPrecompileArc<EVMCTX, EXTCTX> =
-    Arc<dyn ContextStatefulPrecompile<EVMCTX, EXTCTX>>;
+pub type ContextStatefulPrecompileArc<EVMCTX> = Arc<dyn ContextStatefulPrecompile<EVMCTX>>;
 
 /// Box over context mutable stateful precompile
-pub type ContextStatefulPrecompileBox<EVMCTX, EXTCTX> =
-    Box<dyn ContextStatefulPrecompileMut<EVMCTX, EXTCTX>>;
+pub type ContextStatefulPrecompileBox<EVMCTX> = Box<dyn ContextStatefulPrecompileMut<EVMCTX>>;
 
-impl<DB: Database, EXTCTX> From<Precompile> for ContextPrecompile<DB, EXTCTX> {
+impl<DB: Database> From<Precompile> for ContextPrecompile<DB> {
     fn from(p: Precompile) -> Self {
         ContextPrecompile::Ordinary(p)
     }
 }
 
-impl<DB: Database, EXTCTX> From<Precompiles> for ContextPrecompiles<DB, EXTCTX> {
+impl<DB: Database> From<Precompiles> for ContextPrecompiles<DB> {
     fn from(p: Precompiles) -> Self {
         ContextPrecompiles {
             inner: p.inner.into_iter().map(|(k, v)| (k, v.into())).collect(),
@@ -146,7 +129,7 @@ impl<DB: Database, EXTCTX> From<Precompiles> for ContextPrecompiles<DB, EXTCTX> 
     }
 }
 
-impl<DB: Database, EXTCTX> From<&Precompiles> for ContextPrecompiles<DB, EXTCTX> {
+impl<DB: Database> From<&Precompiles> for ContextPrecompiles<DB> {
     fn from(p: &Precompiles) -> Self {
         ContextPrecompiles {
             inner: p

--- a/crates/revm/src/context/evm_context.rs
+++ b/crates/revm/src/context/evm_context.rs
@@ -13,8 +13,9 @@ use core::{
 };
 use std::boxed::Box;
 
-//#[derive(Debug)]
+/// EVM context that contains the inner EVM context and precompiles.
 pub struct EvmContext<DB: Database> {
+    /// Inner EVM context.
     pub inner: InnerEvmContext<DB>,
     /// Precompiles that are available for evm.
     pub precompiles: ContextPrecompiles<DB>,
@@ -60,6 +61,7 @@ impl<DB: Database> DerefMut for EvmContext<DB> {
 }
 
 impl<DB: Database> EvmContext<DB> {
+    /// Create new context with database.
     pub fn new(db: DB) -> Self {
         Self {
             inner: InnerEvmContext::new(db),

--- a/crates/revm/src/context/evm_context.rs
+++ b/crates/revm/src/context/evm_context.rs
@@ -1,0 +1,471 @@
+use crate::{
+    db::Database,
+    interpreter::{
+        analysis::to_analysed, gas, return_ok, Contract, CreateInputs, Gas, InstructionResult,
+        Interpreter, InterpreterResult, MAX_CODE_SIZE,
+    },
+    journaled_state::JournaledState,
+    primitives::{
+        keccak256, Account, Address, AnalysisKind, Bytecode, Bytes, CreateScheme, EVMError, Env,
+        HashSet, Spec,
+        SpecId::{self, *},
+        B256, U256,
+    },
+    FrameOrResult, JournalCheckpoint, CALL_STACK_LIMIT,
+};
+use core::{fmt, ops::{Deref, DerefMut}};
+use revm_interpreter::{SStoreResult, SelfDestructResult};
+use std::boxed::Box;
+
+//#[derive(Debug)]
+pub struct EvmContext<DB: Database> {
+    pub inner: InnerEvmContext<DB>,
+    pub precompiles: (),
+}
+
+impl<DB: Database + Clone> Clone for EvmContext<DB>
+where
+    DB::Error: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            precompiles: (),
+        }
+    }
+}
+
+impl<DB> fmt::Debug for EvmContext<DB>
+where
+    DB: Database + fmt::Debug,
+    DB::Error: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EvmContext")
+            .field("inner", &self.inner)
+            .field("precompiles", &self.inner)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<DB: Database> Deref for EvmContext<DB> {
+    type Target = InnerEvmContext<DB>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<DB: Database> DerefMut for EvmContext<DB> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<DB: Database> EvmContext<DB> {
+    pub fn new(db: DB) -> Self {
+        Self {
+            inner: InnerEvmContext::new(db),
+            precompiles: (),
+        }
+    }
+
+    /// Creates a new context with the given environment and database.
+    #[inline]
+    pub fn new_with_env(db: DB, env: Box<Env>) -> Self {
+        Self {
+            inner: InnerEvmContext::new_with_env(db, env),
+            precompiles: (),
+        }
+    }
+
+    /// Sets the database.
+    ///
+    /// Note that this will ignore the previous `error` if set.
+    #[inline]
+    pub fn with_db<ODB: Database>(self, db: ODB) -> EvmContext<ODB> {
+        EvmContext {
+            inner: self.inner.with_db(db),
+            precompiles: (),
+        }
+    }
+}
+
+/// EVM contexts contains data that EVM needs for execution.
+#[derive(Debug)]
+pub struct InnerEvmContext<DB: Database> {
+    /// EVM Environment contains all the information about config, block and transaction that
+    /// evm needs.
+    pub env: Box<Env>,
+    /// EVM State with journaling support.
+    pub journaled_state: JournaledState,
+    /// Database to load data from.
+    pub db: DB,
+    /// Error that happened during execution.
+    pub error: Result<(), EVMError<DB::Error>>,
+    /// Used as temporary value holder to store L1 block info.
+    #[cfg(feature = "optimism")]
+    pub l1_block_info: Option<crate::optimism::L1BlockInfo>,
+}
+
+impl<DB: Database + Clone> Clone for InnerEvmContext<DB>
+where
+    DB::Error: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            env: self.env.clone(),
+            journaled_state: self.journaled_state.clone(),
+            db: self.db.clone(),
+            error: self.error.clone(),
+            #[cfg(feature = "optimism")]
+            l1_block_info: self.l1_block_info.clone(),
+        }
+    }
+}
+
+impl<DB: Database> InnerEvmContext<DB> {
+    pub fn new(db: DB) -> Self {
+        Self {
+            env: Box::default(),
+            journaled_state: JournaledState::new(SpecId::LATEST, HashSet::new()),
+            db,
+            error: Ok(()),
+            #[cfg(feature = "optimism")]
+            l1_block_info: None,
+        }
+    }
+
+    /// Creates a new context with the given environment and database.
+    #[inline]
+    pub fn new_with_env(db: DB, env: Box<Env>) -> Self {
+        Self {
+            env,
+            journaled_state: JournaledState::new(SpecId::LATEST, HashSet::new()),
+            db,
+            error: Ok(()),
+            #[cfg(feature = "optimism")]
+            l1_block_info: None,
+        }
+    }
+
+    /// Sets the database.
+    ///
+    /// Note that this will ignore the previous `error` if set.
+    #[inline]
+    pub fn with_db<ODB: Database>(self, db: ODB) -> InnerEvmContext<ODB> {
+        InnerEvmContext {
+            env: self.env,
+            journaled_state: self.journaled_state,
+            db,
+            error: Ok(()),
+            #[cfg(feature = "optimism")]
+            l1_block_info: self.l1_block_info,
+        }
+    }
+
+    /// Returns the configured EVM spec ID.
+    #[inline]
+    pub const fn spec_id(&self) -> SpecId {
+        self.journaled_state.spec
+    }
+
+    /// Load access list for berlin hard fork.
+    ///
+    /// Loading of accounts/storages is needed to make them warm.
+    #[inline]
+    pub fn load_access_list(&mut self) -> Result<(), EVMError<DB::Error>> {
+        for (address, slots) in self.env.tx.access_list.iter() {
+            self.journaled_state
+                .initial_account_load(*address, slots, &mut self.db)?;
+        }
+        Ok(())
+    }
+
+    /// Return environment.
+    #[inline]
+    pub fn env(&mut self) -> &mut Env {
+        &mut self.env
+    }
+
+    /// Fetch block hash from database.
+    #[inline]
+    pub fn block_hash(&mut self, number: U256) -> Result<B256, EVMError<DB::Error>> {
+        self.db.block_hash(number).map_err(EVMError::Database)
+    }
+
+    /// Mark account as touched as only touched accounts will be added to state.
+    #[inline]
+    pub fn touch(&mut self, address: &Address) {
+        self.journaled_state.touch(address);
+    }
+
+    /// Loads an account into memory. Returns `true` if it is cold accessed.
+    #[inline]
+    pub fn load_account(
+        &mut self,
+        address: Address,
+    ) -> Result<(&mut Account, bool), EVMError<DB::Error>> {
+        self.journaled_state.load_account(address, &mut self.db)
+    }
+
+    /// Load account from database to JournaledState.
+    ///
+    /// Return boolean pair where first is `is_cold` second bool `exists`.
+    #[inline]
+    pub fn load_account_exist(
+        &mut self,
+        address: Address,
+    ) -> Result<(bool, bool), EVMError<DB::Error>> {
+        self.journaled_state
+            .load_account_exist(address, &mut self.db)
+    }
+
+    /// Return account balance and is_cold flag.
+    #[inline]
+    pub fn balance(&mut self, address: Address) -> Result<(U256, bool), EVMError<DB::Error>> {
+        self.journaled_state
+            .load_account(address, &mut self.db)
+            .map(|(acc, is_cold)| (acc.info.balance, is_cold))
+    }
+
+    /// Return account code and if address is cold loaded.
+    #[inline]
+    pub fn code(&mut self, address: Address) -> Result<(Bytecode, bool), EVMError<DB::Error>> {
+        self.journaled_state
+            .load_code(address, &mut self.db)
+            .map(|(a, is_cold)| (a.info.code.clone().unwrap(), is_cold))
+    }
+
+    /// Get code hash of address.
+    #[inline]
+    pub fn code_hash(&mut self, address: Address) -> Result<(B256, bool), EVMError<DB::Error>> {
+        let (acc, is_cold) = self.journaled_state.load_code(address, &mut self.db)?;
+        if acc.is_empty() {
+            return Ok((B256::ZERO, is_cold));
+        }
+        Ok((acc.info.code_hash, is_cold))
+    }
+
+    /// Load storage slot, if storage is not present inside the account then it will be loaded from database.
+    #[inline]
+    pub fn sload(
+        &mut self,
+        address: Address,
+        index: U256,
+    ) -> Result<(U256, bool), EVMError<DB::Error>> {
+        // account is always warm. reference on that statement https://eips.ethereum.org/EIPS/eip-2929 see `Note 2:`
+        self.journaled_state.sload(address, index, &mut self.db)
+    }
+
+    /// Storage change of storage slot, before storing `sload` will be called for that slot.
+    #[inline]
+    pub fn sstore(
+        &mut self,
+        address: Address,
+        index: U256,
+        value: U256,
+    ) -> Result<SStoreResult, EVMError<DB::Error>> {
+        self.journaled_state
+            .sstore(address, index, value, &mut self.db)
+    }
+
+    /// Returns transient storage value.
+    #[inline]
+    pub fn tload(&mut self, address: Address, index: U256) -> U256 {
+        self.journaled_state.tload(address, index)
+    }
+
+    /// Stores transient storage value.
+    #[inline]
+    pub fn tstore(&mut self, address: Address, index: U256, value: U256) {
+        self.journaled_state.tstore(address, index, value)
+    }
+
+    /// Selfdestructs the account.
+    #[inline]
+    pub fn selfdestruct(
+        &mut self,
+        address: Address,
+        target: Address,
+    ) -> Result<SelfDestructResult, EVMError<DB::Error>> {
+        self.journaled_state
+            .selfdestruct(address, target, &mut self.db)
+    }
+
+    /// Make create frame.
+    #[inline]
+    pub fn make_create_frame(
+        &mut self,
+        spec_id: SpecId,
+        inputs: &CreateInputs,
+    ) -> Result<FrameOrResult, EVMError<DB::Error>> {
+        // Prepare crate.
+        let gas = Gas::new(inputs.gas_limit);
+
+        let return_error = |e| {
+            Ok(FrameOrResult::new_create_result(
+                InterpreterResult {
+                    result: e,
+                    gas,
+                    output: Bytes::new(),
+                },
+                None,
+            ))
+        };
+
+        // Check depth
+        if self.journaled_state.depth() > CALL_STACK_LIMIT {
+            return return_error(InstructionResult::CallTooDeep);
+        }
+
+        // Fetch balance of caller.
+        let (caller_balance, _) = self.balance(inputs.caller)?;
+
+        // Check if caller has enough balance to send to the created contract.
+        if caller_balance < inputs.value {
+            return return_error(InstructionResult::OutOfFunds);
+        }
+
+        // Increase nonce of caller and check if it overflows
+        let old_nonce;
+        if let Some(nonce) = self.journaled_state.inc_nonce(inputs.caller) {
+            old_nonce = nonce - 1;
+        } else {
+            return return_error(InstructionResult::Return);
+        }
+
+        // Create address
+        let mut init_code_hash = B256::ZERO;
+        let created_address = match inputs.scheme {
+            CreateScheme::Create => inputs.caller.create(old_nonce),
+            CreateScheme::Create2 { salt } => {
+                init_code_hash = keccak256(&inputs.init_code);
+                inputs.caller.create2(salt.to_be_bytes(), init_code_hash)
+            }
+        };
+
+        // Load account so it needs to be marked as warm for access list.
+        self.journaled_state
+            .load_account(created_address, &mut self.db)?;
+
+        // create account, transfer funds and make the journal checkpoint.
+        let checkpoint = match self.journaled_state.create_account_checkpoint(
+            inputs.caller,
+            created_address,
+            inputs.value,
+            spec_id,
+        ) {
+            Ok(checkpoint) => checkpoint,
+            Err(e) => {
+                return return_error(e);
+            }
+        };
+
+        let bytecode = Bytecode::new_raw(inputs.init_code.clone());
+
+        let contract = Box::new(Contract::new(
+            Bytes::new(),
+            bytecode,
+            init_code_hash,
+            created_address,
+            inputs.caller,
+            inputs.value,
+        ));
+
+        Ok(FrameOrResult::new_create_frame(
+            created_address,
+            checkpoint,
+            Interpreter::new(contract, gas.limit(), false),
+        ))
+    }
+
+    /// Handles call return.
+    #[inline]
+    pub fn call_return(
+        &mut self,
+        interpreter_result: &InterpreterResult,
+        journal_checkpoint: JournalCheckpoint,
+    ) {
+        // revert changes or not.
+        if matches!(interpreter_result.result, return_ok!()) {
+            self.journaled_state.checkpoint_commit();
+        } else {
+            self.journaled_state.checkpoint_revert(journal_checkpoint);
+        }
+    }
+
+    /// Handles create return.
+    #[inline]
+    pub fn create_return<SPEC: Spec>(
+        &mut self,
+        interpreter_result: &mut InterpreterResult,
+        address: Address,
+        journal_checkpoint: JournalCheckpoint,
+    ) {
+        // if return is not ok revert and return.
+        if !matches!(interpreter_result.result, return_ok!()) {
+            self.journaled_state.checkpoint_revert(journal_checkpoint);
+            return;
+        }
+        // Host error if present on execution
+        // if ok, check contract creation limit and calculate gas deduction on output len.
+        //
+        // EIP-3541: Reject new contract code starting with the 0xEF byte
+        if SPEC::enabled(LONDON)
+            && !interpreter_result.output.is_empty()
+            && interpreter_result.output.first() == Some(&0xEF)
+        {
+            self.journaled_state.checkpoint_revert(journal_checkpoint);
+            interpreter_result.result = InstructionResult::CreateContractStartingWithEF;
+            return;
+        }
+
+        // EIP-170: Contract code size limit
+        // By default limit is 0x6000 (~25kb)
+        if SPEC::enabled(SPURIOUS_DRAGON)
+            && interpreter_result.output.len()
+                > self
+                    .env
+                    .cfg
+                    .limit_contract_code_size
+                    .unwrap_or(MAX_CODE_SIZE)
+        {
+            self.journaled_state.checkpoint_revert(journal_checkpoint);
+            interpreter_result.result = InstructionResult::CreateContractSizeLimit;
+            return;
+        }
+        let gas_for_code = interpreter_result.output.len() as u64 * gas::CODEDEPOSIT;
+        if !interpreter_result.gas.record_cost(gas_for_code) {
+            // record code deposit gas cost and check if we are out of gas.
+            // EIP-2 point 3: If contract creation does not have enough gas to pay for the
+            // final gas fee for adding the contract code to the state, the contract
+            //  creation fails (i.e. goes out-of-gas) rather than leaving an empty contract.
+            if SPEC::enabled(HOMESTEAD) {
+                self.journaled_state.checkpoint_revert(journal_checkpoint);
+                interpreter_result.result = InstructionResult::OutOfGas;
+                return;
+            } else {
+                interpreter_result.output = Bytes::new();
+            }
+        }
+        // if we have enough gas we can commit changes.
+        self.journaled_state.checkpoint_commit();
+
+        // Do analysis of bytecode straight away.
+        let bytecode = match self.env.cfg.perf_analyse_created_bytecodes {
+            AnalysisKind::Raw => Bytecode::new_raw(interpreter_result.output.clone()),
+            AnalysisKind::Check => {
+                Bytecode::new_raw(interpreter_result.output.clone()).to_checked()
+            }
+            AnalysisKind::Analyse => {
+                to_analysed(Bytecode::new_raw(interpreter_result.output.clone()))
+            }
+        };
+
+        // set code
+        self.journaled_state.set_code(address, bytecode);
+
+        interpreter_result.result = InstructionResult::Return;
+    }
+}

--- a/crates/revm/src/context/evm_context.rs
+++ b/crates/revm/src/context/evm_context.rs
@@ -1,26 +1,23 @@
+use super::inner_evm_context::InnerEvmContext;
 use crate::{
     db::Database,
     interpreter::{
-        analysis::to_analysed, gas, return_ok, Contract, CreateInputs, Gas, InstructionResult,
-        Interpreter, InterpreterResult, MAX_CODE_SIZE,
+        return_ok, CallInputs, Contract, Gas, InstructionResult, Interpreter, InterpreterResult,
     },
-    journaled_state::JournaledState,
-    primitives::{
-        keccak256, Account, Address, AnalysisKind, Bytecode, Bytes, CreateScheme, EVMError, Env,
-        HashSet, Spec,
-        SpecId::{self, *},
-        B256, U256,
-    },
-    FrameOrResult, JournalCheckpoint, CALL_STACK_LIMIT,
+    primitives::{Address, Bytes, EVMError, Env, HashSet, U256},
+    ContextPrecompiles, FrameOrResult, CALL_STACK_LIMIT,
 };
-use core::{fmt, ops::{Deref, DerefMut}};
-use revm_interpreter::{SStoreResult, SelfDestructResult};
+use core::{
+    fmt,
+    ops::{Deref, DerefMut},
+};
 use std::boxed::Box;
 
 //#[derive(Debug)]
 pub struct EvmContext<DB: Database> {
     pub inner: InnerEvmContext<DB>,
-    pub precompiles: (),
+    /// Precompiles that are available for evm.
+    pub precompiles: ContextPrecompiles<DB>,
 }
 
 impl<DB: Database + Clone> Clone for EvmContext<DB>
@@ -30,7 +27,7 @@ where
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
-            precompiles: (),
+            precompiles: ContextPrecompiles::default(),
         }
     }
 }
@@ -66,7 +63,7 @@ impl<DB: Database> EvmContext<DB> {
     pub fn new(db: DB) -> Self {
         Self {
             inner: InnerEvmContext::new(db),
-            precompiles: (),
+            precompiles: ContextPrecompiles::default(),
         }
     }
 
@@ -75,7 +72,7 @@ impl<DB: Database> EvmContext<DB> {
     pub fn new_with_env(db: DB, env: Box<Env>) -> Self {
         Self {
             inner: InnerEvmContext::new_with_env(db, env),
-            precompiles: (),
+            precompiles: ContextPrecompiles::default(),
         }
     }
 
@@ -86,386 +83,324 @@ impl<DB: Database> EvmContext<DB> {
     pub fn with_db<ODB: Database>(self, db: ODB) -> EvmContext<ODB> {
         EvmContext {
             inner: self.inner.with_db(db),
-            precompiles: (),
-        }
-    }
-}
-
-/// EVM contexts contains data that EVM needs for execution.
-#[derive(Debug)]
-pub struct InnerEvmContext<DB: Database> {
-    /// EVM Environment contains all the information about config, block and transaction that
-    /// evm needs.
-    pub env: Box<Env>,
-    /// EVM State with journaling support.
-    pub journaled_state: JournaledState,
-    /// Database to load data from.
-    pub db: DB,
-    /// Error that happened during execution.
-    pub error: Result<(), EVMError<DB::Error>>,
-    /// Used as temporary value holder to store L1 block info.
-    #[cfg(feature = "optimism")]
-    pub l1_block_info: Option<crate::optimism::L1BlockInfo>,
-}
-
-impl<DB: Database + Clone> Clone for InnerEvmContext<DB>
-where
-    DB::Error: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            env: self.env.clone(),
-            journaled_state: self.journaled_state.clone(),
-            db: self.db.clone(),
-            error: self.error.clone(),
-            #[cfg(feature = "optimism")]
-            l1_block_info: self.l1_block_info.clone(),
-        }
-    }
-}
-
-impl<DB: Database> InnerEvmContext<DB> {
-    pub fn new(db: DB) -> Self {
-        Self {
-            env: Box::default(),
-            journaled_state: JournaledState::new(SpecId::LATEST, HashSet::new()),
-            db,
-            error: Ok(()),
-            #[cfg(feature = "optimism")]
-            l1_block_info: None,
+            precompiles: ContextPrecompiles::default(),
         }
     }
 
-    /// Creates a new context with the given environment and database.
+    /// Sets precompiles
     #[inline]
-    pub fn new_with_env(db: DB, env: Box<Env>) -> Self {
-        Self {
-            env,
-            journaled_state: JournaledState::new(SpecId::LATEST, HashSet::new()),
-            db,
-            error: Ok(()),
-            #[cfg(feature = "optimism")]
-            l1_block_info: None,
-        }
+    pub fn set_precompiles(&mut self, precompiles: ContextPrecompiles<DB>) {
+        // set warm loaded addresses.
+        self.journaled_state.warm_preloaded_addresses =
+            precompiles.addresses().copied().collect::<HashSet<_>>();
+        self.precompiles = precompiles;
     }
 
-    /// Sets the database.
-    ///
-    /// Note that this will ignore the previous `error` if set.
+    /// Call precompile contract
     #[inline]
-    pub fn with_db<ODB: Database>(self, db: ODB) -> InnerEvmContext<ODB> {
-        InnerEvmContext {
-            env: self.env,
-            journaled_state: self.journaled_state,
-            db,
-            error: Ok(()),
-            #[cfg(feature = "optimism")]
-            l1_block_info: self.l1_block_info,
-        }
-    }
-
-    /// Returns the configured EVM spec ID.
-    #[inline]
-    pub const fn spec_id(&self) -> SpecId {
-        self.journaled_state.spec
-    }
-
-    /// Load access list for berlin hard fork.
-    ///
-    /// Loading of accounts/storages is needed to make them warm.
-    #[inline]
-    pub fn load_access_list(&mut self) -> Result<(), EVMError<DB::Error>> {
-        for (address, slots) in self.env.tx.access_list.iter() {
-            self.journaled_state
-                .initial_account_load(*address, slots, &mut self.db)?;
-        }
-        Ok(())
-    }
-
-    /// Return environment.
-    #[inline]
-    pub fn env(&mut self) -> &mut Env {
-        &mut self.env
-    }
-
-    /// Fetch block hash from database.
-    #[inline]
-    pub fn block_hash(&mut self, number: U256) -> Result<B256, EVMError<DB::Error>> {
-        self.db.block_hash(number).map_err(EVMError::Database)
-    }
-
-    /// Mark account as touched as only touched accounts will be added to state.
-    #[inline]
-    pub fn touch(&mut self, address: &Address) {
-        self.journaled_state.touch(address);
-    }
-
-    /// Loads an account into memory. Returns `true` if it is cold accessed.
-    #[inline]
-    pub fn load_account(
+    fn call_precompile(
         &mut self,
         address: Address,
-    ) -> Result<(&mut Account, bool), EVMError<DB::Error>> {
-        self.journaled_state.load_account(address, &mut self.db)
-    }
+        input_data: &Bytes,
+        gas: Gas,
+    ) -> Option<InterpreterResult> {
+        let out = self
+            .precompiles
+            .call(address, input_data, gas.limit(), &mut self.inner)?;
 
-    /// Load account from database to JournaledState.
-    ///
-    /// Return boolean pair where first is `is_cold` second bool `exists`.
-    #[inline]
-    pub fn load_account_exist(
-        &mut self,
-        address: Address,
-    ) -> Result<(bool, bool), EVMError<DB::Error>> {
-        self.journaled_state
-            .load_account_exist(address, &mut self.db)
-    }
+        let mut result = InterpreterResult {
+            result: InstructionResult::Return,
+            gas,
+            output: Bytes::new(),
+        };
 
-    /// Return account balance and is_cold flag.
-    #[inline]
-    pub fn balance(&mut self, address: Address) -> Result<(U256, bool), EVMError<DB::Error>> {
-        self.journaled_state
-            .load_account(address, &mut self.db)
-            .map(|(acc, is_cold)| (acc.info.balance, is_cold))
-    }
-
-    /// Return account code and if address is cold loaded.
-    #[inline]
-    pub fn code(&mut self, address: Address) -> Result<(Bytecode, bool), EVMError<DB::Error>> {
-        self.journaled_state
-            .load_code(address, &mut self.db)
-            .map(|(a, is_cold)| (a.info.code.clone().unwrap(), is_cold))
-    }
-
-    /// Get code hash of address.
-    #[inline]
-    pub fn code_hash(&mut self, address: Address) -> Result<(B256, bool), EVMError<DB::Error>> {
-        let (acc, is_cold) = self.journaled_state.load_code(address, &mut self.db)?;
-        if acc.is_empty() {
-            return Ok((B256::ZERO, is_cold));
+        match out {
+            Ok((gas_used, data)) => {
+                if result.gas.record_cost(gas_used) {
+                    result.result = InstructionResult::Return;
+                    result.output = data;
+                } else {
+                    result.result = InstructionResult::PrecompileOOG;
+                }
+            }
+            Err(e) => {
+                result.result = if e == crate::precompile::Error::OutOfGas {
+                    InstructionResult::PrecompileOOG
+                } else {
+                    InstructionResult::PrecompileError
+                };
+            }
         }
-        Ok((acc.info.code_hash, is_cold))
+        Some(result)
     }
 
-    /// Load storage slot, if storage is not present inside the account then it will be loaded from database.
+    /// Make call frame
     #[inline]
-    pub fn sload(
+    pub fn make_call_frame(
         &mut self,
-        address: Address,
-        index: U256,
-    ) -> Result<(U256, bool), EVMError<DB::Error>> {
-        // account is always warm. reference on that statement https://eips.ethereum.org/EIPS/eip-2929 see `Note 2:`
-        self.journaled_state.sload(address, index, &mut self.db)
-    }
-
-    /// Storage change of storage slot, before storing `sload` will be called for that slot.
-    #[inline]
-    pub fn sstore(
-        &mut self,
-        address: Address,
-        index: U256,
-        value: U256,
-    ) -> Result<SStoreResult, EVMError<DB::Error>> {
-        self.journaled_state
-            .sstore(address, index, value, &mut self.db)
-    }
-
-    /// Returns transient storage value.
-    #[inline]
-    pub fn tload(&mut self, address: Address, index: U256) -> U256 {
-        self.journaled_state.tload(address, index)
-    }
-
-    /// Stores transient storage value.
-    #[inline]
-    pub fn tstore(&mut self, address: Address, index: U256, value: U256) {
-        self.journaled_state.tstore(address, index, value)
-    }
-
-    /// Selfdestructs the account.
-    #[inline]
-    pub fn selfdestruct(
-        &mut self,
-        address: Address,
-        target: Address,
-    ) -> Result<SelfDestructResult, EVMError<DB::Error>> {
-        self.journaled_state
-            .selfdestruct(address, target, &mut self.db)
-    }
-
-    /// Make create frame.
-    #[inline]
-    pub fn make_create_frame(
-        &mut self,
-        spec_id: SpecId,
-        inputs: &CreateInputs,
+        inputs: &CallInputs,
     ) -> Result<FrameOrResult, EVMError<DB::Error>> {
-        // Prepare crate.
         let gas = Gas::new(inputs.gas_limit);
 
-        let return_error = |e| {
-            Ok(FrameOrResult::new_create_result(
+        let return_result = |instruction_result: InstructionResult| {
+            Ok(FrameOrResult::new_call_result(
                 InterpreterResult {
-                    result: e,
+                    result: instruction_result,
                     gas,
                     output: Bytes::new(),
                 },
-                None,
+                inputs.return_memory_offset.clone(),
             ))
         };
 
         // Check depth
         if self.journaled_state.depth() > CALL_STACK_LIMIT {
-            return return_error(InstructionResult::CallTooDeep);
+            return return_result(InstructionResult::CallTooDeep);
         }
 
-        // Fetch balance of caller.
-        let (caller_balance, _) = self.balance(inputs.caller)?;
+        let (account, _) = self
+            .inner
+            .journaled_state
+            .load_code(inputs.contract, &mut self.inner.db)?;
+        let code_hash = account.info.code_hash();
+        let bytecode = account.info.code.clone().unwrap_or_default();
 
-        // Check if caller has enough balance to send to the created contract.
-        if caller_balance < inputs.value {
-            return return_error(InstructionResult::OutOfFunds);
+        // Create subroutine checkpoint
+        let checkpoint = self.journaled_state.checkpoint();
+
+        // Touch address. For "EIP-158 State Clear", this will erase empty accounts.
+        if inputs.transfer.value == U256::ZERO {
+            self.load_account(inputs.context.address)?;
+            self.journaled_state.touch(&inputs.context.address);
         }
 
-        // Increase nonce of caller and check if it overflows
-        let old_nonce;
-        if let Some(nonce) = self.journaled_state.inc_nonce(inputs.caller) {
-            old_nonce = nonce - 1;
-        } else {
-            return return_error(InstructionResult::Return);
+        // Transfer value from caller to called account
+        if let Some(result) = self.inner.journaled_state.transfer(
+            &inputs.transfer.source,
+            &inputs.transfer.target,
+            inputs.transfer.value,
+            &mut self.inner.db,
+        )? {
+            self.journaled_state.checkpoint_revert(checkpoint);
+            return return_result(result);
         }
 
-        // Create address
-        let mut init_code_hash = B256::ZERO;
-        let created_address = match inputs.scheme {
-            CreateScheme::Create => inputs.caller.create(old_nonce),
-            CreateScheme::Create2 { salt } => {
-                init_code_hash = keccak256(&inputs.init_code);
-                inputs.caller.create2(salt.to_be_bytes(), init_code_hash)
-            }
-        };
-
-        // Load account so it needs to be marked as warm for access list.
-        self.journaled_state
-            .load_account(created_address, &mut self.db)?;
-
-        // create account, transfer funds and make the journal checkpoint.
-        let checkpoint = match self.journaled_state.create_account_checkpoint(
-            inputs.caller,
-            created_address,
-            inputs.value,
-            spec_id,
-        ) {
-            Ok(checkpoint) => checkpoint,
-            Err(e) => {
-                return return_error(e);
-            }
-        };
-
-        let bytecode = Bytecode::new_raw(inputs.init_code.clone());
-
-        let contract = Box::new(Contract::new(
-            Bytes::new(),
-            bytecode,
-            init_code_hash,
-            created_address,
-            inputs.caller,
-            inputs.value,
-        ));
-
-        Ok(FrameOrResult::new_create_frame(
-            created_address,
-            checkpoint,
-            Interpreter::new(contract, gas.limit(), false),
-        ))
-    }
-
-    /// Handles call return.
-    #[inline]
-    pub fn call_return(
-        &mut self,
-        interpreter_result: &InterpreterResult,
-        journal_checkpoint: JournalCheckpoint,
-    ) {
-        // revert changes or not.
-        if matches!(interpreter_result.result, return_ok!()) {
-            self.journaled_state.checkpoint_commit();
-        } else {
-            self.journaled_state.checkpoint_revert(journal_checkpoint);
-        }
-    }
-
-    /// Handles create return.
-    #[inline]
-    pub fn create_return<SPEC: Spec>(
-        &mut self,
-        interpreter_result: &mut InterpreterResult,
-        address: Address,
-        journal_checkpoint: JournalCheckpoint,
-    ) {
-        // if return is not ok revert and return.
-        if !matches!(interpreter_result.result, return_ok!()) {
-            self.journaled_state.checkpoint_revert(journal_checkpoint);
-            return;
-        }
-        // Host error if present on execution
-        // if ok, check contract creation limit and calculate gas deduction on output len.
-        //
-        // EIP-3541: Reject new contract code starting with the 0xEF byte
-        if SPEC::enabled(LONDON)
-            && !interpreter_result.output.is_empty()
-            && interpreter_result.output.first() == Some(&0xEF)
-        {
-            self.journaled_state.checkpoint_revert(journal_checkpoint);
-            interpreter_result.result = InstructionResult::CreateContractStartingWithEF;
-            return;
-        }
-
-        // EIP-170: Contract code size limit
-        // By default limit is 0x6000 (~25kb)
-        if SPEC::enabled(SPURIOUS_DRAGON)
-            && interpreter_result.output.len()
-                > self
-                    .env
-                    .cfg
-                    .limit_contract_code_size
-                    .unwrap_or(MAX_CODE_SIZE)
-        {
-            self.journaled_state.checkpoint_revert(journal_checkpoint);
-            interpreter_result.result = InstructionResult::CreateContractSizeLimit;
-            return;
-        }
-        let gas_for_code = interpreter_result.output.len() as u64 * gas::CODEDEPOSIT;
-        if !interpreter_result.gas.record_cost(gas_for_code) {
-            // record code deposit gas cost and check if we are out of gas.
-            // EIP-2 point 3: If contract creation does not have enough gas to pay for the
-            // final gas fee for adding the contract code to the state, the contract
-            //  creation fails (i.e. goes out-of-gas) rather than leaving an empty contract.
-            if SPEC::enabled(HOMESTEAD) {
-                self.journaled_state.checkpoint_revert(journal_checkpoint);
-                interpreter_result.result = InstructionResult::OutOfGas;
-                return;
+        if let Some(result) = self.call_precompile(inputs.contract, &inputs.input, gas) {
+            if matches!(result.result, return_ok!()) {
+                self.journaled_state.checkpoint_commit();
             } else {
-                interpreter_result.output = Bytes::new();
+                self.journaled_state.checkpoint_revert(checkpoint);
             }
+            Ok(FrameOrResult::new_call_result(
+                result,
+                inputs.return_memory_offset.clone(),
+            ))
+        } else if !bytecode.is_empty() {
+            let contract = Box::new(Contract::new_with_context(
+                inputs.input.clone(),
+                bytecode,
+                code_hash,
+                &inputs.context,
+            ));
+            // Create interpreter and executes call and push new CallStackFrame.
+            Ok(FrameOrResult::new_call_frame(
+                inputs.return_memory_offset.clone(),
+                checkpoint,
+                Interpreter::new(contract, gas.limit(), inputs.is_static),
+            ))
+        } else {
+            self.journaled_state.checkpoint_commit();
+            return_result(InstructionResult::Stop)
         }
-        // if we have enough gas we can commit changes.
-        self.journaled_state.checkpoint_commit();
+    }
+}
 
-        // Do analysis of bytecode straight away.
-        let bytecode = match self.env.cfg.perf_analyse_created_bytecodes {
-            AnalysisKind::Raw => Bytecode::new_raw(interpreter_result.output.clone()),
-            AnalysisKind::Check => {
-                Bytecode::new_raw(interpreter_result.output.clone()).to_checked()
-            }
-            AnalysisKind::Analyse => {
-                to_analysed(Bytecode::new_raw(interpreter_result.output.clone()))
-            }
+/// Test utilities for the [`EvmContext`].
+#[cfg(any(test, feature = "test-utils"))]
+pub(crate) mod test_utils {
+    use super::*;
+    use crate::{
+        db::{CacheDB, EmptyDB},
+        journaled_state::JournaledState,
+        primitives::{address, Address, Bytes, Env, HashSet, SpecId, B256, U256},
+        InnerEvmContext,
+    };
+    use std::boxed::Box;
+
+    /// Mock caller address.
+    pub const MOCK_CALLER: Address = address!("0000000000000000000000000000000000000000");
+
+    /// Creates `CallInputs` that calls a provided contract address from the mock caller.
+    pub fn create_mock_call_inputs(to: Address) -> CallInputs {
+        CallInputs {
+            contract: to,
+            transfer: revm_interpreter::Transfer {
+                source: MOCK_CALLER,
+                target: to,
+                value: U256::ZERO,
+            },
+            input: Bytes::new(),
+            gas_limit: 0,
+            context: revm_interpreter::CallContext {
+                address: MOCK_CALLER,
+                caller: MOCK_CALLER,
+                code_address: MOCK_CALLER,
+                apparent_value: U256::ZERO,
+                scheme: revm_interpreter::CallScheme::Call,
+            },
+            is_static: false,
+            return_memory_offset: 0..0,
+        }
+    }
+
+    /// Creates an evm context with a cache db backend.
+    /// Additionally loads the mock caller account into the db,
+    /// and sets the balance to the provided U256 value.
+    pub fn create_cache_db_evm_context_with_balance(
+        env: Box<Env>,
+        mut db: CacheDB<EmptyDB>,
+        balance: U256,
+    ) -> EvmContext<CacheDB<EmptyDB>> {
+        db.insert_account_info(
+            test_utils::MOCK_CALLER,
+            crate::primitives::AccountInfo {
+                nonce: 0,
+                balance,
+                code_hash: B256::default(),
+                code: None,
+            },
+        );
+        create_cache_db_evm_context(env, db)
+    }
+
+    /// Creates a cached db evm context.
+    pub fn create_cache_db_evm_context(
+        env: Box<Env>,
+        db: CacheDB<EmptyDB>,
+    ) -> EvmContext<CacheDB<EmptyDB>> {
+        EvmContext {
+            inner: InnerEvmContext {
+                env,
+                journaled_state: JournaledState::new(SpecId::CANCUN, HashSet::new()),
+                db,
+                error: Ok(()),
+                #[cfg(feature = "optimism")]
+                l1_block_info: None,
+            },
+            precompiles: ContextPrecompiles::default(),
+        }
+    }
+
+    /// Returns a new `EvmContext` with an empty journaled state.
+    pub fn create_empty_evm_context(env: Box<Env>, db: EmptyDB) -> EvmContext<EmptyDB> {
+        EvmContext {
+            inner: InnerEvmContext {
+                env,
+                journaled_state: JournaledState::new(SpecId::CANCUN, HashSet::new()),
+                db,
+                error: Ok(()),
+                #[cfg(feature = "optimism")]
+                l1_block_info: None,
+            },
+            precompiles: ContextPrecompiles::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_utils::*;
+
+    use crate::{
+        db::{CacheDB, EmptyDB},
+        interpreter::InstructionResult,
+        primitives::{address, Bytecode, Bytes, Env, U256},
+        Frame, FrameOrResult, JournalEntry,
+    };
+    use std::boxed::Box;
+
+    // Tests that the `EVMContext::make_call_frame` function returns an error if the
+    // call stack is too deep.
+    #[test]
+    fn test_make_call_frame_stack_too_deep() {
+        let env = Env::default();
+        let db = EmptyDB::default();
+        let mut context = test_utils::create_empty_evm_context(Box::new(env), db);
+        context.journaled_state.depth = CALL_STACK_LIMIT as usize + 1;
+        let contract = address!("dead10000000000000000000000000000001dead");
+        let call_inputs = test_utils::create_mock_call_inputs(contract);
+        let res = context.make_call_frame(&call_inputs);
+        let Ok(FrameOrResult::Result(err)) = res else {
+            panic!("Expected FrameOrResult::Result");
         };
+        assert_eq!(
+            err.interpreter_result().result,
+            InstructionResult::CallTooDeep
+        );
+    }
 
-        // set code
-        self.journaled_state.set_code(address, bytecode);
+    // Tests that the `EVMContext::make_call_frame` function returns an error if the
+    // transfer fails on the journaled state. It also verifies that the revert was
+    // checkpointed on the journaled state correctly.
+    #[test]
+    fn test_make_call_frame_transfer_revert() {
+        let env = Env::default();
+        let db = EmptyDB::default();
+        let mut evm_context = test_utils::create_empty_evm_context(Box::new(env), db);
+        let contract = address!("dead10000000000000000000000000000001dead");
+        let mut call_inputs = test_utils::create_mock_call_inputs(contract);
+        call_inputs.transfer.value = U256::from(1);
+        let res = evm_context.make_call_frame(&call_inputs);
+        let Ok(FrameOrResult::Result(result)) = res else {
+            panic!("Expected FrameOrResult::Result");
+        };
+        assert_eq!(
+            result.interpreter_result().result,
+            InstructionResult::OutOfFunds
+        );
+        let checkpointed = vec![vec![JournalEntry::AccountLoaded { address: contract }]];
+        assert_eq!(evm_context.journaled_state.journal, checkpointed);
+        assert_eq!(evm_context.journaled_state.depth, 0);
+    }
 
-        interpreter_result.result = InstructionResult::Return;
+    #[test]
+    fn test_make_call_frame_missing_code_context() {
+        let env = Env::default();
+        let cdb = CacheDB::new(EmptyDB::default());
+        let bal = U256::from(3_000_000_000_u128);
+        let mut context = create_cache_db_evm_context_with_balance(Box::new(env), cdb, bal);
+        let contract = address!("dead10000000000000000000000000000001dead");
+        let call_inputs = test_utils::create_mock_call_inputs(contract);
+        let res = context.make_call_frame(&call_inputs);
+        let Ok(FrameOrResult::Result(result)) = res else {
+            panic!("Expected FrameOrResult::Result");
+        };
+        assert_eq!(result.interpreter_result().result, InstructionResult::Stop);
+    }
+
+    #[test]
+    fn test_make_call_frame_succeeds() {
+        let env = Env::default();
+        let mut cdb = CacheDB::new(EmptyDB::default());
+        let bal = U256::from(3_000_000_000_u128);
+        let by = Bytecode::new_raw(Bytes::from(vec![0x60, 0x00, 0x60, 0x00]));
+        let contract = address!("dead10000000000000000000000000000001dead");
+        cdb.insert_account_info(
+            contract,
+            crate::primitives::AccountInfo {
+                nonce: 0,
+                balance: bal,
+                code_hash: by.clone().hash_slow(),
+                code: Some(by),
+            },
+        );
+        let mut evm_context = create_cache_db_evm_context_with_balance(Box::new(env), cdb, bal);
+        let call_inputs = test_utils::create_mock_call_inputs(contract);
+        let res = evm_context.make_call_frame(&call_inputs);
+        let Ok(FrameOrResult::Frame(Frame::Call(call_frame))) = res else {
+            panic!("Expected FrameOrResult::Frame(Frame::Call(..))");
+        };
+        assert_eq!(call_frame.return_memory_range, 0..0,);
     }
 }

--- a/crates/revm/src/context/inner_evm_context.rs
+++ b/crates/revm/src/context/inner_evm_context.rs
@@ -1,0 +1,396 @@
+use crate::{
+    db::Database,
+    interpreter::{
+        analysis::to_analysed, gas, return_ok, Contract, CreateInputs, Gas, InstructionResult,
+        Interpreter, InterpreterResult, MAX_CODE_SIZE,
+    },
+    journaled_state::JournaledState,
+    primitives::{
+        keccak256, Account, Address, AnalysisKind, Bytecode, Bytes, CreateScheme, EVMError, Env,
+        HashSet, Spec,
+        SpecId::{self, *},
+        B256, U256,
+    },
+    FrameOrResult, JournalCheckpoint, CALL_STACK_LIMIT,
+};
+use revm_interpreter::{SStoreResult, SelfDestructResult};
+use std::boxed::Box;
+
+/// EVM contexts contains data that EVM needs for execution.
+#[derive(Debug)]
+pub struct InnerEvmContext<DB: Database> {
+    /// EVM Environment contains all the information about config, block and transaction that
+    /// evm needs.
+    pub env: Box<Env>,
+    /// EVM State with journaling support.
+    pub journaled_state: JournaledState,
+    /// Database to load data from.
+    pub db: DB,
+    /// Error that happened during execution.
+    pub error: Result<(), EVMError<DB::Error>>,
+    /// Used as temporary value holder to store L1 block info.
+    #[cfg(feature = "optimism")]
+    pub l1_block_info: Option<crate::optimism::L1BlockInfo>,
+}
+
+impl<DB: Database + Clone> Clone for InnerEvmContext<DB>
+where
+    DB::Error: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            env: self.env.clone(),
+            journaled_state: self.journaled_state.clone(),
+            db: self.db.clone(),
+            error: self.error.clone(),
+            #[cfg(feature = "optimism")]
+            l1_block_info: self.l1_block_info.clone(),
+        }
+    }
+}
+
+impl<DB: Database> InnerEvmContext<DB> {
+    pub fn new(db: DB) -> Self {
+        Self {
+            env: Box::default(),
+            journaled_state: JournaledState::new(SpecId::LATEST, HashSet::new()),
+            db,
+            error: Ok(()),
+            #[cfg(feature = "optimism")]
+            l1_block_info: None,
+        }
+    }
+
+    /// Creates a new context with the given environment and database.
+    #[inline]
+    pub fn new_with_env(db: DB, env: Box<Env>) -> Self {
+        Self {
+            env,
+            journaled_state: JournaledState::new(SpecId::LATEST, HashSet::new()),
+            db,
+            error: Ok(()),
+            #[cfg(feature = "optimism")]
+            l1_block_info: None,
+        }
+    }
+
+    /// Sets the database.
+    ///
+    /// Note that this will ignore the previous `error` if set.
+    #[inline]
+    pub fn with_db<ODB: Database>(self, db: ODB) -> InnerEvmContext<ODB> {
+        InnerEvmContext {
+            env: self.env,
+            journaled_state: self.journaled_state,
+            db,
+            error: Ok(()),
+            #[cfg(feature = "optimism")]
+            l1_block_info: self.l1_block_info,
+        }
+    }
+
+    /// Returns the configured EVM spec ID.
+    #[inline]
+    pub const fn spec_id(&self) -> SpecId {
+        self.journaled_state.spec
+    }
+
+    /// Load access list for berlin hard fork.
+    ///
+    /// Loading of accounts/storages is needed to make them warm.
+    #[inline]
+    pub fn load_access_list(&mut self) -> Result<(), EVMError<DB::Error>> {
+        for (address, slots) in self.env.tx.access_list.iter() {
+            self.journaled_state
+                .initial_account_load(*address, slots, &mut self.db)?;
+        }
+        Ok(())
+    }
+
+    /// Return environment.
+    #[inline]
+    pub fn env(&mut self) -> &mut Env {
+        &mut self.env
+    }
+
+    /// Fetch block hash from database.
+    #[inline]
+    pub fn block_hash(&mut self, number: U256) -> Result<B256, EVMError<DB::Error>> {
+        self.db.block_hash(number).map_err(EVMError::Database)
+    }
+
+    /// Mark account as touched as only touched accounts will be added to state.
+    #[inline]
+    pub fn touch(&mut self, address: &Address) {
+        self.journaled_state.touch(address);
+    }
+
+    /// Loads an account into memory. Returns `true` if it is cold accessed.
+    #[inline]
+    pub fn load_account(
+        &mut self,
+        address: Address,
+    ) -> Result<(&mut Account, bool), EVMError<DB::Error>> {
+        self.journaled_state.load_account(address, &mut self.db)
+    }
+
+    /// Load account from database to JournaledState.
+    ///
+    /// Return boolean pair where first is `is_cold` second bool `exists`.
+    #[inline]
+    pub fn load_account_exist(
+        &mut self,
+        address: Address,
+    ) -> Result<(bool, bool), EVMError<DB::Error>> {
+        self.journaled_state
+            .load_account_exist(address, &mut self.db)
+    }
+
+    /// Return account balance and is_cold flag.
+    #[inline]
+    pub fn balance(&mut self, address: Address) -> Result<(U256, bool), EVMError<DB::Error>> {
+        self.journaled_state
+            .load_account(address, &mut self.db)
+            .map(|(acc, is_cold)| (acc.info.balance, is_cold))
+    }
+
+    /// Return account code and if address is cold loaded.
+    #[inline]
+    pub fn code(&mut self, address: Address) -> Result<(Bytecode, bool), EVMError<DB::Error>> {
+        self.journaled_state
+            .load_code(address, &mut self.db)
+            .map(|(a, is_cold)| (a.info.code.clone().unwrap(), is_cold))
+    }
+
+    /// Get code hash of address.
+    #[inline]
+    pub fn code_hash(&mut self, address: Address) -> Result<(B256, bool), EVMError<DB::Error>> {
+        let (acc, is_cold) = self.journaled_state.load_code(address, &mut self.db)?;
+        if acc.is_empty() {
+            return Ok((B256::ZERO, is_cold));
+        }
+        Ok((acc.info.code_hash, is_cold))
+    }
+
+    /// Load storage slot, if storage is not present inside the account then it will be loaded from database.
+    #[inline]
+    pub fn sload(
+        &mut self,
+        address: Address,
+        index: U256,
+    ) -> Result<(U256, bool), EVMError<DB::Error>> {
+        // account is always warm. reference on that statement https://eips.ethereum.org/EIPS/eip-2929 see `Note 2:`
+        self.journaled_state.sload(address, index, &mut self.db)
+    }
+
+    /// Storage change of storage slot, before storing `sload` will be called for that slot.
+    #[inline]
+    pub fn sstore(
+        &mut self,
+        address: Address,
+        index: U256,
+        value: U256,
+    ) -> Result<SStoreResult, EVMError<DB::Error>> {
+        self.journaled_state
+            .sstore(address, index, value, &mut self.db)
+    }
+
+    /// Returns transient storage value.
+    #[inline]
+    pub fn tload(&mut self, address: Address, index: U256) -> U256 {
+        self.journaled_state.tload(address, index)
+    }
+
+    /// Stores transient storage value.
+    #[inline]
+    pub fn tstore(&mut self, address: Address, index: U256, value: U256) {
+        self.journaled_state.tstore(address, index, value)
+    }
+
+    /// Selfdestructs the account.
+    #[inline]
+    pub fn selfdestruct(
+        &mut self,
+        address: Address,
+        target: Address,
+    ) -> Result<SelfDestructResult, EVMError<DB::Error>> {
+        self.journaled_state
+            .selfdestruct(address, target, &mut self.db)
+    }
+
+    /// Make create frame.
+    #[inline]
+    pub fn make_create_frame(
+        &mut self,
+        spec_id: SpecId,
+        inputs: &CreateInputs,
+    ) -> Result<FrameOrResult, EVMError<DB::Error>> {
+        // Prepare crate.
+        let gas = Gas::new(inputs.gas_limit);
+
+        let return_error = |e| {
+            Ok(FrameOrResult::new_create_result(
+                InterpreterResult {
+                    result: e,
+                    gas,
+                    output: Bytes::new(),
+                },
+                None,
+            ))
+        };
+
+        // Check depth
+        if self.journaled_state.depth() > CALL_STACK_LIMIT {
+            return return_error(InstructionResult::CallTooDeep);
+        }
+
+        // Fetch balance of caller.
+        let (caller_balance, _) = self.balance(inputs.caller)?;
+
+        // Check if caller has enough balance to send to the created contract.
+        if caller_balance < inputs.value {
+            return return_error(InstructionResult::OutOfFunds);
+        }
+
+        // Increase nonce of caller and check if it overflows
+        let old_nonce;
+        if let Some(nonce) = self.journaled_state.inc_nonce(inputs.caller) {
+            old_nonce = nonce - 1;
+        } else {
+            return return_error(InstructionResult::Return);
+        }
+
+        // Create address
+        let mut init_code_hash = B256::ZERO;
+        let created_address = match inputs.scheme {
+            CreateScheme::Create => inputs.caller.create(old_nonce),
+            CreateScheme::Create2 { salt } => {
+                init_code_hash = keccak256(&inputs.init_code);
+                inputs.caller.create2(salt.to_be_bytes(), init_code_hash)
+            }
+        };
+
+        // Load account so it needs to be marked as warm for access list.
+        self.journaled_state
+            .load_account(created_address, &mut self.db)?;
+
+        // create account, transfer funds and make the journal checkpoint.
+        let checkpoint = match self.journaled_state.create_account_checkpoint(
+            inputs.caller,
+            created_address,
+            inputs.value,
+            spec_id,
+        ) {
+            Ok(checkpoint) => checkpoint,
+            Err(e) => {
+                return return_error(e);
+            }
+        };
+
+        let bytecode = Bytecode::new_raw(inputs.init_code.clone());
+
+        let contract = Box::new(Contract::new(
+            Bytes::new(),
+            bytecode,
+            init_code_hash,
+            created_address,
+            inputs.caller,
+            inputs.value,
+        ));
+
+        Ok(FrameOrResult::new_create_frame(
+            created_address,
+            checkpoint,
+            Interpreter::new(contract, gas.limit(), false),
+        ))
+    }
+
+    /// Handles call return.
+    #[inline]
+    pub fn call_return(
+        &mut self,
+        interpreter_result: &InterpreterResult,
+        journal_checkpoint: JournalCheckpoint,
+    ) {
+        // revert changes or not.
+        if matches!(interpreter_result.result, return_ok!()) {
+            self.journaled_state.checkpoint_commit();
+        } else {
+            self.journaled_state.checkpoint_revert(journal_checkpoint);
+        }
+    }
+
+    /// Handles create return.
+    #[inline]
+    pub fn create_return<SPEC: Spec>(
+        &mut self,
+        interpreter_result: &mut InterpreterResult,
+        address: Address,
+        journal_checkpoint: JournalCheckpoint,
+    ) {
+        // if return is not ok revert and return.
+        if !matches!(interpreter_result.result, return_ok!()) {
+            self.journaled_state.checkpoint_revert(journal_checkpoint);
+            return;
+        }
+        // Host error if present on execution
+        // if ok, check contract creation limit and calculate gas deduction on output len.
+        //
+        // EIP-3541: Reject new contract code starting with the 0xEF byte
+        if SPEC::enabled(LONDON)
+            && !interpreter_result.output.is_empty()
+            && interpreter_result.output.first() == Some(&0xEF)
+        {
+            self.journaled_state.checkpoint_revert(journal_checkpoint);
+            interpreter_result.result = InstructionResult::CreateContractStartingWithEF;
+            return;
+        }
+
+        // EIP-170: Contract code size limit
+        // By default limit is 0x6000 (~25kb)
+        if SPEC::enabled(SPURIOUS_DRAGON)
+            && interpreter_result.output.len()
+                > self
+                    .env
+                    .cfg
+                    .limit_contract_code_size
+                    .unwrap_or(MAX_CODE_SIZE)
+        {
+            self.journaled_state.checkpoint_revert(journal_checkpoint);
+            interpreter_result.result = InstructionResult::CreateContractSizeLimit;
+            return;
+        }
+        let gas_for_code = interpreter_result.output.len() as u64 * gas::CODEDEPOSIT;
+        if !interpreter_result.gas.record_cost(gas_for_code) {
+            // record code deposit gas cost and check if we are out of gas.
+            // EIP-2 point 3: If contract creation does not have enough gas to pay for the
+            // final gas fee for adding the contract code to the state, the contract
+            //  creation fails (i.e. goes out-of-gas) rather than leaving an empty contract.
+            if SPEC::enabled(HOMESTEAD) {
+                self.journaled_state.checkpoint_revert(journal_checkpoint);
+                interpreter_result.result = InstructionResult::OutOfGas;
+                return;
+            } else {
+                interpreter_result.output = Bytes::new();
+            }
+        }
+        // if we have enough gas we can commit changes.
+        self.journaled_state.checkpoint_commit();
+
+        // Do analysis of bytecode straight away.
+        let bytecode = match self.env.cfg.perf_analyse_created_bytecodes {
+            AnalysisKind::Raw => Bytecode::new_raw(interpreter_result.output.clone()),
+            AnalysisKind::Check => {
+                Bytecode::new_raw(interpreter_result.output.clone()).to_checked()
+            }
+            AnalysisKind::Analyse => {
+                to_analysed(Bytecode::new_raw(interpreter_result.output.clone()))
+            }
+        };
+
+        // set code
+        self.journaled_state.set_code(address, bytecode);
+
+        interpreter_result.result = InstructionResult::Return;
+    }
+}

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -338,7 +338,7 @@ impl<EXT, DB: Database> Evm<'_, EXT, DB> {
 
         // load precompiles
         let precompiles = pre_exec.load_precompiles();
-        ctx.set_precompiles(precompiles);
+        ctx.evm.set_precompiles(precompiles);
 
         // deduce caller balance with its limit.
         pre_exec.deduct_caller(ctx)?;

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -198,9 +198,9 @@ impl<EXT, DB: Database> Evm<'_, EXT, DB> {
     #[inline]
     pub fn into_db_and_env_with_handler_cfg(self) -> (DB, EnvWithHandlerCfg) {
         (
-            self.context.evm.db,
+            self.context.evm.inner.db,
             EnvWithHandlerCfg {
-                env: self.context.evm.env,
+                env: self.context.evm.inner.env,
                 handler_cfg: self.handler.cfg,
             },
         )
@@ -460,8 +460,9 @@ impl<EXT, DB: Database> Host for Evm<'_, EXT, DB> {
     fn selfdestruct(&mut self, address: Address, target: Address) -> Option<SelfDestructResult> {
         self.context
             .evm
+            .inner
             .journaled_state
-            .selfdestruct(address, target, &mut self.context.evm.db)
+            .selfdestruct(address, target, &mut self.context.evm.inner.db)
             .map_err(|e| self.context.evm.error = Err(e))
             .ok()
     }

--- a/crates/revm/src/handler/handle_types/pre_execution.rs
+++ b/crates/revm/src/handler/handle_types/pre_execution.rs
@@ -7,7 +7,7 @@ use crate::{
 use std::sync::Arc;
 
 /// Loads precompiles into Evm
-pub type LoadPrecompilesHandle<'a, EXT, DB> = Arc<dyn Fn() -> ContextPrecompiles<DB, EXT> + 'a>;
+pub type LoadPrecompilesHandle<'a, DB> = Arc<dyn Fn() -> ContextPrecompiles<DB> + 'a>;
 
 /// Load access list accounts and beneficiary.
 /// There is no need to load Caller as it is assumed that
@@ -22,7 +22,7 @@ pub type DeductCallerHandle<'a, EXT, DB> =
 /// Handles related to pre execution before the stack loop is started.
 pub struct PreExecutionHandler<'a, EXT, DB: Database> {
     /// Load precompiles
-    pub load_precompiles: LoadPrecompilesHandle<'a, EXT, DB>,
+    pub load_precompiles: LoadPrecompilesHandle<'a, DB>,
     /// Main load handle
     pub load_accounts: LoadAccountsHandle<'a, EXT, DB>,
     /// Deduct max value from the caller.
@@ -33,7 +33,7 @@ impl<'a, EXT: 'a, DB: Database + 'a> PreExecutionHandler<'a, EXT, DB> {
     /// Creates mainnet MainHandles.
     pub fn new<SPEC: Spec + 'a>() -> Self {
         Self {
-            load_precompiles: Arc::new(mainnet::load_precompiles::<SPEC, EXT, DB>),
+            load_precompiles: Arc::new(mainnet::load_precompiles::<SPEC, DB>),
             load_accounts: Arc::new(mainnet::load_accounts::<SPEC, EXT, DB>),
             deduct_caller: Arc::new(mainnet::deduct_caller::<SPEC, EXT, DB>),
         }
@@ -52,7 +52,7 @@ impl<'a, EXT, DB: Database> PreExecutionHandler<'a, EXT, DB> {
     }
 
     /// Load precompiles
-    pub fn load_precompiles(&self) -> ContextPrecompiles<DB, EXT> {
+    pub fn load_precompiles(&self) -> ContextPrecompiles<DB> {
         (self.load_precompiles)()
     }
 }

--- a/crates/revm/src/handler/mainnet/execution.rs
+++ b/crates/revm/src/handler/mainnet/execution.rs
@@ -64,7 +64,7 @@ pub fn call<SPEC: Spec, EXT, DB: Database>(
     context: &mut Context<EXT, DB>,
     inputs: Box<CallInputs>,
 ) -> Result<FrameOrResult, EVMError<DB::Error>> {
-    context.make_call_frame(&inputs)
+    context.evm.make_call_frame(&inputs)
 }
 
 #[inline]

--- a/crates/revm/src/handler/mainnet/post_execution.rs
+++ b/crates/revm/src/handler/mainnet/post_execution.rs
@@ -33,7 +33,8 @@ pub fn reward_beneficiary<SPEC: Spec, EXT, DB: Database>(
     };
 
     let (coinbase_account, _) = context
-        .evm.inner
+        .evm
+        .inner
         .journaled_state
         .load_account(beneficiary, &mut context.evm.inner.db)?;
 

--- a/crates/revm/src/handler/mainnet/post_execution.rs
+++ b/crates/revm/src/handler/mainnet/post_execution.rs
@@ -33,9 +33,9 @@ pub fn reward_beneficiary<SPEC: Spec, EXT, DB: Database>(
     };
 
     let (coinbase_account, _) = context
-        .evm
+        .evm.inner
         .journaled_state
-        .load_account(beneficiary, &mut context.evm.db)?;
+        .load_account(beneficiary, &mut context.evm.inner.db)?;
 
     coinbase_account.mark_touch();
     coinbase_account.info.balance = coinbase_account
@@ -57,8 +57,9 @@ pub fn reimburse_caller<SPEC: Spec, EXT, DB: Database>(
     // return balance of not spend gas.
     let (caller_account, _) = context
         .evm
+        .inner
         .journaled_state
-        .load_account(caller, &mut context.evm.db)?;
+        .load_account(caller, &mut context.evm.inner.db)?;
 
     caller_account.info.balance = caller_account
         .info

--- a/crates/revm/src/handler/mainnet/pre_execution.rs
+++ b/crates/revm/src/handler/mainnet/pre_execution.rs
@@ -15,7 +15,7 @@ use crate::{
 
 /// Main precompile load
 #[inline]
-pub fn load_precompiles<SPEC: Spec, EXT, DB: Database>() -> ContextPrecompiles<DB, EXT> {
+pub fn load_precompiles<SPEC: Spec, DB: Database>() -> ContextPrecompiles<DB> {
     Precompiles::new(PrecompileSpecId::from_spec_id(SPEC::SPEC_ID))
         .clone()
         .into()
@@ -32,10 +32,10 @@ pub fn load_accounts<SPEC: Spec, EXT, DB: Database>(
     // load coinbase
     // EIP-3651: Warm COINBASE. Starts the `COINBASE` address warm
     if SPEC::enabled(SHANGHAI) {
-        context.evm.journaled_state.initial_account_load(
-            context.evm.env.block.coinbase,
+        context.evm.inner.journaled_state.initial_account_load(
+            context.evm.inner.env.block.coinbase,
             &[],
-            &mut context.evm.db,
+            &mut context.evm.inner.db,
         )?;
     }
 
@@ -77,11 +77,12 @@ pub fn deduct_caller<SPEC: Spec, EXT, DB: Database>(
     // load caller's account.
     let (caller_account, _) = context
         .evm
+        .inner
         .journaled_state
-        .load_account(context.evm.env.tx.caller, &mut context.evm.db)?;
+        .load_account(context.evm.inner.env.tx.caller, &mut context.evm.inner.db)?;
 
     // deduct gas cost from caller's account.
-    deduct_caller_inner::<SPEC>(caller_account, &context.evm.env);
+    deduct_caller_inner::<SPEC>(caller_account, &context.evm.inner.env);
 
     Ok(())
 }

--- a/crates/revm/src/handler/mainnet/validation.rs
+++ b/crates/revm/src/handler/mainnet/validation.rs
@@ -21,11 +21,13 @@ pub fn validate_tx_against_state<SPEC: Spec, EXT, DB: Database>(
     let tx_caller = context.evm.env.tx.caller;
     let (caller_account, _) = context
         .evm
+        .inner
         .journaled_state
-        .load_account(tx_caller, &mut context.evm.db)?;
+        .load_account(tx_caller, &mut context.evm.inner.db)?;
 
     context
         .evm
+        .inner
         .env
         .validate_tx_against_state::<SPEC>(caller_account)
         .map_err(EVMError::Transaction)?;

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -32,7 +32,7 @@ pub use builder::EvmBuilder;
 pub use context::{
     Context, ContextPrecompile, ContextPrecompiles, ContextStatefulPrecompile,
     ContextStatefulPrecompileArc, ContextStatefulPrecompileBox, ContextStatefulPrecompileMut,
-    ContextWithHandlerCfg, EvmContext,
+    ContextWithHandlerCfg, EvmContext, InnerEvmContext,
 };
 pub use db::{
     CacheState, DBBox, State, StateBuilder, StateDBBox, TransitionAccount, TransitionState,

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -13,7 +13,6 @@ extern crate alloc as std;
 
 mod builder;
 mod context;
-mod context_precompiles;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
@@ -30,10 +29,10 @@ pub mod optimism;
 // Export items.
 
 pub use builder::EvmBuilder;
-pub use context::{Context, ContextWithHandlerCfg, EvmContext};
-pub use context_precompiles::{
-    ContextPrecompile, ContextPrecompiles, ContextStatefulPrecompile, ContextStatefulPrecompileArc,
-    ContextStatefulPrecompileBox, ContextStatefulPrecompileMut,
+pub use context::{
+    Context, ContextPrecompile, ContextPrecompiles, ContextStatefulPrecompile,
+    ContextStatefulPrecompileArc, ContextStatefulPrecompileBox, ContextStatefulPrecompileMut,
+    ContextWithHandlerCfg, EvmContext,
 };
 pub use db::{
     CacheState, DBBox, State, StateBuilder, StateDBBox, TransitionAccount, TransitionState,

--- a/crates/revm/src/test_utils.rs
+++ b/crates/revm/src/test_utils.rs
@@ -1,2 +1,2 @@
 #[doc(hidden)]
-pub use crate::context::test_utils::*;
+pub use crate::context::evm_context::test_utils::*;

--- a/examples/db_by_ref.rs
+++ b/examples/db_by_ref.rs
@@ -32,7 +32,7 @@ fn run_transaction<EXT, DB: DatabaseRefDebugError>(
         .build();
 
     let result = evm.transact()?;
-    Ok((result, evm.into_context().evm.db.0))
+    Ok((result, evm.into_context().evm.inner.db.0))
 }
 
 fn run_transaction_and_commit_with_ext<EXT, DB: DatabaseRefDebugError + DatabaseCommit>(


### PR DESCRIPTION
Making context precompiles take full context (External and Evm) would make a problem in Inspector

On main we have moved Precompiles from EvmContext and Inspector would not have access to it, this would break foundry and other tracers.

This PR make Context precompile access only EvmContext and makes no changes to Inspector.

 EvmContext is now:
 ```
 pub struct EvmContext<DB: Database> {
    pub inner: InnerEvmContext<DB>,
    /// Precompiles that are available for evm.
    pub precompiles: ContextPrecompiles<DB>,
}
```
and it implemented `Deref` and `DerefMut` on `inner`