### PR TITLE
Fix some nits in bls12_381 precompiles

### DIFF
--- a/crates/precompile/src/bls12_381/g1.rs
+++ b/crates/precompile/src/bls12_381/g1.rs
@@ -85,7 +85,9 @@ pub(super) fn extract_g1_input(
         //
         // SAFETY: out is a blst value.
         if unsafe { !blst_p1_affine_on_curve(&out) } {
-            return Err(PrecompileError::Other("Element not on G1 curve".to_string()));
+            return Err(PrecompileError::Other(
+                "Element not on G1 curve".to_string(),
+            ));
         }
     }
 

--- a/crates/precompile/src/bls12_381/g1.rs
+++ b/crates/precompile/src/bls12_381/g1.rs
@@ -69,7 +69,7 @@ pub(super) fn extract_g1_input(
         // As endomorphism acceleration requires input on the correct subgroup, implementers MAY
         // use endomorphism acceleration.
         if unsafe { !blst_p1_affine_in_g1(&out) } {
-            return Err(PrecompileError::Other("Element not in G2".to_string()));
+            return Err(PrecompileError::Other("Element not in G1".to_string()));
         }
     } else {
         // From EIP-2537:
@@ -80,14 +80,12 @@ pub(super) fn extract_g1_input(
         //
         // NB: There is no subgroup check for the G1 addition precompile.
         //
-        // We use blst_p1_affine_on_curve instead of blst_p1_affine_in_g2 because the latter performs
+        // We use blst_p1_affine_on_curve instead of blst_p1_affine_in_g1 because the latter performs
         // the subgroup check.
         //
         // SAFETY: out is a blst value.
         if unsafe { !blst_p1_affine_on_curve(&out) } {
-            return Err(PrecompileError::Other(
-                "Element not on G2 curve".to_string(),
-            ));
+            return Err(PrecompileError::Other("Element not on G1 curve".to_string()));
         }
     }
 

--- a/crates/precompile/src/bls12_381/g1_msm.rs
+++ b/crates/precompile/src/bls12_381/g1_msm.rs
@@ -45,8 +45,8 @@ pub(super) fn g1_msm(input: &Bytes, gas_limit: u64) -> PrecompileResult {
         let slice =
             &input[i * g1_mul::INPUT_LENGTH..i * g1_mul::INPUT_LENGTH + G1_INPUT_ITEM_LENGTH];
 
-        // BLST batch API for p1_affines blows up when you pass it a point at infinity and returns
-        // point at infinity so we just skip the element, and return 128 bytes in the response
+        // BLST batch API for p1_affines blows up when you pass it a point at infinity, so we must
+        // filter points at infinity (and their corresponding scalars) from the input.
         if slice.iter().all(|i| *i == 0) {
             continue;
         }

--- a/crates/precompile/src/bls12_381/g2.rs
+++ b/crates/precompile/src/bls12_381/g2.rs
@@ -68,7 +68,7 @@ pub(super) fn extract_g2_input(
         )));
     }
 
-    let mut input_fps: [&[u8; FP_LENGTH]; 4] = [&[0; FP_LENGTH]; 4];
+    let mut input_fps = [&[0; FP_LENGTH]; 4];
     for i in 0..4 {
         input_fps[i] = remove_padding(&input[i * PADDED_FP_LENGTH..(i + 1) * PADDED_FP_LENGTH])?;
     }
@@ -105,9 +105,7 @@ pub(super) fn extract_g2_input(
         //
         // SAFETY: out is a blst value.
         if unsafe { !blst_p2_affine_on_curve(&out) } {
-            return Err(PrecompileError::Other(
-                "Element not on G2 curve".to_string(),
-            ));
+            return Err(PrecompileError::Other("Element not on G2 curve".to_string()));
         }
     }
 

--- a/crates/precompile/src/bls12_381/g2.rs
+++ b/crates/precompile/src/bls12_381/g2.rs
@@ -105,7 +105,9 @@ pub(super) fn extract_g2_input(
         //
         // SAFETY: out is a blst value.
         if unsafe { !blst_p2_affine_on_curve(&out) } {
-            return Err(PrecompileError::Other("Element not on G2 curve".to_string()));
+            return Err(PrecompileError::Other(
+                "Element not on G2 curve".to_string(),
+            ));
         }
     }
 

