### PR TITLE
Drops check for .json when testing a single file

### DIFF
--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -60,12 +60,16 @@ pub enum TestErrorKind {
 }
 
 pub fn find_all_json_tests(path: &Path) -> Vec<PathBuf> {
-    WalkDir::new(path)
-        .into_iter()
-        .filter_map(Result::ok)
-        .filter(|e| e.path().extension() == Some("json".as_ref()))
-        .map(DirEntry::into_path)
-        .collect()
+    if path.is_file() {
+        vec![path.to_path_buf()]
+    } else {
+        WalkDir::new(path)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|e| e.path().extension() == Some("json".as_ref()))
+            .map(DirEntry::into_path)
+            .collect()
+    }
 }
 
 fn skip_test(path: &Path) -> bool {


### PR DESCRIPTION
This allows statetest to be run on files that don't have a .json extension if test path is a single file path.

Fixes #1247 