### PR TITLE
fix: blockchash for devnet-0 

### DIFF
--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -5,7 +5,6 @@ use crate::{
     Host, InstructionResult, SStoreResult,
 };
 use core::cmp::min;
-use revm_primitives::{BLOCKHASH_SERVE_WINDOW, BLOCKHASH_STORAGE_ADDRESS, BLOCK_HASH_HISTORY};
 use std::vec::Vec;
 
 pub fn balance<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
@@ -108,38 +107,11 @@ pub fn blockhash<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, ho
     pop_top!(interpreter, number);
 
     let block_number = host.env().block.number;
-
-    match block_number.checked_sub(*number) {
-        // blockhash should push zero if number is same as current block number.
-        Some(diff) if !diff.is_zero() => {
-            let diff = as_usize_saturated!(diff);
-
-            if diff <= BLOCK_HASH_HISTORY {
-                let Some(hash) = host.block_hash(*number) else {
-                    interpreter.instruction_result = InstructionResult::FatalExternalError;
-                    return;
-                };
-                *number = U256::from_be_bytes(hash.0);
-                return;
-            }
-
-            if SPEC::enabled(PRAGUE) && diff <= BLOCKHASH_SERVE_WINDOW {
-                let index = number.wrapping_rem(U256::from(BLOCKHASH_SERVE_WINDOW));
-                let Some((value, _)) = host.sload(BLOCKHASH_STORAGE_ADDRESS, index) else {
-                    interpreter.instruction_result = InstructionResult::FatalExternalError;
-                    return;
-                };
-                *number = value;
-                return;
-            }
-        }
-        _ => {
-            // If blockhash is requested for the current block, the hash should be 0, so we fall
-            // through.
-        }
-    }
-
-    *number = U256::ZERO;
+    let Some(hash) = host.block_hash(block_number) else {
+        interpreter.instruction_result = InstructionResult::FatalExternalError;
+        return;
+    };
+    *number = U256::from_be_bytes(hash.0);
 }
 
 pub fn sload<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {


### PR DESCRIPTION
move code to the `Context::block_hash` and dont warm load storage if it is more than 256 blocks.