### PR TITLE
fix(EOF): returncontract immediate is one byte

### DIFF
--- a/crates/interpreter/src/instructions/contract.rs
+++ b/crates/interpreter/src/instructions/contract.rs
@@ -92,7 +92,7 @@ pub fn eofcreate<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H)
 
 pub fn return_contract<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     require_init_eof!(interpreter);
-    let deploy_container_index = unsafe { read_u16(interpreter.instruction_pointer) };
+    let deploy_container_index = unsafe { *interpreter.instruction_pointer };
     pop!(interpreter, aux_data_offset, aux_data_size);
     let aux_data_size = as_usize_or_fail!(interpreter, aux_data_size);
     // important: offset must be ignored if len is zeros

--- a/crates/interpreter/src/instructions/contract.rs
+++ b/crates/interpreter/src/instructions/contract.rs
@@ -7,7 +7,6 @@ use revm_primitives::{keccak256, BerlinSpec};
 
 use crate::{
     gas::{self, cost_per_word, EOF_CREATE_GAS, KECCAK256WORD},
-    instructions::utility::read_u16,
     interpreter::Interpreter,
     primitives::{Address, Bytes, Eof, Spec, SpecId::*, U256},
     CallInputs, CallScheme, CallValue, CreateInputs, CreateScheme, EOFCreateInput, Host,


### PR DESCRIPTION
From spec:
https://github.com/ipsilon/eof/blob/main/spec/eof.md
```
RETURNCONTRACT (0xee) instruction

loads uint8 immediate deploy_container_index
```