### PR TITLE
fix: use correct bn128 mul input length

### DIFF
--- a/crates/precompile/src/bn128.rs
+++ b/crates/precompile/src/bn128.rs
@@ -92,13 +92,17 @@ pub mod pair {
 }
 
 /// Input length for the add operation.
-pub const ADD_INPUT_LEN: usize = 128;
+/// `ADD` takes two uncompressed G1 points (64 bytes each).
+pub const ADD_INPUT_LEN: usize = 64 + 64;
 
 /// Input length for the multiplication operation.
-pub const MUL_INPUT_LEN: usize = 128;
+/// `MUL` takes an uncompressed G1 point (64 bytes) and scalar (32 bytes).
+pub const MUL_INPUT_LEN: usize = 64 + 32;
 
 /// Pair element length.
-pub const PAIR_ELEMENT_LEN: usize = 192;
+/// `PAIR` elements are composed of an uncompressed G1 point (64 bytes) and an uncompressed G2 point
+/// (128 bytes).
+pub const PAIR_ELEMENT_LEN: usize = 64 + 128;
 
 /// Reads a single `Fq` from the input slice.
 ///


### PR DESCRIPTION
This is pretty minor, but `MUL_INPUT_LEN` was 128 when it only needed to be 96. So there was some unnecessary padding. I don't expect any performance difference from this, just fixing to be more correct. As part of this, I added comments explaining the size and splitting the value into each component.