### PR TITLE
fix: use correct rand package for thread_rng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2353,6 +2353,7 @@ dependencies = [
  "criterion",
  "k256",
  "once_cell",
+ "rand",
  "revm-primitives",
  "ripemd",
  "secp256k1",

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -35,6 +35,7 @@ secp256k1 = { version = "0.28.2", default-features = false, features = [
 
 [dev-dependencies]
 criterion = { version = "0.5" }
+rand = { version = "0.8", features = ["std"] }
 
 [features]
 default = ["std", "c-kzg", "secp256k1", "portable"]

--- a/crates/precompile/benches/bench.rs
+++ b/crates/precompile/benches/bench.rs
@@ -9,7 +9,7 @@ use revm_precompile::{
     Bytes,
 };
 use revm_primitives::{hex, keccak256, Env, U256, VERSIONED_HASH_VERSION_KZG};
-use secp256k1::{rand, Message, SecretKey, SECP256K1};
+use secp256k1::{Message, SecretKey, SECP256K1};
 use sha2::{Digest, Sha256};
 
 /// Benchmarks different cryptography-related precompiles.


### PR DESCRIPTION
This PR fixes the precompile benchmarks. When I tried running them I got this error:

```
error[E0425]: cannot find function `thread_rng` in crate `rand`
   --> crates/precompile/benches/bench.rs:56:48
    |
56  |     let secret_key = SecretKey::new(&mut rand::thread_rng());
    |                                                ^^^^^^^^^^ not found in `rand`
    |
note: found an item that was configured out
   --> /Users/jtraglia/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rand-0.8.5/src/lib.rs:105:30
    |
105 | pub use crate::rngs::thread::thread_rng;
    |                              ^^^^^^^^^^
```