### PR TITLE
fix(eip2935): Preload blockhash storage address

### DIFF
--- a/crates/revm/src/handler/mainnet/pre_execution.rs
+++ b/crates/revm/src/handler/mainnet/pre_execution.rs
@@ -7,8 +7,8 @@ use crate::{
     primitives::{
         db::Database,
         Account, EVMError, Env, Spec,
-        SpecId::{CANCUN, SHANGHAI},
-        TransactTo, U256,
+        SpecId::{CANCUN, PRAGUE, SHANGHAI},
+        TransactTo, BLOCKHASH_STORAGE_ADDRESS, U256,
     },
     Context, ContextPrecompiles,
 };
@@ -34,6 +34,16 @@ pub fn load_accounts<SPEC: Spec, EXT, DB: Database>(
     if SPEC::enabled(SHANGHAI) {
         context.evm.inner.journaled_state.initial_account_load(
             context.evm.inner.env.block.coinbase,
+            &[],
+            &mut context.evm.inner.db,
+        )?;
+    }
+
+    // Load blockhash storage address
+    // EIP-2935: Serve historical block hashes from state
+    if SPEC::enabled(PRAGUE) {
+        context.evm.inner.journaled_state.initial_account_load(
+            BLOCKHASH_STORAGE_ADDRESS,
             &[],
             &mut context.evm.inner.db,
         )?;


### PR DESCRIPTION
Preload blockhash storage address so it does not panic on access in JournalState.

Behavior in EIP is undefined, and we would prefer if preloading stays.

fixing https://github.com/bluealloy/revm/issues/1388 panic