### PR TITLE
non-allocating U256 mul_mod (ported from ruint)

### DIFF
--- a/crates/interpreter/src/instructions/arithmetic.rs
+++ b/crates/interpreter/src/instructions/arithmetic.rs
@@ -99,8 +99,6 @@ pub fn signextend<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H
     }
 }
 
-
-
 // Copy/pasted from https://github.com/recmo/uint/commit/9f2a4beecaca69c8e43e3a0175671b4ed4e3594c
 // Changes:
 // - Converted from 'self' version to be lhs/rhs
@@ -124,7 +122,7 @@ fn mul_mod_na256(lhs: U256, rhs: U256, mut modulus: U256) -> U256 {
     // Compute modulus using `div_rem`.
     // This stores the remainder in the divisor, `modulus`.
     unsafe {
-      algorithms::div(&mut product, modulus.as_limbs_mut());
+        algorithms::div(&mut product, modulus.as_limbs_mut());
     }
 
     modulus

--- a/crates/interpreter/src/instructions/arithmetic.rs
+++ b/crates/interpreter/src/instructions/arithmetic.rs
@@ -106,7 +106,7 @@ pub fn signextend<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H
 // - Converted from 'self' version to be lhs/rhs
 // - Removed generics in favor of hardcoding U256
 // - unsafe block around as_limbs_mut() (previously was self.limbs, but that is private)
-/// Alloc free variant of [`mul_mod`](Self::mul_mod).
+/// Alloc free variant of [`mul_mod`](U256::mul_mod).
 ///
 /// Requires `N` to be set to `nlimbs(2 * BITS)`.
 #[inline]


### PR DESCRIPTION
U256::mul_mod is one of the few things in revm that allocates, potentially in tight loops (UniswapV3 contracts).

This pulls in a non-allocating mul_mod from ruint (https://github.com/recmo/uint/commit/9f2a4beecaca69c8e43e3a0175671b4ed4e3594c) and uses it in place of the allocating version.

Since the original version was a self method on U256, this has been modified to be lhs/rhs (non-self), hardcoded for U256 rather than generic, and uses an unsafe block to access limbs (since its private).

Please let me know if you'd like some cleanup, or if this isn't something you'd like to add.