### PR TITLE
perf(interpreter): use `pop_top!` where possible

### DIFF
--- a/crates/interpreter/src/instructions/control.rs
+++ b/crates/interpreter/src/instructions/control.rs
@@ -6,27 +6,27 @@ use crate::{
 
 pub fn jump<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::MID);
-    pop!(interpreter, dest);
-    jump_inner(interpreter, dest);
+    pop!(interpreter, target);
+    jump_inner(interpreter, target);
 }
 
 pub fn jumpi<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::HIGH);
-    pop!(interpreter, dest, value);
-    if value != U256::ZERO {
-        jump_inner(interpreter, dest);
+    pop!(interpreter, target, cond);
+    if cond != U256::ZERO {
+        jump_inner(interpreter, target);
     }
 }
 
 #[inline(always)]
-fn jump_inner(interpreter: &mut Interpreter, dest: U256) {
-    let dest = as_usize_or_fail!(interpreter, dest, InstructionResult::InvalidJump);
-    if !interpreter.contract.is_valid_jump(dest) {
+fn jump_inner(interpreter: &mut Interpreter, target: U256) {
+    let target = as_usize_or_fail!(interpreter, target, InstructionResult::InvalidJump);
+    if !interpreter.contract.is_valid_jump(target) {
         interpreter.instruction_result = InstructionResult::InvalidJump;
         return;
     }
     // SAFETY: `is_valid_jump` ensures that `dest` is in bounds.
-    interpreter.instruction_pointer = unsafe { interpreter.contract.bytecode.as_ptr().add(dest) };
+    interpreter.instruction_pointer = unsafe { interpreter.contract.bytecode.as_ptr().add(target) };
 }
 
 pub fn jumpdest<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -140,14 +140,14 @@ pub fn blockhash<H: Host + ?Sized>(interpreter: &mut Interpreter, host: &mut H) 
 }
 
 pub fn sload<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
-    pop!(interpreter, index);
+    pop_top!(interpreter, index);
 
-    let Some((value, is_cold)) = host.sload(interpreter.contract.address, index) else {
+    let Some((value, is_cold)) = host.sload(interpreter.contract.address, *index) else {
         interpreter.instruction_result = InstructionResult::FatalExternalError;
         return;
     };
     gas!(interpreter, gas::sload_cost(SPEC::SPEC_ID, is_cold));
-    push!(interpreter, value);
+    *index = value;
 }
 
 pub fn sstore<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {

--- a/crates/interpreter/src/instructions/memory.rs
+++ b/crates/interpreter/src/instructions/memory.rs
@@ -7,26 +7,26 @@ use core::cmp::max;
 
 pub fn mload<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
-    pop!(interpreter, index);
-    let index = as_usize_or_fail!(interpreter, index);
-    resize_memory!(interpreter, index, 32);
-    push!(interpreter, interpreter.shared_memory.get_u256(index));
+    pop_top!(interpreter, offset_ptr);
+    let offset = as_usize_or_fail!(interpreter, offset_ptr);
+    resize_memory!(interpreter, offset, 32);
+    *offset_ptr = interpreter.shared_memory.get_u256(offset);
 }
 
 pub fn mstore<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
-    pop!(interpreter, index, value);
-    let index = as_usize_or_fail!(interpreter, index);
-    resize_memory!(interpreter, index, 32);
-    interpreter.shared_memory.set_u256(index, value);
+    pop!(interpreter, offset, value);
+    let offset = as_usize_or_fail!(interpreter, offset);
+    resize_memory!(interpreter, offset, 32);
+    interpreter.shared_memory.set_u256(offset, value);
 }
 
 pub fn mstore8<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
-    pop!(interpreter, index, value);
-    let index = as_usize_or_fail!(interpreter, index);
-    resize_memory!(interpreter, index, 1);
-    interpreter.shared_memory.set_byte(index, value.byte(0))
+    pop!(interpreter, offset, value);
+    let offset = as_usize_or_fail!(interpreter, offset);
+    resize_memory!(interpreter, offset, 1);
+    interpreter.shared_memory.set_byte(offset, value.byte(0))
 }
 
 pub fn msize<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {

--- a/crates/interpreter/src/interpreter/stack.rs
+++ b/crates/interpreter/src/interpreter/stack.rs
@@ -184,7 +184,7 @@ impl Stack {
     /// unchanged.
     #[inline]
     pub fn push(&mut self, value: U256) -> Result<(), InstructionResult> {
-        // allows the compiler to optimize out the `Vec::push` capacity check
+        // Allows the compiler to optimize out the `Vec::push` capacity check.
         assume!(self.data.capacity() == STACK_LIMIT);
         if self.data.len() == STACK_LIMIT {
             return Err(InstructionResult::StackOverflow);

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -382,11 +382,12 @@ impl<EXT, DB: Database> Evm<'_, EXT, DB> {
 }
 
 impl<EXT, DB: Database> Host for Evm<'_, EXT, DB> {
-    fn env_mut(&mut self) -> &mut Env {
-        &mut self.context.evm.env
-    }
     fn env(&self) -> &Env {
         &self.context.evm.env
+    }
+
+    fn env_mut(&mut self) -> &mut Env {
+        &mut self.context.evm.env
     }
 
     fn block_hash(&mut self, number: U256) -> Option<B256> {


### PR DESCRIPTION
Avoids a branch and a load/store of the stack length in `*LOAD` opcodes.

This is usually optimized out, but the code ends up being less than optimal as the optimizer does not recognize that we're writing into the same slot / it can't make that assumption for some reason.

I also removed slice bound checks in CALLDATALOAD as they were not optimized out, see inline comments.

Snailtracer:
- before: 1'326'516'806
- after: 1'315'075'774 (-0.86%)