### PR TITLE
feat(interpreter): test Host object-safety, allow `dyn Host` in instructions

### DIFF
--- a/crates/interpreter/src/host.rs
+++ b/crates/interpreter/src/host.rs
@@ -65,3 +65,16 @@ pub struct SStoreResult {
     /// Is storage slot loaded from database
     pub is_cold: bool,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_host<H: Host + ?Sized>() {}
+
+    #[test]
+    fn object_safety() {
+        assert_host::<DummyHost>();
+        assert_host::<dyn Host>();
+    }
+}

--- a/crates/interpreter/src/instructions/arithmetic.rs
+++ b/crates/interpreter/src/instructions/arithmetic.rs
@@ -5,25 +5,25 @@ use crate::{
     Host, Interpreter,
 };
 
-pub fn wrapping_add<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn wrapping_add<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = op1.wrapping_add(*op2);
 }
 
-pub fn wrapping_mul<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn wrapping_mul<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::LOW);
     pop_top!(interpreter, op1, op2);
     *op2 = op1.wrapping_mul(*op2);
 }
 
-pub fn wrapping_sub<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn wrapping_sub<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = op1.wrapping_sub(*op2);
 }
 
-pub fn div<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn div<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::LOW);
     pop_top!(interpreter, op1, op2);
     if *op2 != U256::ZERO {
@@ -31,13 +31,13 @@ pub fn div<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
     }
 }
 
-pub fn sdiv<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn sdiv<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::LOW);
     pop_top!(interpreter, op1, op2);
     *op2 = i256_div(op1, *op2);
 }
 
-pub fn rem<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn rem<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::LOW);
     pop_top!(interpreter, op1, op2);
     if *op2 != U256::ZERO {
@@ -45,7 +45,7 @@ pub fn rem<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
     }
 }
 
-pub fn smod<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn smod<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::LOW);
     pop_top!(interpreter, op1, op2);
     if *op2 != U256::ZERO {
@@ -53,19 +53,19 @@ pub fn smod<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
     }
 }
 
-pub fn addmod<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn addmod<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::MID);
     pop_top!(interpreter, op1, op2, op3);
     *op3 = op1.add_mod(op2, *op3)
 }
 
-pub fn mulmod<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn mulmod<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::MID);
     pop_top!(interpreter, op1, op2, op3);
     *op3 = op1.mul_mod(op2, *op3)
 }
 
-pub fn exp<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn exp<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     pop_top!(interpreter, op1, op2);
     gas_or_fail!(interpreter, gas::exp_cost::<SPEC>(*op2));
     *op2 = op1.pow(*op2);
@@ -86,7 +86,7 @@ pub fn exp<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
 /// `y | !mask` where `|` is the bitwise `OR` and `!` is bitwise negation. Similarly, if
 /// `b == 0` then the yellow paper says the output should start with all zeros, then end with
 /// bits from `b`; this is equal to `y & mask` where `&` is bitwise `AND`.
-pub fn signextend<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn signextend<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::LOW);
     pop_top!(interpreter, ext, x);
     // For 31 we also don't need to do anything.

--- a/crates/interpreter/src/instructions/bitwise.rs
+++ b/crates/interpreter/src/instructions/bitwise.rs
@@ -6,67 +6,67 @@ use crate::{
 };
 use core::cmp::Ordering;
 
-pub fn lt<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn lt<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = U256::from(op1 < *op2);
 }
 
-pub fn gt<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn gt<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = U256::from(op1 > *op2);
 }
 
-pub fn slt<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn slt<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = U256::from(i256_cmp(&op1, op2) == Ordering::Less);
 }
 
-pub fn sgt<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn sgt<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = U256::from(i256_cmp(&op1, op2) == Ordering::Greater);
 }
 
-pub fn eq<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn eq<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = U256::from(op1 == *op2);
 }
 
-pub fn iszero<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn iszero<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1);
     *op1 = U256::from(*op1 == U256::ZERO);
 }
 
