### PR TITLE
feat: rm EvmBuilder stage generics

### DIFF
--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -1,5 +1,5 @@
 use crate::{
-    builder::{EvmBuilder, HandlerStage, SetGenericStage},
+    builder::EvmBuilder,
     db::{Database, DatabaseCommit, EmptyDB},
     handler::Handler,
     interpreter::{
@@ -54,7 +54,7 @@ impl<EXT, DB: Database + DatabaseCommit> Evm<'_, EXT, DB> {
 
 impl<'a> Evm<'a, (), EmptyDB> {
     /// Returns evm builder with empty database and empty external context.
-    pub fn builder() -> EvmBuilder<'a, SetGenericStage, (), EmptyDB> {
+    pub fn builder() -> EvmBuilder<'a, (), EmptyDB> {
         EvmBuilder::default()
     }
 }
@@ -71,7 +71,7 @@ impl<'a, EXT, DB: Database> Evm<'a, EXT, DB> {
 
     /// Allow for evm setting to be modified by feeding current evm
     /// into the builder for modifications.
-    pub fn modify(self) -> EvmBuilder<'a, HandlerStage, EXT, DB> {
+    pub fn modify(self) -> EvmBuilder<'a, EXT, DB> {
         EvmBuilder::new(self)
     }
 }


### PR DESCRIPTION
Removes the stage generic types from the builder, making it possible to use the type.

The stages don't contain any context, so even after removing them, the code still compiles

## Motivation

This type signature would be much more convenient when integrating it in an abstraction like:

https://github.com/paradigmxyz/reth/blob/b1026e0e23dd458e2ca507cbca824b3af25310e0/crates/node-api/src/evm/traits.rs#L5-L24

I believe these stages exist because with_db, resets the handlers because the types can't be converted to a new db type?

> /// Second stage of the builder allows appending handler registers.
/// Requires the database and external context to be set.
pub struct HandlerStage;

https://github.com/bluealloy/revm/blob/a201a2d92c4a41f6530fe2b84ec23467255c0636/crates/revm/src/builder.rs#L69-L69

which makes sense, in order to prevent misuse while keeping the API, we could add separate types for these stages, this removes the generics, and makes the EvmBuilder type usable as a return type 