### PR TITLE
nit: remove unnecessary call to into_u256() for bn128 add

### DIFF
--- a/crates/precompile/src/bn128.rs
+++ b/crates/precompile/src/bn128.rs
@@ -141,16 +141,9 @@ pub fn run_add(input: &[u8]) -> Result<Bytes, Error> {
 
     let mut output = [0u8; 64];
     if let Some(sum) = AffineG1::from_jacobian(p1 + p2) {
-        sum.x()
-            .into_u256()
-            .to_big_endian(&mut output[..32])
-            .unwrap();
-        sum.y()
-            .into_u256()
-            .to_big_endian(&mut output[32..])
-            .unwrap();
+        sum.x().to_big_endian(&mut output[..32]).unwrap();
+        sum.y().to_big_endian(&mut output[32..]).unwrap();
     }
-
     Ok(output.into())
 }
 

--- a/crates/precompile/src/bn128.rs
+++ b/crates/precompile/src/bn128.rs
@@ -155,12 +155,12 @@ pub fn run_mul(input: &[u8]) -> Result<Bytes, Error> {
     // `Fr::from_slice` can only fail when the length is not 32.
     let fr = bn::Fr::from_slice(&input[64..96]).unwrap();
 
-    let mut out = [0u8; 64];
+    let mut output = [0u8; 64];
     if let Some(mul) = AffineG1::from_jacobian(p * fr) {
-        mul.x().to_big_endian(&mut out[..32]).unwrap();
-        mul.y().to_big_endian(&mut out[32..]).unwrap();
+        mul.x().to_big_endian(&mut output[..32]).unwrap();
+        mul.y().to_big_endian(&mut output[32..]).unwrap();
     }
-    Ok(out.into())
+    Ok(output.into())
 }
 
 pub fn run_pair(


### PR DESCRIPTION
This PR removes the intermediate call to `into_u256()` which appears to be unnecessary. I noticed that `ecmul` does it like this, and I think it's cleaner this way:

https://github.com/bluealloy/revm/blob/c3107ec3acf79119016acac203b1c2437005a90e/crates/precompile/src/bn128.rs#L157-L171

Also, rename `out` to `output` in `run_mul` for consistency.