### PR TITLE
add blob_count and max_blobs to `TooManyBlobs` err enum

### DIFF
--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -361,7 +361,7 @@ pub fn execute_test_suite(
                     .build();
                 let mut evm = Evm::builder()
                     .with_db(&mut state)
-                    .modify_env(|e| *e = env.clone())
+                    .modify_env(|e| e.clone_from(&env))
                     .with_spec_id(spec_id)
                     .build();
 

--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -172,8 +172,12 @@ impl Env {
 
                 // ensure the total blob gas spent is at most equal to the limit
                 // assert blob_gas_used <= MAX_BLOB_GAS_PER_BLOCK
-                if self.tx.blob_hashes.len() > MAX_BLOB_NUMBER_PER_BLOCK as usize {
-                    return Err(InvalidTransaction::TooManyBlobs);
+                let num_blobs = self.tx.blob_hashes.len();
+                if num_blobs > MAX_BLOB_NUMBER_PER_BLOCK as usize {
+                    return Err(InvalidTransaction::TooManyBlobs(
+                        num_blobs,
+                        MAX_BLOB_NUMBER_PER_BLOCK as usize,
+                    ));
                 }
             }
         } else {

--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -174,10 +174,10 @@ impl Env {
                 // assert blob_gas_used <= MAX_BLOB_GAS_PER_BLOCK
                 let num_blobs = self.tx.blob_hashes.len();
                 if num_blobs > MAX_BLOB_NUMBER_PER_BLOCK as usize {
-                    return Err(InvalidTransaction::TooManyBlobs(
-                        num_blobs,
-                        MAX_BLOB_NUMBER_PER_BLOCK as usize,
-                    ));
+                    return Err(InvalidTransaction::TooManyBlobs {
+                        have: num_blobs,
+                        max: MAX_BLOB_NUMBER_PER_BLOCK as usize,
+                    });
                 }
             }
         } else {

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -242,7 +242,10 @@ pub enum InvalidTransaction {
     /// `to` must be present
     BlobCreateTransaction,
     /// Transaction has more then [`crate::MAX_BLOB_NUMBER_PER_BLOCK`] blobs
-    TooManyBlobs(usize, usize),
+    TooManyBlobs {
+         max: usize,
+         have: usize,
+     },
     /// Blob transaction contains a versioned hash with an incorrect version
     BlobVersionNotSupported,
     /// EOF TxCreate transaction is not supported before Prague hardfork.

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -242,7 +242,7 @@ pub enum InvalidTransaction {
     /// `to` must be present
     BlobCreateTransaction,
     /// Transaction has more then [`crate::MAX_BLOB_NUMBER_PER_BLOCK`] blobs
-    TooManyBlobs,
+    TooManyBlobs(usize, usize),
     /// Blob transaction contains a versioned hash with an incorrect version
     BlobVersionNotSupported,
     /// EOF TxCreate transaction is not supported before Prague hardfork.
@@ -339,7 +339,9 @@ impl fmt::Display for InvalidTransaction {
             }
             Self::EmptyBlobs => write!(f, "empty blobs"),
             Self::BlobCreateTransaction => write!(f, "blob create transaction"),
-            Self::TooManyBlobs => write!(f, "too many blobs"),
+            Self::TooManyBlobs(num_blobs, max) => {
+                write!(f, "too many blobs, have {num_blobs}, max {max}")
+            }
             Self::BlobVersionNotSupported => write!(f, "blob version not supported"),
             Self::EofInitcodesNotSupported => write!(f, "EOF initcodes not supported"),
             Self::EofCrateShouldHaveToAddress => write!(f, "EOF crate should have `to` address"),

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -243,9 +243,9 @@ pub enum InvalidTransaction {
     BlobCreateTransaction,
     /// Transaction has more then [`crate::MAX_BLOB_NUMBER_PER_BLOCK`] blobs
     TooManyBlobs {
-         max: usize,
-         have: usize,
-     },
+        max: usize,
+        have: usize,
+    },
     /// Blob transaction contains a versioned hash with an incorrect version
     BlobVersionNotSupported,
     /// EOF TxCreate transaction is not supported before Prague hardfork.
@@ -342,8 +342,8 @@ impl fmt::Display for InvalidTransaction {
             }
             Self::EmptyBlobs => write!(f, "empty blobs"),
             Self::BlobCreateTransaction => write!(f, "blob create transaction"),
-            Self::TooManyBlobs(num_blobs, max) => {
-                write!(f, "too many blobs, have {num_blobs}, max {max}")
+            Self::TooManyBlobs { max, have } => {
+                write!(f, "too many blobs, have {have}, max {max}")
             }
             Self::BlobVersionNotSupported => write!(f, "blob version not supported"),
             Self::EofInitcodesNotSupported => write!(f, "EOF initcodes not supported"),

--- a/crates/revm/src/db/states/transition_account.rs
+++ b/crates/revm/src/db/states/transition_account.rs
@@ -85,7 +85,7 @@ impl TransitionAccount {
     /// Update new values of transition. Don't override old values.
     /// Both account info and old storages need to be left intact.
     pub fn update(&mut self, other: Self) {
-        self.info = other.info.clone();
+        self.info.clone_from(&other.info);
         self.status = other.status;
 
         // if transition is from some to destroyed drop the storage.

--- a/crates/revm/src/inspector/eip3155.rs
+++ b/crates/revm/src/inspector/eip3155.rs
@@ -191,7 +191,7 @@ impl<DB: Database> Inspector<DB> for TracerEip3155 {
 
     fn step(&mut self, interp: &mut Interpreter, context: &mut EvmContext<DB>) {
         self.gas_inspector.step(interp, context);
-        self.stack = interp.stack.data().clone();
+        self.stack.clone_from(interp.stack.data());
         self.memory = if self.include_memory {
             Some(hex::encode_prefixed(interp.shared_memory.context_memory()))
         } else {


### PR DESCRIPTION
## Motivation

`TooManyBlobs` enum does not have a blob count being processed in the tx and max blob count.

For example in anvil, ideally we'd like to show the error with these details here  - https://github.com/foundry-rs/foundry/blob/8766dc3e1f7a860bc75b4ebfc675dde3d02581fb/crates/anvil/src/eth/error.rs#L287

## Solution

Change enum to `TooManyBlobs(usize, usize)`.
