### PR TITLE
fix(op): Remove `UintTryFrom<{float}>` dep in `l1block` module

### DIFF
--- a/crates/revm/src/optimism/l1block.rs
+++ b/crates/revm/src/optimism/l1block.rs
@@ -223,7 +223,7 @@ impl L1BlockInfo {
 
         estimated_size
             .saturating_mul(l1_fee_scaled)
-            .wrapping_div(U256::from(1e12))
+            .wrapping_div(U256::from(1000000000000u64))
     }
 
     // l1BaseFee*16*l1BaseFeeScalar + l1BlobBaseFee*l1BlobBaseFeeScalar


### PR DESCRIPTION
## Overview

Specifies the type of `1e12` as `u64` in the `l1block.rs` module, rather than a float literal, removing the need for `UintTryFrom<{float}>`. Certain environments, like the OP Stack's fault proof VMs, do not support floating point arithmetic.