### PR TITLE
chore: don't clone bytes in `Bytecode::bytes`

### DIFF
--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -87,7 +87,7 @@ impl Interpreter {
             panic!("Contract is not execution ready {:?}", contract.bytecode);
         }
         let is_eof = contract.bytecode.is_eof();
-        let bytecode = contract.bytecode.bytecode_bytes();
+        let bytecode = contract.bytecode.bytecode().clone();
         Self {
             instruction_pointer: bytecode.as_ptr(),
             bytecode,

--- a/crates/primitives/src/bytecode.rs
+++ b/crates/primitives/src/bytecode.rs
@@ -91,17 +91,17 @@ impl Bytecode {
     }
 
     /// Returns a reference to the bytecode.
+    ///
     /// In case of EOF this will be the first code section.
     #[inline]
-    pub fn bytecode_bytes(&self) -> Bytes {
+    pub fn bytecode(&self) -> &Bytes {
         match self {
-            Self::LegacyRaw(bytes) => bytes.clone(),
-            Self::LegacyAnalyzed(analyzed) => analyzed.bytes(),
+            Self::LegacyRaw(bytes) => bytes,
+            Self::LegacyAnalyzed(analyzed) => analyzed.bytecode(),
             Self::Eof(eof) => eof
                 .body
                 .code(0)
-                .expect("Valid EOF has at least one code section")
-                .clone(),
+                .expect("Valid EOF has at least one code section"),
         }
     }
 

--- a/crates/primitives/src/bytecode/legacy.rs
+++ b/crates/primitives/src/bytecode/legacy.rs
@@ -39,11 +39,11 @@ impl LegacyAnalyzedBytecode {
         }
     }
 
-    /// Returns bytes of bytecode.
+    /// Returns a reference to the bytecode.
     ///
-    /// Bytes are padded with 32 zero bytes.
-    pub fn bytes(&self) -> Bytes {
-        self.bytecode.clone()
+    /// The bytecode is padded with 32 zero bytes.
+    pub fn bytecode(&self) -> &Bytes {
+        &self.bytecode
     }
 
     /// Original bytes length.


### PR DESCRIPTION
We can return a reference to `Bytes` instead of cloning it.
Because this change has not been released yet, I also renamed it for consistency to just `fn bytes`.