### PR TITLE
feat: parse opcodes from strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2443,6 +2443,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2878,6 +2920,8 @@ name = "revm-interpreter"
 version = "4.0.0"
 dependencies = [
  "bincode",
+ "paste",
+ "phf",
  "revm-primitives",
  "serde",
  "serde_json",
@@ -3412,6 +3456,12 @@ dependencies = [
  "thiserror",
  "time",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -16,6 +16,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 revm-primitives = { path = "../primitives", version = "3.1.1", default-features = false }
 
+paste = { version = "1.0", optional = true }
+phf = { version = "0.11", default-features = false, optional = true, features = [
+    "macros",
+] }
+
 # optional
 serde = { version = "1.0", default-features = false, features = [
     "derive",
@@ -24,7 +29,7 @@ serde = { version = "1.0", default-features = false, features = [
 
 [dev-dependencies]
 walkdir = "2.5"
-serde_json = { version = "1.0"}
+serde_json = "1.0"
 bincode = "1.3"
 
 [[test]]
@@ -33,13 +38,14 @@ path = "tests/eof.rs"
 required-features = ["serde"]
 
 [features]
-default = ["std"]
+default = ["std", "parse"]
 std = ["serde?/std", "revm-primitives/std"]
 hashbrown = ["revm-primitives/hashbrown"]
 serde = ["dep:serde", "revm-primitives/serde"]
 arbitrary = ["std", "revm-primitives/arbitrary"]
 asm-keccak = ["revm-primitives/asm-keccak"]
 portable = ["revm-primitives/portable"]
+parse = ["dep:paste", "dep:phf"]
 
 optimism = ["revm-primitives/optimism"]
 # Optimism default handler enabled Optimism handler register by default in EvmBuilder.


### PR DESCRIPTION
Add `FromStr` to `OpCode` as the inverse of `fn as_str`. I put it under a default feature because we need `phf` for the map, but the dependency might not be desired if this feature is not used.