### PR TITLE
feat: load account should return db error

### DIFF
--- a/crates/revm/src/optimism/handler_register.rs
+++ b/crates/revm/src/optimism/handler_register.rs
@@ -240,33 +240,20 @@ pub fn reward_beneficiary<SPEC: Spec, EXT, DB: Database>(
         let l1_cost = l1_block_info.calculate_tx_l1_cost(enveloped_tx, SPEC::SPEC_ID);
 
         // Send the L1 cost of the transaction to the L1 Fee Vault.
-        let l1_fee_vault_account = match context
+        let (l1_fee_vault_account, _) = context
             .evm
             .inner
             .journaled_state
-            .load_account(optimism::L1_FEE_RECIPIENT, &mut context.evm.inner.db)
-        {
-            Ok((l1_fee_vault_account, _)) => l1_fee_vault_account,
-            Err(err) => {
-                return Err(err);
-            }
-        };
-
+            .load_account(optimism::L1_FEE_RECIPIENT, &mut context.evm.inner.db)?;
         l1_fee_vault_account.mark_touch();
         l1_fee_vault_account.info.balance += l1_cost;
 
         // Send the base fee of the transaction to the Base Fee Vault.
-        let base_fee_vault_account = match context
+        let (base_fee_vault_account, _) = context
             .evm
             .inner
             .journaled_state
-            .load_account(optimism::BASE_FEE_RECIPIENT, &mut context.evm.inner.db)
-        {
-            Ok((base_fee_vault_account, _)) => base_fee_vault_account,
-            Err(err) => {
-                return Err(err);
-            }
-        };
+            .load_account(optimism::BASE_FEE_RECIPIENT, &mut context.evm.inner.db)?;
         base_fee_vault_account.mark_touch();
         base_fee_vault_account.info.balance += context
             .evm

--- a/crates/revm/src/optimism/handler_register.rs
+++ b/crates/revm/src/optimism/handler_register.rs
@@ -240,29 +240,32 @@ pub fn reward_beneficiary<SPEC: Spec, EXT, DB: Database>(
         let l1_cost = l1_block_info.calculate_tx_l1_cost(enveloped_tx, SPEC::SPEC_ID);
 
         // Send the L1 cost of the transaction to the L1 Fee Vault.
-        let Ok((l1_fee_vault_account, _)) = context
+        let l1_fee_vault_account = match context
             .evm
             .inner
             .journaled_state
             .load_account(optimism::L1_FEE_RECIPIENT, &mut context.evm.inner.db)
-        else {
-            return Err(EVMError::Custom(
-                "[OPTIMISM] Failed to load L1 Fee Vault account.".to_string(),
-            ));
+        {
+            Ok((l1_fee_vault_account, _)) => l1_fee_vault_account,
+            Err(err) => {
+                return Err(err);
+            }
         };
+
         l1_fee_vault_account.mark_touch();
         l1_fee_vault_account.info.balance += l1_cost;
 
         // Send the base fee of the transaction to the Base Fee Vault.
-        let Ok((base_fee_vault_account, _)) = context
+        let base_fee_vault_account = match context
             .evm
             .inner
             .journaled_state
             .load_account(optimism::BASE_FEE_RECIPIENT, &mut context.evm.inner.db)
-        else {
-            return Err(EVMError::Custom(
-                "[OPTIMISM] Failed to load Base Fee Vault account.".to_string(),
-            ));
+        {
+            Ok((base_fee_vault_account, _)) => base_fee_vault_account,
+            Err(err) => {
+                return Err(err);
+            }
         };
         base_fee_vault_account.mark_touch();
         base_fee_vault_account.info.balance += context


### PR DESCRIPTION
Since the db may be a remote db, it could happen a network error under the db error. 
And when remote db error happen, the application level maybe need to retry it. So it's better to keep db error original rather than be a custom string.

Or just return another db error with extra error info?