### PR TITLE
chore: add rustc-ice-*.txt to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ book
 traces
 
 burntpix/svgs
+
+# Rust bug report
+rustc-ice-*


### PR DESCRIPTION
Cargo fmt has had some issues recently, this should prevent accidentally committing the bug reports