### PR TITLE
feat: pass rand feature to alloy_primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,7 @@ dependencies = [
  "derive_arbitrary",
  "derive_more",
  "ethereum_ssz",
+ "getrandom",
  "hex-literal",
  "itoa",
  "k256",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -87,6 +87,7 @@ optional_eip3607 = []
 optional_gas_refund = []
 optional_no_base_fee = []
 optional_beneficiary_reward = []
+rand = ["alloy-primitives/rand"]
 
 # See comments in `revm-precompile`
 c-kzg = ["dep:c-kzg", "dep:once_cell", "dep:derive_more"]


### PR DESCRIPTION
This allows forwarding of the `rand` flag to `alloy_primitives` to enable random APIs on the primitive types