### PR TITLE
fix(interpreter): avoid overflow when checking if mem limit reached

### DIFF
--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -90,7 +90,7 @@ impl SharedMemory {
     #[cfg(feature = "memory_limit")]
     #[inline]
     pub fn limit_reached(&self, new_size: usize) -> bool {
-        (self.last_checkpoint + new_size) as u64 > self.memory_limit
+        self.last_checkpoint.saturating_add(new_size) as u64 > self.memory_limit
     }
 
     /// Prepares the shared memory for a new context.


### PR DESCRIPTION
I hit this panic while doing intensive tests with foundry
```
Message:  attempt to add with overflow
Location: /home/george/.cargo/registry/src/index.crates.io-6f17d22bba15001f/revm-interpreter-4.0.0/src/interpreter/shared_memory.rs:98

This is a bug. Consider reporting it at https://github.com/foundry-rs/foundry

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                ⋮ 7 frames hidden ⋮                               
   8: core::panicking::panic::h44790a89027c670f
      at <unknown source file>:<unknown line>
   9: revm_interpreter::instructions::control::revert::h42b8d8e64679ada4
      at <unknown source file>:<unknown line>
  10: revm::inspector::handler_register::inspector_instruction::{{closure}}::h1d34c1afe43f7f83
      at <unknown source file>:<unknown line>
  11: revm::evm::Evm<EXT,DB>::start_the_loop::h22480a9a2ae84bf9
      at <unknown source file>:<unknown line>
  12: revm::evm::Evm<EXT,DB>::transact_preverified_inner::hb7a7358a7d8cf414
      at <unknown source file>:<unknown line>
```

Proposed fix is to use saturating add to check if limit reached
