### PR TITLE
feat(EOF): Put EOF bytecode behind an Arc

### DIFF
--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -260,7 +260,7 @@ pub fn execute_test_suite(
             let code_hash = keccak256(&info.code);
             let bytecode = match info.code.get(..2) {
                 Some(magic) if magic == &EOF_MAGIC_BYTES => {
-                    Bytecode::Eof(Eof::decode(info.code.clone()).unwrap())
+                    Bytecode::Eof(Eof::decode(info.code.clone()).unwrap().into())
                 }
                 _ => Bytecode::new_raw(info.code),
             };

--- a/crates/interpreter/src/instructions/control.rs
+++ b/crates/interpreter/src/instructions/control.rs
@@ -204,6 +204,8 @@ pub fn unknown<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
 
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
+
     use revm_primitives::{bytes, eof::TypesSection, Bytecode, Eof, PragueSpec};
 
     use super::*;
@@ -322,7 +324,7 @@ mod test {
         eof.body.code_section.push(bytes2.clone());
         eof.body.types_section.push(types);
 
-        let mut interp = Interpreter::new_bytecode(Bytecode::Eof(eof));
+        let mut interp = Interpreter::new_bytecode(Bytecode::Eof(Arc::new(eof)));
         interp.gas = Gas::new(10000);
         interp
     }

--- a/crates/interpreter/src/instructions/data.rs
+++ b/crates/interpreter/src/instructions/data.rs
@@ -73,7 +73,7 @@ pub fn data_copy<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H)
     gas_or_fail!(interpreter, cost_per_word(size as u64, VERYLOW));
 
     let offset = as_usize_saturated!(offset);
-    let data = interpreter.contract.bytecode.eof().expect("EOF").data();
+    let data = interpreter.contract.bytecode.eof().expect("eof").data();
 
     // set data from the eof to the shared memory. Padd it with zeros.
     interpreter
@@ -84,6 +84,7 @@ pub fn data_copy<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H)
 #[cfg(test)]
 mod test {
     use revm_primitives::{b256, bytes, Bytecode, Bytes, Eof, PragueSpec};
+    use std::sync::Arc;
 
     use super::*;
     use crate::{
@@ -101,7 +102,7 @@ mod test {
 
         eof.header.code_sizes[0] = code_bytes.len() as u16;
         eof.body.code_section[0] = code_bytes;
-        Bytecode::Eof(eof)
+        Bytecode::Eof(Arc::new(eof))
     }
 
     #[test]

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -17,6 +17,7 @@ use crate::{
 use core::cmp::min;
 use revm_primitives::{Bytecode, Eof, U256};
 use std::borrow::ToOwned;
+use std::sync::Arc;
 
 /// EVM bytecode interpreter.
 #[derive(Debug)]
@@ -100,7 +101,7 @@ impl Interpreter {
     }
 
     #[inline]
-    pub fn eof(&self) -> Option<&Eof> {
+    pub fn eof(&self) -> Option<&Arc<Eof>> {
         self.contract.bytecode.eof()
     }
 

--- a/crates/revm/src/context/inner_evm_context.rs
+++ b/crates/revm/src/context/inner_evm_context.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     FrameOrResult, JournalCheckpoint, CALL_STACK_LIMIT,
 };
-use std::boxed::Box;
+use std::{boxed::Box, sync::Arc};
 
 /// EVM contexts contains data that EVM needs for execution.
 #[derive(Debug)]
@@ -297,7 +297,7 @@ impl<DB: Database> InnerEvmContext<DB> {
         let contract = Contract::new(
             inputs.input.clone(),
             // fine to clone as it is Bytes.
-            Bytecode::Eof(inputs.eof_init_code.clone()),
+            Bytecode::Eof(Arc::new(inputs.eof_init_code.clone())),
             None,
             inputs.created_address,
             inputs.caller,
@@ -343,7 +343,7 @@ impl<DB: Database> InnerEvmContext<DB> {
 
         // eof bytecode is going to be hashed.
         self.journaled_state
-            .set_code(address, Bytecode::Eof(bytecode));
+            .set_code(address, Bytecode::Eof(Arc::new(bytecode)));
     }
 
     /// Make create frame.


### PR DESCRIPTION
This is the [ISSUE](https://github.com/bluealloy/revm/issues/1488)

DaniPopes: EOF structure is present inside of Bytecode, and is cloned internally in AccountInfo and other places. It would improve performance to put behind an Arc to avoid cloning the underlying memory.

cc: @rakita @DaniPopes 
