### PR TITLE
perf: avoid cloning precompiles

### DIFF
--- a/crates/precompile/src/bls12_381/utils.rs
+++ b/crates/precompile/src/bls12_381/utils.rs
@@ -1,5 +1,4 @@
 use core::cmp::Ordering;
-
 use blst::{
     blst_bendian_from_fp, blst_fp, blst_fp_from_bendian, blst_scalar, blst_scalar_from_bendian,
 };

--- a/crates/precompile/src/bls12_381/utils.rs
+++ b/crates/precompile/src/bls12_381/utils.rs
@@ -1,7 +1,7 @@
-use core::cmp::Ordering;
 use blst::{
     blst_bendian_from_fp, blst_fp, blst_fp_from_bendian, blst_scalar, blst_scalar_from_bendian,
 };
+use core::cmp::Ordering;
 use revm_primitives::PrecompileError;
 
 /// Number of bits used in the BLS12-381 curve finite field elements.

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -26,10 +26,9 @@ use core::hash::Hash;
 use once_cell::race::OnceBox;
 #[doc(hidden)]
 pub use revm_primitives as primitives;
-use revm_primitives::HashSet;
 pub use revm_primitives::{
     precompile::{PrecompileError as Error, *},
-    Address, Bytes, HashMap, Log, B256,
+    Address, Bytes, HashMap, HashSet, Log, B256,
 };
 use std::boxed::Box;
 

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -30,7 +30,7 @@ pub use revm_primitives::{
     precompile::{PrecompileError as Error, *},
     Address, Bytes, HashMap, HashSet, Log, B256,
 };
