### PR TITLE
perf: Removed .clone() in ExecutionHandler::call, and reusing output buffer…

### DIFF
--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -250,24 +250,24 @@ impl Interpreter {
         call_outcome: CallOutcome,
     ) {
         self.instruction_result = InstructionResult::Continue;
-        self.return_data_buffer.clone_from(call_outcome.output());
 
         let out_offset = call_outcome.memory_start();
         let out_len = call_outcome.memory_length();
+        let out_ins_result = *call_outcome.instruction_result();
+        let out_gas = call_outcome.gas();
+        self.return_data_buffer = call_outcome.result.output;
 
         let target_len = min(out_len, self.return_data_buffer.len());
-        match call_outcome.instruction_result() {
+        match out_ins_result {
             return_ok!() => {
                 // return unspend gas.
-                let remaining = call_outcome.gas().remaining();
-                let refunded = call_outcome.gas().refunded();
-                self.gas.erase_cost(remaining);
-                self.gas.record_refund(refunded);
+                self.gas.erase_cost(out_gas.remaining());
+                self.gas.record_refund(out_gas.refunded());
                 shared_memory.set(out_offset, &self.return_data_buffer[..target_len]);
                 push!(self, U256::from(1));
             }
             return_revert!() => {
-                self.gas.erase_cost(call_outcome.gas().remaining());
+                self.gas.erase_cost(out_gas.remaining());
                 shared_memory.set(out_offset, &self.return_data_buffer[..target_len]);
                 push!(self, U256::ZERO);
             }

--- a/crates/revm/src/handler/handle_types/execution.rs
+++ b/crates/revm/src/handler/handle_types/execution.rs
@@ -192,7 +192,7 @@ impl<'a, EXT, DB: Database> ExecutionHandler<'a, EXT, DB> {
         context: &mut Context<EXT, DB>,
         inputs: Box<CallInputs>,
     ) -> Result<FrameOrResult, EVMError<DB::Error>> {
-        (self.call)(context, inputs.clone())
+        (self.call)(context, inputs)
     }
 
     /// Call registered handler for call return.


### PR DESCRIPTION
Reduces allocations in a two places.

1) In ExecutionHandler::call(), drops a .clone() on the inputs (allocated cloned Bytes)
2) In Interpreter::insert_call_outcome, re-uses the passed in call_outcome.result.output rather than cloning the Bytes into a the new location

All the tests pass as far as I can tell, but I'm getting a bit lower in the stack than I'm super comfortable in, so would love an extra set of eyes to tell me if I'm missing something.