### PR TITLE
Add example pre-run instruction handler in EVM execution loop

### DIFF
--- a/crates/revm/src/handler/mainnet.rs
+++ b/crates/revm/src/handler/mainnet.rs
@@ -6,8 +6,8 @@ mod pre_execution;
 mod validation;
 
 pub use execution_loop::{
-    create_first_frame, first_frame_return, frame_return, frame_return_with_refund_flag, sub_call,
-    sub_create,
+    create_first_frame, first_frame_return, frame_return, frame_return_with_refund_flag, pre_run,
+    sub_call, sub_create,
 };
 pub use post_execution::{end, output, reimburse_caller, reward_beneficiary};
 pub use pre_execution::{deduct_caller, deduct_caller_inner, load, load_precompiles};

--- a/crates/revm/src/handler/mainnet/execution_loop.rs
+++ b/crates/revm/src/handler/mainnet/execution_loop.rs
@@ -5,11 +5,11 @@ use crate::{
         InterpreterResult, SharedMemory,
     },
     primitives::{Env, Spec, TransactTo},
-    CallStackFrame, Context, FrameData, FrameOrResult,
+    CallStackFrame, Context, Evm, FrameData, FrameOrResult,
 };
 use alloc::boxed::Box;
 use core::ops::Range;
-use revm_interpreter::CallOutcome;
+use revm_interpreter::{CallOutcome, Interpreter, InterpreterAction};
 
 /// Creates first frame.
 #[inline]
@@ -159,6 +159,16 @@ pub fn sub_create<SPEC: Spec, EXT, DB: Database>(
             None
         }
     }
+}
+
+/// Handle intrepreter pre-run.
+#[inline]
+pub fn pre_run<SPEC: Spec, EXT, DB: Database>(
+    _evm: &mut Evm<'_, EXT, DB>,
+    _ins: &[Box<dyn Fn(&mut Interpreter, &mut Evm<'_, EXT, DB>)>; 256],
+    _frame: &mut Box<CallStackFrame>,
+) -> Option<InterpreterAction> {
+    None
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add example of (unsafe) implementation of a handler that can be used to execute arbitrary EVM calls before a given evm instruction.  Useful in the new REVM model.


Example usage in EVM builder:
```
let old_handle = handler.execution_loop.pre_run_interpreter.clone();
            handler.execution_loop.pre_run_interpreter = Arc::new(
                move |evm: &mut Evm<'_, IE, DB>,
                      table: &[Box<dyn Fn(&mut Interpreter, &mut Evm<'_, IE, DB>)>; 256],
                      frame: &mut Box<CallStackFrame>|
                      -> Option<InterpreterAction> {
                    let engine_evm = EngineEVM {
                        evm,
                        table,
                        current_stack_frame: frame,
                    };
                    if let Some(pre_run) = IE::on_pre_run_interpreter(engine_evm) {
                        return Some(pre_run);
                    }
                    old_handle(evm, table, frame)
                },
            );
```