### PR TITLE
chore(interpreter): use max gas limit in `impl Default for Interpreter`

### DIFF
--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -64,7 +64,7 @@ pub struct Interpreter {
 
 impl Default for Interpreter {
     fn default() -> Self {
-        Self::new(Contract::default(), 0, false)
+        Self::new(Contract::default(), u64::MAX, false)
     }
 }
 


### PR DESCRIPTION
Otherwise it's unusable because gas limit cannot be set after initialization.