-use std::boxed::Box;
+use std::{boxed::Box, vec::Vec};
 
 pub fn calc_linear_cost_u32(len: usize, base: u64, word: u64) -> u64 {
     (len as u64 + 32 - 1) / 32 * word + base

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -168,13 +168,13 @@ impl Precompiles {
 
     /// Returns an iterator over the precompiles addresses.
     #[inline]
-    pub fn addresses(&self) -> impl Iterator<Item = &Address> {
+    pub fn addresses(&self) -> impl ExactSizeIterator<Item = &Address> {
         self.inner.keys()
     }
 
     /// Consumes the type and returns all precompile addresses.
     #[inline]
-    pub fn into_addresses(self) -> impl Iterator<Item = Address> {
+    pub fn into_addresses(self) -> impl ExactSizeIterator<Item = Address> {
         self.inner.into_keys()
     }
 

--- a/crates/primitives/src/precompile.rs
+++ b/crates/primitives/src/precompile.rs
@@ -110,11 +110,25 @@ impl Precompile {
 
     /// Call the precompile with the given input and gas limit and return the result.
     pub fn call(&mut self, bytes: &Bytes, gas_price: u64, env: &Env) -> PrecompileResult {
-        match self {
+        match *self {
             Precompile::Standard(p) => p(bytes, gas_price),
             Precompile::Env(p) => p(bytes, gas_price, env),
-            Precompile::Stateful(p) => p.call(bytes, gas_price, env),
-            Precompile::StatefulMut(p) => p.call_mut(bytes, gas_price, env),
+            Precompile::Stateful(ref p) => p.call(bytes, gas_price, env),
+            Precompile::StatefulMut(ref mut p) => p.call_mut(bytes, gas_price, env),
+        }
+    }
+
+    /// Call the precompile with the given input and gas limit and return the result.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the precompile is a mutable stateful precompile.
+    pub fn call_ref(&self, bytes: &Bytes, gas_price: u64, env: &Env) -> PrecompileResult {
+        match *self {
+            Precompile::Standard(p) => p(bytes, gas_price),
+            Precompile::Env(p) => p(bytes, gas_price, env),
+            Precompile::Stateful(ref p) => p.call(bytes, gas_price, env),
+            Precompile::StatefulMut(_) => panic!("call_ref on mutable stateful precompile"),
         }
     }
 }

--- a/crates/primitives/src/precompile.rs
+++ b/crates/primitives/src/precompile.rs
@@ -120,9 +120,7 @@ impl Precompile {
 
     /// Call the precompile with the given input and gas limit and return the result.
     ///
-    /// # Panics
-    ///
-    /// Panics if the precompile is a mutable stateful precompile.
+    /// Returns an error if the precompile is mutable.
     pub fn call_ref(&self, bytes: &Bytes, gas_price: u64, env: &Env) -> PrecompileResult {
         match *self {
             Precompile::Standard(p) => p(bytes, gas_price),

--- a/crates/primitives/src/precompile.rs
+++ b/crates/primitives/src/precompile.rs
@@ -128,7 +128,9 @@ impl Precompile {
             Precompile::Standard(p) => p(bytes, gas_price),
             Precompile::Env(p) => p(bytes, gas_price, env),
             Precompile::Stateful(ref p) => p.call(bytes, gas_price, env),
-            Precompile::StatefulMut(_) => panic!("call_ref on mutable stateful precompile"),
+            Precompile::StatefulMut(_) => Err(PrecompileErrors::Fatal {
+                msg: "call_ref on mutable stateful precompile".to_string(),
+            }),
         }
     }
 }

--- a/crates/primitives/src/precompile.rs
+++ b/crates/primitives/src/precompile.rs
@@ -129,7 +129,7 @@ impl Precompile {
             Precompile::Env(p) => p(bytes, gas_price, env),
             Precompile::Stateful(ref p) => p.call(bytes, gas_price, env),
             Precompile::StatefulMut(_) => Err(PrecompileErrors::Fatal {
-                msg: "call_ref on mutable stateful precompile".to_string(),
+                msg: "call_ref on mutable stateful precompile".into(),
             }),
         }
     }

--- a/crates/revm/src/context/context_precompiles.rs
+++ b/crates/revm/src/context/context_precompiles.rs
@@ -137,17 +137,19 @@ impl<DB: Database> ContextPrecompiles<DB> {
     /// Clones the precompiles map if it is shared.
     #[inline]
     pub fn to_mut(&mut self) -> &mut HashMap<Address, ContextPrecompile<DB>> {
-        self.mutate_into_owned();
+        if let PrecompilesCow::StaticRef(_) = self.inner {
+            self.mutate_into_owned();
+        }
 
         let PrecompilesCow::Owned(inner) = &mut self.inner else {
-            unreachable!()
+            unreachable!("self is mutated to Owned.")
         };
         inner
     }
 
     /// Mutates Self into Owned variant, or do nothing if it is already Owned.
     /// Mutation will clone all precompiles.
-    #[inline]
+    #[cold]
     fn mutate_into_owned(&mut self) {
         let PrecompilesCow::StaticRef(precompiles) = self.inner else {
             return;

--- a/crates/revm/src/context/context_precompiles.rs
+++ b/crates/revm/src/context/context_precompiles.rs
@@ -45,9 +45,16 @@ impl<DB: Database> Clone for PrecompilesCow<DB> {
 }
 
 /// Precompiles context.
-#[derive(Clone)]
 pub struct ContextPrecompiles<DB: Database> {
     inner: PrecompilesCow<DB>,
+}
+
+impl<DB: Database> Clone for ContextPrecompiles<DB> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
 }
 
 impl<DB: Database> ContextPrecompiles<DB> {
@@ -141,7 +148,7 @@ impl<DB: Database> ContextPrecompiles<DB> {
     /// Mutates Self into Owned variant, or do nothing if it is already Owned.
     /// Mutation will clone all precompiles.
     #[inline]
-    pub fn mutate_into_owned(&mut self) {
+    fn mutate_into_owned(&mut self) {
         let PrecompilesCow::StaticRef(precompiles) = self.inner else {
             return;
         };

--- a/crates/revm/src/context/evm_context.rs
+++ b/crates/revm/src/context/evm_context.rs
@@ -105,7 +105,7 @@ impl<DB: Database> EvmContext<DB> {
     #[inline]
     fn call_precompile(
         &mut self,
-        address: Address,
+        address: &Address,
         input_data: &Bytes,
         gas: Gas,
     ) -> Result<Option<InterpreterResult>, EVMError<DB::Error>> {
@@ -199,7 +199,7 @@ impl<DB: Database> EvmContext<DB> {
             _ => {}
         };
 
-        if let Some(result) = self.call_precompile(inputs.bytecode_address, &inputs.input, gas)? {
+        if let Some(result) = self.call_precompile(&inputs.bytecode_address, &inputs.input, gas)? {
             if matches!(result.result, return_ok!()) {
                 self.journaled_state.checkpoint_commit();
             } else {

--- a/crates/revm/src/context/evm_context.rs
+++ b/crates/revm/src/context/evm_context.rs
@@ -7,7 +7,7 @@ use crate::{
     interpreter::{
         return_ok, CallInputs, Contract, Gas, InstructionResult, Interpreter, InterpreterResult,
     },
-    primitives::{Address, Bytes, EVMError, Env, HashSet, U256},
+    primitives::{Address, Bytes, EVMError, Env, U256},
     ContextPrecompiles, FrameOrResult, CALL_STACK_LIMIT,
 };
 use core::{
@@ -96,8 +96,7 @@ impl<DB: Database> EvmContext<DB> {
     #[inline]
     pub fn set_precompiles(&mut self, precompiles: ContextPrecompiles<DB>) {
         // set warm loaded addresses.
-        self.journaled_state.warm_preloaded_addresses =
-            precompiles.addresses().copied().collect::<HashSet<_>>();
+        self.journaled_state.warm_preloaded_addresses = precompiles.addresses_set();
         self.precompiles = precompiles;
     }
 
@@ -232,7 +231,7 @@ pub(crate) mod test_utils {
     use crate::{
         db::{CacheDB, EmptyDB},
         journaled_state::JournaledState,
-        primitives::{address, SpecId, B256},
+        primitives::{address, HashSet, SpecId, B256},
     };
 
     /// Mock caller address.

--- a/crates/revm/src/handler/mainnet/pre_execution.rs
+++ b/crates/revm/src/handler/mainnet/pre_execution.rs
@@ -3,7 +3,7 @@
 //! They handle initial setup of the EVM, call loop and the final return of the EVM
 
 use crate::{
-    precompile::{PrecompileSpecId, Precompiles},
+    precompile::PrecompileSpecId,
     primitives::{
         db::Database,
         Account, EVMError, Env, Spec,
@@ -16,9 +16,7 @@ use crate::{
 /// Main precompile load
 #[inline]
 pub fn load_precompiles<SPEC: Spec, DB: Database>() -> ContextPrecompiles<DB> {
-    Precompiles::new(PrecompileSpecId::from_spec_id(SPEC::SPEC_ID))
-        .clone()
-        .into()
+    ContextPrecompiles::new(PrecompileSpecId::from_spec_id(SPEC::SPEC_ID))
 }
 
 /// Main load handle

--- a/crates/revm/src/optimism/handler_register.rs
+++ b/crates/revm/src/optimism/handler_register.rs
@@ -14,7 +14,7 @@ use crate::{
     Context, ContextPrecompiles, FrameResult,
 };
 use core::ops::Mul;
-use revm_precompile::{secp256r1, PrecompileSpecId, Precompiles};
+use revm_precompile::{secp256r1, PrecompileSpecId};
 use std::string::ToString;
 use std::sync::Arc;
 
@@ -143,7 +143,7 @@ pub fn last_frame_return<SPEC: Spec, EXT, DB: Database>(
 /// Load precompiles for Optimism chain.
 #[inline]
 pub fn load_precompiles<SPEC: Spec, EXT, DB: Database>() -> ContextPrecompiles<DB> {
-    let mut precompiles = Precompiles::new(PrecompileSpecId::from_spec_id(SPEC::SPEC_ID)).clone();
+    let mut precompiles = ContextPrecompiles::new(PrecompileSpecId::from_spec_id(SPEC::SPEC_ID));
 
     if SPEC::enabled(SpecId::FJORD) {
         precompiles.extend([
@@ -152,7 +152,7 @@ pub fn load_precompiles<SPEC: Spec, EXT, DB: Database>() -> ContextPrecompiles<D
         ])
     }
 
-    precompiles.into()
+    precompiles
 }
 
 /// Load account (make them warm) and l1 data from database.


### PR DESCRIPTION
`Precompiles::new().clone().into()` would first clone the static default precompiles, then collect them into a new hashmap again in `ContextPrecompiles`. This shows up as about ~3% in `Evm::transact` profiles.

Avoid both cloning and collecting by using a CoW structure internally. This requires us to remove the `Deref` and `DerefMut` implementations as the internal type will be different depending on whether we have the default static precompiles, or a custom map. This should be fine as we can still support all necessary operations without exposing the underlying map type.