### PR TITLE
chore: tag v32 revm v7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
 
+# v32 tag
+date: 08.03.2024
+
+Extends v7.0.0 with more restrictive context precompile.
+
+revm: 7.0.0(yanked) -> 7.1.0 (⚠️ API breaking changes)
+revm-interpreter: 3.2.0 -> 3.3.0 (✓ API compatible changes)
+
 # v31 tag
 date 08.03.2024
 
 Stateful and context aware precompiles types added. Few improvements and fixes.
 
 revme: 0.2.2 -> 0.3.0 (⚠️ API breaking changes)
-revm: 6.1.0 -> 7.0.0 (⚠️ API breaking changes)
+revm: 6.1.0 -> 7.0.0(yanked) (⚠️ API breaking changes)
 revm-interpreter: 3.1.0 -> 3.2.0 (✓ API compatible changes)
 revm-primitives: 2.1.0 -> 3.0.0 (⚠️ API breaking changes)
 revm-precompile: 4.1.0 -> 5.0.0 (⚠️ API breaking changes)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2321,7 +2321,7 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "7.0.0"
+version = "7.1.0"
 dependencies = [
  "anyhow",
  "auto_impl",
@@ -2341,7 +2341,7 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "revm-primitives",
  "serde",

--- a/bins/revm-test/Cargo.toml
+++ b/bins/revm-test/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 bytes = "1.4"
 hex = "0.4"
-revm = { path = "../../crates/revm", version = "7.0.0",default-features=false }
+revm = { path = "../../crates/revm", version = "7.1.0",default-features=false }
 microbench = "0.5"
 alloy-sol-macro = "0.6.4"
 alloy-sol-types = "0.6.4"

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -15,7 +15,7 @@ hashbrown = "0.14"
 indicatif = "0.17"
 microbench = "0.5"
 plain_hasher = "0.2"
-revm = { path = "../../crates/revm", version = "7.0.0", default-features = false, features = [
+revm = { path = "../../crates/revm", version = "7.1.0", default-features = false, features = [
     "ethersdb",
     "std",
     "serde-json",

--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.0](https://github.com/bluealloy/revm/compare/revm-interpreter-v3.2.0...revm-interpreter-v3.3.0) - 2024-03-08
+
+### Added
+- *(interpreter)* OpCode struct constants ([#1173](https://github.com/bluealloy/revm/pull/1173))
+
+
 ## [3.2.0](https://github.com/bluealloy/revm/compare/revm-interpreter-v3.1.0...revm-interpreter-v3.2.0) - 2024-03-08
 
 ### Added

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["no_std", "ethereum", "evm", "revm", "interpreter"]
 license = "MIT"
 name = "revm-interpreter"
 repository = "https://github.com/bluealloy/revm"
-version = "3.2.0"
+version = "3.3.0"
 readme = "../../README.md"
 
 [package.metadata.docs.rs]

--- a/crates/revm/CHANGELOG.md
+++ b/crates/revm/CHANGELOG.md
@@ -6,7 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.1.0](https://github.com/bluealloy/revm/compare/revm-v7.0.0...revm-v8.0.0) - 2024-03-08
+
+### Added
+- Restrict ContextPrecompiles only to EvmContext ([#1174](https://github.com/bluealloy/revm/pull/1174))
+
 ## [7.0.0](https://github.com/bluealloy/revm/compare/revm-v6.1.0...revm-v7.0.0) - 2024-03-08
+
+This release got yanked and replaced with 7.1.0
 
 ### Added
 - add insert method on instruction table ([#1167](https://github.com/bluealloy/revm/pull/1167))

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["no_std", "ethereum", "evm", "revm"]
 license = "MIT"
 name = "revm"
 repository = "https://github.com/bluealloy/revm"
-version = "7.0.0"
+version = "7.1.0"
 readme = "../../README.md"
 
 [package.metadata.docs.rs]
@@ -15,7 +15,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 # revm
-revm-interpreter = { path = "../interpreter", version = "3.2.0", default-features = false }
+revm-interpreter = { path = "../interpreter", version = "3.3.0", default-features = false }
 revm-precompile = { path = "../precompile", version = "5.0.0", default-features = false }
 
 # misc


### PR DESCRIPTION
revm v7.0.0 got yanked and replaced with v7.1.0

PR that got included is https://github.com/bluealloy/revm/pull/1174

one more small PR got through in Interpreter, not related to this situation.