### PR TITLE
chore(interpreter): unbox contract field

### DIFF
--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -17,10 +17,11 @@ use revm_primitives::U256;
 use std::borrow::ToOwned;
 use std::boxed::Box;
 
+/// EVM bytecode interpreter.
 #[derive(Debug)]
 pub struct Interpreter {
     /// Contract information and invoking data
-    pub contract: Box<Contract>,
+    pub contract: Contract,
     /// The current instruction pointer.
     pub instruction_pointer: *const u8,
     /// The execution control flag. If this is not set to `Continue`, the interpreter will stop
@@ -114,7 +115,7 @@ impl InterpreterAction {
 
 impl Interpreter {
     /// Create new interpreter
-    pub fn new(contract: Box<Contract>, gas_limit: u64, is_static: bool) -> Self {
+    pub fn new(contract: Contract, gas_limit: u64, is_static: bool) -> Self {
         Self {
             instruction_pointer: contract.bytecode.as_ptr(),
             contract,

--- a/crates/revm/benches/bench.rs
+++ b/crates/revm/benches/bench.rs
@@ -114,7 +114,7 @@ fn bench_eval(g: &mut BenchmarkGroup<'_, WallTime>, evm: &mut Evm<'static, (), B
             // replace memory with empty memory to use it inside interpreter.
             // Later return memory back.
             let temp = core::mem::replace(&mut shared_memory, EMPTY_SHARED_MEMORY);
-            let mut interpreter = Interpreter::new(Box::new(contract.clone()), u64::MAX, false);
+            let mut interpreter = Interpreter::new(contract.clone(), u64::MAX, false);
             let res = interpreter.run(temp, &instruction_table, &mut host);
             shared_memory = interpreter.take_memory();
             host.clear();

--- a/crates/revm/src/context/evm_context.rs
+++ b/crates/revm/src/context/evm_context.rs
@@ -198,12 +198,12 @@ impl<DB: Database> EvmContext<DB> {
                 inputs.return_memory_offset.clone(),
             ))
         } else if !bytecode.is_empty() {
-            let contract = Box::new(Contract::new_with_context(
+            let contract = Contract::new_with_context(
                 inputs.input.clone(),
                 bytecode,
                 code_hash,
                 &inputs.context,
-            ));
+            );
             // Create interpreter and executes call and push new CallStackFrame.
             Ok(FrameOrResult::new_call_frame(
                 inputs.return_memory_offset.clone(),

--- a/crates/revm/src/context/inner_evm_context.rs
+++ b/crates/revm/src/context/inner_evm_context.rs
@@ -289,14 +289,14 @@ impl<DB: Database> InnerEvmContext<DB> {
 
         let bytecode = Bytecode::new_raw(inputs.init_code.clone());
 
-        let contract = Box::new(Contract::new(
+        let contract = Contract::new(
             Bytes::new(),
             bytecode,
             init_code_hash,
             created_address,
             inputs.caller,
             inputs.value,
-        ));
+        );
 
         Ok(FrameOrResult::new_create_frame(
             created_address,


### PR DESCRIPTION
I don't see a reason for this to be boxed, it's 184 bytes big when the interpreter is 256 already, bringing it to 432 doesn't change much.

This doesn't affect the size of frames as they themselves are boxed.