### PR TITLE
perf: remove bounds check in DUP, SWAP/EXCHANGE

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,11 @@ default-members = ["crates/revm"]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[profile.release]
+lto = true
+codegen-units = 1
+debug = true
+
 [profile.ethtests]
 inherits = "test"
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,6 @@ default-members = ["crates/revm"]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
-[profile.release]
-lto = true
-codegen-units = 1
-debug = true
-
 [profile.ethtests]
 inherits = "test"
 opt-level = 3

--- a/crates/interpreter/src/interpreter/stack.rs
+++ b/crates/interpreter/src/interpreter/stack.rs
@@ -275,9 +275,11 @@ impl Stack {
         }
         // SAFETY: `n` and `n_m` are checked to be within bounds, and they don't overlap.
         unsafe {
-            // NOTE: `mem::swap` performs better than `slice::swap`/`ptr::swap`, as they cannot
-            // assume that the pointers are non-overlapping when we know they are not.
+            // NOTE: `mem::swap` is more efficient than `slice::swap` or `ptr::swap` because it
+            // operates under the assumption that the pointers do not overlap,
+            // which is a condition we know to be true in this context.
             let top = self.data.as_mut_ptr().add(len - 1);
+            #[allow(clippy::swap_ptr_to_ref)] // See above.
             core::mem::swap(&mut *top.sub(n), &mut *top.sub(n_m_index));
         }
         Ok(())

--- a/crates/interpreter/src/interpreter/stack.rs
+++ b/crates/interpreter/src/interpreter/stack.rs
@@ -275,12 +275,12 @@ impl Stack {
         }
         // SAFETY: `n` and `n_m` are checked to be within bounds, and they don't overlap.
         unsafe {
-            // NOTE: `mem::swap` is more efficient than `slice::swap` or `ptr::swap` because it
-            // operates under the assumption that the pointers do not overlap,
+            // NOTE: `ptr::swap_nonoverlapping` is more efficient than `slice::swap` or `ptr::swap`
+            // because it operates under the assumption that the pointers do not overlap,
+            // eliminating an intemediate copy,
             // which is a condition we know to be true in this context.
             let top = self.data.as_mut_ptr().add(len - 1);
-            #[allow(clippy::swap_ptr_to_ref)] // See above.
-            core::mem::swap(&mut *top.sub(n), &mut *top.sub(n_m_index));
+            core::ptr::swap_nonoverlapping(top.sub(n), top.sub(n_m_index), 1);
         }
         Ok(())
     }

--- a/crates/interpreter/src/interpreter_action/call_inputs.rs
+++ b/crates/interpreter/src/interpreter_action/call_inputs.rs
@@ -36,7 +36,7 @@ pub struct CallInputs {
     ///
     /// Previously `context.scheme`.
     pub scheme: CallScheme,
-    /// Whether the call is initiated inside a static call.
+    /// Whether the call is a static call, or is initiated inside a static call.
     pub is_static: bool,
     /// Whether the call is initiated from EOF bytecode.
     pub is_eof: bool,


### PR DESCRIPTION
It was introduced by making `n` dynamic instead of constant