### PR TITLE
feat: add EIP-7702 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2979,6 +2979,7 @@ name = "revm-primitives"
 version = "4.0.0"
 dependencies = [
  "alloy-primitives",
+ "alloy-rlp",
  "auto_impl",
  "bitflags 2.5.0",
  "bitvec",
@@ -2989,6 +2990,7 @@ dependencies = [
  "enumn",
  "hashbrown",
  "hex",
+ "k256",
  "once_cell",
  "serde",
 ]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -25,6 +25,8 @@ all = "warn"
 alloy-primitives = { version = "0.7.2", default-features = false, features = [
     "rlp",
 ] }
+alloy-rlp = { version = "0.3", default-features = false }
+k256 = { version = "0.13.3", default-features = false, features = ["ecdsa"] }
 hashbrown = "0.14"
 auto_impl = "1.2"
 bitvec = { version = "1", default-features = false, features = ["alloc"] }

--- a/crates/primitives/src/authorization.rs
+++ b/crates/primitives/src/authorization.rs
@@ -1,0 +1,76 @@
+//! [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) Set EOA account code for one transaction
+//!
+//! These transactions include a list of [`Authorization`]
+
+use crate::AUTHORIZATION_MAGIC_BYTE;
+use alloy_primitives::{Address, ChainId, Keccak256, U256};
+use alloy_rlp::{BufMut, Encodable, Header};
+use k256::{
+    ecdsa::{RecoveryId, Signature, VerifyingKey},
+    FieldBytes,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Authorization {
+    /// Chain ID, will not be checked if set to zero
+    pub chain_id: ChainId,
+    /// The address of the code that will get set to the signer's address
+    pub address: Address,
+    /// Optional nonce
+    pub nonce: Option<u64>,
+    /// yParity: Signature Y parity
+    pub y_parity: bool,
+    /// The R field of the signature
+    pub r: U256,
+    /// The S field of the signature
+    pub s: U256,
+}
+
+impl Authorization {
+    /// Recover the address of the signer for EIP-7702 transactions
+    /// Since these authorizations are fallible, we will ignore errors and optionally
+    /// return the signer's address
+    pub fn recovered_authority(&self) -> Option<Address> {
+        Signature::from_scalars(
+            *FieldBytes::from_slice(&self.r.to_be_bytes::<32>()),
+            *FieldBytes::from_slice(&self.s.to_be_bytes::<32>()),
+        )
+        .ok()
+        .and_then(|sig| RecoveryId::from_byte(self.y_parity as u8).map(|recid| (sig, recid)))
+        .and_then(|(sig, recid)| {
+            let nonce = self.nonce.map(|n| vec![n]).unwrap_or(vec![]);
+
+            let mut length = 0;
+            length += self.chain_id.length();
+            length += self.address.length();
+            length += nonce.length();
+
+            let mut buffer = Vec::new();
+
+            buffer.put_u8(AUTHORIZATION_MAGIC_BYTE);
+
+            Header {
+                list: true,
+                payload_length: length,
+            }
+            .encode(&mut buffer);
+            self.chain_id.encode(&mut buffer);
+            self.address.encode(&mut buffer);
+            nonce.encode(&mut buffer);
+
+            let mut hasher = Keccak256::new();
+            hasher.update(buffer);
+            let hash = hasher.finalize();
+
+            let recovered_key =
+                VerifyingKey::recover_from_prehash(&hash.as_slice(), &sig, recid).ok()?;
+            let encoded_point = recovered_key.to_encoded_point(false);
+
+            let mut hasher = Keccak256::new();
+            hasher.update(&encoded_point.as_bytes()[1..]);
+            let address = &hasher.finalize()[12..];
+            Some(Address::from_slice(address))
+        })
+    }
+}

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -60,3 +60,8 @@ pub const BLOB_GASPRICE_UPDATE_FRACTION: u64 = 3338477;
 
 /// First version of the blob.
 pub const VERSIONED_HASH_VERSION_KZG: u8 = 0x01;
+
+// === EIP-7702 constants ===
+
+// Magic byte prepended to the rlp-encoded payload of authorizations
+pub const AUTHORIZATION_MAGIC_BYTE: u8 = 0x05;

--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -3,9 +3,9 @@ pub mod handler_cfg;
 pub use handler_cfg::{CfgEnvWithHandlerCfg, EnvWithHandlerCfg, HandlerCfg};
 
 use crate::{
-    calc_blob_gasprice, Account, Address, Bytes, HashMap, InvalidHeader, InvalidTransaction, Spec,
-    SpecId, B256, GAS_PER_BLOB, KECCAK_EMPTY, MAX_BLOB_NUMBER_PER_BLOCK, MAX_INITCODE_SIZE, U256,
-    VERSIONED_HASH_VERSION_KZG,
+    calc_blob_gasprice, Account, Address, Authorization, Bytes, HashMap, InvalidHeader,
+    InvalidTransaction, Spec, SpecId, B256, GAS_PER_BLOB, KECCAK_EMPTY, MAX_BLOB_NUMBER_PER_BLOCK,
+    MAX_INITCODE_SIZE, U256, VERSIONED_HASH_VERSION_KZG,
 };
 use core::cmp::{min, Ordering};
 use core::hash::Hash;
@@ -584,6 +584,13 @@ pub struct TxEnv {
     /// [EIP-4844]: https://eips.ethereum.org/EIPS/eip-4844
     pub max_fee_per_blob_gas: Option<U256>,
 
+    /// The list of authorizations for this transaction
+    ///
+    /// Incorporated as part of the Prague upgrade via [EIP-7702].
+    ///
+    /// [EIP-7702]: https://eips.ethereum.org/EIPS/eip-7702
+    pub authorization_list: Vec<Authorization>,
+
     /// EOF Initcodes for EOF CREATE transaction
     ///
     /// Incorporated as part of the Prague upgrade via [EOF]
@@ -642,6 +649,7 @@ impl Default for TxEnv {
             access_list: Vec::new(),
             blob_hashes: Vec::new(),
             max_fee_per_blob_gas: None,
+            authorization_list: Vec::new(),
             eof_initcodes: Vec::new(),
             eof_initcodes_hashed: HashMap::new(),
             #[cfg(feature = "optimism")]

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -9,6 +9,8 @@ extern crate alloc as std;
 
 mod bytecode;
 mod constants;
+
+pub mod authorization;
 pub mod db;
 pub mod env;
 
@@ -19,10 +21,12 @@ pub mod result;
 pub mod specification;
 pub mod state;
 pub mod utilities;
+
 pub use alloy_primitives::{
     self, address, b256, bytes, fixed_bytes, hex, hex_literal, ruint, uint, Address, Bytes,
     FixedBytes, Log, LogData, B256, I256, U256,
 };
+pub use authorization::*;
 pub use bitvec;
 pub use bytecode::*;
 pub use constants::*;

--- a/crates/revm/src/handler/mainnet/post_execution.rs
+++ b/crates/revm/src/handler/mainnet/post_execution.rs
@@ -18,6 +18,9 @@ pub fn end<EXT, DB: Database>(
 /// Clear handle clears error and journal state.
 #[inline]
 pub fn clear<EXT, DB: Database>(context: &mut Context<EXT, DB>) {
+    // TODO(eip7702): teardown
+    // 'set the code of each authority back to empty'
+
     // clear error and journaled state.
     let _ = context.evm.take_error();
     context.evm.inner.journaled_state.clear();


### PR DESCRIPTION
Sharing our work for adding EIP-7702 transaction support to reth / revm / alloy

Current state:

- 7702 transaction support has been added to reth and alloy
- EOA code loading has been added to revm but full 7702 execution has not been tested yet
- The teardown of 7702 transactions in revm has not been added yet
- Gas calculations have not been updated and are not correct
- Compact encoding of added types in reth is currently byte-for-byte
- Overall correctness needs to be checked
- Not all tests have been added or updated

Incomplete items and points of discussion are marked with `TODO(eip7702)` 

If you have any questions about any of this work let us know

The three related PRs:

https://github.com/paradigmxyz/reth/pull/8895
https://github.com/bluealloy/revm/pull/1541
https://github.com/alloy-rs/alloy/pull/928
