### PR TITLE
docs(inspectors): change `serde` to `serde-json` for `TracerEip3155`

### DIFF
--- a/documentation/src/crates/revm/inspector.md
+++ b/documentation/src/crates/revm/inspector.md
@@ -14,7 +14,7 @@ There are several built-in inspectors in this module:
 - `TracerEip3155`:
   This is an inspector that conforms to the [EIP-3155](https://eips.ethereum.org/EIPS/eip-3155) standard for tracing Ethereum transactions.
   It's used to generate detailed trace data of transaction execution, which can be useful for debugging, analysis, or for building tools that need to understand the inner workings of Ethereum transactions.
-  This is only available when both `std` and `serde` features are enabled.
+  This is only available when both `std` and `serde-json` features are enabled.
 
 ## Inspector trait
 


### PR DESCRIPTION
# Motivation

The feature you actually need to enable for `revm::inspectors::TracerEip3155` is `serde-json` and `std`, not `serde`.

https://github.com/bluealloy/revm/blob/1edfeb6893a4b053170886a026eb5742c5561fa6/crates/revm/src/inspector.rs#L25-L26