### PR TITLE
fix: build with warnings treated as errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,11 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace ${{ matrix.flags }}
+        env:
+          RUSTFLAGS: -Dwarnings
 
-  test-no-std:
-    name: test no_std
+  check-no-std:
+    name: check no_std
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -94,7 +96,7 @@ jobs:
           components: rust-docs
       - run: cargo doc --workspace --all-features --no-deps --document-private-items
         env:
-          RUSTDOCFLAGS: "--cfg docsrs -D warnings"
+          RUSTDOCFLAGS: "--cfg docsrs -Dwarnings"
 
   fmt:
     name: fmt

--- a/crates/interpreter/src/gas/calc.rs
+++ b/crates/interpreter/src/gas/calc.rs
@@ -1,7 +1,6 @@
 use super::constants::*;
 use crate::inner_models::SelfDestructResult;
 use crate::primitives::{Address, Spec, SpecId::*, U256};
-use std::vec::Vec;
 
 #[allow(clippy::collapsible_else_if)]
 pub fn sstore_refund<SPEC: Spec>(original: U256, current: U256, new: U256) -> i64 {

--- a/crates/interpreter/src/host/dummy.rs
+++ b/crates/interpreter/src/host/dummy.rs
@@ -3,7 +3,6 @@ use crate::{
     primitives::{Address, Env, Log, B256, KECCAK_EMPTY},
     Host, SStoreResult, SelfDestructResult,
 };
-use std::vec::Vec;
 
 /// A dummy [Host] implementation.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]

--- a/crates/interpreter/src/inner_models.rs
+++ b/crates/interpreter/src/inner_models.rs
@@ -1,7 +1,6 @@
 pub use crate::primitives::CreateScheme;
 use crate::primitives::{Address, Bytes, TransactTo, TxEnv, U256};
 use core::ops::Range;
-use std::boxed::Box;
 
 /// Inputs for a call.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use core::cmp::min;
 use revm_primitives::BLOCK_HASH_HISTORY;
-use std::{boxed::Box, vec::Vec};
 
 pub fn balance<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     pop_address!(interpreter, address);

--- a/crates/interpreter/src/instructions/opcode.rs
+++ b/crates/interpreter/src/instructions/opcode.rs
@@ -7,7 +7,6 @@ use crate::{
     Host, Interpreter,
 };
 use core::fmt;
-use std::boxed::Box;
 
 /// EVM opcode function signature.
 pub type Instruction<H> = fn(&mut Interpreter, &mut H);

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -14,8 +14,6 @@ use crate::{
 };
 use core::cmp::min;
 use revm_primitives::U256;
-use std::borrow::ToOwned;
-use std::boxed::Box;
 
 /// EVM bytecode interpreter.
 #[derive(Debug)]

--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -5,7 +5,6 @@ use core::{
     fmt,
     ops::{BitAnd, Not},
 };
-use std::vec::Vec;
 
 /// A sequential memory shared between calls, which uses
 /// a `Vec` for internal representation.

--- a/crates/interpreter/src/interpreter/stack.rs
+++ b/crates/interpreter/src/interpreter/stack.rs
@@ -3,7 +3,6 @@ use crate::{
     InstructionResult,
 };
 use core::fmt;
-use std::vec::Vec;
 
 /// EVM interpreter stack limit.
 pub const STACK_LIMIT: usize = 1024;

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -28,7 +28,6 @@ pub use revm_primitives::{
     precompile::{PrecompileError as Error, *},
     Address, Bytes, HashMap, Log, B256,
 };
-use std::{boxed::Box, vec::Vec};
 
 pub fn calc_linear_cost_u32(len: usize, base: u64, word: u64) -> u64 {
     (len as u64 + 32 - 1) / 32 * word + base

--- a/crates/precompile/src/modexp.rs
+++ b/crates/precompile/src/modexp.rs
@@ -166,7 +166,6 @@ pub fn berlin_gas_calc(
 mod tests {
     use super::*;
     use revm_primitives::hex;
-    use std::vec::Vec;
 
     struct Test {
         input: &'static str,

--- a/crates/primitives/src/bytecode.rs
+++ b/crates/primitives/src/bytecode.rs
@@ -4,7 +4,7 @@ use bitvec::{
     vec::BitVec,
 };
 use core::fmt::Debug;
-use std::{sync::Arc, vec::Vec};
+use std::sync::Arc;
 
 /// A map of valid `jump` destinations.
 #[derive(Clone, Default, PartialEq, Eq, Hash)]

--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -8,8 +8,6 @@ use crate::{
     VERSIONED_HASH_VERSION_KZG,
 };
 use core::cmp::{min, Ordering};
-use std::boxed::Box;
-use std::vec::Vec;
 
 /// EVM environment configuration.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]

--- a/crates/primitives/src/env/handler_cfg.rs
+++ b/crates/primitives/src/env/handler_cfg.rs
@@ -1,6 +1,5 @@
 use super::{BlockEnv, CfgEnv, Env, SpecId, TxEnv};
 use core::ops::{Deref, DerefMut};
-use std::boxed::Box;
 
 /// Handler configuration fields. It is used to configure the handler.
 /// It contains specification id and the Optimism related field if

--- a/crates/primitives/src/kzg/env_settings.rs
+++ b/crates/primitives/src/kzg/env_settings.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use core::hash::{Hash, Hasher};
 use once_cell::race::OnceBox;
-use std::{boxed::Box, sync::Arc};
+use std::sync::Arc;
 
 /// KZG Settings that allow us to specify a custom trusted setup.
 /// or use hardcoded default settings.

--- a/crates/primitives/src/kzg/trusted_setup_points.rs
+++ b/crates/primitives/src/kzg/trusted_setup_points.rs
@@ -1,6 +1,5 @@
 use core::fmt;
 use derive_more::{AsMut, AsRef, Deref, DerefMut};
-use std::boxed::Box;
 
 pub use c_kzg::{BYTES_PER_G1_POINT, BYTES_PER_G2_POINT};
 

--- a/crates/primitives/src/precompile.rs
+++ b/crates/primitives/src/precompile.rs
@@ -1,7 +1,7 @@
 use crate::{Bytes, Env};
 use core::fmt;
 use dyn_clone::DynClone;
-use std::{boxed::Box, string::String, sync::Arc};
+use std::sync::Arc;
 
 /// A precompile operation result.
 ///

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -1,6 +1,5 @@
 use crate::{Address, Bytes, Log, State, U256};
 use core::fmt;
-use std::{boxed::Box, string::String, vec::Vec};
 
 /// Result of EVM execution.
 pub type EVMResult<DBError> = EVMResultGeneric<ResultAndState, DBError>;

--- a/crates/revm/src/builder.rs
+++ b/crates/revm/src/builder.rs
@@ -7,7 +7,6 @@ use crate::{
     Context, ContextWithHandlerCfg, Evm, Handler,
 };
 use core::marker::PhantomData;
-use std::boxed::Box;
 
 /// Evm Builder allows building or modifying EVM.
 /// Note that some of the methods that changes underlying structures

--- a/crates/revm/src/context.rs
+++ b/crates/revm/src/context.rs
@@ -13,7 +13,6 @@ use crate::{
     db::{Database, EmptyDB},
     primitives::HandlerCfg,
 };
-use std::boxed::Box;
 
 /// Main Context structure that contains both EvmContext and External context.
 pub struct Context<EXT, DB: Database> {

--- a/crates/revm/src/context/context_precompiles.rs
+++ b/crates/revm/src/context/context_precompiles.rs
@@ -5,7 +5,7 @@ use crate::{
 use core::ops::{Deref, DerefMut};
 use dyn_clone::DynClone;
 use revm_precompile::Precompiles;
-use std::{boxed::Box, sync::Arc};
+use std::sync::Arc;
 
 use super::InnerEvmContext;
 

--- a/crates/revm/src/context/evm_context.rs
+++ b/crates/revm/src/context/evm_context.rs
@@ -11,7 +11,6 @@ use core::{
     fmt,
     ops::{Deref, DerefMut},
 };
-use std::boxed::Box;
 
 /// EVM context that contains the inner EVM context and precompiles.
 pub struct EvmContext<DB: Database> {
@@ -224,10 +223,8 @@ pub(crate) mod test_utils {
     use crate::{
         db::{CacheDB, EmptyDB},
         journaled_state::JournaledState,
-        primitives::{address, Address, Bytes, Env, HashSet, SpecId, B256, U256},
-        InnerEvmContext,
+        primitives::{address, SpecId, B256},
     };
-    use std::boxed::Box;
 
     /// Mock caller address.
     pub const MOCK_CALLER: Address = address!("0000000000000000000000000000000000000000");
@@ -316,11 +313,9 @@ mod tests {
 
     use crate::{
         db::{CacheDB, EmptyDB},
-        interpreter::InstructionResult,
-        primitives::{address, Bytecode, Bytes, Env, U256},
-        Frame, FrameOrResult, JournalEntry,
+        primitives::{address, Bytecode},
+        Frame, JournalEntry,
     };
-    use std::boxed::Box;
 
     // Tests that the `EVMContext::make_call_frame` function returns an error if the
     // call stack is too deep.

--- a/crates/revm/src/context/inner_evm_context.rs
+++ b/crates/revm/src/context/inner_evm_context.rs
@@ -14,7 +14,6 @@ use crate::{
     FrameOrResult, JournalCheckpoint, CALL_STACK_LIMIT,
 };
 use revm_interpreter::{SStoreResult, SelfDestructResult};
-use std::boxed::Box;
 
 /// EVM contexts contains data that EVM needs for execution.
 #[derive(Debug)]

--- a/crates/revm/src/db/emptydb.rs
+++ b/crates/revm/src/db/emptydb.rs
@@ -3,7 +3,6 @@ use revm_interpreter::primitives::{
     db::{Database, DatabaseRef},
     keccak256, AccountInfo, Address, Bytecode, B256, U256,
 };
-use std::string::ToString;
 
 /// An empty database that always returns default values when queried.
 pub type EmptyDB = EmptyDBTyped<Infallible>;

--- a/crates/revm/src/db/in_memory_db.rs
+++ b/crates/revm/src/db/in_memory_db.rs
@@ -5,7 +5,6 @@ use crate::primitives::{
 };
 use crate::Database;
 use core::convert::Infallible;
-use std::vec::Vec;
 
 /// A [Database] implementation that stores all state changes in memory.
 pub type InMemoryDB = CacheDB<EmptyDB>;

--- a/crates/revm/src/db/states/bundle_state.rs
+++ b/crates/revm/src/db/states/bundle_state.rs
@@ -8,10 +8,7 @@ use revm_interpreter::primitives::{
     hash_map::{self, Entry},
     AccountInfo, Address, Bytecode, HashMap, HashSet, StorageSlot, B256, KECCAK_EMPTY, U256,
 };
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    vec::Vec,
-};
+use std::collections::{BTreeMap, BTreeSet};
 
 /// This builder is used to help to facilitate the initialization of `BundleState` struct
 #[derive(Debug)]
@@ -697,7 +694,6 @@ impl BundleState {
 mod tests {
     use super::*;
     use crate::{db::StorageWithOriginalValues, TransitionAccount};
-    use revm_interpreter::primitives::KECCAK_EMPTY;
 
     #[test]
     fn transition_states() {

--- a/crates/revm/src/db/states/cache.rs
+++ b/crates/revm/src/db/states/cache.rs
@@ -4,7 +4,6 @@ use super::{
 use revm_interpreter::primitives::{
     Account, AccountInfo, Address, Bytecode, HashMap, State as EVMState, B256,
 };
-use std::vec::Vec;
 
 /// Cache state contains both modified and original values.
 ///

--- a/crates/revm/src/db/states/changes.rs
+++ b/crates/revm/src/db/states/changes.rs
@@ -1,6 +1,5 @@
 use super::RevertToSlot;
 use revm_interpreter::primitives::{AccountInfo, Address, Bytecode, B256, U256};
-use std::vec::Vec;
 
 /// accounts/storages/contracts for inclusion into database.
 /// Structure is made so it is easier to apply directly to database

--- a/crates/revm/src/db/states/reverts.rs
+++ b/crates/revm/src/db/states/reverts.rs
@@ -4,7 +4,6 @@ use super::{
 };
 use core::ops::{Deref, DerefMut};
 use revm_interpreter::primitives::{AccountInfo, Address, HashMap, U256};
-use std::vec::Vec;
 
 /// Contains reverts of multiple account in multiple transitions (Transitions as a block).
 #[derive(Clone, Debug, Default, PartialEq, Eq)]

--- a/crates/revm/src/db/states/state.rs
+++ b/crates/revm/src/db/states/state.rs
@@ -7,11 +7,7 @@ use revm_interpreter::primitives::{
     db::{Database, DatabaseCommit},
     hash_map, Account, AccountInfo, Address, Bytecode, HashMap, B256, BLOCK_HASH_HISTORY, U256,
 };
-use std::{
-    boxed::Box,
-    collections::{btree_map, BTreeMap},
-    vec::Vec,
-};
+use std::collections::{btree_map, BTreeMap};
 
 /// Database boxed with a lifetime and Send.
 pub type DBBox<'a, E> = Box<dyn Database<Error = E> + Send + 'a>;

--- a/crates/revm/src/db/states/transition_state.rs
+++ b/crates/revm/src/db/states/transition_state.rs
@@ -1,6 +1,5 @@
 use super::TransitionAccount;
 use revm_interpreter::primitives::{hash_map::Entry, Address, HashMap};
-use std::vec::Vec;
 
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct TransitionState {

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -15,7 +15,6 @@ use crate::{
 };
 use core::fmt;
 use revm_interpreter::{CallInputs, CreateInputs};
-use std::vec::Vec;
 
 /// EVM call stack limit.
 pub const CALL_STACK_LIMIT: u64 = 1024;

--- a/crates/revm/src/frame.rs
+++ b/crates/revm/src/frame.rs
@@ -5,7 +5,6 @@ use crate::{
 };
 use core::ops::Range;
 use revm_interpreter::{CallOutcome, CreateOutcome, Gas, InstructionResult, InterpreterResult};
-use std::boxed::Box;
 
 /// Call CallStackFrame.
 #[derive(Debug)]

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -13,7 +13,6 @@ use crate::{
     Evm,
 };
 use register::{EvmHandler, HandleRegisters};
-use std::vec::Vec;
 
 use self::register::{HandleRegister, HandleRegisterBox};
 

--- a/crates/revm/src/handler/handle_types/execution.rs
+++ b/crates/revm/src/handler/handle_types/execution.rs
@@ -4,7 +4,7 @@ use crate::{
     primitives::{db::Database, EVMError, Spec},
     CallFrame, Context, CreateFrame, Frame, FrameOrResult, FrameResult,
 };
-use std::{boxed::Box, sync::Arc};
+use std::sync::Arc;
 
 use revm_interpreter::{CallOutcome, CreateOutcome, InterpreterResult};
 

--- a/crates/revm/src/handler/mainnet/execution.rs
+++ b/crates/revm/src/handler/mainnet/execution.rs
@@ -7,7 +7,6 @@ use crate::{
     primitives::{EVMError, Env, Spec},
     CallFrame, Context, CreateFrame, Frame, FrameOrResult, FrameResult,
 };
-use std::boxed::Box;
 
 use revm_interpreter::{CallOutcome, InterpreterResult};
 
@@ -139,7 +138,7 @@ pub fn insert_create_outcome<EXT, DB: Database>(
 
 #[cfg(test)]
 mod tests {
-    use revm_interpreter::{primitives::CancunSpec, InterpreterResult};
+    use revm_interpreter::{primitives::CancunSpec};
     use revm_precompile::Bytes;
 
     use super::*;

--- a/crates/revm/src/handler/register.rs
+++ b/crates/revm/src/handler/register.rs
@@ -1,5 +1,4 @@
 use crate::{db::Database, handler::Handler, Evm};
-use std::boxed::Box;
 
 /// EVM Handler
 pub type EvmHandler<'a, EXT, DB> = Handler<'a, Evm<'a, EXT, DB>, EXT, DB>;

--- a/crates/revm/src/inspector/handler_register.rs
+++ b/crates/revm/src/inspector/handler_register.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use core::cell::RefCell;
 use revm_interpreter::opcode::InstructionTables;
-use std::{boxed::Box, rc::Rc, sync::Arc, vec::Vec};
+use std::{rc::Rc, sync::Arc};
 
 /// Provides access to an `Inspector` instance.
 pub trait GetInspector<DB: Database> {
@@ -265,9 +265,9 @@ mod tests {
     use crate::{
         db::EmptyDB,
         inspectors::NoOpInspector,
-        interpreter::{opcode::*, CallInputs, CreateInputs, Interpreter},
+        interpreter::{opcode::*, CallInputs, CreateInputs},
         primitives::BerlinSpec,
-        Database, Evm, EvmContext, Inspector,
+        EvmContext,
     };
 
     use revm_interpreter::{CallOutcome, CreateOutcome};

--- a/crates/revm/src/journaled_state.rs
+++ b/crates/revm/src/journaled_state.rs
@@ -6,7 +6,6 @@ use crate::primitives::{
 use core::mem;
 use revm_interpreter::primitives::SpecId;
 use revm_interpreter::SStoreResult;
-use std::vec::Vec;
 
 /// JournalState is internal EVM state that is used to contain state and track changes to that state.
 /// It contains journal of changes that happened to state so that they can be reverted.


### PR DESCRIPTION
This PR will build/test with warnings treated as errors. It also fixes the issues, all of which were redundant imports.

Also, rename `test-no-std` to `check-no-std` which is more accurate.