### PR TITLE
feat: optional nonce check

### DIFF
--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -48,6 +48,7 @@ dev = [
     "optional_gas_refund",
     "optional_no_base_fee",
     "optional_beneficiary_reward",
+    "optional_nonce_check",
 ]
 memory_limit = ["revm-primitives/memory_limit"]
 optional_balance_check = ["revm-primitives/optional_balance_check"]
@@ -56,3 +57,4 @@ optional_eip3607 = ["revm-primitives/optional_eip3607"]
 optional_gas_refund = ["revm-primitives/optional_gas_refund"]
 optional_no_base_fee = ["revm-primitives/optional_no_base_fee"]
 optional_beneficiary_reward = ["revm-primitives/optional_beneficiary_reward"]
+optional_nonce_check = ["revm-primitives/optional_nonce_check"]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -79,6 +79,7 @@ dev = [
     "optional_gas_refund",
     "optional_no_base_fee",
     "optional_beneficiary_reward",
+    "optional_nonce_check",
 ]
 memory_limit = []
 optional_balance_check = []
@@ -87,6 +88,7 @@ optional_eip3607 = []
 optional_gas_refund = []
 optional_no_base_fee = []
 optional_beneficiary_reward = []
+optional_nonce_check = []
 
 # See comments in `revm-precompile`
 c-kzg = ["dep:c-kzg", "dep:once_cell", "dep:derive_more"]

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -90,6 +90,7 @@ dev = [
     "optional_gas_refund",
     "optional_no_base_fee",
     "optional_beneficiary_reward",
+    "optional_nonce_check",
 ]
 memory_limit = ["revm-interpreter/memory_limit"]
 optional_balance_check = ["revm-interpreter/optional_balance_check"]
@@ -98,6 +99,7 @@ optional_eip3607 = ["revm-interpreter/optional_eip3607"]
 optional_gas_refund = ["revm-interpreter/optional_gas_refund"]
 optional_no_base_fee = ["revm-interpreter/optional_no_base_fee"]
 optional_beneficiary_reward = ["revm-interpreter/optional_beneficiary_reward"]
+optional_nonce_check = ["revm-interpreter/optional_nonce_check"]
 
 # See comments in `revm-precompile`
 secp256k1 = ["revm-precompile/secp256k1"]


### PR DESCRIPTION
For Hardhat we need the ability to disable nonce checks. This PR follows the existing pattern for similar features and adds it to the `dev` feature flag.