### PR TITLE
chore(ci): use more stable rust toolchain plugin

### DIFF
--- a/.github/workflows/cachegrind.yml
+++ b/.github/workflows/cachegrind.yml
@@ -14,9 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup | Rust
-        uses: ATiltedTree/setup-rust@v1
-        with:
-          rust-version: stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install Valgrind
         run: |


### PR DESCRIPTION
Repo got removed: https://github.com/ATiltedTree/setup-rust

Switching to better option.