### PR TITLE
perf(interpreter): branch less in as_usize_or_fail

### DIFF
--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -361,7 +361,7 @@ pub fn execute_test_suite(
                     .build();
                 let mut evm = Evm::builder()
                     .with_db(&mut state)
-                    .modify_env(|e| *e = env.clone())
+                    .modify_env(|e| e.clone_from(&env))
                     .with_spec_id(spec_id)
                     .build();
 

--- a/crates/interpreter/src/instructions/i256.rs
+++ b/crates/interpreter/src/instructions/i256.rs
@@ -33,7 +33,7 @@ pub fn i256_sign(val: &U256) -> Sign {
         Sign::Minus
     } else {
         // SAFETY: false == 0 == Zero, true == 1 == Plus
-        unsafe { core::mem::transmute(*val != U256::ZERO) }
+        unsafe { core::mem::transmute::<bool, Sign>(*val != U256::ZERO) }
     }
 }
 

--- a/crates/interpreter/src/instructions/macros.rs
+++ b/crates/interpreter/src/instructions/macros.rs
@@ -300,14 +300,17 @@ macro_rules! push {
 /// Converts a `U256` value to a `u64`, saturating to `MAX` if the value is too large.
 #[macro_export]
 macro_rules! as_u64_saturated {
-    ($v:expr) => {{
-        let x: &[u64; 4] = $v.as_limbs();
-        if x[1] == 0 && x[2] == 0 && x[3] == 0 {
-            x[0]
-        } else {
-            u64::MAX
+    ($v:expr) => {
+        match $v.as_limbs() {
+            x => {
+                if (x[1] == 0) & (x[2] == 0) & (x[3] == 0) {
+                    x[0]
+                } else {
+                    u64::MAX
+                }
+            }
         }
-    }};
+    };
 }
 
 /// Converts a `U256` value to a `usize`, saturating to `MAX` if the value is too large.
@@ -352,16 +355,15 @@ macro_rules! as_usize_or_fail_ret {
         )
     };
 
-    ($interp:expr, $v:expr, $reason:expr, $ret:expr) => {{
-        let x = $v.as_limbs();
-        if x[1] != 0 || x[2] != 0 || x[3] != 0 {
-            $interp.instruction_result = $reason;
-            return $ret;
+    ($interp:expr, $v:expr, $reason:expr, $ret:expr) => {
+        match $v.as_limbs() {
+            x => {
+                if (x[0] > usize::MAX as u64) | (x[1] != 0) | (x[2] != 0) | (x[3] != 0) {
+                    $interp.instruction_result = $reason;
+                    return $ret;
+                }
+                x[0] as usize
+            }
         }
-        let Ok(val) = usize::try_from(x[0]) else {
-            $interp.instruction_result = $reason;
-            return $ret;
-        };
-        val
-    }};
+    };
 }

--- a/crates/revm/src/db/states/transition_account.rs
+++ b/crates/revm/src/db/states/transition_account.rs
@@ -85,7 +85,7 @@ impl TransitionAccount {
     /// Update new values of transition. Don't override old values.
     /// Both account info and old storages need to be left intact.
     pub fn update(&mut self, other: Self) {
-        self.info = other.info.clone();
+        self.info.clone_from(&other.info);
         self.status = other.status;
 
         // if transition is from some to destroyed drop the storage.

--- a/crates/revm/src/inspector/eip3155.rs
+++ b/crates/revm/src/inspector/eip3155.rs
@@ -191,7 +191,7 @@ impl<DB: Database> Inspector<DB> for TracerEip3155 {
 
     fn step(&mut self, interp: &mut Interpreter, context: &mut EvmContext<DB>) {
         self.gas_inspector.step(interp, context);
-        self.stack = interp.stack.data().clone();
+        self.stack.clone_from(interp.stack.data());
         self.memory = if self.include_memory {
             Some(hex::encode_prefixed(interp.shared_memory.context_memory()))
         } else {


### PR DESCRIPTION
`cmp ..., 0; jne` * 3 -> `mov; or; or; je`
The compiler already does this for the saturated but maybe because it has an early return it didn't do it for this as well