-pub fn bitand<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn bitand<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = op1 & *op2;
 }
 
-pub fn bitor<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn bitor<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = op1 | *op2;
 }
 
-pub fn bitxor<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn bitxor<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = op1 ^ *op2;
 }
 
-pub fn not<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn not<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1);
     *op1 = !*op1;
 }
 
-pub fn byte<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn byte<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
 
@@ -80,7 +80,7 @@ pub fn byte<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
 }
 
 /// EIP-145: Bitwise shifting instructions in EVM
-pub fn shl<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn shl<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     check!(interpreter, CONSTANTINOPLE);
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
@@ -88,7 +88,7 @@ pub fn shl<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
 }
 
 /// EIP-145: Bitwise shifting instructions in EVM
-pub fn shr<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn shr<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     check!(interpreter, CONSTANTINOPLE);
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
@@ -96,7 +96,7 @@ pub fn shr<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
 }
 
 /// EIP-145: Bitwise shifting instructions in EVM
-pub fn sar<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn sar<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     check!(interpreter, CONSTANTINOPLE);
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);

--- a/crates/interpreter/src/instructions/control.rs
+++ b/crates/interpreter/src/instructions/control.rs
@@ -4,13 +4,13 @@ use crate::{
     Host, InstructionResult, Interpreter, InterpreterResult,
 };
 
-pub fn jump<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn jump<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::MID);
     pop!(interpreter, dest);
     jump_inner(interpreter, dest);
 }
 
-pub fn jumpi<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn jumpi<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::HIGH);
     pop!(interpreter, dest, value);
     if value != U256::ZERO {
@@ -29,11 +29,11 @@ fn jump_inner(interpreter: &mut Interpreter, dest: U256) {
     interpreter.instruction_pointer = unsafe { interpreter.contract.bytecode.as_ptr().add(dest) };
 }
 
-pub fn jumpdest<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn jumpdest<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::JUMPDEST);
 }
 
-pub fn pc<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn pc<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::BASE);
     // - 1 because we have already advanced the instruction pointer in `Interpreter::step`
     push!(interpreter, U256::from(interpreter.program_counter() - 1));
@@ -63,27 +63,27 @@ fn return_inner(interpreter: &mut Interpreter, instruction_result: InstructionRe
     };
 }
 
-pub fn ret<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn ret<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     return_inner(interpreter, InstructionResult::Return);
 }
 
 /// EIP-140: REVERT instruction
-pub fn revert<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn revert<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     check!(interpreter, BYZANTIUM);
     return_inner(interpreter, InstructionResult::Revert);
 }
 
 /// Stop opcode. This opcode halts the execution.
-pub fn stop<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn stop<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     interpreter.instruction_result = InstructionResult::Stop;
 }
 
 /// Invalid opcode. This opcode halts the execution.
-pub fn invalid<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn invalid<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     interpreter.instruction_result = InstructionResult::InvalidFEOpcode;
 }
 
 /// Unknown opcode. This opcode halts the execution.
-pub fn unknown<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn unknown<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     interpreter.instruction_result = InstructionResult::OpcodeNotFound;
 }

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -13,7 +13,7 @@ use core::cmp::min;
 use revm_primitives::BLOCK_HASH_HISTORY;
 use std::{boxed::Box, vec::Vec};
 
-pub fn balance<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn balance<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     pop_address!(interpreter, address);
     let Some((balance, is_cold)) = host.balance(address) else {
         interpreter.instruction_result = InstructionResult::FatalExternalError;
@@ -34,7 +34,7 @@ pub fn balance<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H)
 }
 
 /// EIP-1884: Repricing for trie-size-dependent opcodes
-pub fn selfbalance<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn selfbalance<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check!(interpreter, ISTANBUL);
     gas!(interpreter, gas::LOW);
     let Some((balance, _)) = host.balance(interpreter.contract.address) else {
@@ -44,7 +44,7 @@ pub fn selfbalance<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mu
     push!(interpreter, balance);
 }
 
