### PR TITLE
feat(precompile): add Prague hardfork specification

### DIFF
--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -63,6 +63,7 @@ impl Precompiles {
             PrecompileSpecId::ISTANBUL => Self::istanbul(),
             PrecompileSpecId::BERLIN => Self::berlin(),
             PrecompileSpecId::CANCUN => Self::cancun(),
+            PrecompileSpecId::PRAGUE => Self::prague(),
             PrecompileSpecId::LATEST => Self::latest(),
         }
     }
@@ -154,9 +155,21 @@ impl Precompiles {
         })
     }
 
+    /// Returns precompiles for Prague spec.
+    pub fn prague() -> &'static Self {
+        static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
+        INSTANCE.get_or_init(|| {
+            let precompiles = Self::cancun().clone();
+            // EIP-2537: Precompile for BLS12-381 curve operations
+            // TODO(alexey): add BLS12-381 precompiles
+            // precompiles.extend(bls12_381::precompiles());
+            Box::new(precompiles)
+        })
+    }
+
     /// Returns the precompiles for the latest spec.
     pub fn latest() -> &'static Self {
-        Self::cancun()
+        Self::prague()
     }
 
     /// Returns an iterator over the precompiles addresses.
@@ -229,6 +242,7 @@ pub enum PrecompileSpecId {
     ISTANBUL,
     BERLIN,
     CANCUN,
+    PRAGUE,
     LATEST,
 }
 
@@ -243,7 +257,8 @@ impl PrecompileSpecId {
             BYZANTIUM | CONSTANTINOPLE | PETERSBURG => Self::BYZANTIUM,
             ISTANBUL | MUIR_GLACIER => Self::ISTANBUL,
             BERLIN | LONDON | ARROW_GLACIER | GRAY_GLACIER | MERGE | SHANGHAI => Self::BERLIN,
-            CANCUN | PRAGUE => Self::CANCUN,
+            CANCUN => Self::CANCUN,
+            PRAGUE => Self::PRAGUE,
             LATEST => Self::LATEST,
             #[cfg(feature = "optimism")]
             BEDROCK | REGOLITH | CANYON => Self::BERLIN,


### PR DESCRIPTION
Ref https://github.com/bluealloy/revm/issues/1268

This PR updates the precompiles spec for the Prague hardfork: the only new precompiles are BLS12-381-related from the [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537) (see [hardfork EIP](https://eips.ethereum.org/EIPS/eip-7600)).

The implementation will be added in the next PR.