### PR TITLE
perf(interpreter): remove EOF branch in CODE{SIZE,COPY}

### DIFF
--- a/crates/interpreter/src/instructions/system.rs
+++ b/crates/interpreter/src/instructions/system.rs
@@ -31,6 +31,8 @@ pub fn caller<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
 
 pub fn codesize<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::BASE);
+    // Inform the optimizer that the bytecode cannot be EOF to remove a bounds check.
+    assume!(!interpreter.contract.bytecode.is_eof());
     push!(interpreter, U256::from(interpreter.contract.bytecode.len()));
 }
 
@@ -45,6 +47,8 @@ pub fn codecopy<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) 
     let code_offset = as_usize_saturated!(code_offset);
     resize_memory!(interpreter, memory_offset, len);
 
+    // Inform the optimizer that the bytecode cannot be EOF to remove a bounds check.
+    assume!(!interpreter.contract.bytecode.is_eof());
     // Note: this can't panic because we resized memory to fit.
     interpreter.shared_memory.set_data(
         memory_offset,

--- a/crates/primitives/src/bytecode.rs
+++ b/crates/primitives/src/bytecode.rs
@@ -52,7 +52,8 @@ impl Bytecode {
     }
 
     /// Return reference to the EOF if bytecode is EOF.
-    pub fn eof(&self) -> Option<&Eof> {
+    #[inline]
+    pub const fn eof(&self) -> Option<&Eof> {
         match self {
             Self::Eof(eof) => Some(eof),
             _ => None,
@@ -60,7 +61,8 @@ impl Bytecode {
     }
 
     /// Return true if bytecode is EOF.
-    pub fn is_eof(&self) -> bool {
+    #[inline]
+    pub const fn is_eof(&self) -> bool {
         matches!(self, Self::Eof(_))
     }
 


### PR DESCRIPTION
CODESIZE and CODECOPY are disabled in EOF, so the EOF branch on the bytecode is not reachable.

codesize assembly diff:

![image](https://github.com/bluealloy/revm/assets/57450786/e3862325-9745-410f-a7a3-5e08baff9092)