-pub fn extcodesize<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn extcodesize<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     pop_address!(interpreter, address);
     let Some((code, is_cold)) = host.code(address) else {
         interpreter.instruction_result = InstructionResult::FatalExternalError;
@@ -69,7 +69,7 @@ pub fn extcodesize<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mu
 }
 
 /// EIP-1052: EXTCODEHASH opcode
-pub fn extcodehash<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn extcodehash<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check!(interpreter, CONSTANTINOPLE);
     pop_address!(interpreter, address);
     let Some((code_hash, is_cold)) = host.code_hash(address) else {
@@ -93,7 +93,7 @@ pub fn extcodehash<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mu
     push_b256!(interpreter, code_hash);
 }
 
-pub fn extcodecopy<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn extcodecopy<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     pop_address!(interpreter, address);
     pop!(interpreter, memory_offset, code_offset, len_u256);
 
@@ -120,7 +120,7 @@ pub fn extcodecopy<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mu
         .set_data(memory_offset, code_offset, len, code.bytes());
 }
 
-pub fn blockhash<H: Host>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn blockhash<H: Host + ?Sized>(interpreter: &mut Interpreter, host: &mut H) {
     gas!(interpreter, gas::BLOCKHASH);
     pop_top!(interpreter, number);
 
@@ -139,7 +139,7 @@ pub fn blockhash<H: Host>(interpreter: &mut Interpreter, host: &mut H) {
     *number = U256::ZERO;
 }
 
-pub fn sload<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn sload<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     pop!(interpreter, index);
 
     let Some((value, is_cold)) = host.sload(interpreter.contract.address, index) else {
@@ -150,7 +150,7 @@ pub fn sload<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     push!(interpreter, value);
 }
 
-pub fn sstore<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn sstore<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check_staticcall!(interpreter);
 
     pop!(interpreter, index, value);
@@ -173,7 +173,7 @@ pub fn sstore<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) 
 
 /// EIP-1153: Transient storage opcodes
 /// Store value to transient storage
-pub fn tstore<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn tstore<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check!(interpreter, CANCUN);
     check_staticcall!(interpreter);
     gas!(interpreter, gas::WARM_STORAGE_READ_COST);
@@ -185,7 +185,7 @@ pub fn tstore<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) 
 
 /// EIP-1153: Transient storage opcodes
 /// Load value from transient storage
-pub fn tload<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn tload<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check!(interpreter, CANCUN);
     gas!(interpreter, gas::WARM_STORAGE_READ_COST);
 
@@ -194,7 +194,7 @@ pub fn tload<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     *index = host.tload(interpreter.contract.address, *index);
 }
 
-pub fn log<const N: usize, H: Host>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn log<const N: usize, H: Host + ?Sized>(interpreter: &mut Interpreter, host: &mut H) {
     check_staticcall!(interpreter);
 
     pop!(interpreter, offset, len);
@@ -227,7 +227,7 @@ pub fn log<const N: usize, H: Host>(interpreter: &mut Interpreter, host: &mut H)
     host.log(log);
 }
 
-pub fn selfdestruct<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn selfdestruct<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check_staticcall!(interpreter);
     pop_address!(interpreter, target);
 
@@ -245,7 +245,7 @@ pub fn selfdestruct<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &m
     interpreter.instruction_result = InstructionResult::SelfDestruct;
 }
 
-pub fn create<const IS_CREATE2: bool, H: Host, SPEC: Spec>(
+pub fn create<const IS_CREATE2: bool, H: Host + ?Sized, SPEC: Spec>(
     interpreter: &mut Interpreter,
     host: &mut H,
 ) {
@@ -314,7 +314,7 @@ pub fn create<const IS_CREATE2: bool, H: Host, SPEC: Spec>(
     interpreter.instruction_result = InstructionResult::CallOrCreate;
 }
 
-pub fn call<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn call<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     pop!(interpreter, local_gas_limit);
     pop_address!(interpreter, to);
     // max gas limit is not possible in real ethereum situation.
@@ -374,7 +374,7 @@ pub fn call<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     interpreter.instruction_result = InstructionResult::CallOrCreate;
 }
 
-pub fn call_code<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn call_code<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     pop!(interpreter, local_gas_limit);
     pop_address!(interpreter, to);
     // max gas limit is not possible in real ethereum situation.
@@ -429,7 +429,7 @@ pub fn call_code<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut 
     interpreter.instruction_result = InstructionResult::CallOrCreate;
 }
 
