### PR TITLE
feat: add convert_boxed and insert_boxed for InstructionTable

### DIFF
--- a/crates/interpreter/src/instructions/opcode.rs
+++ b/crates/interpreter/src/instructions/opcode.rs
@@ -81,12 +81,10 @@ impl<'a, H: Host + 'a> InstructionTables<'a, H> {
     pub fn convert_boxed(&mut self) {
         match self {
             Self::Plain(table) => {
-                let boxed_table = Self::Boxed(core::array::from_fn(|i| {
+                *self = Self::Boxed(core::array::from_fn(|i| {
                     let instruction: BoxedInstruction<'a, H> = Box::new(table[i]);
                     instruction
                 }));
-
-                *self = boxed_table;
             }
             Self::Boxed(_) => {}
         };

--- a/crates/interpreter/src/instructions/opcode.rs
+++ b/crates/interpreter/src/instructions/opcode.rs
@@ -90,7 +90,6 @@ impl<'a, H: Host + 'a> InstructionTables<'a, H> {
         };
     }
 }
-}
 
 /// Make instruction table.
 #[inline]

--- a/crates/interpreter/src/instructions/opcode.rs
+++ b/crates/interpreter/src/instructions/opcode.rs
@@ -7,6 +7,7 @@ use crate::{
     Host, Interpreter,
 };
 use core::fmt;
+use std::boxed::Box;
 
 /// EVM opcode function signature.
 pub type Instruction<H> = fn(&mut Interpreter, &mut H);

--- a/crates/interpreter/src/instructions/opcode.rs
+++ b/crates/interpreter/src/instructions/opcode.rs
@@ -90,12 +90,6 @@ impl<'a, H: Host + 'a> InstructionTables<'a, H> {
         };
     }
 }
-
-/// An error that can occur when trying to insert instructions into the instruction table.
-#[derive(Debug)]
-pub enum InsertError {
-    /// Tried to insert a boxed instruction into an instruction table which was not boxed.
-    NotBoxed,
 }
 
 /// Make instruction table.

--- a/crates/interpreter/src/instructions/opcode.rs
+++ b/crates/interpreter/src/instructions/opcode.rs
@@ -44,7 +44,8 @@ impl<H: Host> InstructionTables<'_, H> {
 impl<'a, H: Host + 'a> InstructionTables<'a, H> {
     /// Inserts a boxed instruction into the table with the specified index.
     ///
-    /// Returns an error if the table is not boxed.
+    /// This will convert the table into the [BoxedInstructionTable] variant if it is currently a
+    /// plain instruction table, before inserting the instruction.
     #[inline]
     pub fn insert_boxed(&mut self, opcode: u8, instruction: BoxedInstruction<'a, H>) {
         // first convert the table to boxed variant

--- a/crates/revm/src/builder.rs
+++ b/crates/revm/src/builder.rs
@@ -7,6 +7,7 @@ use crate::{
     Context, ContextWithHandlerCfg, Evm, Handler,
 };
 use core::marker::PhantomData;
+use std::boxed::Box;
 
 /// Evm Builder allows building or modifying EVM.
 /// Note that some of the methods that changes underlying structures

--- a/crates/revm/src/builder.rs
+++ b/crates/revm/src/builder.rs
@@ -7,7 +7,6 @@ use crate::{
     Context, ContextWithHandlerCfg, Evm, Handler,
 };
 use core::marker::PhantomData;
-use std::boxed::Box;
 
 /// Evm Builder allows building or modifying EVM.
 /// Note that some of the methods that changes underlying structures
@@ -448,8 +447,59 @@ mod test {
         },
         Context, ContextPrecompile, ContextStatefulPrecompile, Evm, InMemoryDB, InnerEvmContext,
     };
