### PR TITLE
feat(op): use RollupCostData instead of full encoding

### DIFF
--- a/crates/interpreter/src/gas/calc.rs
+++ b/crates/interpreter/src/gas/calc.rs
@@ -351,6 +351,15 @@ pub const fn memory_gas(num_words: u64) -> u64 {
         .saturating_add(num_words.saturating_mul(num_words) / 512)
 }
 
+/// This counts the number of zero, and non-zero bytes in the input data.
+///
+/// Returns a tuple of (zero_bytes, non_zero_bytes).
+pub fn count_zero_bytes(data: &[u8]) -> (u64, u64) {
+    let zero_data_len = data.iter().filter(|v| **v == 0).count() as u64;
+    let non_zero_data_len = data.len() as u64 - zero_data_len;
+    (zero_data_len, non_zero_data_len)
+}
+
 /// Initial gas that is deducted for transaction to be included.
 /// Initial gas contains initial stipend gas, gas for access list and input data.
 pub fn validate_initial_tx_gas(
@@ -360,8 +369,7 @@ pub fn validate_initial_tx_gas(
     access_list: &[(Address, Vec<U256>)],
 ) -> u64 {
     let mut initial_gas = 0;
-    let zero_data_len = input.iter().filter(|v| **v == 0).count() as u64;
-    let non_zero_data_len = input.len() as u64 - zero_data_len;
+    let (zero_data_len, non_zero_data_len) = count_zero_bytes(input);
 
     // initdate stipend
     initial_gas += zero_data_len * TRANSACTION_ZERO_DATA;

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -71,7 +71,9 @@ alloy-provider = { git = "https://github.com/alloy-rs/alloy.git", rev = "44b8a6d
 alloy-transport-http = { git = "https://github.com/alloy-rs/alloy.git", rev = "44b8a6d" }
 
 [features]
-default = ["std", "c-kzg", "secp256k1", "portable", "blst"]
+# default = ["std", "c-kzg", "secp256k1", "portable", "blst"]
+# for developing in editor w op
+default = ["std", "c-kzg", "secp256k1", "portable", "blst", "optimism"]
 std = [
     "serde?/std",
     "serde_json?/std",

--- a/crates/revm/src/optimism.rs
+++ b/crates/revm/src/optimism.rs
@@ -3,9 +3,11 @@
 mod fast_lz;
 mod handler_register;
 mod l1block;
+mod rollup_cost;
 
 pub use handler_register::{
     deduct_caller, end, last_frame_return, load_accounts, load_precompiles,
     optimism_handle_register, output, reward_beneficiary, validate_env, validate_tx_against_state,
 };
 pub use l1block::{L1BlockInfo, BASE_FEE_RECIPIENT, L1_BLOCK_CONTRACT, L1_FEE_RECIPIENT};
+pub use rollup_cost::RollupCostData;

--- a/crates/revm/src/optimism/l1block.rs
+++ b/crates/revm/src/optimism/l1block.rs
@@ -136,7 +136,9 @@ impl L1BlockInfo {
 
         let mut rollup_data_gas_cost = U256::from(cost_data.ones)
             .saturating_mul(U256::from(NON_ZERO_BYTE_COST))
-            .saturating_add(U256::from(cost_data.zeroes).saturating_mul(U256::from(ZERO_BYTE_COST)));
+            .saturating_add(
+                U256::from(cost_data.zeroes).saturating_mul(U256::from(ZERO_BYTE_COST)),
+            );
 
         // Prior to regolith, an extra 68 non zero bytes were included in the rollup data costs.
         if !spec_id.is_enabled_in(SpecId::REGOLITH) {

--- a/crates/revm/src/optimism/l1block.rs
+++ b/crates/revm/src/optimism/l1block.rs
@@ -132,11 +132,10 @@ impl L1BlockInfo {
                 .wrapping_div(1_000_000);
         };
 
-        let mut rollup_data_gas_cost = cost_data.ones.get()
+        let mut rollup_data_gas_cost = cost_data
+            .ones
             .saturating_mul(NON_ZERO_BYTE_COST)
-            .saturating_add(
-                cost_data.zeroes.get().saturating_mul(ZERO_BYTE_COST),
-            );
+            .saturating_add(cost_data.zeroes.saturating_mul(ZERO_BYTE_COST));
 
         // Prior to regolith, an extra 68 non zero bytes were included in the rollup data costs.
         if !spec_id.is_enabled_in(SpecId::REGOLITH) {
@@ -150,7 +149,8 @@ impl L1BlockInfo {
     // This value is computed based on the following formula:
     // max(minTransactionSize, intercept + fastlzCoef*fastlzSize)
     fn tx_estimated_size_fjord(&self, cost_data: RollupCostData) -> u32 {
-        cost_data.fastlz_size
+        cost_data
+            .fastlz_size
             .saturating_mul(836_500)
             .saturating_sub(42_585_600)
             .max(100_000_000)

--- a/crates/revm/src/optimism/l1block.rs
+++ b/crates/revm/src/optimism/l1block.rs
@@ -134,10 +134,10 @@ impl L1BlockInfo {
                 .wrapping_div(U256::from(1_000_000));
         };
 
-        let mut rollup_data_gas_cost = U256::from(cost_data.ones)
+        let mut rollup_data_gas_cost = U256::from(cost_data.ones.get())
             .saturating_mul(U256::from(NON_ZERO_BYTE_COST))
             .saturating_add(
-                U256::from(cost_data.zeroes).saturating_mul(U256::from(ZERO_BYTE_COST)),
+                U256::from(cost_data.zeroes.get()).saturating_mul(U256::from(ZERO_BYTE_COST)),
             );
 
         // Prior to regolith, an extra 68 non zero bytes were included in the rollup data costs.

--- a/crates/revm/src/optimism/rollup_cost.rs
+++ b/crates/revm/src/optimism/rollup_cost.rs
@@ -1,0 +1,39 @@
+//! This contains a struct, [`RollupCostData`], that is used to compute the data availability costs
+//! for a transaction.
+
+use crate::optimism::fast_lz::flz_compress_len;
+
+/// RollupCostData contains three fields, which are used depending on the current optimism fork.
+///
+/// The `zeroes` and `ones` fields are used to compute the data availability costs for a
+/// transaction pre-fjord.
+///
+/// The `fastlz_size` field is used to compute the data availability costs for a transaction
+/// post-fjord.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RollupCostData {
+    /// The number of zeroes in the transaction.
+    pub(crate) zeroes: u64,
+    /// The number of ones in the transaction.
+    pub(crate) ones: u64,
+    /// The size of the transaction after fastLZ compression.
+    pub(crate) fastlz_size: u32,
+}
+
+impl RollupCostData {
+    /// This takes bytes as input, creating a [`RollupCostData`] struct based on the encoded data.
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        let mut data = RollupCostData::default();
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == 0 {
+                data.zeroes += 1;
+            } else {
+                data.ones += 1;
+            }
+            i += 1;
+        }
+        data.fastlz_size = flz_compress_len(bytes);
+        data
+    }
+}

--- a/crates/revm/src/optimism/rollup_cost.rs
+++ b/crates/revm/src/optimism/rollup_cost.rs
@@ -2,7 +2,6 @@
 //! for a transaction.
 
 use crate::optimism::fast_lz::flz_compress_len;
-use core::num::NonZeroU64;
 use revm_interpreter::gas::count_zero_bytes;
 
 /// RollupCostData contains three fields, which are used depending on the current optimism fork.
@@ -15,9 +14,9 @@ use revm_interpreter::gas::count_zero_bytes;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RollupCostData {
     /// The number of zeroes in the transaction.
-    pub(crate) zeroes: NonZeroU64,
+    pub(crate) zeroes: u64,
     /// The number of ones in the transaction.
-    pub(crate) ones: NonZeroU64,
+    pub(crate) ones: u64,
     /// The size of the transaction after fastLZ compression.
     pub(crate) fastlz_size: u32,
 }
@@ -27,8 +26,8 @@ impl RollupCostData {
     pub fn from_bytes(bytes: &[u8]) -> Self {
         let (zeroes, ones) = count_zero_bytes(bytes);
         Self {
-            zeroes: NonZeroU64::new(zeroes).unwrap(),
-            ones: NonZeroU64::new(ones).unwrap(),
+            zeroes,
+            ones,
             fastlz_size: flz_compress_len(bytes),
         }
     }


### PR DESCRIPTION
This is a WIP to ultimately replace the `tx_envelope` part of the `OptimismFields` with a new struct.

Currently it just introduces the struct, which basically mirrors the `RollupCostData` from op-geth, and uses it in a few places. The plan is to first integrate this internally, without breaking `OptimismFields`, and once it is properly tested, break `OptimismFields` to use this instead.