### PR TITLE
fix(stack): pop with five items was not correct

### DIFF
--- a/crates/interpreter/src/instructions/macros.rs
+++ b/crates/interpreter/src/instructions/macros.rs
@@ -165,7 +165,7 @@ macro_rules! pop {
         $crate::pop_ret!($interp, $x1, $x2, $x3, $x4, ())
     };
     ($interp:expr, $x1:ident, $x2:ident, $x3:ident, $x4:ident, $x5:ident) => {
-        pop_ret!($interp, $x1, $x2, $x3, $x4, $x5, ())
+        $crate::pop_ret!($interp, $x1, $x2, $x3, $x4, $x5, ())
     };
 }
 
@@ -206,7 +206,7 @@ macro_rules! pop_ret {
         let ($x1, $x2, $x3, $x4) = unsafe { $interp.stack.pop4_unsafe() };
     };
     ($interp:expr, $x1:ident, $x2:ident, $x3:ident, $x4:ident, $x5:ident, $ret:expr) => {
-        if $interp.stack.len() < 4 {
+        if $interp.stack.len() < 5 {
             $interp.instruction_result = $crate::InstructionResult::StackUnderflow;
             return $ret;
         }

--- a/crates/interpreter/src/instructions/system.rs
+++ b/crates/interpreter/src/instructions/system.rs
@@ -149,11 +149,18 @@ pub fn returndataload<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &m
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, offset);
     let offset_usize = as_usize_or_fail!(interpreter, offset);
+    // TODO EOF needs to be padded with zeros, it is not correct to fail.
+    /*
+    if offset + 32 > len(returndata buffer) the result is zero-padded
+    (same behavior as CALLDATALOAD).see matching behavior of RETURNDATACOPY
+    in Modified Behavior section.
+     */
     if offset_usize.saturating_add(32) > interpreter.return_data_buffer.len() {
         // TODO(EOF) proper error.
         interpreter.instruction_result = InstructionResult::OutOfOffset;
         return;
     }
+
     *offset =
         B256::from_slice(&interpreter.return_data_buffer[offset_usize..offset_usize + 32]).into();
 }


### PR DESCRIPTION
pop or pop_ret with 5 items was not used inside codebase. Either way it is a bug.

Added TODO comment for EOF returndataload, it should pad the output and not fail. This is recent behaviour change: https://github.com/ipsilon/eof/pull/90