-    use revm_interpreter::{Host, Interpreter};
-    use std::sync::Arc;
+    use revm_interpreter::{opcode::InstructionTables, Host, Interpreter};
+    use std::{cell::RefCell, rc::Rc, sync::Arc};
+
+    /// Custom evm context
+    #[derive(Default, Clone, Debug)]
+    pub(crate) struct CustomContext {
+        pub(crate) inner: Rc<RefCell<u8>>,
+    }
+
+    #[test]
+    fn simple_add_stateful_instruction() {
+        let code = Bytecode::new_raw([0xEF, 0x00].into());
+        let code_hash = code.hash_slow();
+        let to_addr = address!("ffffffffffffffffffffffffffffffffffffffff");
+
+        // initialize the custom context and make sure it's zero
+        let custom_context = CustomContext::default();
+        assert_eq!(*custom_context.inner.borrow(), 0);
+
+        let mut evm = Evm::builder()
+            .with_db(InMemoryDB::default())
+            .modify_db(|db| {
+                db.insert_account_info(to_addr, AccountInfo::new(U256::ZERO, 0, code_hash, code))
+            })
+            .modify_tx_env(|tx| tx.transact_to = TransactTo::Call(to_addr))
+            // we need to use handle register box to capture the custom context in the handle
+            // register
+            .append_handler_register_box(Box::new(move |handler| {
+                let custom_context = custom_context.clone();
+
+                // we need to use a box to capture the custom context in the instruction
+                let custom_instruction = Box::new(
+                    move |_interp: &mut Interpreter, _host: &mut Evm<'_, (), InMemoryDB>| {
+                        // modify the value
+                        let mut inner = custom_context.inner.borrow_mut();
+                        *inner += 1;
+                    },
+                );
+
+                // need to make esure the instruction table is a boxed instruction table so that we
+                // can insert the custom instruction as a boxed instruction
+                let mut table = handler.take_instruction_table();
+                table = table.map(InstructionTables::to_boxed).map(|mut table| {
+                    // now we can finally insert
+                    table.insert_boxed(0xEF, custom_instruction).unwrap();
+                    table
+                });
+                handler.instruction_table = table;
+            }))
+            .build();
+
+        let _result_and_state = evm.transact().unwrap();
+    }
 
     #[test]
     fn simple_add_instruction() {

--- a/crates/revm/src/builder.rs
+++ b/crates/revm/src/builder.rs
@@ -466,6 +466,7 @@ mod test {
         let custom_context = CustomContext::default();
         assert_eq!(*custom_context.inner.borrow(), 0);
 
+        let to_capture = custom_context.clone();
         let mut evm = Evm::builder()
             .with_db(InMemoryDB::default())
             .modify_db(|db| {
@@ -475,7 +476,7 @@ mod test {
             // we need to use handle register box to capture the custom context in the handle
             // register
             .append_handler_register_box(Box::new(move |handler| {
-                let custom_context = custom_context.clone();
+                let custom_context = to_capture.clone();
 
                 // we need to use a box to capture the custom context in the instruction
                 let custom_instruction = Box::new(
@@ -499,6 +500,9 @@ mod test {
             .build();
 
         let _result_and_state = evm.transact().unwrap();
+
+        // ensure the custom context was modified
+        assert_eq!(*custom_context.inner.borrow(), 1);
     }
 
     #[test]

--- a/crates/revm/src/builder.rs
+++ b/crates/revm/src/builder.rs
@@ -448,7 +448,7 @@ mod test {
         },
         Context, ContextPrecompile, ContextStatefulPrecompile, Evm, InMemoryDB, InnerEvmContext,
     };
-    use revm_interpreter::{opcode::InstructionTables, Host, Interpreter};
+    use revm_interpreter::{Host, Interpreter};
     use std::{cell::RefCell, rc::Rc, sync::Arc};
 
     /// Custom evm context
@@ -491,9 +491,9 @@ mod test {
                 // need to make esure the instruction table is a boxed instruction table so that we
                 // can insert the custom instruction as a boxed instruction
                 let mut table = handler.take_instruction_table();
-                table = table.map(InstructionTables::to_boxed).map(|mut table| {
+                table = table.map(|mut table| {
                     // now we can finally insert
-                    table.insert_boxed(0xEF, custom_instruction).unwrap();
+                    table.insert_boxed(0xEF, custom_instruction);
                     table
                 });
                 handler.instruction_table = table;


### PR DESCRIPTION
This adds a test which serves as an example for adding custom instructions which require some context. This also adds `convert_boxed` and `insert_boxed` which should make it easier to do this using the revm builder.