### PR TITLE
feat: add tests for shift instructions

### DIFF
--- a/bins/revm-test/src/bin/analysis.rs
+++ b/bins/revm-test/src/bin/analysis.rs
@@ -25,7 +25,7 @@ fn main() {
         .with_db(BenchmarkDB::new_bytecode(bytecode_raw))
         .build();
 
-    // just to spead up processor.
+    // Just to warm up the processor.
     for _ in 0..10000 {
         let _ = evm.transact().unwrap();
     }

--- a/crates/interpreter/src/instructions/bitwise.rs
+++ b/crates/interpreter/src/instructions/bitwise.rs
@@ -135,13 +135,8 @@ mod tests {
 
     #[test]
     fn test_shift_left() {
-        let contract = Contract {
-            input: Bytes::default(),
-            bytecode: BytecodeLocked::default(),
-            ..Default::default()
-        };
         let mut host = DummyHost::new(Env::default());
-        let mut interpreter = Interpreter::new(contract.clone(), u64::MAX, false);
+        let mut interpreter = Interpreter::new(Contract::default(), u64::MAX, false);
 
         struct TestCase {
             value: &'static str,
@@ -296,13 +291,8 @@ mod tests {
 
     #[test]
     fn test_logical_shift_right() {
-        let contract = Contract {
-            input: Bytes::default(),
-            bytecode: BytecodeLocked::default(),
-            ..Default::default()
-        };
         let mut host = DummyHost::new(Env::default());
-        let mut interpreter = Interpreter::new(contract.clone(), u64::MAX, false);
+        let mut interpreter = Interpreter::new(Contract::default(), u64::MAX, false);
 
         struct TestCase {
             value: &'static str,
@@ -457,13 +447,8 @@ mod tests {
 
     #[test]
     fn test_arithmetic_shift_right() {
-        let contract = Contract {
-            input: Bytes::default(),
-            bytecode: BytecodeLocked::default(),
-            ..Default::default()
-        };
         let mut host = DummyHost::new(Env::default());
-        let mut interpreter = Interpreter::new(contract.clone(), u64::MAX, false);
+        let mut interpreter = Interpreter::new(Contract::default(), u64::MAX, false);
 
         struct TestCase {
             value: &'static str,

--- a/crates/interpreter/src/instructions/bitwise.rs
+++ b/crates/interpreter/src/instructions/bitwise.rs
@@ -116,7 +116,7 @@ pub fn sar<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
             Sign::Minus => U256::MAX,
         }
     } else {
-        const ONE: U256 = uint!{1_U256};
+        const ONE: U256 = uint! {1_U256};
         // SAFETY: shift count is checked above; it's less than 255.
         let shift = usize::try_from(op1).unwrap();
         match value_sign {
@@ -131,7 +131,7 @@ mod tests {
     use crate::instructions::bitwise::{sar, shl, shr};
     use crate::{BytecodeLocked, Contract, DummyHost, Interpreter};
     use core::str::FromStr;
-    use revm_primitives::{Bytes, LatestSpec, Env, U256};
+    use revm_primitives::{Bytes, Env, LatestSpec, U256};
 
     #[test]
     fn test_shift_left() {

--- a/crates/interpreter/src/instructions/bitwise.rs
+++ b/crates/interpreter/src/instructions/bitwise.rs
@@ -116,7 +116,7 @@ pub fn sar<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
             Sign::Minus => U256::MAX,
         }
     } else {
-        const ONE: U256 = uint! {1_U256};
+        const ONE: U256 = uint!(1_U256);
         // SAFETY: shift count is checked above; it's less than 255.
         let shift = usize::try_from(op1).unwrap();
         match value_sign {

--- a/crates/interpreter/src/instructions/bitwise.rs
+++ b/crates/interpreter/src/instructions/bitwise.rs
@@ -129,9 +129,9 @@ pub fn sar<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
 #[cfg(test)]
 mod tests {
     use crate::instructions::bitwise::{sar, shl, shr};
-    use crate::{BytecodeLocked, Contract, DummyHost, Interpreter};
+    use crate::{Contract, DummyHost, Interpreter};
     use core::str::FromStr;
-    use revm_primitives::{Bytes, Env, LatestSpec, U256};
+    use revm_primitives::{Env, LatestSpec, U256};
 
     #[test]
     fn test_shift_left() {

--- a/crates/interpreter/src/instructions/bitwise.rs
+++ b/crates/interpreter/src/instructions/bitwise.rs
@@ -131,7 +131,7 @@ mod tests {
     use crate::instructions::bitwise::{sar, shl, shr};
     use crate::{BytecodeLocked, Contract, DummyHost, Interpreter};
     use core::str::FromStr;
-    use revm_primitives::{Bytes, CancunSpec, Env, U256};
+    use revm_primitives::{Bytes, LatestSpec, Env, U256};
 
     #[test]
     fn test_shift_left() {
@@ -288,7 +288,7 @@ mod tests {
             host.clear();
             push!(interpreter, U256::from_str(test.value).unwrap());
             push!(interpreter, U256::from_str(test.shift).unwrap());
-            shl::<DummyHost, CancunSpec>(&mut interpreter, &mut host);
+            shl::<DummyHost, LatestSpec>(&mut interpreter, &mut host);
             pop!(interpreter, res);
             assert_eq!(res, U256::from_str(test.expected).unwrap());
         }
@@ -449,7 +449,7 @@ mod tests {
             host.clear();
             push!(interpreter, U256::from_str(test.value).unwrap());
             push!(interpreter, U256::from_str(test.shift).unwrap());
-            shr::<DummyHost, CancunSpec>(&mut interpreter, &mut host);
+            shr::<DummyHost, LatestSpec>(&mut interpreter, &mut host);
             pop!(interpreter, res);
             assert_eq!(res, U256::from_str(test.expected).unwrap());
         }
@@ -670,7 +670,7 @@ mod tests {
             host.clear();
             push!(interpreter, U256::from_str(test.value).unwrap());
             push!(interpreter, U256::from_str(test.shift).unwrap());
-            sar::<DummyHost, CancunSpec>(&mut interpreter, &mut host);
+            sar::<DummyHost, LatestSpec>(&mut interpreter, &mut host);
             pop!(interpreter, res);
             assert_eq!(res, U256::from_str(test.expected).unwrap());
         }

--- a/crates/interpreter/src/instructions/bitwise.rs
+++ b/crates/interpreter/src/instructions/bitwise.rs
@@ -130,8 +130,7 @@ pub fn sar<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
 mod tests {
     use crate::instructions::bitwise::{sar, shl, shr};
     use crate::{Contract, DummyHost, Interpreter};
-    use core::str::FromStr;
-    use revm_primitives::{Env, LatestSpec, U256};
+    use revm_primitives::{uint, Env, LatestSpec, U256};
 
     #[test]
     fn test_shift_left() {
@@ -139,76 +138,78 @@ mod tests {
         let mut interpreter = Interpreter::new(Contract::default(), u64::MAX, false);
 
         struct TestCase {
-            value: &'static str,
-            shift: &'static str,
-            expected: &'static str,
+            value: U256,
+            shift: U256,
+            expected: U256,
         }
 
-        let test_cases = [
-            TestCase {
-                value: "0x0000000000000000000000000000000000000000000000000000000000000001",
-                shift: "0x00",
-                expected: "0x0000000000000000000000000000000000000000000000000000000000000001",
-            },
-            TestCase {
-                value: "0x0000000000000000000000000000000000000000000000000000000000000001",
-                shift: "0x01",
-                expected: "0x0000000000000000000000000000000000000000000000000000000000000002",
-            },
-            TestCase {
-                value: "0x0000000000000000000000000000000000000000000000000000000000000001",
-                shift: "0xff",
-                expected: "0x8000000000000000000000000000000000000000000000000000000000000000",
-            },
-            TestCase {
-                value: "0x0000000000000000000000000000000000000000000000000000000000000001",
-                shift: "0x0100",
-                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
-            },
-            TestCase {
-                value: "0x0000000000000000000000000000000000000000000000000000000000000001",
-                shift: "0x0101",
-                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
-            },
-            TestCase {
-                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-                shift: "0x00",
-                expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-            },
-            TestCase {
-                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-                shift: "0x01",
-                expected: "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe",
-            },
-            TestCase {
-                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-                shift: "0xff",
-                expected: "0x8000000000000000000000000000000000000000000000000000000000000000",
-            },
-            TestCase {
-                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-                shift: "0x0100",
-                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
-            },
-            TestCase {
-                value: "0x0000000000000000000000000000000000000000000000000000000000000000",
-                shift: "0x01",
-                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
-            },
-            TestCase {
-                value: "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-                shift: "0x01",
-                expected: "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe",
-            },
-        ];
+        uint! {
+            let test_cases = [
+                TestCase {
+                    value: 0x0000000000000000000000000000000000000000000000000000000000000001_U256,
+                    shift: 0x00_U256,
+                    expected: 0x0000000000000000000000000000000000000000000000000000000000000001_U256,
+                },
+                TestCase {
+                    value: 0x0000000000000000000000000000000000000000000000000000000000000001_U256,
+                    shift: 0x01_U256,
+                    expected: 0x0000000000000000000000000000000000000000000000000000000000000002_U256,
+                },
+                TestCase {
+                    value: 0x0000000000000000000000000000000000000000000000000000000000000001_U256,
+                    shift: 0xff_U256,
+                    expected: 0x8000000000000000000000000000000000000000000000000000000000000000_U256,
+                },
+                TestCase {
+                    value: 0x0000000000000000000000000000000000000000000000000000000000000001_U256,
+                    shift: 0x0100_U256,
+                    expected: 0x0000000000000000000000000000000000000000000000000000000000000000_U256,
+                },
+                TestCase {
+                    value: 0x0000000000000000000000000000000000000000000000000000000000000001_U256,
+                    shift: 0x0101_U256,
+                    expected: 0x0000000000000000000000000000000000000000000000000000000000000000_U256,
+                },
+                TestCase {
+                    value: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
+                    shift: 0x00_U256,
+                    expected: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
+                },
+                TestCase {
+                    value: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
+                    shift: 0x01_U256,
+                    expected: 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe_U256,
+                },
+                TestCase {
+                    value: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
+                    shift: 0xff_U256,
+                    expected: 0x8000000000000000000000000000000000000000000000000000000000000000_U256,
+                },
+                TestCase {
+                    value: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
+                    shift: 0x0100_U256,
+                    expected: 0x0000000000000000000000000000000000000000000000000000000000000000_U256,
+                },
+                TestCase {
+                    value: 0x0000000000000000000000000000000000000000000000000000000000000000_U256,
+                    shift: 0x01_U256,
+                    expected: 0x0000000000000000000000000000000000000000000000000000000000000000_U256,
+                },
+                TestCase {
+                    value: 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
+                    shift: 0x01_U256,
+                    expected: 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe_U256,
+                },
+            ];
+        }
 
         for test in test_cases {
             host.clear();
-            push!(interpreter, U256::from_str(test.value).unwrap());
-            push!(interpreter, U256::from_str(test.shift).unwrap());
+            push!(interpreter, test.value);
+            push!(interpreter, test.shift);
             shl::<DummyHost, LatestSpec>(&mut interpreter, &mut host);
             pop!(interpreter, res);
-            assert_eq!(res, U256::from_str(test.expected).unwrap());
+            assert_eq!(res, test.expected);
         }
     }
 
@@ -218,76 +219,78 @@ mod tests {
         let mut interpreter = Interpreter::new(Contract::default(), u64::MAX, false);
 
         struct TestCase {
-            value: &'static str,
-            shift: &'static str,
-            expected: &'static str,
+            value: U256,
+            shift: U256,
+            expected: U256,
         }
 
-        let test_cases = [
-            TestCase {
-                value: "0x0000000000000000000000000000000000000000000000000000000000000001",
-                shift: "0x00",
-                expected: "0x0000000000000000000000000000000000000000000000000000000000000001",
-            },
-            TestCase {
-                value: "0x0000000000000000000000000000000000000000000000000000000000000001",
-                shift: "0x01",
-                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
-            },
-            TestCase {
-                value: "0x8000000000000000000000000000000000000000000000000000000000000000",
-                shift: "0x01",
-                expected: "0x4000000000000000000000000000000000000000000000000000000000000000",
-            },
-            TestCase {
-                value: "0x8000000000000000000000000000000000000000000000000000000000000000",
-                shift: "0xff",
-                expected: "0x0000000000000000000000000000000000000000000000000000000000000001",
-            },
-            TestCase {
-                value: "0x8000000000000000000000000000000000000000000000000000000000000000",
-                shift: "0x0100",
-                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
-            },
-            TestCase {
-                value: "0x8000000000000000000000000000000000000000000000000000000000000000",
-                shift: "0x0101",
-                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
-            },
-            TestCase {
-                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-                shift: "0x00",
-                expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-            },
-            TestCase {
-                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-                shift: "0x01",
-                expected: "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-            },
-            TestCase {
-                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-                shift: "0xff",
-                expected: "0x0000000000000000000000000000000000000000000000000000000000000001",
-            },
-            TestCase {
-                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-                shift: "0x0100",
-                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
-            },
-            TestCase {
-                value: "0x0000000000000000000000000000000000000000000000000000000000000000",
-                shift: "0x01",
-                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
-            },
-        ];
+        uint! {
+            let test_cases = [
+                TestCase {
+                    value: 0x0000000000000000000000000000000000000000000000000000000000000001_U256,
+                    shift: 0x00_U256,
+                    expected: 0x0000000000000000000000000000000000000000000000000000000000000001_U256,
+                },
+                TestCase {
+                    value: 0x0000000000000000000000000000000000000000000000000000000000000001_U256,
+                    shift: 0x01_U256,
+                    expected: 0x0000000000000000000000000000000000000000000000000000000000000000_U256,
+                },
+                TestCase {
+                    value: 0x8000000000000000000000000000000000000000000000000000000000000000_U256,
+                    shift: 0x01_U256,
+                    expected: 0x4000000000000000000000000000000000000000000000000000000000000000_U256,
+                },
+                TestCase {
+                    value: 0x8000000000000000000000000000000000000000000000000000000000000000_U256,
+                    shift: 0xff_U256,
+                    expected: 0x0000000000000000000000000000000000000000000000000000000000000001_U256,
+                },
+                TestCase {
+                    value: 0x8000000000000000000000000000000000000000000000000000000000000000_U256,
+                    shift: 0x0100_U256,
+                    expected: 0x0000000000000000000000000000000000000000000000000000000000000000_U256,
+                },
+                TestCase {
+                    value: 0x8000000000000000000000000000000000000000000000000000000000000000_U256,
+                    shift: 0x0101_U256,
+                    expected: 0x0000000000000000000000000000000000000000000000000000000000000000_U256,
+                },
+                TestCase {
+                    value: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
+                    shift: 0x00_U256,
+                    expected: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
+                },
+                TestCase {
+                    value: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
+                    shift: 0x01_U256,
+                    expected: 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
+                },
+                TestCase {
+                    value: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
+                    shift: 0xff_U256,
+                    expected: 0x0000000000000000000000000000000000000000000000000000000000000001_U256,
+                },
+                TestCase {
+                    value: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
+                    shift: 0x0100_U256,
+                    expected: 0x0000000000000000000000000000000000000000000000000000000000000000_U256,
+                },
+                TestCase {
+                    value: 0x0000000000000000000000000000000000000000000000000000000000000000_U256,
+                    shift: 0x01_U256,
+                    expected: 0x0000000000000000000000000000000000000000000000000000000000000000_U256,
+                },
+            ];
+        }
 
         for test in test_cases {
             host.clear();
-            push!(interpreter, U256::from_str(test.value).unwrap());
-            push!(interpreter, U256::from_str(test.shift).unwrap());
+            push!(interpreter, test.value);
+            push!(interpreter, test.shift);
             shr::<DummyHost, LatestSpec>(&mut interpreter, &mut host);
             pop!(interpreter, res);
-            assert_eq!(res, U256::from_str(test.expected).unwrap());
+            assert_eq!(res, test.expected);
         }
     }
 
@@ -297,101 +300,103 @@ mod tests {
         let mut interpreter = Interpreter::new(Contract::default(), u64::MAX, false);
 
         struct TestCase {
-            value: &'static str,
-            shift: &'static str,
-            expected: &'static str,
+            value: U256,
+            shift: U256,
+            expected: U256,
         }
 
+        uint! {
         let test_cases = [
             TestCase {
-                value: "0x0000000000000000000000000000000000000000000000000000000000000001",
-                shift: "0x00",
-                expected: "0x0000000000000000000000000000000000000000000000000000000000000001",
+                value: 0x0000000000000000000000000000000000000000000000000000000000000001_U256,
+                shift: 0x00_U256,
+                expected: 0x0000000000000000000000000000000000000000000000000000000000000001_U256,
             },
             TestCase {
-                value: "0x0000000000000000000000000000000000000000000000000000000000000001",
-                shift: "0x01",
-                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
+                value: 0x0000000000000000000000000000000000000000000000000000000000000001_U256,
+                shift: 0x01_U256,
+                expected: 0x0000000000000000000000000000000000000000000000000000000000000000_U256,
             },
             TestCase {
-                value: "0x8000000000000000000000000000000000000000000000000000000000000000",
-                shift: "0x01",
-                expected: "0xc000000000000000000000000000000000000000000000000000000000000000",
+                value: 0x8000000000000000000000000000000000000000000000000000000000000000_U256,
+                shift: 0x01_U256,
+                expected: 0xc000000000000000000000000000000000000000000000000000000000000000_U256,
             },
             TestCase {
-                value: "0x8000000000000000000000000000000000000000000000000000000000000000",
-                shift: "0xff",
-                expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                value: 0x8000000000000000000000000000000000000000000000000000000000000000_U256,
+                shift: 0xff_U256,
+                expected: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
             },
             TestCase {
-                value: "0x8000000000000000000000000000000000000000000000000000000000000000",
-                shift: "0x0100",
-                expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                value: 0x8000000000000000000000000000000000000000000000000000000000000000_U256,
+                shift: 0x0100_U256,
+                expected: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
             },
             TestCase {
-                value: "0x8000000000000000000000000000000000000000000000000000000000000000",
-                shift: "0x0101",
-                expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                value: 0x8000000000000000000000000000000000000000000000000000000000000000_U256,
+                shift: 0x0101_U256,
+                expected: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
             },
             TestCase {
-                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-                shift: "0x00",
-                expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                value: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
+                shift: 0x00_U256,
+                expected: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
             },
             TestCase {
-                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-                shift: "0x01",
-                expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                value: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
+                shift: 0x01_U256,
+                expected: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
             },
             TestCase {
-                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-                shift: "0xff",
-                expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                value: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
+                shift: 0xff_U256,
+                expected: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
             },
             TestCase {
-                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-                shift: "0x0100",
-                expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                value: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
+                shift: 0x0100_U256,
+                expected: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
             },
             TestCase {
-                value: "0x0000000000000000000000000000000000000000000000000000000000000000",
-                shift: "0x01",
-                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
+                value: 0x0000000000000000000000000000000000000000000000000000000000000000_U256,
+                shift: 0x01_U256,
+                expected: 0x0000000000000000000000000000000000000000000000000000000000000000_U256,
             },
             TestCase {
-                value: "0x4000000000000000000000000000000000000000000000000000000000000000",
-                shift: "0xfe",
-                expected: "0x0000000000000000000000000000000000000000000000000000000000000001",
+                value: 0x4000000000000000000000000000000000000000000000000000000000000000_U256,
+                shift: 0xfe_U256,
+                expected: 0x0000000000000000000000000000000000000000000000000000000000000001_U256,
             },
             TestCase {
-                value: "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-                shift: "0xf8",
-                expected: "0x000000000000000000000000000000000000000000000000000000000000007f",
+                value: 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
+                shift: 0xf8_U256,
+                expected: 0x000000000000000000000000000000000000000000000000000000000000007f_U256,
             },
             TestCase {
-                value: "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-                shift: "0xfe",
-                expected: "0x0000000000000000000000000000000000000000000000000000000000000001",
+                value: 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
+                shift: 0xfe_U256,
+                expected: 0x0000000000000000000000000000000000000000000000000000000000000001_U256,
             },
             TestCase {
-                value: "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-                shift: "0xff",
-                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
+                value: 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
+                shift: 0xff_U256,
+                expected: 0x0000000000000000000000000000000000000000000000000000000000000000_U256,
             },
             TestCase {
-                value: "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-                shift: "0x0100",
-                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
+                value: 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
+                shift: 0x0100_U256,
+                expected: 0x0000000000000000000000000000000000000000000000000000000000000000_U256,
             },
         ];
+            }
 
         for test in test_cases {
             host.clear();
-            push!(interpreter, U256::from_str(test.value).unwrap());
-            push!(interpreter, U256::from_str(test.shift).unwrap());
+            push!(interpreter, test.value);
+            push!(interpreter, test.shift);
             sar::<DummyHost, LatestSpec>(&mut interpreter, &mut host);
             pop!(interpreter, res);
-            assert_eq!(res, U256::from_str(test.expected).unwrap());
+            assert_eq!(res, test.expected);
         }
     }
 }

--- a/crates/interpreter/src/instructions/bitwise.rs
+++ b/crates/interpreter/src/instructions/bitwise.rs
@@ -5,6 +5,7 @@ use crate::{
     Host, Interpreter,
 };
 use core::cmp::Ordering;
+use revm_primitives::uint;
 
 pub fn lt<H: Host>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
@@ -103,7 +104,11 @@ pub fn sar<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
 
     let value_sign = i256_sign_compl(op2);
 
-    *op2 = if value_sign == Sign::Zero || op1 >= U256::from(256) {
+    // If the shift count is 255+, we can short-circuit. This is because shifting by 255 bits is the
+    // maximum shift that still leaves 1 bit in the original 256-bit number. Shifting by 256 bits or
+    // more would mean that no original bits remain. The result depends on what the highest bit of
+    // the value is.
+    *op2 = if value_sign == Sign::Zero || op1 >= U256::from(255) {
         match value_sign {
             // value is 0 or >=1, pushing 0
             Sign::Plus | Sign::Zero => U256::ZERO,
@@ -111,11 +116,563 @@ pub fn sar<H: Host, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
             Sign::Minus => U256::MAX,
         }
     } else {
-        const ONE: U256 = U256::from_limbs([1, 0, 0, 0]);
+        const ONE: U256 = uint!{1_U256};
+        // SAFETY: shift count is checked above; it's less than 255.
         let shift = usize::try_from(op1).unwrap();
         match value_sign {
             Sign::Plus | Sign::Zero => op2.wrapping_shr(shift),
             Sign::Minus => two_compl(op2.wrapping_sub(ONE).wrapping_shr(shift).wrapping_add(ONE)),
         }
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::instructions::bitwise::{sar, shl, shr};
+    use crate::{BytecodeLocked, Contract, DummyHost, Interpreter};
+    use core::str::FromStr;
+    use revm_primitives::{Bytes, CancunSpec, Env, U256};
+
+    #[test]
+    fn test_shift_left() {
+        let contract = Contract {
+            input: Bytes::default(),
+            bytecode: BytecodeLocked::default(),
+            ..Default::default()
+        };
+        let mut host = DummyHost::new(Env::default());
+        let mut interpreter = Interpreter::new(contract.clone(), u64::MAX, false);
+
+        struct TestCase {
+            value: &'static str,
+            shift: &'static str,
+            expected: &'static str,
+        }
+
+        let test_cases = [
+            /*
+            PUSH 0x0000000000000000000000000000000000000000000000000000000000000001
+            PUSH 0x00
+            SHL
+            ---
+            0x0000000000000000000000000000000000000000000000000000000000000001
+            */
+            TestCase {
+                value: "0x0000000000000000000000000000000000000000000000000000000000000001",
+                shift: "0x00",
+                expected: "0x0000000000000000000000000000000000000000000000000000000000000001",
+            },
+            /*
+            PUSH 0x0000000000000000000000000000000000000000000000000000000000000001
+            PUSH 0x01
+            SHL
+            ---
+            0x0000000000000000000000000000000000000000000000000000000000000002
+            */
+            TestCase {
+                value: "0x0000000000000000000000000000000000000000000000000000000000000001",
+                shift: "0x01",
+                expected: "0x0000000000000000000000000000000000000000000000000000000000000002",
+            },
+            /*
+            PUSH 0x0000000000000000000000000000000000000000000000000000000000000001
+            PUSH 0xff
+            SHL
+            ---
+            0x8000000000000000000000000000000000000000000000000000000000000000
+            */
+            TestCase {
+                value: "0x0000000000000000000000000000000000000000000000000000000000000001",
+                shift: "0xff",
+                expected: "0x8000000000000000000000000000000000000000000000000000000000000000",
+            },
+            /*
+            PUSH 0x0000000000000000000000000000000000000000000000000000000000000001
+            PUSH 0x0100
+            SHL
+            ---
+            0x0000000000000000000000000000000000000000000000000000000000000000
+            */
+            TestCase {
+                value: "0x0000000000000000000000000000000000000000000000000000000000000001",
+                shift: "0x0100",
+                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
+            },
+            /*
+            PUSH 0x0000000000000000000000000000000000000000000000000000000000000001
+            PUSH 0x0101
+            SHL
+            ---
+            0x0000000000000000000000000000000000000000000000000000000000000000
+            */
+            TestCase {
+                value: "0x0000000000000000000000000000000000000000000000000000000000000001",
+                shift: "0x0101",
+                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
+            },
+            /*
+            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            PUSH 0x00
+            SHL
+            ---
+            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            */
+            TestCase {
+                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                shift: "0x00",
+                expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            },
+            /*
+            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            PUSH 0x01
+            SHL
+            ---
+            0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe
+            */
+            TestCase {
+                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                shift: "0x01",
+                expected: "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe",
+            },
+            /*
+            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            PUSH 0xff
+            SHL
+            ---
+            0x8000000000000000000000000000000000000000000000000000000000000000
+            */
+            TestCase {
+                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                shift: "0xff",
+                expected: "0x8000000000000000000000000000000000000000000000000000000000000000",
+            },
+            /*
+            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            PUSH 0x0100
+            SHL
+            ---
+            0x0000000000000000000000000000000000000000000000000000000000000000
+            */
+            TestCase {
+                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                shift: "0x0100",
+                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
+            },
+            /*
+            PUSH 0x0000000000000000000000000000000000000000000000000000000000000000
+            PUSH 0x01
+            SHL
+            ---
+            0x0000000000000000000000000000000000000000000000000000000000000000
+            */
+            TestCase {
+                value: "0x0000000000000000000000000000000000000000000000000000000000000000",
+                shift: "0x01",
+                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
+            },
+            /*
+            PUSH 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            PUSH 0x01
+            SHL
+            ---
+            0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe
+            */
+            TestCase {
+                value: "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                shift: "0x01",
+                expected: "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe",
+            },
+        ];
+
+        for test in test_cases {
+            host.clear();
+            push!(interpreter, U256::from_str(test.value).unwrap());
+            push!(interpreter, U256::from_str(test.shift).unwrap());
+            shl::<DummyHost, CancunSpec>(&mut interpreter, &mut host);
+            pop!(interpreter, res);
+            assert_eq!(res, U256::from_str(test.expected).unwrap());
+        }
+    }
+
+    #[test]
+    fn test_logical_shift_right() {
+        let contract = Contract {
+            input: Bytes::default(),
+            bytecode: BytecodeLocked::default(),
+            ..Default::default()
+        };
+        let mut host = DummyHost::new(Env::default());
+        let mut interpreter = Interpreter::new(contract.clone(), u64::MAX, false);
+
+        struct TestCase {
+            value: &'static str,
+            shift: &'static str,
+            expected: &'static str,
+        }
+
+        let test_cases = [
+            /*
+            PUSH 0x0000000000000000000000000000000000000000000000000000000000000001
+            PUSH 0x00
+            SHR
+            ---
+            0x0000000000000000000000000000000000000000000000000000000000000001
+            */
+            TestCase {
+                value: "0x0000000000000000000000000000000000000000000000000000000000000001",
+                shift: "0x00",
+                expected: "0x0000000000000000000000000000000000000000000000000000000000000001",
+            },
+            /*
+            PUSH 0x0000000000000000000000000000000000000000000000000000000000000001
+            PUSH 0x01
+            SHR
+            ---
+            0x0000000000000000000000000000000000000000000000000000000000000000
+            */
+            TestCase {
+                value: "0x0000000000000000000000000000000000000000000000000000000000000001",
+                shift: "0x01",
+                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
+            },
+            /*
+            PUSH 0x8000000000000000000000000000000000000000000000000000000000000000
+            PUSH 0x01
+            SHR
+            ---
+            0x4000000000000000000000000000000000000000000000000000000000000000
+            */
+            TestCase {
+                value: "0x8000000000000000000000000000000000000000000000000000000000000000",
+                shift: "0x01",
+                expected: "0x4000000000000000000000000000000000000000000000000000000000000000",
+            },
+            /*
+            PUSH 0x8000000000000000000000000000000000000000000000000000000000000000
+            PUSH 0xff
+            SHR
+            ---
+            0x0000000000000000000000000000000000000000000000000000000000000001
+            */
+            TestCase {
+                value: "0x8000000000000000000000000000000000000000000000000000000000000000",
+                shift: "0xff",
+                expected: "0x0000000000000000000000000000000000000000000000000000000000000001",
+            },
+            /*
+            PUSH 0x8000000000000000000000000000000000000000000000000000000000000000
+            PUSH 0x0100
+            SHR
+            ---
+            0x0000000000000000000000000000000000000000000000000000000000000000
+            */
+            TestCase {
+                value: "0x8000000000000000000000000000000000000000000000000000000000000000",
+                shift: "0x0100",
+                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
+            },
+            /*
+            PUSH 0x8000000000000000000000000000000000000000000000000000000000000000
+            PUSH 0x0101
+            SHR
+            ---
+            0x0000000000000000000000000000000000000000000000000000000000000000
+            */
+            TestCase {
+                value: "0x8000000000000000000000000000000000000000000000000000000000000000",
+                shift: "0x0101",
+                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
+            },
+            /*
+            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            PUSH 0x00
+            SHR
+            ---
+            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            */
+            TestCase {
+                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                shift: "0x00",
+                expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            },
+            /*
+            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            PUSH 0x01
+            SHR
+            ---
+            0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            */
+            TestCase {
+                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                shift: "0x01",
+                expected: "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            },
+            /*
+            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            PUSH 0xff
+            SHR
+            ---
+            0x0000000000000000000000000000000000000000000000000000000000000001
+            */
+            TestCase {
+                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                shift: "0xff",
+                expected: "0x0000000000000000000000000000000000000000000000000000000000000001",
+            },
+            /*
+            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            PUSH 0x0100
+            SHR
+            ---
+            0x0000000000000000000000000000000000000000000000000000000000000000
+            */
+            TestCase {
+                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                shift: "0x0100",
+                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
+            },
+            /*
+            PUSH 0x0000000000000000000000000000000000000000000000000000000000000000
+            PUSH 0x01
+            SHR
+            ---
+            0x0000000000000000000000000000000000000000000000000000000000000000
+            */
+            TestCase {
+                value: "0x0000000000000000000000000000000000000000000000000000000000000000",
+                shift: "0x01",
+                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
+            },
+        ];
+
+        for test in test_cases {
+            host.clear();
+            push!(interpreter, U256::from_str(test.value).unwrap());
+            push!(interpreter, U256::from_str(test.shift).unwrap());
+            shr::<DummyHost, CancunSpec>(&mut interpreter, &mut host);
+            pop!(interpreter, res);
+            assert_eq!(res, U256::from_str(test.expected).unwrap());
+        }
+    }
+
+    #[test]
+    fn test_arithmetic_shift_right() {
+        let contract = Contract {
+            input: Bytes::default(),
+            bytecode: BytecodeLocked::default(),
+            ..Default::default()
+        };
+        let mut host = DummyHost::new(Env::default());
+        let mut interpreter = Interpreter::new(contract.clone(), u64::MAX, false);
+
+        struct TestCase {
+            value: &'static str,
+            shift: &'static str,
+            expected: &'static str,
+        }
+
+        let test_cases = [
+            /*
+            PUSH 0x0000000000000000000000000000000000000000000000000000000000000001
+            PUSH 0x00
+            SAR
+            ---
+            0x0000000000000000000000000000000000000000000000000000000000000001
+            */
+            TestCase {
+                value: "0x0000000000000000000000000000000000000000000000000000000000000001",
+                shift: "0x00",
+                expected: "0x0000000000000000000000000000000000000000000000000000000000000001",
+            },
+            /*
+            PUSH 0x0000000000000000000000000000000000000000000000000000000000000001
+            PUSH 0x01
+            SAR
+            ---
+            0x0000000000000000000000000000000000000000000000000000000000000000
+            */
+            TestCase {
+                value: "0x0000000000000000000000000000000000000000000000000000000000000001",
+                shift: "0x01",
+                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
+            },
+            /*
+            PUSH 0x8000000000000000000000000000000000000000000000000000000000000000
+            PUSH 0x01
+            SAR
+            ---
+            0xc000000000000000000000000000000000000000000000000000000000000000
+            */
+            TestCase {
+                value: "0x8000000000000000000000000000000000000000000000000000000000000000",
+                shift: "0x01",
+                expected: "0xc000000000000000000000000000000000000000000000000000000000000000",
+            },
+            /*
+            PUSH 0x8000000000000000000000000000000000000000000000000000000000000000
+            PUSH 0xff
+            SAR
+            ---
+            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            */
+            TestCase {
+                value: "0x8000000000000000000000000000000000000000000000000000000000000000",
+                shift: "0xff",
+                expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            },
+            /*
+            PUSH 0x8000000000000000000000000000000000000000000000000000000000000000
+            PUSH 0x0100
+            SAR
+            ---
+            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            */
+            TestCase {
+                value: "0x8000000000000000000000000000000000000000000000000000000000000000",
+                shift: "0x0100",
+                expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            },
+            /*
+            PUSH 0x8000000000000000000000000000000000000000000000000000000000000000
+            PUSH 0x0101
+            SAR
+            ---
+            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            */
+            TestCase {
+                value: "0x8000000000000000000000000000000000000000000000000000000000000000",
+                shift: "0x0101",
+                expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            },
+            /*
+            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            PUSH 0x00
+            SAR
+            ---
+            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            */
+            TestCase {
+                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                shift: "0x00",
+                expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            },
+            /*
+            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            PUSH 0x01
+            SAR
+            ---
+            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            */
+            TestCase {
+                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                shift: "0x01",
+                expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            },
+            /*
+            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            PUSH 0xff
+            SAR
+            ---
+            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            */
+            TestCase {
+                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                shift: "0xff",
+                expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            },
+            /*
+            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            PUSH 0x0100
+            SAR
+            ---
+            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            */
+            TestCase {
+                value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                shift: "0x0100",
+                expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            },
+            /*
+            PUSH 0x0000000000000000000000000000000000000000000000000000000000000000
+            PUSH 0x01
+            SAR
+            ---
+            0x0000000000000000000000000000000000000000000000000000000000000000
+            */
+            TestCase {
+                value: "0x0000000000000000000000000000000000000000000000000000000000000000",
+                shift: "0x01",
+                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
+            },
+            /*
+            PUSH 0x4000000000000000000000000000000000000000000000000000000000000000
+            PUSH 0xfe
+            SAR
+            ---
+            0x0000000000000000000000000000000000000000000000000000000000000001
+            */
+            TestCase {
+                value: "0x4000000000000000000000000000000000000000000000000000000000000000",
+                shift: "0xfe",
+                expected: "0x0000000000000000000000000000000000000000000000000000000000000001",
+            },
+            /*
+            PUSH 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            PUSH 0xf8
+            SAR
+            ---
+            0x000000000000000000000000000000000000000000000000000000000000007f
+            */
+            TestCase {
+                value: "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                shift: "0xf8",
+                expected: "0x000000000000000000000000000000000000000000000000000000000000007f",
+            },
+            /*
+            PUSH 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            PUSH 0xfe
+            SAR
+            ---
+            0x0000000000000000000000000000000000000000000000000000000000000001
+            */
+            TestCase {
+                value: "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                shift: "0xfe",
+                expected: "0x0000000000000000000000000000000000000000000000000000000000000001",
+            },
+            /*
+            PUSH 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            PUSH 0xff
+            SAR
+            ---
+            0x0000000000000000000000000000000000000000000000000000000000000000
+            */
+            TestCase {
+                value: "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                shift: "0xff",
+                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
+            },
+            /*
+            PUSH 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            PUSH 0x0100
+            SAR
+            ---
+            0x0000000000000000000000000000000000000000000000000000000000000000
+            */
+            TestCase {
+                value: "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                shift: "0x0100",
+                expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
+            },
+        ];
+
+        for test in test_cases {
+            host.clear();
+            push!(interpreter, U256::from_str(test.value).unwrap());
+            push!(interpreter, U256::from_str(test.shift).unwrap());
+            sar::<DummyHost, CancunSpec>(&mut interpreter, &mut host);
+            pop!(interpreter, res);
+            assert_eq!(res, U256::from_str(test.expected).unwrap());
+        }
+    }
 }

--- a/crates/interpreter/src/instructions/bitwise.rs
+++ b/crates/interpreter/src/instructions/bitwise.rs
@@ -145,133 +145,56 @@ mod tests {
         }
 
         let test_cases = [
-            /*
-            PUSH 0x0000000000000000000000000000000000000000000000000000000000000001
-            PUSH 0x00
-            SHL
-            ---
-            0x0000000000000000000000000000000000000000000000000000000000000001
-            */
             TestCase {
                 value: "0x0000000000000000000000000000000000000000000000000000000000000001",
                 shift: "0x00",
                 expected: "0x0000000000000000000000000000000000000000000000000000000000000001",
             },
-            /*
-            PUSH 0x0000000000000000000000000000000000000000000000000000000000000001
-            PUSH 0x01
-            SHL
-            ---
-            0x0000000000000000000000000000000000000000000000000000000000000002
-            */
             TestCase {
                 value: "0x0000000000000000000000000000000000000000000000000000000000000001",
                 shift: "0x01",
                 expected: "0x0000000000000000000000000000000000000000000000000000000000000002",
             },
-            /*
-            PUSH 0x0000000000000000000000000000000000000000000000000000000000000001
-            PUSH 0xff
-            SHL
-            ---
-            0x8000000000000000000000000000000000000000000000000000000000000000
-            */
             TestCase {
                 value: "0x0000000000000000000000000000000000000000000000000000000000000001",
                 shift: "0xff",
                 expected: "0x8000000000000000000000000000000000000000000000000000000000000000",
             },
-            /*
-            PUSH 0x0000000000000000000000000000000000000000000000000000000000000001
-            PUSH 0x0100
-            SHL
-            ---
-            0x0000000000000000000000000000000000000000000000000000000000000000
-            */
             TestCase {
                 value: "0x0000000000000000000000000000000000000000000000000000000000000001",
                 shift: "0x0100",
                 expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
             },
-            /*
-            PUSH 0x0000000000000000000000000000000000000000000000000000000000000001
-            PUSH 0x0101
-            SHL
-            ---
-            0x0000000000000000000000000000000000000000000000000000000000000000
-            */
             TestCase {
                 value: "0x0000000000000000000000000000000000000000000000000000000000000001",
                 shift: "0x0101",
                 expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
             },
-            /*
-            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            PUSH 0x00
-            SHL
-            ---
-            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            */
             TestCase {
                 value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 shift: "0x00",
                 expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
             },
-            /*
-            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            PUSH 0x01
-            SHL
-            ---
-            0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe
-            */
             TestCase {
                 value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 shift: "0x01",
                 expected: "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe",
             },
-            /*
-            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            PUSH 0xff
-            SHL
-            ---
-            0x8000000000000000000000000000000000000000000000000000000000000000
-            */
             TestCase {
                 value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 shift: "0xff",
                 expected: "0x8000000000000000000000000000000000000000000000000000000000000000",
             },
-            /*
-            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            PUSH 0x0100
-            SHL
-            ---
-            0x0000000000000000000000000000000000000000000000000000000000000000
-            */
             TestCase {
                 value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 shift: "0x0100",
                 expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
             },
-            /*
-            PUSH 0x0000000000000000000000000000000000000000000000000000000000000000
-            PUSH 0x01
-            SHL
-            ---
-            0x0000000000000000000000000000000000000000000000000000000000000000
-            */
             TestCase {
                 value: "0x0000000000000000000000000000000000000000000000000000000000000000",
                 shift: "0x01",
                 expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
             },
-            /*
-            PUSH 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            PUSH 0x01
-            SHL
-            ---
-            0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe
-            */
             TestCase {
                 value: "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 shift: "0x01",
@@ -301,133 +224,56 @@ mod tests {
         }
 
         let test_cases = [
-            /*
-            PUSH 0x0000000000000000000000000000000000000000000000000000000000000001
-            PUSH 0x00
-            SHR
-            ---
-            0x0000000000000000000000000000000000000000000000000000000000000001
-            */
             TestCase {
                 value: "0x0000000000000000000000000000000000000000000000000000000000000001",
                 shift: "0x00",
                 expected: "0x0000000000000000000000000000000000000000000000000000000000000001",
             },
-            /*
-            PUSH 0x0000000000000000000000000000000000000000000000000000000000000001
-            PUSH 0x01
-            SHR
-            ---
-            0x0000000000000000000000000000000000000000000000000000000000000000
-            */
             TestCase {
                 value: "0x0000000000000000000000000000000000000000000000000000000000000001",
                 shift: "0x01",
                 expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
             },
-            /*
-            PUSH 0x8000000000000000000000000000000000000000000000000000000000000000
-            PUSH 0x01
-            SHR
-            ---
-            0x4000000000000000000000000000000000000000000000000000000000000000
-            */
             TestCase {
                 value: "0x8000000000000000000000000000000000000000000000000000000000000000",
                 shift: "0x01",
                 expected: "0x4000000000000000000000000000000000000000000000000000000000000000",
             },
-            /*
-            PUSH 0x8000000000000000000000000000000000000000000000000000000000000000
-            PUSH 0xff
-            SHR
-            ---
-            0x0000000000000000000000000000000000000000000000000000000000000001
-            */
             TestCase {
                 value: "0x8000000000000000000000000000000000000000000000000000000000000000",
                 shift: "0xff",
                 expected: "0x0000000000000000000000000000000000000000000000000000000000000001",
             },
-            /*
-            PUSH 0x8000000000000000000000000000000000000000000000000000000000000000
-            PUSH 0x0100
-            SHR
-            ---
-            0x0000000000000000000000000000000000000000000000000000000000000000
-            */
             TestCase {
                 value: "0x8000000000000000000000000000000000000000000000000000000000000000",
                 shift: "0x0100",
                 expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
             },
-            /*
-            PUSH 0x8000000000000000000000000000000000000000000000000000000000000000
-            PUSH 0x0101
-            SHR
-            ---
-            0x0000000000000000000000000000000000000000000000000000000000000000
-            */
             TestCase {
                 value: "0x8000000000000000000000000000000000000000000000000000000000000000",
                 shift: "0x0101",
                 expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
             },
-            /*
-            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            PUSH 0x00
-            SHR
-            ---
-            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            */
             TestCase {
                 value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 shift: "0x00",
                 expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
             },
-            /*
-            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            PUSH 0x01
-            SHR
-            ---
-            0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            */
             TestCase {
                 value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 shift: "0x01",
                 expected: "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
             },
-            /*
-            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            PUSH 0xff
-            SHR
-            ---
-            0x0000000000000000000000000000000000000000000000000000000000000001
-            */
             TestCase {
                 value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 shift: "0xff",
                 expected: "0x0000000000000000000000000000000000000000000000000000000000000001",
             },
-            /*
-            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            PUSH 0x0100
-            SHR
-            ---
-            0x0000000000000000000000000000000000000000000000000000000000000000
-            */
             TestCase {
                 value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 shift: "0x0100",
                 expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
             },
-            /*
-            PUSH 0x0000000000000000000000000000000000000000000000000000000000000000
-            PUSH 0x01
-            SHR
-            ---
-            0x0000000000000000000000000000000000000000000000000000000000000000
-            */
             TestCase {
                 value: "0x0000000000000000000000000000000000000000000000000000000000000000",
                 shift: "0x01",
@@ -457,193 +303,81 @@ mod tests {
         }
 
         let test_cases = [
-            /*
-            PUSH 0x0000000000000000000000000000000000000000000000000000000000000001
-            PUSH 0x00
-            SAR
-            ---
-            0x0000000000000000000000000000000000000000000000000000000000000001
-            */
             TestCase {
                 value: "0x0000000000000000000000000000000000000000000000000000000000000001",
                 shift: "0x00",
                 expected: "0x0000000000000000000000000000000000000000000000000000000000000001",
             },
-            /*
-            PUSH 0x0000000000000000000000000000000000000000000000000000000000000001
-            PUSH 0x01
-            SAR
-            ---
-            0x0000000000000000000000000000000000000000000000000000000000000000
-            */
             TestCase {
                 value: "0x0000000000000000000000000000000000000000000000000000000000000001",
                 shift: "0x01",
                 expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
             },
-            /*
-            PUSH 0x8000000000000000000000000000000000000000000000000000000000000000
-            PUSH 0x01
-            SAR
-            ---
-            0xc000000000000000000000000000000000000000000000000000000000000000
-            */
             TestCase {
                 value: "0x8000000000000000000000000000000000000000000000000000000000000000",
                 shift: "0x01",
                 expected: "0xc000000000000000000000000000000000000000000000000000000000000000",
             },
-            /*
-            PUSH 0x8000000000000000000000000000000000000000000000000000000000000000
-            PUSH 0xff
-            SAR
-            ---
-            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            */
             TestCase {
                 value: "0x8000000000000000000000000000000000000000000000000000000000000000",
                 shift: "0xff",
                 expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
             },
-            /*
-            PUSH 0x8000000000000000000000000000000000000000000000000000000000000000
-            PUSH 0x0100
-            SAR
-            ---
-            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            */
             TestCase {
                 value: "0x8000000000000000000000000000000000000000000000000000000000000000",
                 shift: "0x0100",
                 expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
             },
-            /*
-            PUSH 0x8000000000000000000000000000000000000000000000000000000000000000
-            PUSH 0x0101
-            SAR
-            ---
-            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            */
             TestCase {
                 value: "0x8000000000000000000000000000000000000000000000000000000000000000",
                 shift: "0x0101",
                 expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
             },
-            /*
-            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            PUSH 0x00
-            SAR
-            ---
-            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            */
             TestCase {
                 value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 shift: "0x00",
                 expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
             },
-            /*
-            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            PUSH 0x01
-            SAR
-            ---
-            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            */
             TestCase {
                 value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 shift: "0x01",
                 expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
             },
-            /*
-            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            PUSH 0xff
-            SAR
-            ---
-            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            */
             TestCase {
                 value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 shift: "0xff",
                 expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
             },
-            /*
-            PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            PUSH 0x0100
-            SAR
-            ---
-            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            */
             TestCase {
                 value: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 shift: "0x0100",
                 expected: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
             },
-            /*
-            PUSH 0x0000000000000000000000000000000000000000000000000000000000000000
-            PUSH 0x01
-            SAR
-            ---
-            0x0000000000000000000000000000000000000000000000000000000000000000
-            */
             TestCase {
                 value: "0x0000000000000000000000000000000000000000000000000000000000000000",
                 shift: "0x01",
                 expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
             },
-            /*
-            PUSH 0x4000000000000000000000000000000000000000000000000000000000000000
-            PUSH 0xfe
-            SAR
-            ---
-            0x0000000000000000000000000000000000000000000000000000000000000001
-            */
             TestCase {
                 value: "0x4000000000000000000000000000000000000000000000000000000000000000",
                 shift: "0xfe",
                 expected: "0x0000000000000000000000000000000000000000000000000000000000000001",
             },
-            /*
-            PUSH 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            PUSH 0xf8
-            SAR
-            ---
-            0x000000000000000000000000000000000000000000000000000000000000007f
-            */
             TestCase {
                 value: "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 shift: "0xf8",
                 expected: "0x000000000000000000000000000000000000000000000000000000000000007f",
             },
-            /*
-            PUSH 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            PUSH 0xfe
-            SAR
-            ---
-            0x0000000000000000000000000000000000000000000000000000000000000001
-            */
             TestCase {
                 value: "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 shift: "0xfe",
                 expected: "0x0000000000000000000000000000000000000000000000000000000000000001",
             },
-            /*
-            PUSH 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            PUSH 0xff
-            SAR
-            ---
-            0x0000000000000000000000000000000000000000000000000000000000000000
-            */
             TestCase {
                 value: "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 shift: "0xff",
                 expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
             },
-            /*
-            PUSH 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            PUSH 0x0100
-            SAR
-            ---
-            0x0000000000000000000000000000000000000000000000000000000000000000
-            */
             TestCase {
                 value: "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 shift: "0x0100",


### PR DESCRIPTION
This PR does the following:

* Add tests for shift operations (`shl`, `shr`, `sar`) from [EIP-145](https://eips.ethereum.org/EIPS/eip-145).
* Replace instance `U256::from_limbs` with `uint!{}` macro, for readability.
* Ever so slightly optimize `sar` short-circuit check. This can be 255.
* Add some comments, one about how `.unwrap()` is safe.

In the tests, is this the best way to execute an EVM instruction?

Also, I can remove the test comments if it's too much. I just copy/pasted the values into the structs.
