### PR TITLE
wip: Host associate type, ChainSpec refactor

### DIFF
--- a/crates/interpreter/src/host.rs
+++ b/crates/interpreter/src/host.rs
@@ -5,12 +5,15 @@ pub use dummy::DummyHost;
 use revm_primitives::ChainSpec;
 
 /// EVM context host.
-pub trait Host<ChainSpecT: ChainSpec> {
+pub trait Host {
+    /// Chain specification.
+    type ChainSpecT: ChainSpec;
+
     /// Returns a reference to the environment.
-    fn env(&self) -> &Env<ChainSpecT>;
+    fn env(&self) -> &Env<Self::ChainSpecT>;
 
     /// Returns a mutable reference to the environment.
-    fn env_mut(&mut self) -> &mut Env<ChainSpecT>;
+    fn env_mut(&mut self) -> &mut Env<Self::ChainSpecT>;
 
     /// Load an account.
     ///
@@ -89,11 +92,11 @@ mod tests {
 
     use super::*;
 
-    fn assert_host<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>() {}
+    fn assert_host<H: Host + ?Sized>() {}
 
     #[test]
     fn object_safety() {
-        assert_host::<EthChainSpec, DummyHost<EthChainSpec>>();
-        assert_host::<EthChainSpec, dyn Host<EthChainSpec>>();
+        assert_host::<DummyHost<EthChainSpec>>();
+        assert_host::<dyn Host<ChainSpecT = EthChainSpec>>();
     }
 }

--- a/crates/interpreter/src/host/dummy.rs
+++ b/crates/interpreter/src/host/dummy.rs
@@ -38,6 +38,7 @@ impl<ChainSpecT: ChainSpec> DummyHost<ChainSpecT> {
 
 impl<ChainSpecT: ChainSpec> Host for DummyHost<ChainSpecT> {
     type ChainSpecT = ChainSpecT;
+
     #[inline]
     fn env(&self) -> &Env<ChainSpecT> {
         &self.env

--- a/crates/interpreter/src/host/dummy.rs
+++ b/crates/interpreter/src/host/dummy.rs
@@ -36,7 +36,8 @@ impl<ChainSpecT: ChainSpec> DummyHost<ChainSpecT> {
     }
 }
 
-impl<ChainSpecT: ChainSpec> Host<ChainSpecT> for DummyHost<ChainSpecT> {
+impl<ChainSpecT: ChainSpec> Host for DummyHost<ChainSpecT> {
+    type ChainSpecT = ChainSpecT;
     #[inline]
     fn env(&self) -> &Env<ChainSpecT> {
         &self.env

--- a/crates/interpreter/src/instructions/arithmetic.rs
+++ b/crates/interpreter/src/instructions/arithmetic.rs
@@ -5,37 +5,25 @@ use crate::{
     Host, Interpreter,
 };
 
-pub fn add<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn add<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = op1.wrapping_add(*op2);
 }
 
-pub fn mul<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn mul<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::LOW);
     pop_top!(interpreter, op1, op2);
     *op2 = op1.wrapping_mul(*op2);
 }
 
-pub fn sub<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn sub<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = op1.wrapping_sub(*op2);
 }
 
-pub fn div<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn div<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::LOW);
     pop_top!(interpreter, op1, op2);
     if *op2 != U256::ZERO {
@@ -43,19 +31,13 @@ pub fn div<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     }
 }
 
-pub fn sdiv<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn sdiv<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::LOW);
     pop_top!(interpreter, op1, op2);
     *op2 = i256_div(op1, *op2);
 }
 
-pub fn rem<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn rem<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::LOW);
     pop_top!(interpreter, op1, op2);
     if *op2 != U256::ZERO {
@@ -63,37 +45,25 @@ pub fn rem<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     }
 }
 
-pub fn smod<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn smod<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::LOW);
     pop_top!(interpreter, op1, op2);
     *op2 = i256_mod(op1, *op2)
 }
 
-pub fn addmod<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn addmod<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::MID);
     pop_top!(interpreter, op1, op2, op3);
     *op3 = op1.add_mod(op2, *op3)
 }
 
-pub fn mulmod<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn mulmod<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::MID);
     pop_top!(interpreter, op1, op2, op3);
     *op3 = op1.mul_mod(op2, *op3)
 }
 
-pub fn exp<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn exp<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     pop_top!(interpreter, op1, op2);
     gas_or_fail!(interpreter, gas::exp_cost(SPEC::SPEC_ID, *op2));
     *op2 = op1.pow(*op2);
@@ -114,10 +84,7 @@ pub fn exp<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
 /// `y | !mask` where `|` is the bitwise `OR` and `!` is bitwise negation. Similarly, if
 /// `b == 0` then the yellow paper says the output should start with all zeros, then end with
 /// bits from `b`; this is equal to `y & mask` where `&` is bitwise `AND`.
-pub fn signextend<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn signextend<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::LOW);
     pop_top!(interpreter, ext, x);
     // For 31 we also don't need to do anything.

--- a/crates/interpreter/src/instructions/bitwise.rs
+++ b/crates/interpreter/src/instructions/bitwise.rs
@@ -7,100 +7,67 @@ use crate::{
 use core::cmp::Ordering;
 use revm_primitives::uint;
 
-pub fn lt<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn lt<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = U256::from(op1 < *op2);
 }
 
-pub fn gt<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn gt<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = U256::from(op1 > *op2);
 }
 
-pub fn slt<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn slt<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = U256::from(i256_cmp(&op1, op2) == Ordering::Less);
 }
 
-pub fn sgt<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn sgt<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = U256::from(i256_cmp(&op1, op2) == Ordering::Greater);
 }
 
-pub fn eq<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn eq<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = U256::from(op1 == *op2);
 }
 
-pub fn iszero<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn iszero<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1);
     *op1 = U256::from(*op1 == U256::ZERO);
 }
 
-pub fn bitand<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn bitand<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = op1 & *op2;
 }
 
-pub fn bitor<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn bitor<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = op1 | *op2;
 }
 
-pub fn bitxor<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn bitxor<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = op1 ^ *op2;
 }
 
-pub fn not<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn not<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1);
     *op1 = !*op1;
 }
 
-pub fn byte<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn byte<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
 
@@ -114,10 +81,7 @@ pub fn byte<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
 }
 
 /// EIP-145: Bitwise shifting instructions in EVM
-pub fn shl<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn shl<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     check!(interpreter, CONSTANTINOPLE);
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
@@ -125,10 +89,7 @@ pub fn shl<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
 }
 
 /// EIP-145: Bitwise shifting instructions in EVM
-pub fn shr<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn shr<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     check!(interpreter, CONSTANTINOPLE);
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
@@ -136,10 +97,7 @@ pub fn shr<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
 }
 
 /// EIP-145: Bitwise shifting instructions in EVM
-pub fn sar<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn sar<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     check!(interpreter, CONSTANTINOPLE);
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
@@ -249,7 +207,7 @@ mod tests {
             host.clear();
             push!(interpreter, test.value);
             push!(interpreter, test.shift);
-            shl::<EthChainSpec, DummyHost<EthChainSpec>, LatestSpec>(&mut interpreter, &mut host);
+            shl::<DummyHost<EthChainSpec>, LatestSpec>(&mut interpreter, &mut host);
             pop!(interpreter, res);
             assert_eq!(res, test.expected);
         }
@@ -330,7 +288,7 @@ mod tests {
             host.clear();
             push!(interpreter, test.value);
             push!(interpreter, test.shift);
-            shr::<EthChainSpec, DummyHost<EthChainSpec>, LatestSpec>(&mut interpreter, &mut host);
+            shr::<DummyHost<EthChainSpec>, LatestSpec>(&mut interpreter, &mut host);
             pop!(interpreter, res);
             assert_eq!(res, test.expected);
         }
@@ -436,7 +394,7 @@ mod tests {
             host.clear();
             push!(interpreter, test.value);
             push!(interpreter, test.shift);
-            sar::<EthChainSpec, DummyHost<EthChainSpec>, LatestSpec>(&mut interpreter, &mut host);
+            sar::<DummyHost<EthChainSpec>, LatestSpec>(&mut interpreter, &mut host);
             pop!(interpreter, res);
             assert_eq!(res, test.expected);
         }

--- a/crates/interpreter/src/instructions/contract.rs
+++ b/crates/interpreter/src/instructions/contract.rs
@@ -38,10 +38,7 @@ pub fn resize_memory(
 }
 
 /// EOF Create instruction
-pub fn eofcreate<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn eofcreate<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     require_eof!(interpreter);
     gas!(interpreter, EOF_CREATE_GAS);
     let initcontainer_index = unsafe { *interpreter.instruction_pointer };
@@ -94,10 +91,7 @@ pub fn eofcreate<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     interpreter.instruction_pointer = unsafe { interpreter.instruction_pointer.offset(1) };
 }
 
-pub fn txcreate<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn txcreate<H: Host + ?Sized>(interpreter: &mut Interpreter, host: &mut H) {
     require_eof!(interpreter);
     gas!(interpreter, EOF_CREATE_GAS);
     pop!(
@@ -176,10 +170,7 @@ pub fn txcreate<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     interpreter.instruction_result = InstructionResult::CallOrCreate;
 }
 
-pub fn return_contract<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn return_contract<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     require_init_eof!(interpreter);
     let deploy_container_index = unsafe { read_u16(interpreter.instruction_pointer) };
     pop!(interpreter, aux_data_offset, aux_data_size);
@@ -246,7 +237,7 @@ pub fn extcall_input(interpreter: &mut Interpreter) -> Option<Bytes> {
     ))
 }
 
-pub fn extcall_gas_calc<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
+pub fn extcall_gas_calc<H: Host + ?Sized>(
     interpreter: &mut Interpreter,
     host: &mut H,
     target: Address,
@@ -288,10 +279,7 @@ pub fn extcall_gas_calc<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     Some(gas_limit)
 }
 
-pub fn extcall<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn extcall<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     require_eof!(interpreter);
     pop_address!(interpreter, target_address);
 
@@ -326,10 +314,7 @@ pub fn extcall<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
     interpreter.instruction_result = InstructionResult::CallOrCreate;
 }
 
-pub fn extdcall<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn extdcall<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     require_eof!(interpreter);
     pop_address!(interpreter, target_address);
 
@@ -362,10 +347,7 @@ pub fn extdcall<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>
     interpreter.instruction_result = InstructionResult::CallOrCreate;
 }
 
-pub fn extscall<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn extscall<H: Host + ?Sized>(interpreter: &mut Interpreter, host: &mut H) {
     require_eof!(interpreter);
     pop_address!(interpreter, target_address);
 
@@ -396,12 +378,7 @@ pub fn extscall<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     interpreter.instruction_result = InstructionResult::CallOrCreate;
 }
 
-pub fn create<
-    const IS_CREATE2: bool,
-    ChainSpecT: ChainSpec,
-    H: Host<ChainSpecT> + ?Sized,
-    SPEC: Spec,
->(
+pub fn create<const IS_CREATE2: bool, H: Host + ?Sized, SPEC: Spec>(
     interpreter: &mut Interpreter,
     host: &mut H,
 ) {
@@ -471,10 +448,7 @@ pub fn create<
     interpreter.instruction_result = InstructionResult::CallOrCreate;
 }
 
-pub fn call<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn call<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     pop!(interpreter, local_gas_limit);
     pop_address!(interpreter, to);
     // max gas limit is not possible in real ethereum situation.
@@ -495,7 +469,7 @@ pub fn call<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
         interpreter.instruction_result = InstructionResult::FatalExternalError;
         return;
     };