-pub fn delegate_call<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn delegate_call<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check!(interpreter, HOMESTEAD);
     pop!(interpreter, local_gas_limit);
     pop_address!(interpreter, to);
@@ -475,7 +475,7 @@ pub fn delegate_call<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &
     interpreter.instruction_result = InstructionResult::CallOrCreate;
 }
 
-pub fn static_call<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn static_call<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check!(interpreter, BYZANTIUM);
     pop!(interpreter, local_gas_limit);
     pop_address!(interpreter, to);

--- a/crates/interpreter/src/instructions/host/call_helpers.rs
+++ b/crates/interpreter/src/instructions/host/call_helpers.rs
@@ -34,7 +34,7 @@ pub fn get_memory_input_and_out_ranges(
 }
 
 #[inline]
-pub fn calc_call_gas<H: Host, SPEC: Spec>(
+pub fn calc_call_gas<H: Host + ?Sized, SPEC: Spec>(
     interpreter: &mut Interpreter,
     host: &mut H,
     to: Address,

--- a/crates/interpreter/src/instructions/host_env.rs
+++ b/crates/interpreter/src/instructions/host_env.rs
@@ -5,28 +5,28 @@ use crate::{
 };
 
 /// EIP-1344: ChainID opcode
-pub fn chainid<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn chainid<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check!(interpreter, ISTANBUL);
     gas!(interpreter, gas::BASE);
     push!(interpreter, U256::from(host.env().cfg.chain_id));
 }
 
-pub fn coinbase<H: Host>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn coinbase<H: Host + ?Sized>(interpreter: &mut Interpreter, host: &mut H) {
     gas!(interpreter, gas::BASE);
     push_b256!(interpreter, host.env().block.coinbase.into_word());
 }
 
-pub fn timestamp<H: Host>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn timestamp<H: Host + ?Sized>(interpreter: &mut Interpreter, host: &mut H) {
     gas!(interpreter, gas::BASE);
     push!(interpreter, host.env().block.timestamp);
 }
 
-pub fn number<H: Host>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn number<H: Host + ?Sized>(interpreter: &mut Interpreter, host: &mut H) {
     gas!(interpreter, gas::BASE);
     push!(interpreter, host.env().block.number);
 }
 
-pub fn difficulty<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn difficulty<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     gas!(interpreter, gas::BASE);
     if SPEC::enabled(MERGE) {
         push_b256!(interpreter, host.env().block.prevrandao.unwrap());
@@ -35,30 +35,30 @@ pub fn difficulty<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut
     }
 }
 
-pub fn gaslimit<H: Host>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn gaslimit<H: Host + ?Sized>(interpreter: &mut Interpreter, host: &mut H) {
     gas!(interpreter, gas::BASE);
     push!(interpreter, host.env().block.gas_limit);
 }
 
-pub fn gasprice<H: Host>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn gasprice<H: Host + ?Sized>(interpreter: &mut Interpreter, host: &mut H) {
     gas!(interpreter, gas::BASE);
     push!(interpreter, host.env().effective_gas_price());
 }
 
 /// EIP-3198: BASEFEE opcode
-pub fn basefee<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn basefee<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check!(interpreter, LONDON);
     gas!(interpreter, gas::BASE);
     push!(interpreter, host.env().block.basefee);
 }
 
-pub fn origin<H: Host>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn origin<H: Host + ?Sized>(interpreter: &mut Interpreter, host: &mut H) {
     gas!(interpreter, gas::BASE);
     push_b256!(interpreter, host.env().tx.caller.into_word());
 }
 
 // EIP-4844: Shard Blob Transactions
