### PR TITLE
fix: use std hashmap with "std" feature

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -30,7 +30,7 @@ pub use constants::*;
 pub use env::*;
 
 cfg_if::cfg_if! {
-    if #[cfg(std)] {
+    if #[cfg(feature = "std")] {
         pub use std::collections::{hash_map, hash_set, HashMap, HashSet};
         use hashbrown as _;
     } else {


### PR DESCRIPTION
Also caught by `-Zcheck-cfg`:
```rust
warning: unexpected `cfg` condition name: `std`
  --> crates/primitives/src/lib.rs:34:14
   |
34 |     if #[cfg(std)] {
   |              ^^^ help: found config with similar value: `feature = "std"`
   |
   = help: expected names are: `clippy`, `debug_assertions`, `doc`, `docsrs`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
   = help: consider using a Cargo feature instead or adding `println!("cargo:rustc-check-cfg=cfg(std)");` to the top of a `build.rs`
   = note: see <https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#check-cfg> for more information about checking conditional configuration
   = note: `#[warn(unexpected_cfgs)]` on by default
```