### PR TITLE
chore(interpreter): rename wrapping_* opcodes

### DIFF
--- a/crates/interpreter/src/instructions/arithmetic.rs
+++ b/crates/interpreter/src/instructions/arithmetic.rs
@@ -5,19 +5,19 @@ use crate::{
     Host, Interpreter,
 };
 
-pub fn wrapping_add<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn add<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = op1.wrapping_add(*op2);
 }
 
-pub fn wrapping_mul<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn mul<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::LOW);
     pop_top!(interpreter, op1, op2);
     *op2 = op1.wrapping_mul(*op2);
 }
 
-pub fn wrapping_sub<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
+pub fn sub<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = op1.wrapping_sub(*op2);

--- a/crates/interpreter/src/opcode.rs
+++ b/crates/interpreter/src/opcode.rs
@@ -379,9 +379,9 @@ pub const fn stack_io<const I: u8, const O: u8>(mut opcode: OpCodeInfo) -> OpCod
 opcodes! {
     0x00 => STOP => control::stop => stack_io<0,0>, terminating;
 
-    0x01 => ADD        => arithmetic::wrapping_add   => stack_io<2, 1>;
-    0x02 => MUL        => arithmetic::wrapping_mul   => stack_io<2, 1>;
-    0x03 => SUB        => arithmetic::wrapping_sub   => stack_io<2, 1>;
+    0x01 => ADD        => arithmetic::add            => stack_io<2, 1>;
+    0x02 => MUL        => arithmetic::mul            => stack_io<2, 1>;
+    0x03 => SUB        => arithmetic::sub            => stack_io<2, 1>;
     0x04 => DIV        => arithmetic::div            => stack_io<2, 1>;
     0x05 => SDIV       => arithmetic::sdiv           => stack_io<2, 1>;
     0x06 => MOD        => arithmetic::rem            => stack_io<2, 1>;


### PR DESCRIPTION
Wrapping doesn't make sense here, these should match the actual opcode name as defined in the yellow paper.