--- a/crates/precompile/src/bls12_381/g2_msm.rs
+++ b/crates/precompile/src/bls12_381/g2_msm.rs
@@ -44,8 +44,8 @@ pub(super) fn g2_msm(input: &Bytes, gas_limit: u64) -> PrecompileResult {
     for i in 0..k {
         let slice =
             &input[i * g2_mul::INPUT_LENGTH..i * g2_mul::INPUT_LENGTH + G2_INPUT_ITEM_LENGTH];
-        // BLST batch API for p2_affines blows up when you pass it a point at infinity and returns
-        // point at infinity so we just skip the element, and return 256 bytes in the response
+        // BLST batch API for p2_affines blows up when you pass it a point at infinity, so we must
+        // filter points at infinity (and their corresponding scalars) from the input.
         if slice.iter().all(|i| *i == 0) {
             continue;
         }

--- a/crates/precompile/src/bls12_381/map_fp2_to_g2.rs
+++ b/crates/precompile/src/bls12_381/map_fp2_to_g2.rs
@@ -17,7 +17,7 @@ pub const ADDRESS: u64 = 0x13;
 /// Base gas fee for BLS12-381 map_fp2_to_g2 operation.
 const BASE_GAS_FEE: u64 = 75000;
 
-/// Field-to-curve call expects 128 bytes as an input that is interpreted as a
+/// Field-to-curve call expects 128 bytes as an input that is interpreted as
 /// an element of Fp2. Output of this call is 256 bytes and is an encoded G2
 /// point.
 /// See also: <https://eips.ethereum.org/EIPS/eip-2537#abi-for-mapping-fp2-element-to-g2-point>

--- a/crates/precompile/src/bls12_381/pairing.rs
+++ b/crates/precompile/src/bls12_381/pairing.rs
@@ -16,7 +16,7 @@ pub const ADDRESS: u64 = 0x11;
 const PAIRING_MULTIPLIER_BASE: u64 = 43000;
 /// Offset gas fee for BLS12-381 pairing operation.
 const PAIRING_OFFSET_BASE: u64 = 65000;
-/// Input length of paitring operation.
+/// Input length of pairing operation.
 const INPUT_LENGTH: usize = 384;
 
 /// Pairing call expects 384*k (k being a positive integer) bytes as an inputs
@@ -25,7 +25,7 @@ const INPUT_LENGTH: usize = 384;
 ///    * 128 bytes of G1 point encoding
 ///    * 256 bytes of G2 point encoding
 /// Each point is expected to be in the subgroup of order q.
-/// Output is a 32 bytes where first 31 bytes are equal to 0x00 and the last byte
+/// Output is 32 bytes where first 31 bytes are equal to 0x00 and the last byte
 /// is 0x01 if pairing result is equal to the multiplicative identity in a pairing
 /// target field and 0x00 otherwise.
 /// See also: <https://eips.ethereum.org/EIPS/eip-2537#abi-for-pairing>
@@ -43,7 +43,7 @@ pub(super) fn pairing(input: &Bytes, gas_limit: u64) -> PrecompileResult {
         return Err(PrecompileError::OutOfGas);
     }
 
-    // accumulator for the fp12 multiplications of the miller loops.
+    // Accumulator for the fp12 multiplications of the miller loops.
     let mut acc = blst_fp12::default();
     for i in 0..k {
         // NB: Scalar multiplications, MSMs and pairings MUST perform a subgroup check.
@@ -64,7 +64,7 @@ pub(super) fn pairing(input: &Bytes, gas_limit: u64) -> PrecompileResult {
         )?;
 
         if i > 0 {
-            // after the first slice (i>0) we use cur_ml to store the current
+            // After the first slice (i>0) we use cur_ml to store the current
             // miller loop and accumulate with the previous results using a fp12
             // multiplication.
             let mut cur_ml = blst_fp12::default();
@@ -76,7 +76,7 @@ pub(super) fn pairing(input: &Bytes, gas_limit: u64) -> PrecompileResult {
             }
             acc = res;
         } else {
-            // on the first slice (i==0) there is no previous results and no need
+            // On the first slice (i==0) there is no previous results and no need
             // to accumulate.
             // SAFETY: acc, p1_aff and p2_aff are blst values.
             unsafe {


### PR DESCRIPTION
I was reviewing the new precompiles and noticed some stuff. This PR does the following:

* Fix a few typos.
* Replace g2 with g1 in `extract_g1_input`.
* Remove unnecessary type hint for `input_fps`.
* Rephrase comment about filtering points at infinity in the MSMs.
  * I found the part about returning bytes a little confusing.
  * We had to do the same thing in ckzg by the way 😢

These look great though. Didn't spot any real issues.