### PR TITLE
fix(eof): eofcreate code deploy gas

### DIFF
--- a/crates/interpreter/src/gas.rs
+++ b/crates/interpreter/src/gas.rs
@@ -72,6 +72,11 @@ impl Gas {
         self.remaining
     }
 
+    /// Return remaining gas after subtracting 63/64 parts.
+    pub const fn remaining_63_of_64_parts(&self) -> u64 {
+        self.remaining - self.remaining / 64
+    }
+
     /// Erases a gas cost from the totals.
     #[inline]
     pub fn erase_cost(&mut self, returned: u64) {

--- a/crates/interpreter/src/instructions/contract.rs
+++ b/crates/interpreter/src/instructions/contract.rs
@@ -59,14 +59,13 @@ pub fn eofcreate<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H)
 
     let created_address = interpreter
         .contract
-        .caller
+        .target_address
         .create2(salt.to_be_bytes(), keccak256(sub_container));
 
-    let gas_reduce = max(interpreter.gas.remaining() / 64, 5000);
-    let gas_limit = interpreter.gas().remaining().saturating_sub(gas_reduce);
+    let gas_limit = interpreter.gas().remaining_63_of_64_parts();
     gas!(interpreter, gas_limit);
-
     // Send container for execution container is preverified.
+    interpreter.instruction_result = InstructionResult::CallOrCreate;
     interpreter.next_action = InterpreterAction::EOFCreate {
         inputs: Box::new(EOFCreateInputs::new(
             interpreter.contract.target_address,

--- a/crates/interpreter/src/instructions/contract/call_helpers.rs
+++ b/crates/interpreter/src/instructions/contract/call_helpers.rs
@@ -55,9 +55,11 @@ pub fn calc_call_gas<SPEC: Spec>(
 
     // EIP-150: Gas cost changes for IO-heavy operations
     let gas_limit = if SPEC::enabled(TANGERINE) {
-        let gas = interpreter.gas().remaining();
         // take l64 part of gas_limit
-        min(gas - gas / 64, local_gas_limit)
+        min(
+            interpreter.gas().remaining_63_of_64_parts(),
+            local_gas_limit,
+        )
     } else {
         local_gas_limit
     };


### PR DESCRIPTION
Deduct code deploy gas.

remove min stipend, will double check this in discord but evmone does not have it and it is not in main EOF repo. It was part of legacy eip-7069 that is why I added it.