### PR TITLE
feat: add flag to force hashbrown usage

### DIFF
--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1.0", default-features = false, features = [
 [features]
 default = ["std"]
 std = ["serde?/std", "revm-primitives/std"]
+hashbrown = ["revm-primitives/hashbrown"]
 serde = ["dep:serde", "revm-primitives/serde"]
 arbitrary = ["std", "revm-primitives/arbitrary"]
 asm-keccak = ["revm-primitives/asm-keccak"]

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -48,6 +48,7 @@ std = [
     "c-kzg?/std",
     "secp256k1?/std",
 ]
+hashbrown = ["revm-primitives/hashbrown"]
 asm-keccak = ["revm-primitives/asm-keccak"]
 
 optimism = ["revm-primitives/optimism"]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -53,6 +53,7 @@ std = [
     "bitvec/std",
     "bitflags/std",
 ]
+hashbrown = []
 serde = [
     "dep:serde",
     "alloy-primitives/serde",

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -30,7 +30,7 @@ pub use constants::*;
 pub use env::*;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "std")] {
+    if #[cfg(all(not(feature = "hashbrown"), feature = "std"))] {
         pub use std::collections::{hash_map, hash_set, HashMap, HashSet};
         use hashbrown as _;
     } else {

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -64,6 +64,7 @@ std = [
     "revm-interpreter/std",
     "revm-precompile/std",
 ]
+hashbrown = ["revm-interpreter/hashbrown", "revm-precompile/hashbrown"]
 serde = ["dep:serde", "revm-interpreter/serde"]
 serde-json = ["serde", "dep:serde_json"]
 arbitrary = ["revm-interpreter/arbitrary"]


### PR DESCRIPTION
This allows re-exporting of `hashbrown`, even if the `std` feature flag is enabled.