### PR TITLE
feat: TracerEip3155 optionally traces memory

### DIFF
--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -358,6 +358,7 @@ pub fn execute_test_suite(
                         .reset_handler_with_external_context(TracerEip3155::new(
                             Box::new(stderr()),
                             false,
+                            false,
                         ))
                         .append_handler_register(inspector_handle_register)
                         .build();
@@ -421,7 +422,7 @@ pub fn execute_test_suite(
                 let mut evm = Evm::builder()
                     .with_spec_id(spec_id)
                     .with_db(state)
-                    .with_external_context(TracerEip3155::new(Box::new(stdout()), false))
+                    .with_external_context(TracerEip3155::new(Box::new(stdout()), false, false))
                     .append_handler_register(inspector_handle_register)
                     .build();
                 let _ = evm.transact_commit();

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -355,11 +355,7 @@ pub fn execute_test_suite(
                 let (e, exec_result) = if trace {
                     let mut evm = evm
                         .modify()
-                        .reset_handler_with_external_context(TracerEip3155::new(
-                            Box::new(stderr()),
-                            false,
-                            false,
-                        ))
+                        .reset_handler_with_external_context(TracerEip3155::new(Box::new(stderr())))
                         .append_handler_register(inspector_handle_register)
                         .build();
 
@@ -422,7 +418,7 @@ pub fn execute_test_suite(
                 let mut evm = Evm::builder()
                     .with_spec_id(spec_id)
                     .with_db(state)
-                    .with_external_context(TracerEip3155::new(Box::new(stdout()), false, false))
+                    .with_external_context(TracerEip3155::new(Box::new(stdout())))
                     .append_handler_register(inspector_handle_register)
                     .build();
                 let _ = evm.transact_commit();

--- a/crates/revm/src/inspector/eip3155.rs
+++ b/crates/revm/src/inspector/eip3155.rs
@@ -168,13 +168,7 @@ impl<DB: Database> Inspector<DB> for TracerEip3155 {
             } else {
                 None
             },
-            memory: match &self.memory {
-                Some(memory) => {
-                    let hex_memory = hex::encode(memory);
-                    Some(format!("0x{hex_memory}"))
-                }
-                None => None,
-            },
+            memory: self.memory.as_ref().map(hex::encode_prefixed),
             storage: None,
             return_stack: None,
         };

--- a/crates/revm/src/inspector/eip3155.rs
+++ b/crates/revm/src/inspector/eip3155.rs
@@ -23,7 +23,7 @@ pub struct TracerEip3155 {
     mem_size: usize,
     skip: bool,
     include_memory: bool,
-    memory: Option<Vec<u8>>,
+    memory: Option<String>,
 }
 
 // # Output
@@ -145,7 +145,7 @@ impl<DB: Database> Inspector<DB> for TracerEip3155 {
         self.gas_inspector.step(interp, context);
         self.stack = interp.stack.data().clone();
         self.memory = if self.include_memory {
-            Some(interp.shared_memory.context_memory().to_owned())
+            Some(hex::encode_prefixed(interp.shared_memory.context_memory()))
         } else {
             None
         };
@@ -180,7 +180,7 @@ impl<DB: Database> Inspector<DB> for TracerEip3155 {
             } else {
                 None
             },
-            memory: self.memory.as_ref().map(hex::encode_prefixed),
+            memory: self.memory.take(),
             storage: None,
             return_stack: None,
         };

--- a/crates/revm/src/inspector/eip3155.rs
+++ b/crates/revm/src/inspector/eip3155.rs
@@ -100,12 +100,12 @@ impl TracerEip3155 {
 }
 
 impl TracerEip3155 {
-    pub fn new(output: Box<dyn Write>, print_summary: bool, include_memory: bool) -> Self {
+    pub fn new(output: Box<dyn Write>) -> Self {
         Self {
             output,
             gas_inspector: GasInspector::default(),
-            print_summary,
-            include_memory,
+            print_summary: true,
+            include_memory: false,
             stack: Default::default(),
             memory: Default::default(),
             pc: 0,
@@ -115,6 +115,18 @@ impl TracerEip3155 {
             mem_size: 0,
             skip: false,
         }
+    }
+
+    /// Don't include a summary at the end of the trace
+    pub fn without_summary(mut self) -> Self {
+        self.print_summary = false;
+        self
+    }
+
+    /// Include a memory field for each step. This significantly increases processing time and output size.
+    pub fn with_memory(mut self) -> Self {
+        self.include_memory = true;
+        self
     }
 
     fn write_value(&mut self, value: &impl serde::Serialize) -> std::io::Result<()> {

--- a/examples/db_by_ref.rs
+++ b/examples/db_by_ref.rs
@@ -72,7 +72,7 @@ fn run_transaction_and_commit(db: &mut CacheDB<EmptyDB>) -> anyhow::Result<()> {
 fn main() -> anyhow::Result<()> {
     let mut cache_db = CacheDB::new(EmptyDB::default());
 
-    let mut tracer = TracerEip3155::new(Box::new(std::io::stdout()), true, false);
+    let mut tracer = TracerEip3155::new(Box::new(std::io::stdout()));
 
     run_transaction_and_commit_with_ext(&mut cache_db, &mut tracer, inspector_handle_register)?;
     run_transaction_and_commit(&mut cache_db)?;

--- a/examples/db_by_ref.rs
+++ b/examples/db_by_ref.rs
@@ -72,7 +72,7 @@ fn run_transaction_and_commit(db: &mut CacheDB<EmptyDB>) -> anyhow::Result<()> {
 fn main() -> anyhow::Result<()> {
     let mut cache_db = CacheDB::new(EmptyDB::default());
 
-    let mut tracer = TracerEip3155::new(Box::new(std::io::stdout()), true);
+    let mut tracer = TracerEip3155::new(Box::new(std::io::stdout()), true, false);
 
     run_transaction_and_commit_with_ext(&mut cache_db, &mut tracer, inspector_handle_register)?;
     run_transaction_and_commit(&mut cache_db)?;

--- a/examples/generate_block_traces.rs
+++ b/examples/generate_block_traces.rs
@@ -76,7 +76,7 @@ async fn main() -> anyhow::Result<()> {
     let mut state = StateBuilder::new_with_database(cache_db).build();
     let mut evm = Evm::builder()
         .with_db(&mut state)
-        .with_external_context(TracerEip3155::new(Box::new(std::io::stdout()), true, false))
+        .with_external_context(TracerEip3155::new(Box::new(std::io::stdout())))
         .modify_block_env(|b| {
             if let Some(number) = block.number {
                 let nn = number.0[0];

--- a/examples/generate_block_traces.rs
+++ b/examples/generate_block_traces.rs
@@ -76,7 +76,7 @@ async fn main() -> anyhow::Result<()> {
     let mut state = StateBuilder::new_with_database(cache_db).build();
     let mut evm = Evm::builder()
         .with_db(&mut state)
-        .with_external_context(TracerEip3155::new(Box::new(std::io::stdout()), true))
+        .with_external_context(TracerEip3155::new(Box::new(std::io::stdout()), true, false))
         .modify_block_env(|b| {
             if let Some(number) = block.number {
                 let nn = number.0[0];


### PR DESCRIPTION
This adds the option to include the memory of each step in the EIP3155 trace.

If the option "include_memory" is true, the tracer will add an additional "memory: "0x..." field to each trace event. The EIP3155 seems to be ambiguous about the (optional) memory field. In the Output section it describes it as a "Array of Hex-Strings", however in the Test Cases it is only a Hex-String, not an Array. This PR implements the Hex-String version.

I think this would be a breaking change, as the TracerEIP3155 signature now has an additional "include_memory" flag. I've written the commit message accordingly.

Also note that this is my first contact with Rust, feel free to modify things that are not best practice :) The unit tests still ran through and I've manually tested the memory output. Also, the memory output makes the tracing much slower if it's enabled.

Example outputs:

```jsonl
{"pc":0,"op":96,"gas":"0x25c26","gasCost":"0x3","stack":[],"depth":1,"returnData":"0x","refund":"0x0","memSize":"0","opName":"PUSH1","memory":"0x"}
{"pc":2,"op":96,"gas":"0x25c23","gasCost":"0x3","stack":["0x80"],"depth":1,"returnData":"0x","refund":"0x0","memSize":"0","opName":"PUSH1","memory":"0x"}
{"pc":4,"op":82,"gas":"0x25c20","gasCost":"0xc","stack":["0x80","0x40"],"depth":1,"returnData":"0x","refund":"0x0","memSize":"0","opName":"MSTORE","memory":"0x"}
{"pc":5,"op":96,"gas":"0x25c14","gasCost":"0x3","stack":[],"depth":1,"returnData":"0x","refund":"0x0","memSize":"96","opName":"PUSH1","memory":"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080"}
```

```jsonl                                                                                                                                                              
{"pc":2724,"op":241,"gas":"0x8e0a","gasCost":"0x238c","stack":["0x2e1a7d4d","0x264","0x16345785d8a0000","0xd9e1ce17f2641f24ae83637ab66a2cca9c378b9f","0x0","0x16345785d8a0000","0x60","0x0","0x60","0x0","0x60","0x16345785d8a0000","0xd9e1ce17f2641f24ae83637ab66a2cca9c378b9f","0x0"],"depth":2,"returnData":"0x","refund":"0x4dbc","memSize":"96","opName":"CALL","error":"CallOrCreate","memory":"0x000000000000000000000000d9e1ce17f2641f24ae83637ab66a2cca9c378b9f00000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000060"}                                               
{"pc":0,"op":96,"gas":"0x8fc","gasCost":"0x3","stack":[],"depth":3,"returnData":"0x","refund":"0x0","memSize":"0","opName":"PUSH1","memory":"0x"}                                                                  
{"pc":2,"op":96,"gas":"0x8f9","gasCost":"0x3","stack":["0x80"],"depth":3,"returnData":"0x","refund":"0x0","memSize":"0","opName":"PUSH1","memory":"0x"}
```