### PR TITLE
chore: Add CI build target for no-std + optimism, use matrix builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,45 +32,33 @@ jobs:
       - run: cargo test --workspace ${{ matrix.flags }}
 
   test-no-std:
-    name: test no_std
+    name: test no_std ${{ matrix.features }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        features: ["", "optimism"]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: riscv32imac-unknown-none-elf
-      - run: cargo check --target riscv32imac-unknown-none-elf --no-default-features
+      - run: cargo check --target riscv32imac-unknown-none-elf --no-default-features --features=${{ matrix.features }}
 
-  check-no-default-features:
-    name: check no-default-features
+  check:
+    name: check ${{ matrix.features }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        features: ["", "serde", "std"]
     steps:
       - uses: actions/checkout@v4
       - run: |
           cd crates/revm
-          cargo check --no-default-features
-
-  check-serde:
-    name: check serde
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - run: |
-          cd crates/revm
-          cargo check --no-default-features --features serde
-
-  check-std:
-    name: check std
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - run: |
-          cd crates/revm
-          cargo check --no-default-features --features std
+          cargo check --no-default-features --features=${{ matrix.features }}
 
   clippy:
     name: clippy

--- a/crates/revm/src/optimism/l1block.rs
+++ b/crates/revm/src/optimism/l1block.rs
@@ -223,7 +223,7 @@ impl L1BlockInfo {
 
         estimated_size
             .saturating_mul(l1_fee_scaled)
-            .wrapping_div(U256::from(1000000000000u64))
+            .wrapping_div(U256::from(1_000_000_000_000u64))
     }
 
     // l1BaseFee*16*l1BaseFeeScalar + l1BlobBaseFee*l1BlobBaseFeeScalar


### PR DESCRIPTION
* Add new CI step to check the no_std (riscv32) build with the `optimism` feature flag enabled.
* Refactors the `cargo check` CI steps to use a feature matrix.