-pub fn blob_hash<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn blob_hash<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check!(interpreter, CANCUN);
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, index);
@@ -70,7 +70,7 @@ pub fn blob_hash<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut 
 }
 
 /// EIP-7516: BLOBBASEFEE opcode
-pub fn blob_basefee<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn blob_basefee<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check!(interpreter, CANCUN);
     gas!(interpreter, gas::BASE);
     push!(

--- a/crates/interpreter/src/instructions/memory.rs
+++ b/crates/interpreter/src/instructions/memory.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use core::cmp::max;
 
-pub fn mload<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn mload<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop!(interpreter, index);
     let index = as_usize_or_fail!(interpreter, index);
@@ -13,7 +13,7 @@ pub fn mload<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
     push!(interpreter, interpreter.shared_memory.get_u256(index));
 }
 
-pub fn mstore<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn mstore<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop!(interpreter, index, value);
     let index = as_usize_or_fail!(interpreter, index);
@@ -21,7 +21,7 @@ pub fn mstore<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
     interpreter.shared_memory.set_u256(index, value);
 }
 
-pub fn mstore8<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn mstore8<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop!(interpreter, index, value);
     let index = as_usize_or_fail!(interpreter, index);
@@ -29,13 +29,13 @@ pub fn mstore8<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
     interpreter.shared_memory.set_byte(index, value.byte(0))
 }
 
-pub fn msize<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn msize<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::BASE);
     push!(interpreter, U256::from(interpreter.shared_memory.len()));
 }
 
 // EIP-5656: MCOPY - Memory copying instruction
-pub fn mcopy<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn mcopy<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     check!(interpreter, CANCUN);
     pop!(interpreter, dst, src, len);
 

--- a/crates/interpreter/src/instructions/opcode.rs
+++ b/crates/interpreter/src/instructions/opcode.rs
@@ -28,12 +28,12 @@ pub type BoxedInstructionTable<'a, H> = [BoxedInstruction<'a, H>; 256];
 /// Note that `Plain` variant gives us 10-20% faster Interpreter execution.
 ///
 /// Boxed variant can be used to wrap plain function pointer with closure.
-pub enum InstructionTables<'a, H> {
+pub enum InstructionTables<'a, H: ?Sized> {
     Plain(InstructionTable<H>),
     Boxed(BoxedInstructionTable<'a, H>),
 }
 
-impl<H: Host> InstructionTables<'_, H> {
+impl<H: Host + ?Sized> InstructionTables<'_, H> {
     /// Creates a plain instruction table for the given spec.
     #[inline]
     pub const fn new_plain<SPEC: Spec>() -> Self {
@@ -41,7 +41,7 @@ impl<H: Host> InstructionTables<'_, H> {
     }
 }
 
-impl<'a, H: Host + 'a> InstructionTables<'a, H> {
+impl<'a, H: Host + ?Sized + 'a> InstructionTables<'a, H> {
     /// Inserts a boxed instruction into the table with the specified index.
     ///
     /// This will convert the table into the [BoxedInstructionTable] variant if it is currently a
@@ -93,13 +93,14 @@ impl<'a, H: Host + 'a> InstructionTables<'a, H> {
 
 /// Make instruction table.
 #[inline]