-    let Some(mut gas_limit) = calc_call_gas::<ChainSpecT, H, SPEC>(
+    let Some(mut gas_limit) = calc_call_gas::<H, SPEC>(
         interpreter,
         is_cold,
         has_transfer,
@@ -530,10 +504,7 @@ pub fn call<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
     interpreter.instruction_result = InstructionResult::CallOrCreate;
 }
 
-pub fn call_code<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn call_code<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     pop!(interpreter, local_gas_limit);
     pop_address!(interpreter, to);
     // max gas limit is not possible in real ethereum situation.
@@ -549,7 +520,7 @@ pub fn call_code<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec
         return;
     };
 
-    let Some(mut gas_limit) = calc_call_gas::<ChainSpecT, H, SPEC>(
+    let Some(mut gas_limit) = calc_call_gas::<H, SPEC>(
         interpreter,
         is_cold,
         value != U256::ZERO,
@@ -584,10 +555,7 @@ pub fn call_code<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec
     interpreter.instruction_result = InstructionResult::CallOrCreate;
 }
 
-pub fn delegate_call<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn delegate_call<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check!(interpreter, HOMESTEAD);
     pop!(interpreter, local_gas_limit);
     pop_address!(interpreter, to);
@@ -603,7 +571,7 @@ pub fn delegate_call<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: 
         return;
     };
     let Some(gas_limit) =
-        calc_call_gas::<ChainSpecT, H, SPEC>(interpreter, is_cold, false, false, local_gas_limit)
+        calc_call_gas::<H, SPEC>(interpreter, is_cold, false, false, local_gas_limit)
     else {
         return;
     };
@@ -628,10 +596,7 @@ pub fn delegate_call<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: 
     interpreter.instruction_result = InstructionResult::CallOrCreate;
 }
 
-pub fn static_call<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn static_call<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check!(interpreter, BYZANTIUM);
     pop!(interpreter, local_gas_limit);
     pop_address!(interpreter, to);
@@ -648,7 +613,7 @@ pub fn static_call<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Sp
     };
 
     let Some(gas_limit) =
-        calc_call_gas::<ChainSpecT, H, SPEC>(interpreter, is_cold, false, false, local_gas_limit)
+        calc_call_gas::<H, SPEC>(interpreter, is_cold, false, false, local_gas_limit)
     else {
         return;
     };

--- a/crates/interpreter/src/instructions/contract/call_helpers.rs
+++ b/crates/interpreter/src/instructions/contract/call_helpers.rs
@@ -45,7 +45,7 @@ pub fn resize_memory_and_return_range(
 }
 
 #[inline]
-pub fn calc_call_gas<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
+pub fn calc_call_gas<H: Host + ?Sized, SPEC: Spec>(
     interpreter: &mut Interpreter,
     is_cold: bool,
     has_transfer: bool,

--- a/crates/interpreter/src/instructions/control.rs
+++ b/crates/interpreter/src/instructions/control.rs
@@ -7,10 +7,7 @@ use crate::{
     Host, InstructionResult, Interpreter, InterpreterResult,
 };
 
-pub fn rjump<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn rjump<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     require_eof!(interpreter);
     gas!(interpreter, gas::BASE);
     let offset = unsafe { read_i16(interpreter.instruction_pointer) } as isize;
@@ -19,10 +16,7 @@ pub fn rjump<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     interpreter.instruction_pointer = unsafe { interpreter.instruction_pointer.offset(offset + 2) };
 }
 
-pub fn rjumpi<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn rjumpi<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     require_eof!(interpreter);
     gas!(interpreter, gas::CONDITION_JUMP_GAS);
     pop!(interpreter, condition);
@@ -36,10 +30,7 @@ pub fn rjumpi<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     interpreter.instruction_pointer = unsafe { interpreter.instruction_pointer.offset(offset) };
 }
 
-pub fn rjumpv<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn rjumpv<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     require_eof!(interpreter);
     gas!(interpreter, gas::CONDITION_JUMP_GAS);
     pop!(interpreter, case);
@@ -64,19 +55,13 @@ pub fn rjumpv<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     interpreter.instruction_pointer = unsafe { interpreter.instruction_pointer.offset(offset) };
 }
 
-pub fn jump<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn jump<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::MID);
     pop!(interpreter, target);
     jump_inner(interpreter, target);
 }
 
-pub fn jumpi<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn jumpi<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::HIGH);
     pop!(interpreter, target, cond);
     if cond != U256::ZERO {
@@ -95,17 +80,11 @@ fn jump_inner(interpreter: &mut Interpreter, target: U256) {
     interpreter.instruction_pointer = unsafe { interpreter.bytecode.as_ptr().add(target) };
 }
 
-pub fn jumpdest_or_nop<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn jumpdest_or_nop<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::JUMPDEST);
 }
 
-pub fn callf<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn callf<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     require_eof!(interpreter);
     gas!(interpreter, gas::LOW);
 
@@ -126,10 +105,7 @@ pub fn callf<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     interpreter.load_eof_code(idx, 0)
 }
 
-pub fn retf<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn retf<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     require_eof!(interpreter);
     gas!(interpreter, gas::RETF_GAS);
 
@@ -140,10 +116,7 @@ pub fn retf<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     interpreter.load_eof_code(fframe.idx, fframe.pc);
 }
 
-pub fn jumpf<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn jumpf<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     require_eof!(interpreter);
     gas!(interpreter, gas::LOW);
 
@@ -155,10 +128,7 @@ pub fn jumpf<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     interpreter.load_eof_code(idx, 0)
 }
 
-pub fn pc<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn pc<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::BASE);
     // - 1 because we have already advanced the instruction pointer in `Interpreter::step`
     push!(interpreter, U256::from(interpreter.program_counter() - 1));
@@ -188,43 +158,28 @@ fn return_inner(interpreter: &mut Interpreter, instruction_result: InstructionRe
     };
 }
 
-pub fn ret<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn ret<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     return_inner(interpreter, InstructionResult::Return);
 }
 
 /// EIP-140: REVERT instruction
-pub fn revert<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn revert<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     check!(interpreter, BYZANTIUM);
     return_inner(interpreter, InstructionResult::Revert);
 }
 
 /// Stop opcode. This opcode halts the execution.
-pub fn stop<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn stop<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     interpreter.instruction_result = InstructionResult::Stop;
 }
 
 /// Invalid opcode. This opcode halts the execution.
-pub fn invalid<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn invalid<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     interpreter.instruction_result = InstructionResult::InvalidFEOpcode;
 }
 
 /// Unknown opcode. This opcode halts the execution.
-pub fn unknown<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn unknown<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     interpreter.instruction_result = InstructionResult::OpcodeNotFound;
 }
 
