### PR TITLE
perf(interpreter): don't run signextend with 31 too

### DIFF
--- a/crates/interpreter/src/instructions/arithmetic.rs
+++ b/crates/interpreter/src/instructions/arithmetic.rs
@@ -88,12 +88,13 @@ pub fn exp<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
 /// bits from `b`; this is equal to `y & mask` where `&` is bitwise `AND`.
 pub fn signextend<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::LOW);
-    pop_top!(interpreter, op1, op2);
-    if op1 < U256::from(32) {
-        // `low_u32` works since op1 < 32
-        let bit_index = (8 * op1.as_limbs()[0] + 7) as usize;
-        let bit = op2.bit(bit_index);
+    pop_top!(interpreter, ext, x);
+    // For 31 we also don't need to do anything.
+    if ext < U256::from(31) {
+        let ext = ext.as_limbs()[0];
+        let bit_index = (8 * ext + 7) as usize;
+        let bit = x.bit(bit_index);
         let mask = (U256::from(1) << bit_index) - U256::from(1);
-        *op2 = if bit { *op2 | !mask } else { *op2 & mask };
+        *x = if bit { *x | !mask } else { *x & mask };
     }
 }


### PR DESCRIPTION
Sign-extending the last bit does nothing. See also [the implementation in `evmone`](https://github.com/ethereum/evmone/blob/7bd7596c2754229f37344e10cdd49d638391f90f/lib/evmone/instructions.hpp#L231C20-L231C64).