### PR TITLE
feat: implement EIP-2935

### DIFF
--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -5,7 +5,7 @@ use crate::{
     Host, InstructionResult, SStoreResult,
 };
 use core::cmp::min;
-use revm_primitives::{Address, BLOCK_HASH_HISTORY, HISTORY_SERVE_WINDOW, HISTORY_STORAGE_ADDRESS};
+use revm_primitives::{BLOCK_HASH_HISTORY, HISTORY_SERVE_WINDOW, HISTORY_STORAGE_ADDRESS};
 use std::vec::Vec;
 
 pub fn balance<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -5,7 +5,7 @@ use crate::{
     Host, InstructionResult, SStoreResult,
 };
 use core::cmp::min;
-use revm_primitives::{BLOCK_HASH_HISTORY, HISTORY_SERVE_WINDOW, HISTORY_STORAGE_ADDRESS};
+use revm_primitives::{BLOCKHASH_SERVE_WINDOW, BLOCKHASH_STORAGE_ADDRESS, BLOCK_HASH_HISTORY};
 use std::vec::Vec;
 
 pub fn balance<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
@@ -114,12 +114,12 @@ pub fn blockhash<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, ho
             let diff = as_usize_saturated!(diff);
 
             // blockhash should push zero if number is same as current block number.
-            if SPEC::enabled(PRAGUE) && diff <= HISTORY_SERVE_WINDOW {
+            if SPEC::enabled(PRAGUE) && diff <= BLOCKHASH_SERVE_WINDOW {
                 let value = sload!(
                     interpreter,
                     host,
-                    HISTORY_STORAGE_ADDRESS,
-                    number.wrapping_rem(U256::from(HISTORY_SERVE_WINDOW))
+                    BLOCKHASH_STORAGE_ADDRESS,
+                    number.wrapping_rem(U256::from(BLOCKHASH_SERVE_WINDOW))
                 );
                 *number = value;
                 return;

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -5,7 +5,7 @@ use crate::{
     Host, InstructionResult, SStoreResult,
 };
 use core::cmp::min;
-use revm_primitives::BLOCK_HASH_HISTORY;
+use revm_primitives::{BLOCK_HASH_HISTORY, HISTORY_SERVE_WINDOW, HISTORY_STORAGE_ADDRESS};
 use std::vec::Vec;
 
 pub fn balance<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
@@ -103,14 +103,27 @@ pub fn extcodecopy<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, 
         .set_data(memory_offset, code_offset, len, &code.original_bytes());
 }
 
-pub fn blockhash<H: Host + ?Sized>(interpreter: &mut Interpreter, host: &mut H) {
+pub fn blockhash<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     gas!(interpreter, gas::BLOCKHASH);
     pop_top!(interpreter, number);
 
-    if let Some(diff) = host.env().block.number.checked_sub(*number) {
+    let block_number = host.env().block.number;
+
+    if let Some(diff) = block_number.checked_sub(*number) {
         let diff = as_usize_saturated!(diff);
+
         // blockhash should push zero if number is same as current block number.
-        if diff <= BLOCK_HASH_HISTORY && diff != 0 {
+        if SPEC::enabled(PRAGUE) && diff <= HISTORY_SERVE_WINDOW && diff != 0 {
+            let Some((value, is_cold)) = host.sload(
+                HISTORY_STORAGE_ADDRESS,
+                number.wrapping_rem(U256::from(HISTORY_SERVE_WINDOW)),
+            ) else {
+                interpreter.instruction_result = InstructionResult::FatalExternalError;
+                return;
+            };
+            gas!(interpreter, gas::sload_cost(SPEC::SPEC_ID, is_cold));
+            *number = value;
+        } else if diff <= BLOCK_HASH_HISTORY && diff != 0 {
             let Some(hash) = host.block_hash(*number) else {
                 interpreter.instruction_result = InstructionResult::FatalExternalError;
                 return;
@@ -119,6 +132,7 @@ pub fn blockhash<H: Host + ?Sized>(interpreter: &mut Interpreter, host: &mut H) 
             return;
         }
     }
+
     *number = U256::ZERO;
 }
 

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -123,6 +123,7 @@ pub fn blockhash<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, ho
             };
             gas!(interpreter, gas::sload_cost(SPEC::SPEC_ID, is_cold));
             *number = value;
+            return;
         } else if diff <= BLOCK_HASH_HISTORY && diff != 0 {
             let Some(hash) = host.block_hash(*number) else {
                 interpreter.instruction_result = InstructionResult::FatalExternalError;

--- a/crates/interpreter/src/instructions/macros.rs
+++ b/crates/interpreter/src/instructions/macros.rs
@@ -45,6 +45,30 @@ macro_rules! check {
     };
 }
 
+/// Performs an `SLOAD` on the target account and storage index.
+///
+/// If the slot could not be loaded, or if the gas cost could not be charged, the expanded code
+/// sets the instruction result and returns accordingly.
+///
+/// # Note
+///
+/// This macro charges gas.
+///
+/// # Returns
+///
+/// Expands to the value of the storage slot.
+#[macro_export]
+macro_rules! sload {
+    ($interp:expr, $host:expr, $address:expr, $index:expr) => {{
+        let Some((value, is_cold)) = $host.sload($address, $index) else {
+            $interp.instruction_result = $crate::InstructionResult::FatalExternalError;
+            return;
+        };
+        $crate::gas!($interp, $crate::gas::sload_cost(SPEC::SPEC_ID, is_cold));
+        value
+    }};
+}
+
 /// Records a `gas` cost and fails the instruction if it would exceed the available gas.
 #[macro_export]
 macro_rules! gas {

--- a/crates/interpreter/src/opcode.rs
+++ b/crates/interpreter/src/opcode.rs
@@ -582,7 +582,7 @@ opcodes! {
     0x3D => RETURNDATASIZE => system::returndatasize::<H, SPEC> => stack_io(0, 1);
     0x3E => RETURNDATACOPY => system::returndatacopy::<H, SPEC> => stack_io(3, 0);
     0x3F => EXTCODEHASH    => host::extcodehash::<H, SPEC>      => stack_io(1, 1), not_eof;
-    0x40 => BLOCKHASH      => host::blockhash<H, SPEC>          => stack_io(1, 1);
+    0x40 => BLOCKHASH      => host::blockhash::<H, SPEC>          => stack_io(1, 1);
     0x41 => COINBASE       => host_env::coinbase                => stack_io(0, 1);
     0x42 => TIMESTAMP      => host_env::timestamp               => stack_io(0, 1);
     0x43 => NUMBER         => host_env::block_number            => stack_io(0, 1);

--- a/crates/interpreter/src/opcode.rs
+++ b/crates/interpreter/src/opcode.rs
@@ -443,7 +443,7 @@ opcodes! {
     0x3D => RETURNDATASIZE => system::returndatasize::<H, SPEC> => stack_io<0, 1>;
     0x3E => RETURNDATACOPY => system::returndatacopy::<H, SPEC> => stack_io<3, 0>;
     0x3F => EXTCODEHASH    => host::extcodehash::<H, SPEC>      => stack_io<1, 1>, not_eof;
-    0x40 => BLOCKHASH      => host::blockhash                   => stack_io<1, 1>;
+    0x40 => BLOCKHASH      => host::blockhash::<H, SPEC>        => stack_io<1, 1>;
     0x41 => COINBASE       => host_env::coinbase                => stack_io<0, 1>;
     0x42 => TIMESTAMP      => host_env::timestamp               => stack_io<0, 1>;
     0x43 => NUMBER         => host_env::block_number            => stack_io<0, 1>;

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -1,11 +1,23 @@
+use alloy_primitives::address;
+
 use crate::Address;
 
 /// EIP-170: Contract code size limit
 /// By default limit is 0x6000 (~25kb)
 pub const MAX_CODE_SIZE: usize = 0x6000;
 
-/// Number of block hashes that EVM can access in the past
+/// Number of block hashes that EVM can access in the past (pre-Prague).
 pub const BLOCK_HASH_HISTORY: usize = 256;
+
+/// EIP-2935: Serve historical block hashes from state
+///
+/// Number of block hashes the EVM can access in the past (Prague).
+pub const HISTORY_SERVE_WINDOW: usize = 8192;
+
+/// EIP-2935: Serve historical block hashes from state
+///
+/// The address where historical blockhashes are available.
+pub const HISTORY_STORAGE_ADDRESS: Address = address!("25a219378dad9b3503c8268c9ca836a52427a4fb");
 
 /// EIP-3860: Limit and meter initcode
 ///

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -11,12 +11,20 @@ pub const BLOCK_HASH_HISTORY: usize = 256;
 /// EIP-2935: Serve historical block hashes from state
 ///
 /// Number of block hashes the EVM can access in the past (Prague).
-pub const HISTORY_SERVE_WINDOW: usize = 8192;
+///
+/// # Note
+///
+/// This is named `HISTORY_SERVE_WINDOW` in the EIP.
+pub const BLOCKHASH_SERVE_WINDOW: usize = 8192;
 
 /// EIP-2935: Serve historical block hashes from state
 ///
 /// The address where historical blockhashes are available.
-pub const HISTORY_STORAGE_ADDRESS: Address = address!("25a219378dad9b3503c8268c9ca836a52427a4fb");
+///
+/// # Note
+///
+/// This is named `HISTORY_STORAGE_ADDRESS` in the EIP.
+pub const BLOCKHASH_STORAGE_ADDRESS: Address = address!("25a219378dad9b3503c8268c9ca836a52427a4fb");
 
 /// EIP-3860: Limit and meter initcode
 ///

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -1,9 +1,8 @@
-use alloy_primitives::address;
-
-use crate::Address;
+use alloy_primitives::{address, Address};
 
 /// EIP-170: Contract code size limit
-/// By default limit is 0x6000 (~25kb)
+///
+/// By default the limit is `0x6000` (~25kb)
 pub const MAX_CODE_SIZE: usize = 0x6000;
 
 /// Number of block hashes that EVM can access in the past (pre-Prague).
@@ -21,26 +20,35 @@ pub const HISTORY_STORAGE_ADDRESS: Address = address!("25a219378dad9b3503c8268c9
 
 /// EIP-3860: Limit and meter initcode
 ///
-/// Limit of maximum initcode size is 2 * MAX_CODE_SIZE
+/// Limit of maximum initcode size is `2 * MAX_CODE_SIZE`.
 pub const MAX_INITCODE_SIZE: usize = 2 * MAX_CODE_SIZE;
 
-/// Precompile 3 is special in few places
+/// The address of precompile 3, which is handled specially in a few places.
 pub const PRECOMPILE3: Address =
     Address::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3]);
-// EIP-4844 constants
+
+// === EIP-4844 constants ===
+
 /// Gas consumption of a single data blob (== blob byte size).
 pub const GAS_PER_BLOB: u64 = 1 << 17;
+
 /// Target number of the blob per block.
 pub const TARGET_BLOB_NUMBER_PER_BLOCK: u64 = 3;
+
 /// Max number of blobs per block
 pub const MAX_BLOB_NUMBER_PER_BLOCK: u64 = 2 * TARGET_BLOB_NUMBER_PER_BLOCK;
+
 /// Maximum consumable blob gas for data blobs per block.
 pub const MAX_BLOB_GAS_PER_BLOCK: u64 = MAX_BLOB_NUMBER_PER_BLOCK * GAS_PER_BLOB;
+
 /// Target consumable blob gas for data blobs per block (for 1559-like pricing).
 pub const TARGET_BLOB_GAS_PER_BLOCK: u64 = TARGET_BLOB_NUMBER_PER_BLOCK * GAS_PER_BLOB;
+
 /// Minimum gas price for data blobs.
 pub const MIN_BLOB_GASPRICE: u64 = 1;
+
 /// Controls the maximum rate of change for blob gas price.
 pub const BLOB_GASPRICE_UPDATE_FRACTION: u64 = 3338477;
+
 /// First version of the blob.
 pub const VERSIONED_HASH_VERSION_KZG: u8 = 0x01;


### PR DESCRIPTION
Implements the changes for `BLOCKHASH` as outlined in [EIP-2935], and adds EIP-2935 constants.

This requires an external processing step to fill the contract's storage with data. See https://github.com/paradigmxyz/reth/pull/7818

Additionally, since `BLOCKHASH` now does an `SLOAD` internally, I pulled the `sload` logic into a reusable `sload!` macro.

[EIP-2935]:  https://eips.ethereum.org/EIPS/eip-2935