@@ -240,7 +195,7 @@ mod test {
 
     #[test]
     fn rjump() {
-        let table = make_instruction_table::<EthChainSpec, _, PragueSpec>();
+        let table = make_instruction_table::<DummyHost<EthChainSpec>, PragueSpec>();
         let mut host = DummyHost::default();
         let mut interp = Interpreter::new_bytecode(Bytecode::LegacyRaw(Bytes::from([
             RJUMP, 0x00, 0x02, STOP, STOP,
@@ -254,7 +209,7 @@ mod test {
 
     #[test]
     fn rjumpi() {
-        let table = make_instruction_table::<EthChainSpec, _, PragueSpec>();
+        let table = make_instruction_table::<DummyHost<EthChainSpec>, PragueSpec>();
         let mut host = DummyHost::default();
         let mut interp = Interpreter::new_bytecode(Bytecode::LegacyRaw(Bytes::from([
             RJUMPI, 0x00, 0x03, RJUMPI, 0x00, 0x01, STOP, STOP,
@@ -274,7 +229,7 @@ mod test {
 
     #[test]
     fn rjumpv() {
-        let table = make_instruction_table::<EthChainSpec, _, PragueSpec>();
+        let table = make_instruction_table::<DummyHost<EthChainSpec>, PragueSpec>();
         let mut host = DummyHost::default();
         let mut interp = Interpreter::new_bytecode(Bytecode::LegacyRaw(Bytes::from([
             RJUMPV,
@@ -330,7 +285,7 @@ mod test {
 
     #[test]
     fn callf_retf_jumpf() {
-        let table = make_instruction_table::<EthChainSpec, _, PragueSpec>();
+        let table = make_instruction_table::<DummyHost<EthChainSpec>, PragueSpec>();
         let mut host = DummyHost::default();
         let mut eof = dummy_eof();
 

--- a/crates/interpreter/src/instructions/data.rs
+++ b/crates/interpreter/src/instructions/data.rs
@@ -8,10 +8,7 @@ use crate::{
     Host,
 };
 
-pub fn data_load<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn data_load<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     require_eof!(interpreter);
     gas!(interpreter, DATA_LOAD_GAS);
     pop_top!(interpreter, offset);
@@ -31,10 +28,7 @@ pub fn data_load<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     *offset = U256::from_be_bytes(word);
 }
 
-pub fn data_loadn<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn data_loadn<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     require_eof!(interpreter);
     gas!(interpreter, VERYLOW);
     let offset = unsafe { read_u16(interpreter.instruction_pointer) } as usize;
@@ -55,10 +49,7 @@ pub fn data_loadn<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     interpreter.instruction_pointer = unsafe { interpreter.instruction_pointer.offset(2) };
 }
 
-pub fn data_size<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn data_size<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     require_eof!(interpreter);
     gas!(interpreter, BASE);
     let data_size = interpreter.eof().expect("eof").header.data_size;
@@ -66,10 +57,7 @@ pub fn data_size<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     push!(interpreter, U256::from(data_size));
 }
 
-pub fn data_copy<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn data_copy<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     require_eof!(interpreter);
     gas!(interpreter, VERYLOW);
     pop!(interpreter, mem_offset, offset, size);
@@ -118,7 +106,7 @@ mod test {
 
     #[test]
     fn dataload_dataloadn() {
-        let table = make_instruction_table::<EthChainSpec, _, PragueSpec>();
+        let table = make_instruction_table::<DummyHost<EthChainSpec>, PragueSpec>();
         let mut host = DummyHost::default();
         let eof = dummy_eof(Bytes::from([
             DATALOAD, DATALOADN, 0x00, 0x00, DATALOAD, DATALOADN, 0x00, 35, DATALOAD, DATALOADN,
@@ -174,7 +162,7 @@ mod test {
 
     #[test]
     fn data_copy() {
-        let table = make_instruction_table::<EthChainSpec, _, PragueSpec>();
+        let table = make_instruction_table::<DummyHost<EthChainSpec>, PragueSpec>();
         let mut host = DummyHost::default();
         let eof = dummy_eof(Bytes::from([DATACOPY, DATACOPY, DATACOPY, DATACOPY]));
 

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -8,10 +8,7 @@ use core::cmp::min;
 use revm_primitives::BLOCK_HASH_HISTORY;
 use std::vec::Vec;
 
-pub fn balance<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn balance<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     pop_address!(interpreter, address);
     let Some((balance, is_cold)) = host.balance(address) else {
         interpreter.instruction_result = InstructionResult::FatalExternalError;
@@ -34,10 +31,7 @@ pub fn balance<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
 }
 
 /// EIP-1884: Repricing for trie-size-dependent opcodes
-pub fn selfbalance<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn selfbalance<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check!(interpreter, ISTANBUL);
     gas!(interpreter, gas::LOW);
     let Some((balance, _)) = host.balance(interpreter.contract.target_address) else {
@@ -47,10 +41,7 @@ pub fn selfbalance<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Sp
     push!(interpreter, balance);
 }
 
-pub fn extcodesize<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn extcodesize<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     pop_address!(interpreter, address);
     let Some((code, is_cold)) = host.code(address) else {
         interpreter.instruction_result = InstructionResult::FatalExternalError;
@@ -68,10 +59,7 @@ pub fn extcodesize<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Sp
 }
 
 /// EIP-1052: EXTCODEHASH opcode
-pub fn extcodehash<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn extcodehash<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check!(interpreter, CONSTANTINOPLE);
     pop_address!(interpreter, address);
     let Some((code_hash, is_cold)) = host.code_hash(address) else {
@@ -88,10 +76,7 @@ pub fn extcodehash<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Sp
     push_b256!(interpreter, code_hash);
 }
 
-pub fn extcodecopy<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn extcodecopy<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     pop_address!(interpreter, address);
     pop!(interpreter, memory_offset, code_offset, len_u256);
 
@@ -118,10 +103,7 @@ pub fn extcodecopy<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Sp
         .set_data(memory_offset, code_offset, len, &code.original_bytes());
 }
 
-pub fn blockhash<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn blockhash<H: Host + ?Sized>(interpreter: &mut Interpreter, host: &mut H) {
     gas!(interpreter, gas::BLOCKHASH);
     pop_top!(interpreter, number);
 
@@ -140,10 +122,7 @@ pub fn blockhash<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     *number = U256::ZERO;
 }
 
-pub fn sload<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn sload<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     pop_top!(interpreter, index);
     let Some((value, is_cold)) = host.sload(interpreter.contract.target_address, *index) else {
         interpreter.instruction_result = InstructionResult::FatalExternalError;
@@ -153,10 +132,7 @@ pub fn sload<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
     *index = value;
 }
 
-pub fn sstore<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn sstore<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     require_non_staticcall!(interpreter);
 
     pop!(interpreter, index, value);
@@ -182,10 +158,7 @@ pub fn sstore<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
 
 /// EIP-1153: Transient storage opcodes
 /// Store value to transient storage
-pub fn tstore<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn tstore<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check!(interpreter, CANCUN);
     require_non_staticcall!(interpreter);
     gas!(interpreter, gas::WARM_STORAGE_READ_COST);
@@ -197,10 +170,7 @@ pub fn tstore<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
 
 /// EIP-1153: Transient storage opcodes
 /// Load value from transient storage
-pub fn tload<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn tload<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check!(interpreter, CANCUN);
     gas!(interpreter, gas::WARM_STORAGE_READ_COST);
 
@@ -209,10 +179,7 @@ pub fn tload<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
     *index = host.tload(interpreter.contract.target_address, *index);
 }
 
-pub fn log<const N: usize, ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn log<const N: usize, H: Host + ?Sized>(interpreter: &mut Interpreter, host: &mut H) {
     require_non_staticcall!(interpreter);
 
     pop!(interpreter, offset, len);
@@ -245,10 +212,7 @@ pub fn log<const N: usize, ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     host.log(log);
 }
 
-pub fn selfdestruct<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn selfdestruct<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     require_non_staticcall!(interpreter);
     pop_address!(interpreter, target);
 

--- a/crates/interpreter/src/instructions/host/call_helpers.rs
+++ b/crates/interpreter/src/instructions/host/call_helpers.rs
@@ -34,7 +34,7 @@ pub fn get_memory_input_and_out_ranges(
 }
 
 #[inline]
-pub fn calc_call_gas<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
+pub fn calc_call_gas<H: Host + ?Sized, SPEC: Spec>(
     interpreter: &mut Interpreter,
     host: &mut H,
     to: Address,

--- a/crates/interpreter/src/instructions/host_env.rs
+++ b/crates/interpreter/src/instructions/host_env.rs
@@ -5,43 +5,28 @@ use crate::{
 };
 
 /// EIP-1344: ChainID opcode
-pub fn chainid<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn chainid<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check!(interpreter, ISTANBUL);
     gas!(interpreter, gas::BASE);
     push!(interpreter, U256::from(host.env().cfg.chain_id));
 }
 
-pub fn coinbase<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn coinbase<H: Host + ?Sized>(interpreter: &mut Interpreter, host: &mut H) {
     gas!(interpreter, gas::BASE);
     push_b256!(interpreter, host.env().block.coinbase().into_word());
 }
 
-pub fn timestamp<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn timestamp<H: Host + ?Sized>(interpreter: &mut Interpreter, host: &mut H) {
     gas!(interpreter, gas::BASE);
     push!(interpreter, *host.env().block.timestamp());
 }
 
-pub fn block_number<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn block_number<H: Host + ?Sized>(interpreter: &mut Interpreter, host: &mut H) {
     gas!(interpreter, gas::BASE);
     push!(interpreter, *host.env().block.number());
 }
 
-pub fn difficulty<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn difficulty<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     gas!(interpreter, gas::BASE);
     if SPEC::enabled(MERGE) {
         push_b256!(interpreter, *host.env().block.prevrandao().unwrap());
@@ -50,45 +35,30 @@ pub fn difficulty<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spe
     }
 }
 
-pub fn gaslimit<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn gaslimit<H: Host + ?Sized>(interpreter: &mut Interpreter, host: &mut H) {
     gas!(interpreter, gas::BASE);
     push!(interpreter, *host.env().block.gas_limit());
 }
 
-pub fn gasprice<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn gasprice<H: Host + ?Sized>(interpreter: &mut Interpreter, host: &mut H) {
     gas!(interpreter, gas::BASE);
     push!(interpreter, host.env().effective_gas_price());
 }
 
 /// EIP-3198: BASEFEE opcode
-pub fn basefee<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn basefee<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check!(interpreter, LONDON);
     gas!(interpreter, gas::BASE);
     push!(interpreter, *host.env().block.basefee());
 }
 
-pub fn origin<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn origin<H: Host + ?Sized>(interpreter: &mut Interpreter, host: &mut H) {
     gas!(interpreter, gas::BASE);
     push_b256!(interpreter, host.env().tx.caller().into_word());
 }
 
 // EIP-4844: Shard Blob Transactions
-pub fn blob_hash<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn blob_hash<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check!(interpreter, CANCUN);
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, index);
@@ -100,10 +70,7 @@ pub fn blob_hash<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec
 }
 
 /// EIP-7516: BLOBBASEFEE opcode
-pub fn blob_basefee<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    host: &mut H,
-) {
+pub fn blob_basefee<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check!(interpreter, CANCUN);
     gas!(interpreter, gas::BASE);
     push!(

--- a/crates/interpreter/src/instructions/memory.rs
+++ b/crates/interpreter/src/instructions/memory.rs
@@ -7,10 +7,7 @@ use crate::{
 };
 use core::cmp::max;
 
-pub fn mload<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn mload<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, top);
     let offset = as_usize_or_fail!(interpreter, top);
@@ -18,10 +15,7 @@ pub fn mload<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     *top = interpreter.shared_memory.get_u256(offset);
 }
 
-pub fn mstore<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn mstore<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop!(interpreter, offset, value);
     let offset = as_usize_or_fail!(interpreter, offset);
@@ -29,10 +23,7 @@ pub fn mstore<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     interpreter.shared_memory.set_u256(offset, value);
 }
 
-pub fn mstore8<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn mstore8<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop!(interpreter, offset, value);
     let offset = as_usize_or_fail!(interpreter, offset);
@@ -40,19 +31,13 @@ pub fn mstore8<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     interpreter.shared_memory.set_byte(offset, value.byte(0))
 }
 
-pub fn msize<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn msize<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::BASE);
     push!(interpreter, U256::from(interpreter.shared_memory.len()));
 }
 
 // EIP-5656: MCOPY - Memory copying instruction
-pub fn mcopy<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn mcopy<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     check!(interpreter, CANCUN);
     pop!(interpreter, dst, src, len);
 

--- a/crates/interpreter/src/instructions/stack.rs
+++ b/crates/interpreter/src/instructions/stack.rs
@@ -4,10 +4,7 @@ use crate::{
     Host, Interpreter,
 };
 
-pub fn pop<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn pop<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::BASE);
     if let Err(result) = interpreter.stack.pop() {
         interpreter.instruction_result = result;
@@ -17,10 +14,7 @@ pub fn pop<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
 /// EIP-3855: PUSH0 instruction
 ///
 /// Introduce a new instruction which pushes the constant value 0 onto the stack.
-pub fn push0<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn push0<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     check!(interpreter, SHANGHAI);
     gas!(interpreter, gas::BASE);
     if let Err(result) = interpreter.stack.push(U256::ZERO) {
@@ -28,10 +22,7 @@ pub fn push0<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
     }
 }
 
-pub fn push<const N: usize, ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn push<const N: usize, H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     // SAFETY: In analysis we append trailing bytes to the bytecode so that this is safe to do
     // without bounds checking.
@@ -46,30 +37,21 @@ pub fn push<const N: usize, ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>
     interpreter.instruction_pointer = unsafe { ip.add(N) };
 }
 
-pub fn dup<const N: usize, ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn dup<const N: usize, H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     if let Err(result) = interpreter.stack.dup(N) {
         interpreter.instruction_result = result;
     }
 }
 
-pub fn swap<const N: usize, ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn swap<const N: usize, H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     if let Err(result) = interpreter.stack.swap(N) {
         interpreter.instruction_result = result;
     }
 }
 
-pub fn dupn<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn dupn<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     require_eof!(interpreter);
     gas!(interpreter, gas::VERYLOW);
     let imm = unsafe { *interpreter.instruction_pointer };
@@ -79,10 +61,7 @@ pub fn dupn<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     interpreter.instruction_pointer = unsafe { interpreter.instruction_pointer.offset(1) };
 }
 
-pub fn swapn<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn swapn<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     require_eof!(interpreter);
     gas!(interpreter, gas::VERYLOW);
     let imm = unsafe { *interpreter.instruction_pointer };
@@ -92,10 +71,7 @@ pub fn swapn<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     interpreter.instruction_pointer = unsafe { interpreter.instruction_pointer.offset(1) };
 }
 
-pub fn exchange<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn exchange<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     require_eof!(interpreter);
     gas!(interpreter, gas::VERYLOW);
     let imm = unsafe { *interpreter.instruction_pointer };
@@ -119,7 +95,7 @@ mod test {
 
     #[test]
     fn dupn() {
-        let table = make_instruction_table::<EthChainSpec, _, PragueSpec>();
+        let table = make_instruction_table::<DummyHost<EthChainSpec>, PragueSpec>();
         let mut host = DummyHost::default();
         let mut interp = Interpreter::new_bytecode(Bytecode::LegacyRaw(Bytes::from([
             DUPN, 0x00, DUPN, 0x01, DUPN, 0x02,
@@ -139,7 +115,7 @@ mod test {
 
     #[test]
     fn swapn() {
-        let table = make_instruction_table::<EthChainSpec, _, PragueSpec>();
+        let table = make_instruction_table::<DummyHost<EthChainSpec>, PragueSpec>();
         let mut host = DummyHost::default();
         let mut interp =
             Interpreter::new_bytecode(Bytecode::LegacyRaw(Bytes::from([SWAPN, 0x00, SWAPN, 0x01])));
@@ -159,7 +135,7 @@ mod test {
 
     #[test]
     fn exchange() {
-        let table = make_instruction_table::<EthChainSpec, _, PragueSpec>();
+        let table = make_instruction_table::<DummyHost<EthChainSpec>, PragueSpec>();
         let mut host = DummyHost::default();
         let mut interp = Interpreter::new_bytecode(Bytecode::LegacyRaw(Bytes::from([
             EXCHANGE, 0x00, EXCHANGE, 0x11,

--- a/crates/interpreter/src/instructions/system.rs
+++ b/crates/interpreter/src/instructions/system.rs
@@ -5,10 +5,7 @@ use crate::{
 };
 use core::ptr;
 
-pub fn keccak256<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn keccak256<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     pop_top!(interpreter, offset, len_ptr);
     let len = as_usize_or_fail!(interpreter, len_ptr);
     gas_or_fail!(interpreter, gas::keccak256_cost(len as u64));
@@ -22,36 +19,24 @@ pub fn keccak256<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     *len_ptr = hash.into();
 }
 
-pub fn address<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn address<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::BASE);
     push_b256!(interpreter, interpreter.contract.target_address.into_word());
 }
 
-pub fn caller<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn caller<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::BASE);
     push_b256!(interpreter, interpreter.contract.caller.into_word());
 }
 
-pub fn codesize<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn codesize<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::BASE);
     // Inform the optimizer that the bytecode cannot be EOF to remove a bounds check.
     assume!(!interpreter.contract.bytecode.is_eof());
     push!(interpreter, U256::from(interpreter.contract.bytecode.len()));
 }
 
-pub fn codecopy<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn codecopy<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     pop!(interpreter, memory_offset, code_offset, len);
     let len = as_usize_or_fail!(interpreter, len);
     gas_or_fail!(interpreter, gas::verylowcopy_cost(len as u64));
@@ -73,10 +58,7 @@ pub fn codecopy<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     );
 }
 
-pub fn calldataload<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn calldataload<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, offset_ptr);
     let mut word = B256::ZERO;
@@ -99,26 +81,17 @@ pub fn calldataload<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
     *offset_ptr = word.into();
 }
 
-pub fn calldatasize<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn calldatasize<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::BASE);
     push!(interpreter, U256::from(interpreter.contract.input.len()));
 }
 
-pub fn callvalue<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn callvalue<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::BASE);
     push!(interpreter, interpreter.contract.call_value);
 }
 
-pub fn calldatacopy<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn calldatacopy<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     pop!(interpreter, memory_offset, data_offset, len);
     let len = as_usize_or_fail!(interpreter, len);
     gas_or_fail!(interpreter, gas::verylowcopy_cost(len as u64));
@@ -139,10 +112,7 @@ pub fn calldatacopy<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
 }
 
 /// EIP-211: New opcodes: RETURNDATASIZE and RETURNDATACOPY
-pub fn returndatasize<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn returndatasize<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     check!(interpreter, BYZANTIUM);
     gas!(interpreter, gas::BASE);
     push!(
@@ -152,10 +122,7 @@ pub fn returndatasize<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC:
 }
 
 /// EIP-211: New opcodes: RETURNDATASIZE and RETURNDATACOPY
-pub fn returndatacopy<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn returndatacopy<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     check!(interpreter, BYZANTIUM);
     pop!(interpreter, memory_offset, offset, len);
     let len = as_usize_or_fail!(interpreter, len);
@@ -177,10 +144,7 @@ pub fn returndatacopy<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC:
 }
 
 /// Part of EOF `<https://eips.ethereum.org/EIPS/eip-7069>`.
-pub fn returndataload<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn returndataload<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     require_eof!(interpreter);
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, offset);
@@ -194,10 +158,7 @@ pub fn returndataload<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
         B256::from_slice(&interpreter.return_data_buffer[offset_usize..offset_usize + 32]).into();
 }
 
-pub fn gas<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized>(
-    interpreter: &mut Interpreter,
-    _host: &mut H,
-) {
+pub fn gas<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::BASE);
     push!(interpreter, U256::from(interpreter.gas.remaining()));
 }
@@ -213,7 +174,7 @@ mod test {
 
     #[test]
     fn returndataload() {
-        let table = make_instruction_table::<EthChainSpec, _, PragueSpec>();
+        let table = make_instruction_table::<DummyHost<EthChainSpec>, PragueSpec>();
         let mut host = DummyHost::default();
 
         let mut interp = Interpreter::new_bytecode(Bytecode::LegacyRaw(

--- a/crates/interpreter/src/opcode.rs
+++ b/crates/interpreter/src/opcode.rs
@@ -606,12 +606,12 @@ opcodes! {
     0x53 => MSTORE8  => memory::mstore8                      => stack_io(2, 0);
     0x54 => SLOAD    => host::sload::<H, SPEC>   => stack_io(1, 1);
     0x55 => SSTORE   => host::sstore::<H, SPEC>  => stack_io(2, 0);
-    0x56 => JUMP     => control::jump                        => stack_io(1, 0), not_eof;
-    0x57 => JUMPI    => control::jumpi                       => stack_io(2, 0), not_eof;
-    0x58 => PC       => control::pc                          => stack_io(0, 1), not_eof;
-    0x59 => MSIZE    => memory::msize                        => stack_io(0, 1);
-    0x5A => GAS      => system::gas                          => stack_io(0, 1), not_eof;
-    0x5B => JUMPDEST => control::jumpdest_or_nop             => stack_io(0, 0);
+    0x56 => JUMP     => control::jump            => stack_io(1, 0), not_eof;
+    0x57 => JUMPI    => control::jumpi           => stack_io(2, 0), not_eof;
+    0x58 => PC       => control::pc              => stack_io(0, 1), not_eof;
+    0x59 => MSIZE    => memory::msize            => stack_io(0, 1);
+    0x5A => GAS      => system::gas              => stack_io(0, 1), not_eof;
+    0x5B => JUMPDEST => control::jumpdest_or_nop => stack_io(0, 0);
     0x5C => TLOAD    => host::tload::<H, SPEC>   => stack_io(1, 1);
     0x5D => TSTORE   => host::tstore::<H, SPEC>  => stack_io(2, 0);
     0x5E => MCOPY    => memory::mcopy::<H, SPEC> => stack_io(3, 0);

--- a/crates/interpreter/src/opcode.rs
+++ b/crates/interpreter/src/opcode.rs
@@ -27,23 +27,20 @@ pub type BoxedInstructionTable<'a, H> = [BoxedInstruction<'a, H>; 256];
 /// Note that `Plain` variant gives us 10-20% faster Interpreter execution.
 ///
 /// Boxed variant can be used to wrap plain function pointer with closure.
-pub enum InstructionTables<'a, ChainSpecT, H> {
+pub enum InstructionTables<'a, H> {
     Plain(InstructionTable<H>),
     Boxed(BoxedInstructionTable<'a, H>),
-    // Necessary until non-lifetime binders land in Rust
-    // https://github.com/rust-lang/rust/issues/108185
-    _Unused(PhantomData<ChainSpecT>),
 }
 
-impl<ChainSpecT: ChainSpec, H: Host<ChainSpecT>> InstructionTables<'_, ChainSpecT, H> {
+impl<H: Host> InstructionTables<'_, H> {
     /// Creates a plain instruction table for the given spec.
     #[inline]
     pub const fn new_plain<SPEC: Spec>() -> Self {
-        Self::Plain(make_instruction_table::<ChainSpecT, H, SPEC>())
+        Self::Plain(make_instruction_table::<H, SPEC>())
     }
 }
 
-impl<'a, ChainSpecT: ChainSpec, H: Host<ChainSpecT> + 'a> InstructionTables<'a, ChainSpecT, H> {
+impl<'a, H: Host + 'a> InstructionTables<'a, H> {
     /// Inserts a boxed instruction into the table with the specified index.
     ///
     /// This will convert the table into the [BoxedInstructionTable] variant if it is currently a
@@ -61,9 +58,6 @@ impl<'a, ChainSpecT: ChainSpec, H: Host<ChainSpecT> + 'a> InstructionTables<'a, 
             Self::Boxed(table) => {
                 table[opcode as usize] = Box::new(instruction);
             }
-            Self::_Unused(_) => {
-                unreachable!("phantom data is not used")
-            }
         }
     }
 
@@ -76,9 +70,6 @@ impl<'a, ChainSpecT: ChainSpec, H: Host<ChainSpecT> + 'a> InstructionTables<'a, 
             }
             Self::Boxed(table) => {
                 table[opcode as usize] = Box::new(instruction);
-            }
-            Self::_Unused(_) => {
-                unreachable!("phantom data is not used")
             }
         }
     }
