### PR TITLE
fix: return the correct error in resize_memory

### DIFF
--- a/crates/interpreter/src/instructions/macros.rs
+++ b/crates/interpreter/src/instructions/macros.rs
@@ -106,7 +106,7 @@ macro_rules! resize_memory {
                 .gas
                 .record_memory($crate::gas::memory_gas(words_num))
             {
-                $interp.instruction_result = $crate::InstructionResult::MemoryLimitOOG;
+                $interp.instruction_result = $crate::InstructionResult::MemoryOOG;
                 return $ret;
             }
             $interp.shared_memory.resize(rounded_size);

--- a/crates/revm/src/builder.rs
+++ b/crates/revm/src/builder.rs
@@ -448,7 +448,7 @@ mod test {
         },
         Context, ContextPrecompile, ContextStatefulPrecompile, Evm, InMemoryDB, InnerEvmContext,
     };
-    use revm_interpreter::{Host, Interpreter};
+    use revm_interpreter::{gas, Host, Interpreter};
     use std::{cell::RefCell, rc::Rc, sync::Arc};
 
     /// Custom evm context
@@ -511,9 +511,10 @@ mod test {
         const CUSTOM_INSTRUCTION_COST: u64 = 133;
         const INITIAL_TX_GAS: u64 = 21000;
         const EXPECTED_RESULT_GAS: u64 = INITIAL_TX_GAS + CUSTOM_INSTRUCTION_COST;
+
         fn custom_instruction(interp: &mut Interpreter, _host: &mut impl Host) {
             // just spend some gas
-            interp.gas.record_cost(CUSTOM_INSTRUCTION_COST);
+            gas!(interp, CUSTOM_INSTRUCTION_COST);
         }
 
         let code = Bytecode::new_raw([0xEF, 0x00].into());


### PR DESCRIPTION
There is a duplicate `MemoryLimitOOG`, when it should be `MemoryOOG`.

Looks like this was never correct https://github.com/bluealloy/revm/commit/9b663bbccba6be2ba70dabb5479f994514d0f8c4