### PR TITLE
remove 'checked' bytecode bench causing benchmarks to crash due to conflict

### DIFF
--- a/crates/revm/benches/bench.rs
+++ b/crates/revm/benches/bench.rs
@@ -35,13 +35,6 @@ fn analysis(c: &mut Criterion) {
         .build();
     bench_transact(&mut g, &mut evm);
 
-    let checked = Bytecode::new_raw(contract_data.clone());
-    let mut evm = evm
-        .modify()
-        .reset_handler_with_db(BenchmarkDB::new_bytecode(checked))
-        .build();
-    bench_transact(&mut g, &mut evm);
-
     let analysed = to_analysed(Bytecode::new_raw(contract_data));
     let mut evm = evm
         .modify()


### PR DESCRIPTION
When trying to run the benchmarks it crashes due to a benchmarking group name conflict. 
This is because of a recent change to the Bytecode struct which removed the "Checked" type. The `bench_transact` function in `bench.rs` uses the group id 'transact/raw' for both benchmark steps. I removed the 'checked' bytecode benchmark which causes the conflict.