@@ -95,52 +86,41 @@ impl<'a, ChainSpecT: ChainSpec, H: Host<ChainSpecT> + 'a> InstructionTables<'a, 
                 }));
             }
             Self::Boxed(_) => {}
-            Self::_Unused(_) => {
-                unreachable!("phantom data is not used")
-            }
         };
     }
 }
 
 /// Make instruction table.
 #[inline]
-pub const fn make_instruction_table<
-    ChainSpecT: ChainSpec,
-    H: Host<ChainSpecT> + ?Sized,
-    SPEC: Spec,
->() -> InstructionTable<H> {
+pub const fn make_instruction_table<H: Host + ?Sized, SPEC: Spec>() -> InstructionTable<H> {
     // Force const-eval of the table creation, making this function trivial.
     // TODO: Replace this with a `const {}` block once it is stable.
-    struct ConstTable<TableChainSpecT: ChainSpec, H: Host<TableChainSpecT> + ?Sized, SPEC: Spec> {
+    struct ConstTable<H: Host + ?Sized, SPEC: Spec> {
         _host: core::marker::PhantomData<H>,
         _spec: core::marker::PhantomData<SPEC>,
-        _chain_spec: core::marker::PhantomData<TableChainSpecT>,
     }
-    impl<ChainSpecT: ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>
-        ConstTable<ChainSpecT, H, SPEC>
-    {
+    impl<H: Host + ?Sized, SPEC: Spec> ConstTable<H, SPEC> {
         const NEW: InstructionTable<H> = {
             let mut tables: InstructionTable<H> = [control::unknown; 256];
             let mut i = 0;
             while i < 256 {
-                tables[i] = instruction::<ChainSpecT, H, SPEC>(i as u8);
+                tables[i] = instruction::<H, SPEC>(i as u8);
                 i += 1;
             }
             tables
         };
     }
-    ConstTable::<ChainSpecT, H, SPEC>::NEW
+    ConstTable::<H, SPEC>::NEW
 }
 
 /// Make boxed instruction table that calls `outer` closure for every instruction.
 #[inline]
-pub fn make_boxed_instruction_table<'a, ChainSpecT, H, SPEC, FN>(
+pub fn make_boxed_instruction_table<'a, H, SPEC, FN>(
     table: InstructionTable<H>,
     mut outer: FN,
 ) -> BoxedInstructionTable<'a, H>
 where
-    ChainSpecT: ChainSpec,
-    H: Host<ChainSpecT>,
+    H: Host,
     SPEC: Spec + 'a,
     FN: FnMut(Instruction<H>) -> BoxedInstruction<'a, H>,
 {
@@ -524,7 +504,7 @@ macro_rules! opcodes {
         static NAME_TO_OPCODE: phf::Map<&'static str, OpCode> = stringify_with_cb! { phf_map_cb; $($name)* };
 
         /// Returns the instruction function for the given opcode and spec.
-        pub const fn instruction<ChainSpecT: revm_primitives::ChainSpec, H: Host<ChainSpecT> + ?Sized, SPEC: Spec>(opcode: u8) -> Instruction<H> {
+        pub const fn instruction<H: Host + ?Sized, SPEC: Spec>(opcode: u8) -> Instruction<H> {
             match opcode {
                 $($name => $f,)*
                 _ => control::unknown,
@@ -549,7 +529,7 @@ opcodes! {
     0x07 => SMOD       => arithmetic::smod                       => stack_io(2, 1);
     0x08 => ADDMOD     => arithmetic::addmod                     => stack_io(3, 1);
     0x09 => MULMOD     => arithmetic::mulmod                     => stack_io(3, 1);
-    0x0A => EXP        => arithmetic::exp::<ChainSpecT, H, SPEC> => stack_io(2, 1);
+    0x0A => EXP        => arithmetic::exp::<H, SPEC> => stack_io(2, 1);
     0x0B => SIGNEXTEND => arithmetic::signextend                 => stack_io(2, 1);
     // 0x0C
     // 0x0D
@@ -566,9 +546,9 @@ opcodes! {
     0x18 => XOR    => bitwise::bitxor                     => stack_io(2, 1);
     0x19 => NOT    => bitwise::not                        => stack_io(1, 1);
     0x1A => BYTE   => bitwise::byte                       => stack_io(2, 1);
-    0x1B => SHL    => bitwise::shl::<ChainSpecT, H, SPEC> => stack_io(2, 1);
-    0x1C => SHR    => bitwise::shr::<ChainSpecT, H, SPEC> => stack_io(2, 1);
-    0x1D => SAR    => bitwise::sar::<ChainSpecT, H, SPEC> => stack_io(2, 1);
+    0x1B => SHL    => bitwise::shl::<H, SPEC> => stack_io(2, 1);
+    0x1C => SHR    => bitwise::shr::<H, SPEC> => stack_io(2, 1);
+    0x1D => SAR    => bitwise::sar::<H, SPEC> => stack_io(2, 1);
     // 0x1E
     // 0x1F
     0x20 => KECCAK256 => system::keccak256    => stack_io(2, 1);
@@ -588,7 +568,7 @@ opcodes! {
     // 0x2E
     // 0x2F
     0x30 => ADDRESS      => system::address                      => stack_io(0, 1);
-    0x31 => BALANCE      => host::balance::<ChainSpecT, H, SPEC> => stack_io(1, 1);
+    0x31 => BALANCE      => host::balance::<H, SPEC> => stack_io(1, 1);
     0x32 => ORIGIN       => host_env::origin                     => stack_io(0, 1);
     0x33 => CALLER       => system::caller                       => stack_io(0, 1);
     0x34 => CALLVALUE    => system::callvalue                    => stack_io(0, 1);
@@ -599,22 +579,22 @@ opcodes! {
     0x39 => CODECOPY     => system::codecopy                     => stack_io(3, 0), not_eof;
 
     0x3A => GASPRICE       => host_env::gasprice                            => stack_io(0, 1);
-    0x3B => EXTCODESIZE    => host::extcodesize::<ChainSpecT, H, SPEC>      => stack_io(1, 1), not_eof;
-    0x3C => EXTCODECOPY    => host::extcodecopy::<ChainSpecT, H, SPEC>      => stack_io(4, 0), not_eof;
-    0x3D => RETURNDATASIZE => system::returndatasize::<ChainSpecT, H, SPEC> => stack_io(0, 1);
-    0x3E => RETURNDATACOPY => system::returndatacopy::<ChainSpecT, H, SPEC> => stack_io(3, 0);
-    0x3F => EXTCODEHASH    => host::extcodehash::<ChainSpecT, H, SPEC>      => stack_io(1, 1), not_eof;
+    0x3B => EXTCODESIZE    => host::extcodesize::<H, SPEC>      => stack_io(1, 1), not_eof;
+    0x3C => EXTCODECOPY    => host::extcodecopy::<H, SPEC>      => stack_io(4, 0), not_eof;
+    0x3D => RETURNDATASIZE => system::returndatasize::<H, SPEC> => stack_io(0, 1);
+    0x3E => RETURNDATACOPY => system::returndatacopy::<H, SPEC> => stack_io(3, 0);
+    0x3F => EXTCODEHASH    => host::extcodehash::<H, SPEC>      => stack_io(1, 1), not_eof;
     0x40 => BLOCKHASH      => host::blockhash                               => stack_io(1, 1);
     0x41 => COINBASE       => host_env::coinbase                            => stack_io(0, 1);
     0x42 => TIMESTAMP      => host_env::timestamp                           => stack_io(0, 1);
     0x43 => NUMBER         => host_env::block_number                        => stack_io(0, 1);
-    0x44 => DIFFICULTY     => host_env::difficulty::<ChainSpecT, H, SPEC>   => stack_io(0, 1);
+    0x44 => DIFFICULTY     => host_env::difficulty::<H, SPEC>   => stack_io(0, 1);
     0x45 => GASLIMIT       => host_env::gaslimit                            => stack_io(0, 1);
-    0x46 => CHAINID        => host_env::chainid::<ChainSpecT, H, SPEC>      => stack_io(0, 1);
-    0x47 => SELFBALANCE    => host::selfbalance::<ChainSpecT, H, SPEC>      => stack_io(0, 1);
-    0x48 => BASEFEE        => host_env::basefee::<ChainSpecT, H, SPEC>      => stack_io(0, 1);
-    0x49 => BLOBHASH       => host_env::blob_hash::<ChainSpecT, H, SPEC>    => stack_io(1, 1);
-    0x4A => BLOBBASEFEE    => host_env::blob_basefee::<ChainSpecT, H, SPEC> => stack_io(0, 1);
+    0x46 => CHAINID        => host_env::chainid::<H, SPEC>      => stack_io(0, 1);
+    0x47 => SELFBALANCE    => host::selfbalance::<H, SPEC>      => stack_io(0, 1);
+    0x48 => BASEFEE        => host_env::basefee::<H, SPEC>      => stack_io(0, 1);
+    0x49 => BLOBHASH       => host_env::blob_hash::<H, SPEC>    => stack_io(1, 1);
+    0x4A => BLOBBASEFEE    => host_env::blob_basefee::<H, SPEC> => stack_io(0, 1);
     // 0x4B
     // 0x4C
     // 0x4D
@@ -624,91 +604,91 @@ opcodes! {
     0x51 => MLOAD    => memory::mload                        => stack_io(1, 1);
     0x52 => MSTORE   => memory::mstore                       => stack_io(2, 0);
     0x53 => MSTORE8  => memory::mstore8                      => stack_io(2, 0);
-    0x54 => SLOAD    => host::sload::<ChainSpecT, H, SPEC>   => stack_io(1, 1);
-    0x55 => SSTORE   => host::sstore::<ChainSpecT, H, SPEC>  => stack_io(2, 0);
+    0x54 => SLOAD    => host::sload::<H, SPEC>   => stack_io(1, 1);
+    0x55 => SSTORE   => host::sstore::<H, SPEC>  => stack_io(2, 0);
     0x56 => JUMP     => control::jump                        => stack_io(1, 0), not_eof;
     0x57 => JUMPI    => control::jumpi                       => stack_io(2, 0), not_eof;
     0x58 => PC       => control::pc                          => stack_io(0, 1), not_eof;
     0x59 => MSIZE    => memory::msize                        => stack_io(0, 1);
     0x5A => GAS      => system::gas                          => stack_io(0, 1), not_eof;
     0x5B => JUMPDEST => control::jumpdest_or_nop             => stack_io(0, 0);
-    0x5C => TLOAD    => host::tload::<ChainSpecT, H, SPEC>   => stack_io(1, 1);
-    0x5D => TSTORE   => host::tstore::<ChainSpecT, H, SPEC>  => stack_io(2, 0);
-    0x5E => MCOPY    => memory::mcopy::<ChainSpecT, H, SPEC> => stack_io(3, 0);
+    0x5C => TLOAD    => host::tload::<H, SPEC>   => stack_io(1, 1);
+    0x5D => TSTORE   => host::tstore::<H, SPEC>  => stack_io(2, 0);
+    0x5E => MCOPY    => memory::mcopy::<H, SPEC> => stack_io(3, 0);
 
-    0x5F => PUSH0  => stack::push0::<ChainSpecT, H, SPEC> => stack_io(0, 1);
-    0x60 => PUSH1  => stack::push::<1, ChainSpecT, H>     => stack_io(0, 1), immediate_size(1);
-    0x61 => PUSH2  => stack::push::<2, ChainSpecT, H>     => stack_io(0, 1), immediate_size(2);
-    0x62 => PUSH3  => stack::push::<3, ChainSpecT, H>     => stack_io(0, 1), immediate_size(3);
-    0x63 => PUSH4  => stack::push::<4, ChainSpecT, H>     => stack_io(0, 1), immediate_size(4);
-    0x64 => PUSH5  => stack::push::<5, ChainSpecT, H>     => stack_io(0, 1), immediate_size(5);
-    0x65 => PUSH6  => stack::push::<6, ChainSpecT, H>     => stack_io(0, 1), immediate_size(6);
-    0x66 => PUSH7  => stack::push::<7, ChainSpecT, H>     => stack_io(0, 1), immediate_size(7);
-    0x67 => PUSH8  => stack::push::<8, ChainSpecT, H>     => stack_io(0, 1), immediate_size(8);
-    0x68 => PUSH9  => stack::push::<9, ChainSpecT, H>     => stack_io(0, 1), immediate_size(9);
-    0x69 => PUSH10 => stack::push::<10, ChainSpecT, H>    => stack_io(0, 1), immediate_size(10);
-    0x6A => PUSH11 => stack::push::<11, ChainSpecT, H>    => stack_io(0, 1), immediate_size(11);
-    0x6B => PUSH12 => stack::push::<12, ChainSpecT, H>    => stack_io(0, 1), immediate_size(12);
-    0x6C => PUSH13 => stack::push::<13, ChainSpecT, H>    => stack_io(0, 1), immediate_size(13);
-    0x6D => PUSH14 => stack::push::<14, ChainSpecT, H>    => stack_io(0, 1), immediate_size(14);
-    0x6E => PUSH15 => stack::push::<15, ChainSpecT, H>    => stack_io(0, 1), immediate_size(15);
-    0x6F => PUSH16 => stack::push::<16, ChainSpecT, H>    => stack_io(0, 1), immediate_size(16);
-    0x70 => PUSH17 => stack::push::<17, ChainSpecT, H>    => stack_io(0, 1), immediate_size(17);
-    0x71 => PUSH18 => stack::push::<18, ChainSpecT, H>    => stack_io(0, 1), immediate_size(18);
-    0x72 => PUSH19 => stack::push::<19, ChainSpecT, H>    => stack_io(0, 1), immediate_size(19);
-    0x73 => PUSH20 => stack::push::<20, ChainSpecT, H>    => stack_io(0, 1), immediate_size(20);
-    0x74 => PUSH21 => stack::push::<21, ChainSpecT, H>    => stack_io(0, 1), immediate_size(21);
-    0x75 => PUSH22 => stack::push::<22, ChainSpecT, H>    => stack_io(0, 1), immediate_size(22);
-    0x76 => PUSH23 => stack::push::<23, ChainSpecT, H>    => stack_io(0, 1), immediate_size(23);
-    0x77 => PUSH24 => stack::push::<24, ChainSpecT, H>    => stack_io(0, 1), immediate_size(24);
-    0x78 => PUSH25 => stack::push::<25, ChainSpecT, H>    => stack_io(0, 1), immediate_size(25);
-    0x79 => PUSH26 => stack::push::<26, ChainSpecT, H>    => stack_io(0, 1), immediate_size(26);
-    0x7A => PUSH27 => stack::push::<27, ChainSpecT, H>    => stack_io(0, 1), immediate_size(27);
-    0x7B => PUSH28 => stack::push::<28, ChainSpecT, H>    => stack_io(0, 1), immediate_size(28);
-    0x7C => PUSH29 => stack::push::<29, ChainSpecT, H>    => stack_io(0, 1), immediate_size(29);
-    0x7D => PUSH30 => stack::push::<30, ChainSpecT, H>    => stack_io(0, 1), immediate_size(30);
-    0x7E => PUSH31 => stack::push::<31, ChainSpecT, H>    => stack_io(0, 1), immediate_size(31);
-    0x7F => PUSH32 => stack::push::<32, ChainSpecT, H>    => stack_io(0, 1), immediate_size(32);
+    0x5F => PUSH0  => stack::push0::<H, SPEC> => stack_io(0, 1);
+    0x60 => PUSH1  => stack::push::<1, H>     => stack_io(0, 1), immediate_size(1);
+    0x61 => PUSH2  => stack::push::<2, H>     => stack_io(0, 1), immediate_size(2);
+    0x62 => PUSH3  => stack::push::<3, H>     => stack_io(0, 1), immediate_size(3);
+    0x63 => PUSH4  => stack::push::<4, H>     => stack_io(0, 1), immediate_size(4);
+    0x64 => PUSH5  => stack::push::<5, H>     => stack_io(0, 1), immediate_size(5);
+    0x65 => PUSH6  => stack::push::<6, H>     => stack_io(0, 1), immediate_size(6);
+    0x66 => PUSH7  => stack::push::<7, H>     => stack_io(0, 1), immediate_size(7);
+    0x67 => PUSH8  => stack::push::<8, H>     => stack_io(0, 1), immediate_size(8);
+    0x68 => PUSH9  => stack::push::<9, H>     => stack_io(0, 1), immediate_size(9);
+    0x69 => PUSH10 => stack::push::<10, H>    => stack_io(0, 1), immediate_size(10);
+    0x6A => PUSH11 => stack::push::<11, H>    => stack_io(0, 1), immediate_size(11);
+    0x6B => PUSH12 => stack::push::<12, H>    => stack_io(0, 1), immediate_size(12);
+    0x6C => PUSH13 => stack::push::<13, H>    => stack_io(0, 1), immediate_size(13);
+    0x6D => PUSH14 => stack::push::<14, H>    => stack_io(0, 1), immediate_size(14);
+    0x6E => PUSH15 => stack::push::<15, H>    => stack_io(0, 1), immediate_size(15);
+    0x6F => PUSH16 => stack::push::<16, H>    => stack_io(0, 1), immediate_size(16);
+    0x70 => PUSH17 => stack::push::<17, H>    => stack_io(0, 1), immediate_size(17);
+    0x71 => PUSH18 => stack::push::<18, H>    => stack_io(0, 1), immediate_size(18);
+    0x72 => PUSH19 => stack::push::<19, H>    => stack_io(0, 1), immediate_size(19);
+    0x73 => PUSH20 => stack::push::<20, H>    => stack_io(0, 1), immediate_size(20);
+    0x74 => PUSH21 => stack::push::<21, H>    => stack_io(0, 1), immediate_size(21);
+    0x75 => PUSH22 => stack::push::<22, H>    => stack_io(0, 1), immediate_size(22);
+    0x76 => PUSH23 => stack::push::<23, H>    => stack_io(0, 1), immediate_size(23);
+    0x77 => PUSH24 => stack::push::<24, H>    => stack_io(0, 1), immediate_size(24);
+    0x78 => PUSH25 => stack::push::<25, H>    => stack_io(0, 1), immediate_size(25);
+    0x79 => PUSH26 => stack::push::<26, H>    => stack_io(0, 1), immediate_size(26);
+    0x7A => PUSH27 => stack::push::<27, H>    => stack_io(0, 1), immediate_size(27);
+    0x7B => PUSH28 => stack::push::<28, H>    => stack_io(0, 1), immediate_size(28);
+    0x7C => PUSH29 => stack::push::<29, H>    => stack_io(0, 1), immediate_size(29);
+    0x7D => PUSH30 => stack::push::<30, H>    => stack_io(0, 1), immediate_size(30);
+    0x7E => PUSH31 => stack::push::<31, H>    => stack_io(0, 1), immediate_size(31);
+    0x7F => PUSH32 => stack::push::<32, H>    => stack_io(0, 1), immediate_size(32);
 
-    0x80 => DUP1  => stack::dup::<1, ChainSpecT, H>  => stack_io(1, 2);
-    0x81 => DUP2  => stack::dup::<2, ChainSpecT, H>  => stack_io(2, 3);
-    0x82 => DUP3  => stack::dup::<3, ChainSpecT, H>  => stack_io(3, 4);
-    0x83 => DUP4  => stack::dup::<4, ChainSpecT, H>  => stack_io(4, 5);
-    0x84 => DUP5  => stack::dup::<5, ChainSpecT, H>  => stack_io(5, 6);
-    0x85 => DUP6  => stack::dup::<6, ChainSpecT, H>  => stack_io(6, 7);
-    0x86 => DUP7  => stack::dup::<7, ChainSpecT, H>  => stack_io(7, 8);
-    0x87 => DUP8  => stack::dup::<8, ChainSpecT, H>  => stack_io(8, 9);
-    0x88 => DUP9  => stack::dup::<9, ChainSpecT, H>  => stack_io(9, 10);
-    0x89 => DUP10 => stack::dup::<10, ChainSpecT, H> => stack_io(10, 11);
-    0x8A => DUP11 => stack::dup::<11, ChainSpecT, H> => stack_io(11, 12);
-    0x8B => DUP12 => stack::dup::<12, ChainSpecT, H> => stack_io(12, 13);
-    0x8C => DUP13 => stack::dup::<13, ChainSpecT, H> => stack_io(13, 14);
-    0x8D => DUP14 => stack::dup::<14, ChainSpecT, H> => stack_io(14, 15);
-    0x8E => DUP15 => stack::dup::<15, ChainSpecT, H> => stack_io(15, 16);
-    0x8F => DUP16 => stack::dup::<16, ChainSpecT, H> => stack_io(16, 17);
+    0x80 => DUP1  => stack::dup::<1, H>  => stack_io(1, 2);
+    0x81 => DUP2  => stack::dup::<2, H>  => stack_io(2, 3);
+    0x82 => DUP3  => stack::dup::<3, H>  => stack_io(3, 4);
+    0x83 => DUP4  => stack::dup::<4, H>  => stack_io(4, 5);
+    0x84 => DUP5  => stack::dup::<5, H>  => stack_io(5, 6);
+    0x85 => DUP6  => stack::dup::<6, H>  => stack_io(6, 7);
+    0x86 => DUP7  => stack::dup::<7, H>  => stack_io(7, 8);
+    0x87 => DUP8  => stack::dup::<8, H>  => stack_io(8, 9);
+    0x88 => DUP9  => stack::dup::<9, H>  => stack_io(9, 10);
+    0x89 => DUP10 => stack::dup::<10, H> => stack_io(10, 11);
+    0x8A => DUP11 => stack::dup::<11, H> => stack_io(11, 12);
+    0x8B => DUP12 => stack::dup::<12, H> => stack_io(12, 13);
+    0x8C => DUP13 => stack::dup::<13, H> => stack_io(13, 14);
+    0x8D => DUP14 => stack::dup::<14, H> => stack_io(14, 15);
+    0x8E => DUP15 => stack::dup::<15, H> => stack_io(15, 16);
+    0x8F => DUP16 => stack::dup::<16, H> => stack_io(16, 17);
 
-    0x90 => SWAP1  => stack::swap::<1, ChainSpecT, H>  => stack_io(2, 2);
-    0x91 => SWAP2  => stack::swap::<2, ChainSpecT, H>  => stack_io(3, 3);
-    0x92 => SWAP3  => stack::swap::<3, ChainSpecT, H>  => stack_io(4, 4);
-    0x93 => SWAP4  => stack::swap::<4, ChainSpecT, H>  => stack_io(5, 5);
-    0x94 => SWAP5  => stack::swap::<5, ChainSpecT, H>  => stack_io(6, 6);
-    0x95 => SWAP6  => stack::swap::<6, ChainSpecT, H>  => stack_io(7, 7);
-    0x96 => SWAP7  => stack::swap::<7, ChainSpecT, H>  => stack_io(8, 8);
-    0x97 => SWAP8  => stack::swap::<8, ChainSpecT, H>  => stack_io(9, 9);
-    0x98 => SWAP9  => stack::swap::<9, ChainSpecT, H>  => stack_io(10, 10);
-    0x99 => SWAP10 => stack::swap::<10, ChainSpecT, H> => stack_io(11, 11);
-    0x9A => SWAP11 => stack::swap::<11, ChainSpecT, H> => stack_io(12, 12);
-    0x9B => SWAP12 => stack::swap::<12, ChainSpecT, H> => stack_io(13, 13);
-    0x9C => SWAP13 => stack::swap::<13, ChainSpecT, H> => stack_io(14, 14);
-    0x9D => SWAP14 => stack::swap::<14, ChainSpecT, H> => stack_io(15, 15);
-    0x9E => SWAP15 => stack::swap::<15, ChainSpecT, H> => stack_io(16, 16);
-    0x9F => SWAP16 => stack::swap::<16, ChainSpecT, H> => stack_io(17, 17);
+    0x90 => SWAP1  => stack::swap::<1, H>  => stack_io(2, 2);
+    0x91 => SWAP2  => stack::swap::<2, H>  => stack_io(3, 3);
+    0x92 => SWAP3  => stack::swap::<3, H>  => stack_io(4, 4);
+    0x93 => SWAP4  => stack::swap::<4, H>  => stack_io(5, 5);
+    0x94 => SWAP5  => stack::swap::<5, H>  => stack_io(6, 6);
+    0x95 => SWAP6  => stack::swap::<6, H>  => stack_io(7, 7);
+    0x96 => SWAP7  => stack::swap::<7, H>  => stack_io(8, 8);
+    0x97 => SWAP8  => stack::swap::<8, H>  => stack_io(9, 9);
+    0x98 => SWAP9  => stack::swap::<9, H>  => stack_io(10, 10);
+    0x99 => SWAP10 => stack::swap::<10, H> => stack_io(11, 11);
+    0x9A => SWAP11 => stack::swap::<11, H> => stack_io(12, 12);
+    0x9B => SWAP12 => stack::swap::<12, H> => stack_io(13, 13);
+    0x9C => SWAP13 => stack::swap::<13, H> => stack_io(14, 14);
+    0x9D => SWAP14 => stack::swap::<14, H> => stack_io(15, 15);
+    0x9E => SWAP15 => stack::swap::<15, H> => stack_io(16, 16);
+    0x9F => SWAP16 => stack::swap::<16, H> => stack_io(17, 17);
 
-    0xA0 => LOG0 => host::log::<0, ChainSpecT, H> => stack_io(2, 0);
-    0xA1 => LOG1 => host::log::<1, ChainSpecT, H> => stack_io(3, 0);
-    0xA2 => LOG2 => host::log::<2, ChainSpecT, H> => stack_io(4, 0);
-    0xA3 => LOG3 => host::log::<3, ChainSpecT, H> => stack_io(5, 0);
-    0xA4 => LOG4 => host::log::<4, ChainSpecT, H> => stack_io(6, 0);
+    0xA0 => LOG0 => host::log::<0, H> => stack_io(2, 0);
+    0xA1 => LOG1 => host::log::<1, H> => stack_io(3, 0);
+    0xA2 => LOG2 => host::log::<2, H> => stack_io(4, 0);
+    0xA3 => LOG3 => host::log::<3, H> => stack_io(5, 0);
+    0xA4 => LOG4 => host::log::<4, H> => stack_io(6, 0);
     // 0xA5
     // 0xA6
     // 0xA7
@@ -784,22 +764,22 @@ opcodes! {
     0xED => TXCREATE        => contract::txcreate             => stack_io(5, 1);
     0xEE => RETURNCONTRACT  => contract::return_contract      => stack_io(2, 0), immediate_size(1), terminating;
     // 0xEF
-    0xF0 => CREATE       => contract::create::<false, ChainSpecT, H, SPEC> => stack_io(3, 1), not_eof;
-    0xF1 => CALL         => contract::call::<ChainSpecT, H, SPEC>          => stack_io(7, 1), not_eof;
-    0xF2 => CALLCODE     => contract::call_code::<ChainSpecT, H, SPEC>     => stack_io(7, 1), not_eof;
+    0xF0 => CREATE       => contract::create::<false, H, SPEC> => stack_io(3, 1), not_eof;
+    0xF1 => CALL         => contract::call::<H, SPEC>          => stack_io(7, 1), not_eof;
+    0xF2 => CALLCODE     => contract::call_code::<H, SPEC>     => stack_io(7, 1), not_eof;
     0xF3 => RETURN       => control::ret                                   => stack_io(2, 0), terminating;
-    0xF4 => DELEGATECALL => contract::delegate_call::<ChainSpecT, H, SPEC> => stack_io(6, 1), not_eof;
-    0xF5 => CREATE2      => contract::create::<true, ChainSpecT, H, SPEC>  => stack_io(4, 1), not_eof;
+    0xF4 => DELEGATECALL => contract::delegate_call::<H, SPEC> => stack_io(6, 1), not_eof;
+    0xF5 => CREATE2      => contract::create::<true, H, SPEC>  => stack_io(4, 1), not_eof;
     // 0xF6
     0xF7 => RETURNDATALOAD => system::returndataload                       => stack_io(1, 1);
-    0xF8 => EXTCALL        => contract::extcall::<ChainSpecT, H, SPEC>     => stack_io(4, 1);
-    0xF9 => EXFCALL        => contract::extdcall::<ChainSpecT, H, SPEC>    => stack_io(3, 1);
-    0xFA => STATICCALL     => contract::static_call::<ChainSpecT, H, SPEC> => stack_io(6, 1), not_eof;
+    0xF8 => EXTCALL        => contract::extcall::<H, SPEC>     => stack_io(4, 1);
+    0xF9 => EXFCALL        => contract::extdcall::<H, SPEC>    => stack_io(3, 1);
+    0xFA => STATICCALL     => contract::static_call::<H, SPEC> => stack_io(6, 1), not_eof;
     0xFB => EXTSCALL       => contract::extscall                           => stack_io(3, 1);
     // 0xFC
-    0xFD => REVERT       => control::revert::<ChainSpecT, H, SPEC>    => stack_io(2, 0), terminating;
+    0xFD => REVERT       => control::revert::<H, SPEC>    => stack_io(2, 0), terminating;
     0xFE => INVALID      => control::invalid                          => stack_io(0, 0), terminating;
-    0xFF => SELFDESTRUCT => host::selfdestruct::<ChainSpecT, H, SPEC> => stack_io(1, 0), not_eof, terminating;
+    0xFF => SELFDESTRUCT => host::selfdestruct::<H, SPEC> => stack_io(1, 0), not_eof, terminating;
 }
 
 #[cfg(test)]

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -1,7 +1,8 @@
 use crate::{Address, BlobExcessGasAndPrice, B256, U256};
+use core::fmt::Debug;
 
 /// Trait for retrieving block information required for execution.
-pub trait Block {
+pub trait Block: Clone + Debug + Default + PartialEq + Eq {
     /// The number of ancestor blocks of this block (block height).
     fn number(&self) -> &U256;
 

--- a/crates/primitives/src/chain_spec.rs
+++ b/crates/primitives/src/chain_spec.rs
@@ -7,27 +7,31 @@ use core::{
     hash::Hash,
 };
 
+/// The type that enumerates the chain's hardforks.
+pub trait HardforkTrait: Clone + Copy + Default + PartialEq + Eq + Into<SpecId> {}
+
+cfg_if! {
+    if #[cfg(feature = "serde")] {
+        /// The type that enumerates chain-specific halt reasons.
+        pub trait HaltReasonTrait: Clone + Debug + PartialEq + Eq + Hash + From<crate::HaltReason> + serde::de::DeserializeOwned + serde::Serialize {}
+    } else {
+        /// The type that enumerates chain-specific halt reasons.
+        pub trait HaltReasonTrait: Clone + Debug + PartialEq + Eq + Hash + From<crate::HaltReason> {}
+    }
+}
+
 pub trait ChainSpec: Clone + Debug + Default + Sized + 'static {
     /// The type that contains all block information.
-    type Block: Block + Clone + Debug + Default + PartialEq + Eq;
-
-    /// The type that enumerates the chain's hardforks.
-    type Hardfork: Clone + Copy + Default + PartialEq + Eq + Into<SpecId>;
-
-    cfg_if! {
-        if #[cfg(feature = "serde")] {
-            /// The type that enumerates chain-specific halt reasons.
-            type HaltReason: Clone + Debug + PartialEq + Eq + Hash + From<crate::HaltReason> + serde::de::DeserializeOwned + serde::Serialize;
-        } else {
-            /// The type that enumerates chain-specific halt reasons.
-            type HaltReason: Clone + Debug + PartialEq + Eq + Hash + From<crate::HaltReason>;
-        }
-    }
+    type Block: Block;
 
     /// The type that contains all transaction information.
-    type Transaction: Clone + Debug + Default + PartialEq + Eq + Transaction;
-    /// The error type that can be returned when validating a transaction.
-    type TransactionValidationError: Debug + Display;
+    type Transaction: Transaction;
+
+    /// The type that enumerates the chain's hardforks.
+    type Hardfork: HardforkTrait;
+
+    /// Halt reason type.
+    type HaltReason: HaltReasonTrait;
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -38,5 +42,4 @@ impl ChainSpec for EthChainSpec {
     type Hardfork = SpecId;
     type HaltReason = crate::HaltReason;
     type Transaction = crate::TxEnv;
-    type TransactionValidationError = InvalidTransaction;
 }

--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -609,6 +609,8 @@ pub struct TxEnv {
 }
 
 impl Transaction for TxEnv {
+    type TransactionValidationError = InvalidTransaction;
+
     #[inline]
     fn caller(&self) -> &Address {
         &self.caller

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -1,4 +1,6 @@
-use crate::{Address, Bytes, ChainSpec, EthChainSpec, Log, State, U256};
+use crate::{
+    Address, Bytes, ChainSpec, EthChainSpec, HaltReasonTrait, Log, State, Transaction, U256,
+};
 use core::fmt;
 use std::{boxed::Box, string::String, vec::Vec};
 
@@ -137,11 +139,11 @@ impl Output {
 }
 
 /// Main EVM error.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum EVMError<ChainSpecT: ChainSpec, DBError> {
     /// Transaction validation error.
-    Transaction(ChainSpecT::TransactionValidationError),
+    Transaction(<ChainSpecT::Transaction as Transaction>::TransactionValidationError),
     /// Header validation error.
     Header(InvalidHeader),
     /// Database error.
@@ -157,7 +159,8 @@ impl<ChainSpecT, DBError: std::error::Error + 'static> std::error::Error
     for EVMError<ChainSpecT, DBError>
 where
     ChainSpecT: ChainSpec,
-    ChainSpecT::TransactionValidationError: std::error::Error + 'static,
+    <ChainSpecT::Transaction as Transaction>::TransactionValidationError:
+        std::error::Error + 'static,
 {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
@@ -385,6 +388,8 @@ pub enum HaltReason {
     OutOfFunds,
     CallTooDeep,
 }
+
+impl HaltReasonTrait for HaltReason {}
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/primitives/src/specification.rs
+++ b/crates/primitives/src/specification.rs
@@ -2,6 +2,8 @@
 
 pub use SpecId::*;
 
+use crate::HardforkTrait;
+
 /// Specification IDs and their activation block.
 ///
 /// Information was obtained from the [Ethereum Execution Specifications](https://github.com/ethereum/execution-specs)
@@ -31,6 +33,8 @@ pub enum SpecId {
     #[default]
     LATEST = u8::MAX,
 }
+
+impl HardforkTrait for SpecId {}
 
 impl SpecId {
     /// Returns the `SpecId` for the given `u8`.

--- a/crates/primitives/src/transaction.rs
+++ b/crates/primitives/src/transaction.rs
@@ -1,7 +1,19 @@
-use crate::{Address, Bytes, HashMap, TransactTo, B256, GAS_PER_BLOB, U256};
+use crate::{Address, Bytes, HashMap, InvalidTransaction, TransactTo, B256, GAS_PER_BLOB, U256};
+use cfg_if::cfg_if;
+use core::fmt::{Debug, Display};
 
 /// Trait for retrieving transaction information required for execution.
-pub trait Transaction {
+pub trait Transaction: Clone + Debug + Default + PartialEq + Eq {
+    cfg_if! {
+        if #[cfg(feature = "serde")] {
+            /// The error type that can be returned when validating a transaction.
+            type TransactionValidationError: Clone + Debug + Display + PartialEq + Eq + serde::de::DeserializeOwned + serde::Serialize + From<InvalidTransaction>;
+        } else {
+            /// The error type that can be returned when validating a transaction.
+            type TransactionValidationError: Clone + Debug + Display + PartialEq + Eq + From<InvalidTransaction>;
+        }
+    }
+
     /// Caller aka Author aka transaction signer.
     fn caller(&self) -> &Address;
     /// The gas limit of the transaction.

--- a/crates/revm/benches/bench.rs
+++ b/crates/revm/benches/bench.rs
@@ -118,8 +118,7 @@ fn bench_eval(
         };
         let mut shared_memory = SharedMemory::new();
         let mut host = DummyHost::new(*evm.context.evm.env.clone());
-        let instruction_table =
-            make_instruction_table::<EthChainSpec, DummyHost<EthChainSpec>, BerlinSpec>();
+        let instruction_table = make_instruction_table::<DummyHost<EthChainSpec>, BerlinSpec>();
         b.iter(move || {
             // replace memory with empty memory to use it inside interpreter.
             // Later return memory back.

--- a/crates/revm/benches/bench.rs
+++ b/crates/revm/benches/bench.rs
@@ -14,7 +14,6 @@ use std::time::Duration;
 
 fn analysis(c: &mut Criterion) {
     let evm = Evm::builder()
-        .with_chain_spec::<EthChainSpec>()
         .modify_tx_env(|tx| {
             tx.caller = address!("0000000000000000000000000000000000000002");
             tx.transact_to = TransactTo::Call(address!("0000000000000000000000000000000000000000"));
@@ -57,7 +56,6 @@ fn analysis(c: &mut Criterion) {
 
 fn snailtracer(c: &mut Criterion) {
     let mut evm = Evm::builder()
-        .with_chain_spec::<EthChainSpec>()
         .with_db(BenchmarkDB::new_bytecode(bytecode(SNAILTRACER)))
         .modify_tx_env(|tx| {
             tx.caller = address!("1000000000000000000000000000000000000000");
@@ -78,7 +76,6 @@ fn snailtracer(c: &mut Criterion) {
 
 fn transfer(c: &mut Criterion) {
     let mut evm = Evm::builder()
-        .with_chain_spec::<EthChainSpec>()
         .with_db(BenchmarkDB::new_bytecode(Bytecode::new()))
         .modify_tx_env(|tx| {
             tx.caller = address!("0000000000000000000000000000000000000001");

--- a/crates/revm/src/builder.rs
+++ b/crates/revm/src/builder.rs
@@ -502,7 +502,7 @@ mod test {
         const INITIAL_TX_GAS: u64 = 21000;
         const EXPECTED_RESULT_GAS: u64 = INITIAL_TX_GAS + CUSTOM_INSTRUCTION_COST;
 
-        fn custom_instruction(interp: &mut Interpreter, _host: &mut impl Host<TestChainSpec>) {
+        fn custom_instruction(interp: &mut Interpreter, _host: &mut impl Host) {
             // just spend some gas
             gas!(interp, CUSTOM_INSTRUCTION_COST);
         }

--- a/crates/revm/src/builder.rs
+++ b/crates/revm/src/builder.rs
@@ -43,16 +43,11 @@ impl<'a> Default for EvmBuilder<'a, SetGenericStage, EthChainSpec, (), EmptyDB> 
 
 impl<'a, ChainSpecT: ChainSpec, EXT, DB: Database>
     EvmBuilder<'a, SetGenericStage, ChainSpecT, EXT, DB>
-where
-    ChainSpecT::TransactionValidationError: From<InvalidTransaction>,
 {
     /// Sets the [`ChainSpec`] that will be used by [`Evm`].
     pub fn with_chain_spec<NewChainSpecT: ChainSpec>(
         self,
-    ) -> EvmBuilder<'a, SetGenericStage, NewChainSpecT, EXT, DB>
-    where
-        NewChainSpecT::TransactionValidationError: From<InvalidTransaction>,
-    {
+    ) -> EvmBuilder<'a, SetGenericStage, NewChainSpecT, EXT, DB> {
         let Context { evm, external } = self.context;
 
         EvmBuilder {
@@ -172,9 +167,8 @@ impl<'a, ChainSpecT: ChainSpec, EXT, DB: Database>
     }
 }
 
-impl<'a, ChainSpecT: ChainSpec, EXT, DB: Database> EvmBuilder<'a, HandlerStage, ChainSpecT, EXT, DB>
-where
-    ChainSpecT::TransactionValidationError: From<InvalidTransaction>,
+impl<'a, ChainSpecT: ChainSpec, EXT, DB: Database>
+    EvmBuilder<'a, HandlerStage, ChainSpecT, EXT, DB>
 {
     /// Sets the [`EmptyDB`] and resets the [`Handler`] to default mainnet.
     pub fn reset_handler_with_empty_db(
@@ -378,8 +372,6 @@ impl<'a, BuilderStage, ChainSpecT: ChainSpec, EXT, DB: Database>
 
 impl<'a, BuilderStage, ChainSpecT: ChainSpec, EXT, DB: Database>
     EvmBuilder<'a, BuilderStage, ChainSpecT, EXT, DB>
-where
-    ChainSpecT::TransactionValidationError: From<InvalidTransaction>,
 {
     /// Creates the default handler.
     ///

--- a/crates/revm/src/custom_upcode.rs
+++ b/crates/revm/src/custom_upcode.rs
@@ -230,7 +230,7 @@ impl<EXT, DB: Database> EvmHandler<'_, CustomOpcodeChainSpec, EXT, DB> {
 
 fn make_custom_instruction_table<
     ChainSpecT: ChainSpec,
-    H: Host<ChainSpecT> + ?Sized,
+    H: Host + ?Sized,
     SPEC: CustomOpcodeSpec,
 >() -> InstructionTable<H> {
     // custom opcode chain can reuse mainnet instructions
@@ -243,7 +243,7 @@ fn make_custom_instruction_table<
 
 fn custom_opcode_handler<
     ChainSpecT: ChainSpec,
-    H: Host<ChainSpecT> + ?Sized,
+    H: Host + ?Sized,
     SPEC: CustomOpcodeSpec,
 >(
     interpreter: &mut Interpreter,

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -240,7 +240,6 @@ impl<ChainSpecT: ChainSpec, EXT, DB: Database> Evm<'_, ChainSpecT, EXT, DB> {
         let frame_result = match &table {
             InstructionTables::Plain(table) => self.run_the_loop(table, first_frame),
             InstructionTables::Boxed(table) => self.run_the_loop(table, first_frame),
-            InstructionTables::_Unused(_) => unreachable!("phantom data is not used"),
         };
 
         // return back instruction table
@@ -420,7 +419,9 @@ where
     }
 }
 
-impl<ChainSpecT: ChainSpec, EXT, DB: Database> Host<ChainSpecT> for Evm<'_, ChainSpecT, EXT, DB> {
+impl<ChainSpecT: ChainSpec, EXT, DB: Database> Host for Evm<'_, ChainSpecT, EXT, DB> {
+    type ChainSpecT = ChainSpecT;
+
     fn env(&self) -> &Env<ChainSpecT> {
         &self.context.evm.env
     }

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -409,10 +409,7 @@ impl<ChainSpecT: ChainSpec, EXT, DB: Database> Evm<'_, ChainSpecT, EXT, DB> {
     }
 }
 
-impl<ChainSpecT: ChainSpec, EXT, DB: Database> Evm<'_, ChainSpecT, EXT, DB>
-where
-    ChainSpecT::TransactionValidationError: From<InvalidTransaction>,
-{
+impl<ChainSpecT: ChainSpec, EXT, DB: Database> Evm<'_, ChainSpecT, EXT, DB> {
     /// Modify spec id, this will create new EVM that matches this spec id.
     pub fn modify_spec_id(&mut self, spec_id: ChainSpecT::Hardfork) {
         self.handler.modify_spec_id(spec_id);

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -22,11 +22,11 @@ use self::register::{HandleRegister, HandleRegisterBox};
 /// Handler acts as a proxy and allow to define different behavior for different
 /// sections of the code. This allows nice integration of different chains or
 /// to disable some mainnet behavior.
-pub struct Handler<'a, ChainSpecT: ChainSpec, H: Host<ChainSpecT> + 'a, EXT, DB: Database> {
+pub struct Handler<'a, ChainSpecT: ChainSpec, H: Host + 'a, EXT, DB: Database> {
     /// Handler hardfork
     pub spec_id: ChainSpecT::Hardfork,
     /// Instruction table type.
-    pub instruction_table: Option<InstructionTables<'a, ChainSpecT, H>>,
+    pub instruction_table: Option<InstructionTables<'a, H>>,
     /// Registers that will be called on initialization.
     pub registers: Vec<HandleRegisters<ChainSpecT, EXT, DB>>,
     /// Validity handles.
@@ -67,14 +67,14 @@ impl<'a, ChainSpecT: ChainSpec, EXT, DB: Database> EvmHandler<'a, ChainSpecT, EX
     /// Take instruction table.
     pub fn take_instruction_table(
         &mut self,
-    ) -> Option<InstructionTables<'a, ChainSpecT, Evm<'a, ChainSpecT, EXT, DB>>> {
+    ) -> Option<InstructionTables<'a, Evm<'a, ChainSpecT, EXT, DB>>> {
         self.instruction_table.take()
     }
 
     /// Set instruction table.
     pub fn set_instruction_table(
         &mut self,
-        table: InstructionTables<'a, ChainSpecT, Evm<'a, ChainSpecT, EXT, DB>>,
+        table: InstructionTables<'a, Evm<'a, ChainSpecT, EXT, DB>>,
     ) {
         self.instruction_table = Some(table);
     }

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -41,10 +41,7 @@ pub struct Handler<'a, ChainSpecT: ChainSpec, H: Host + 'a, EXT, DB: Database> {
 
 impl<'a, ChainSpecT: ChainSpec, EXT, DB: Database> EvmHandler<'a, ChainSpecT, EXT, DB> {
     /// Creates a base/vanilla Ethereum handler with the provided spec id.
-    pub fn mainnet_with_spec(spec_id: ChainSpecT::Hardfork) -> Self
-    where
-        ChainSpecT::TransactionValidationError: From<InvalidTransaction>,
-    {
+    pub fn mainnet_with_spec(spec_id: ChainSpecT::Hardfork) -> Self {
         spec_to_generic!(
             spec_id.into(),
             Self {
@@ -121,10 +118,7 @@ impl<'a, ChainSpecT: ChainSpec, EXT, DB: Database> EvmHandler<'a, ChainSpecT, EX
     }
 }
 
-impl<'a, ChainSpecT: ChainSpec, EXT, DB: Database> EvmHandler<'a, ChainSpecT, EXT, DB>
-where
-    ChainSpecT::TransactionValidationError: From<InvalidTransaction>,
-{
+impl<'a, ChainSpecT: ChainSpec, EXT, DB: Database> EvmHandler<'a, ChainSpecT, EXT, DB> {
     /// Pop last handle register and reapply all registers that are left.
     pub fn pop_handle_register(&mut self) -> Option<HandleRegisters<ChainSpecT, EXT, DB>> {
         let out = self.registers.pop();

--- a/crates/revm/src/handler/handle_types/validation.rs
+++ b/crates/revm/src/handler/handle_types/validation.rs
@@ -37,10 +37,7 @@ impl<'a, ChainSpecT: ChainSpec, EXT: 'a, DB: Database + 'a>
     ValidationHandler<'a, ChainSpecT, EXT, DB>
 {
     /// Create new ValidationHandles
-    pub fn new<SPEC: Spec + 'a>() -> Self
-    where
-        ChainSpecT::TransactionValidationError: From<InvalidTransaction>,
-    {
+    pub fn new<SPEC: Spec + 'a>() -> Self {
         Self {
             initial_tx_gas: Arc::new(mainnet::validate_initial_tx_gas::<ChainSpecT, SPEC, DB>),
             env: Arc::new(mainnet::validate_env::<ChainSpecT, SPEC, DB>),

--- a/crates/revm/src/handler/mainnet/validation.rs
+++ b/crates/revm/src/handler/mainnet/validation.rs
@@ -8,10 +8,7 @@ use crate::{
 /// Validate environment for the mainnet.
 pub fn validate_env<ChainSpecT: ChainSpec, SPEC: Spec, DB: Database>(
     env: &Env<ChainSpecT>,
-) -> Result<(), EVMError<ChainSpecT, DB::Error>>
-where
-    ChainSpecT::TransactionValidationError: From<InvalidTransaction>,
-{
+) -> Result<(), EVMError<ChainSpecT, DB::Error>> {
     // Important: validate block before tx.
     env.validate_block_env::<SPEC>()?;
     env.validate_tx::<SPEC>()
@@ -22,10 +19,7 @@ where
 /// Validates transaction against the state.
 pub fn validate_tx_against_state<ChainSpecT: ChainSpec, SPEC: Spec, EXT, DB: Database>(
     context: &mut Context<ChainSpecT, EXT, DB>,
-) -> Result<(), EVMError<ChainSpecT, DB::Error>>
-where
-    ChainSpecT::TransactionValidationError: From<InvalidTransaction>,
-{
+) -> Result<(), EVMError<ChainSpecT, DB::Error>> {
     // load acc
     let tx_caller = context.evm.env.tx.caller();
     let (caller_account, _) = context
@@ -48,10 +42,7 @@ where
 /// Validate initial transaction gas.
 pub fn validate_initial_tx_gas<ChainSpecT: ChainSpec, SPEC: Spec, DB: Database>(
     env: &Env<ChainSpecT>,
-) -> Result<u64, EVMError<ChainSpecT, DB::Error>>
-where
-    ChainSpecT::TransactionValidationError: From<InvalidTransaction>,
-{
+) -> Result<u64, EVMError<ChainSpecT, DB::Error>> {
     let input = &env.tx.data();
     let is_create = env.tx.transact_to().is_create();
     let access_list = &env.tx.access_list();

--- a/crates/revm/src/inspector/handler_register.rs
+++ b/crates/revm/src/inspector/handler_register.rs
@@ -60,7 +60,6 @@ pub fn inspector_handle_register<
             .into_iter()
             .map(|i| inspector_instruction(i))
             .collect::<Vec<_>>(),
-        InstructionTables::_Unused(_) => unreachable!("phantom data is not used"),
     };
 
     // Register inspector Log instruction.
@@ -300,10 +299,9 @@ mod tests {
     #[test]
     fn test_make_boxed_instruction_table() {
         type MyEvm<'a> = Evm<'a, TestChainSpec, NoOpInspector, EmptyDB>;
-        let table: InstructionTable<MyEvm<'_>> =
-            make_instruction_table::<TestChainSpec, MyEvm<'_>, BerlinSpec>();
+        let table: InstructionTable<MyEvm<'_>> = make_instruction_table::<MyEvm<'_>, BerlinSpec>();
         let _boxed_table: BoxedInstructionTable<'_, MyEvm<'_>> =
-            make_boxed_instruction_table::<'_, TestChainSpec, MyEvm<'_>, BerlinSpec, _>(
+            make_boxed_instruction_table::<'_, MyEvm<'_>, BerlinSpec, _>(
                 table,
                 inspector_instruction,
             );


### PR DESCRIPTION
This adds ChainSpec as associate type inside Host and removed a need to modify instruction.

Small refactor on `ChainSpec` where associate types are moved to standalone traits.