-pub const fn make_instruction_table<H: Host, SPEC: Spec>() -> InstructionTable<H> {
+pub const fn make_instruction_table<H: Host + ?Sized, SPEC: Spec>() -> InstructionTable<H> {
     // Force const-eval of the table creation, making this function trivial.
     // TODO: Replace this with a `const {}` block once it is stable.
-    struct ConstTable<H: Host, SPEC: Spec> {
-        _phantom: core::marker::PhantomData<(H, SPEC)>,
+    struct ConstTable<H: Host + ?Sized, SPEC: Spec> {
+        _host: core::marker::PhantomData<H>,
+        _spec: core::marker::PhantomData<SPEC>,
     }
-    impl<H: Host, SPEC: Spec> ConstTable<H, SPEC> {
+    impl<H: Host + ?Sized, SPEC: Spec> ConstTable<H, SPEC> {
         const NEW: InstructionTable<H> = {
             let mut tables: InstructionTable<H> = [control::unknown; 256];
             let mut i = 0;
@@ -120,7 +121,7 @@ pub fn make_boxed_instruction_table<'a, H, SPEC, FN>(
     mut outer: FN,
 ) -> BoxedInstructionTable<'a, H>
 where
-    H: Host,
+    H: Host + ?Sized,
     SPEC: Spec + 'a,
     FN: FnMut(Instruction<H>) -> BoxedInstruction<'a, H>,
 {
@@ -154,7 +155,7 @@ macro_rules! opcodes {
         };
 
         /// Returns the instruction function for the given opcode and spec.
-        pub const fn instruction<H: Host, SPEC: Spec>(opcode: u8) -> Instruction<H> {
+        pub const fn instruction<H: Host + ?Sized, SPEC: Spec>(opcode: u8) -> Instruction<H> {
             match opcode {
                 $($name => $f,)*
                 _ => control::unknown,

--- a/crates/interpreter/src/instructions/stack.rs
+++ b/crates/interpreter/src/instructions/stack.rs
@@ -4,7 +4,7 @@ use crate::{
     Host, Interpreter,
 };
 
-pub fn pop<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn pop<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::BASE);
     if let Err(result) = interpreter.stack.pop() {
         interpreter.instruction_result = result;
@@ -14,7 +14,7 @@ pub fn pop<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
 /// EIP-3855: PUSH0 instruction
 ///
 /// Introduce a new instruction which pushes the constant value 0 onto the stack.
-pub fn push0<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn push0<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     check!(interpreter, SHANGHAI);
     gas!(interpreter, gas::BASE);
     if let Err(result) = interpreter.stack.push(U256::ZERO) {
@@ -22,7 +22,7 @@ pub fn push0<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) 
     }
 }
 
-pub fn push<const N: usize, H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn push<const N: usize, H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     // SAFETY: In analysis we append trailing bytes to the bytecode so that this is safe to do
     // without bounds checking.
@@ -37,14 +37,14 @@ pub fn push<const N: usize, H: Host>(interpreter: &mut Interpreter, _host: &mut 
     interpreter.instruction_pointer = unsafe { ip.add(N) };
 }
 
-pub fn dup<const N: usize, H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn dup<const N: usize, H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     if let Err(result) = interpreter.stack.dup::<N>() {
         interpreter.instruction_result = result;
     }
 }
 
-pub fn swap<const N: usize, H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn swap<const N: usize, H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     if let Err(result) = interpreter.stack.swap::<N>() {
         interpreter.instruction_result = result;

--- a/crates/interpreter/src/instructions/system.rs
+++ b/crates/interpreter/src/instructions/system.rs
@@ -4,7 +4,7 @@ use crate::{
     Host, InstructionResult, Interpreter,
 };
 
-pub fn keccak256<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn keccak256<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     pop!(interpreter, from, len);
     let len = as_usize_or_fail!(interpreter, len);
     gas_or_fail!(interpreter, gas::keccak256_cost(len as u64));
@@ -19,22 +19,22 @@ pub fn keccak256<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
     push_b256!(interpreter, hash);
 }
 
-pub fn address<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn address<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::BASE);
     push_b256!(interpreter, interpreter.contract.address.into_word());
 }
 
-pub fn caller<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn caller<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::BASE);
     push_b256!(interpreter, interpreter.contract.caller.into_word());
 }
 
-pub fn codesize<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn codesize<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::BASE);
     push!(interpreter, U256::from(interpreter.contract.bytecode.len()));
 }
 
-pub fn codecopy<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn codecopy<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     pop!(interpreter, memory_offset, code_offset, len);
     let len = as_usize_or_fail!(interpreter, len);
     gas_or_fail!(interpreter, gas::verylowcopy_cost(len as u64));
@@ -54,7 +54,7 @@ pub fn codecopy<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
     );
 }
 
-pub fn calldataload<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn calldataload<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop!(interpreter, index);
     let index = as_usize_saturated!(index);
@@ -70,17 +70,17 @@ pub fn calldataload<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
     push_b256!(interpreter, load);
 }
 
-pub fn calldatasize<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn calldatasize<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::BASE);
     push!(interpreter, U256::from(interpreter.contract.input.len()));
 }
 
-pub fn callvalue<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn callvalue<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::BASE);
     push!(interpreter, interpreter.contract.value);
 }
 
-pub fn calldatacopy<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn calldatacopy<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     pop!(interpreter, memory_offset, data_offset, len);
     let len = as_usize_or_fail!(interpreter, len);
     gas_or_fail!(interpreter, gas::verylowcopy_cost(len as u64));
@@ -101,7 +101,7 @@ pub fn calldatacopy<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
 }
 
 /// EIP-211: New opcodes: RETURNDATASIZE and RETURNDATACOPY
-pub fn returndatasize<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn returndatasize<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     check!(interpreter, BYZANTIUM);
     gas!(interpreter, gas::BASE);
     push!(
@@ -111,7 +111,7 @@ pub fn returndatasize<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, _host:
 }
 
 /// EIP-211: New opcodes: RETURNDATASIZE and RETURNDATACOPY
-pub fn returndatacopy<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn returndatacopy<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     check!(interpreter, BYZANTIUM);
     pop!(interpreter, memory_offset, offset, len);
     let len = as_usize_or_fail!(interpreter, len);
@@ -132,7 +132,7 @@ pub fn returndatacopy<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, _host:
     }
 }
 
-pub fn gas<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn gas<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::BASE);
     push!(interpreter, U256::from(interpreter.gas.remaining()));
 }

--- a/crates/revm/src/inspector/handler_register.rs
+++ b/crates/revm/src/inspector/handler_register.rs
@@ -260,26 +260,23 @@ pub fn inspector_instruction<
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
     use crate::{
         db::EmptyDB,
         inspectors::NoOpInspector,
-        interpreter::{opcode::*, CallInputs, CreateInputs, Interpreter},
+        interpreter::{opcode::*, CallInputs, CallOutcome, CreateInputs, CreateOutcome},
         primitives::BerlinSpec,
-        Database, Evm, EvmContext, Inspector,
+        EvmContext,
     };
 
-    use revm_interpreter::{CallOutcome, CreateOutcome};
-
+    // Test that this pattern builds.
     #[test]
     fn test_make_boxed_instruction_table() {
-        // test that this pattern builds.
-        let inst: InstructionTable<Evm<'_, NoOpInspector, EmptyDB>> =
-            make_instruction_table::<Evm<'_, _, _>, BerlinSpec>();
-        let _test: BoxedInstructionTable<'_, Evm<'_, _, _>> =
-            make_boxed_instruction_table::<'_, Evm<'_, NoOpInspector, EmptyDB>, BerlinSpec, _>(
-                inst,
+        type MyEvm<'a> = Evm<'a, NoOpInspector, EmptyDB>;
+        let table: InstructionTable<MyEvm<'_>> = make_instruction_table::<MyEvm<'_>, BerlinSpec>();
+        let _boxed_table: BoxedInstructionTable<'_, MyEvm<'_>> =
+            make_boxed_instruction_table::<'_, MyEvm<'_>, BerlinSpec, _>(
+                table,
                 inspector_instruction,
             );
     }


### PR DESCRIPTION
This allows running the interpreter with `&mut dyn Host`.

Useful to have in contexts where generics are not possible (e.g. dynamic callbacks / FFI, etc.) or testing/benchmarking code.

This was only limited by the type system requiring the maybe-sized (`+ ?Sized`) bound on the `Host` generics.