### PR TITLE
feat: add bytecode_address from CallInputs to Contract during construction.

### DIFF
--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -113,7 +113,7 @@ impl Interpreter {
                 bytecode,
                 None,
                 crate::primitives::Address::default(),
-                crate::primitives::Address::default(),
+                None,
                 crate::primitives::Address::default(),
                 U256::ZERO,
             ),

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -111,6 +111,7 @@ impl Interpreter {
             Contract::new(
                 Bytes::new(),
                 bytecode,
+                crate::primitives::Address::default(),
                 None,
                 crate::primitives::Address::default(),
                 crate::primitives::Address::default(),

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -111,8 +111,8 @@ impl Interpreter {
             Contract::new(
                 Bytes::new(),
                 bytecode,
-                crate::primitives::Address::default(),
                 None,
+                crate::primitives::Address::default(),
                 crate::primitives::Address::default(),
                 crate::primitives::Address::default(),
                 U256::ZERO,

--- a/crates/interpreter/src/interpreter/contract.rs
+++ b/crates/interpreter/src/interpreter/contract.rs
@@ -15,13 +15,13 @@ pub struct Contract {
     /// Bytecode contains contract code, size of original code, analysis with gas block and jump table.
     /// Note that current code is extended with push padding and STOP at end.
     pub bytecode: Bytecode,
-    /// Address of the account the bytecode was loaded from. This can be different from target_address
-    /// in the case of DELEGATECALL or CALLCODE
-    pub bytecode_address: Address,
     /// Bytecode hash for legacy. For EOF this would be None.
     pub hash: Option<B256>,
     /// Target address of the account. Storage of this address is going to be modified.
     pub target_address: Address,
+    /// Address of the account the bytecode was loaded from. This can be different from target_address
+    /// in the case of DELEGATECALL or CALLCODE
+    pub bytecode_address: Address,
     /// Caller of the EVM.
     pub caller: Address,
     /// Value send to contract from transaction or from CALL opcodes.
@@ -34,9 +34,9 @@ impl Contract {
     pub fn new(
         input: Bytes,
         bytecode: Bytecode,
-        bytecode_address: Address,
         hash: Option<B256>,
         target_address: Address,
+        bytecode_address: Address,
         caller: Address,
         call_value: U256,
     ) -> Self {
@@ -45,9 +45,9 @@ impl Contract {
         Self {
             input,
             bytecode,
-            bytecode_address,
             hash,
             target_address,
+            bytecode_address,
             caller,
             call_value,
         }
@@ -63,8 +63,8 @@ impl Contract {
         Self::new(
             env.tx.data.clone(),
             bytecode,
-            contract_address,
             hash,
+            contract_address,
             contract_address,
             env.tx.caller,
             env.tx.value,
@@ -82,9 +82,9 @@ impl Contract {
         Self::new(
             input,
             bytecode,
-            call_context.bytecode_address,
             hash,
             call_context.target_address,
+            call_context.bytecode_address,
             call_context.caller,
             call_context.call_value(),
         )

--- a/crates/interpreter/src/interpreter/contract.rs
+++ b/crates/interpreter/src/interpreter/contract.rs
@@ -21,7 +21,7 @@ pub struct Contract {
     pub target_address: Address,
     /// Address of the account the bytecode was loaded from. This can be different from target_address
     /// in the case of DELEGATECALL or CALLCODE
-    pub bytecode_address: Address,
+    pub bytecode_address: Option<Address>,
     /// Caller of the EVM.
     pub caller: Address,
     /// Value send to contract from transaction or from CALL opcodes.
@@ -36,7 +36,7 @@ impl Contract {
         bytecode: Bytecode,
         hash: Option<B256>,
         target_address: Address,
-        bytecode_address: Address,
+        bytecode_address: Option<Address>,
         caller: Address,
         call_value: U256,
     ) -> Self {
@@ -65,7 +65,7 @@ impl Contract {
             bytecode,
             hash,
             contract_address,
-            contract_address,
+            None,
             env.tx.caller,
             env.tx.value,
         )
@@ -84,7 +84,7 @@ impl Contract {
             bytecode,
             hash,
             call_context.target_address,
-            call_context.bytecode_address,
+            Some(call_context.bytecode_address),
             call_context.caller,
             call_context.call_value(),
         )

--- a/crates/interpreter/src/interpreter/contract.rs
+++ b/crates/interpreter/src/interpreter/contract.rs
@@ -15,6 +15,8 @@ pub struct Contract {
     /// Bytecode contains contract code, size of original code, analysis with gas block and jump table.
     /// Note that current code is extended with push padding and STOP at end.
     pub bytecode: Bytecode,
+    /// Address of the account the bytecode was loaded from.
+    pub bytecode_address: Address,
     /// Bytecode hash for legacy. For EOF this would be None.
     pub hash: Option<B256>,
     /// Target address of the account. Storage of this address is going to be modified.
@@ -31,6 +33,7 @@ impl Contract {
     pub fn new(
         input: Bytes,
         bytecode: Bytecode,
+        bytecode_address: Address,
         hash: Option<B256>,
         target_address: Address,
         caller: Address,
@@ -41,6 +44,7 @@ impl Contract {
         Self {
             input,
             bytecode,
+            bytecode_address,
             hash,
             target_address,
             caller,
@@ -58,6 +62,7 @@ impl Contract {
         Self::new(
             env.tx.data.clone(),
             bytecode,
+            contract_address,
             hash,
             contract_address,
             env.tx.caller,
@@ -76,6 +81,7 @@ impl Contract {
         Self::new(
             input,
             bytecode,
+            call_context.bytecode_address,
             hash,
             call_context.target_address,
             call_context.caller,

--- a/crates/interpreter/src/interpreter/contract.rs
+++ b/crates/interpreter/src/interpreter/contract.rs
@@ -15,7 +15,8 @@ pub struct Contract {
     /// Bytecode contains contract code, size of original code, analysis with gas block and jump table.
     /// Note that current code is extended with push padding and STOP at end.
     pub bytecode: Bytecode,
-    /// Address of the account the bytecode was loaded from.
+    /// Address of the account the bytecode was loaded from. This can be different from target_address
+    /// in the case of DELEGATECALL or CALLCODE
     pub bytecode_address: Address,
     /// Bytecode hash for legacy. For EOF this would be None.
     pub hash: Option<B256>,

--- a/crates/interpreter/src/interpreter/contract.rs
+++ b/crates/interpreter/src/interpreter/contract.rs
@@ -60,12 +60,16 @@ impl Contract {
             TxKind::Call(caller) => caller,
             TxKind::Create => Address::ZERO,
         };
+        let bytecode_address = match env.tx.transact_to {
+            TxKind::Call(caller) => Some(caller),
+            TxKind::Create => None,
+        };
         Self::new(
             env.tx.data.clone(),
             bytecode,
             hash,
             contract_address,
-            None,
+            bytecode_address,
             env.tx.caller,
             env.tx.value,
         )

--- a/crates/revm/src/context/inner_evm_context.rs
+++ b/crates/revm/src/context/inner_evm_context.rs
@@ -337,6 +337,7 @@ impl<DB: Database> InnerEvmContext<DB> {
             input.clone(),
             // fine to clone as it is Bytes.
             Bytecode::Eof(Arc::new(initcode.clone())),
+            created_address,
             None,
             created_address,
             inputs.caller,
@@ -475,6 +476,7 @@ impl<DB: Database> InnerEvmContext<DB> {
         let contract = Contract::new(
             Bytes::new(),
             bytecode,
+            created_address,
             Some(init_code_hash),
             created_address,
             inputs.caller,

--- a/crates/revm/src/context/inner_evm_context.rs
+++ b/crates/revm/src/context/inner_evm_context.rs
@@ -339,7 +339,7 @@ impl<DB: Database> InnerEvmContext<DB> {
             Bytecode::Eof(Arc::new(initcode.clone())),
             None,
             created_address,
-            created_address,
+            None,
             inputs.caller,
             inputs.value,
         );
@@ -478,7 +478,7 @@ impl<DB: Database> InnerEvmContext<DB> {
             bytecode,
             Some(init_code_hash),
             created_address,
-            created_address,
+            None,
             inputs.caller,
             inputs.value,
         );

--- a/crates/revm/src/context/inner_evm_context.rs
+++ b/crates/revm/src/context/inner_evm_context.rs
@@ -337,8 +337,8 @@ impl<DB: Database> InnerEvmContext<DB> {
             input.clone(),
             // fine to clone as it is Bytes.
             Bytecode::Eof(Arc::new(initcode.clone())),
-            created_address,
             None,
+            created_address,
             created_address,
             inputs.caller,
             inputs.value,
@@ -476,8 +476,8 @@ impl<DB: Database> InnerEvmContext<DB> {
         let contract = Contract::new(
             Bytes::new(),
             bytecode,
-            created_address,
             Some(init_code_hash),
+            created_address,
             created_address,
             inputs.caller,
             inputs.value,


### PR DESCRIPTION
It's completely possible I am missing something, but I couldn't find a good way to access the address of the account which owns the bytecode being executed while using the Inspector::step hook. It would be really convenient if the contract stored on the interpreter also contained the bytecode address like the CallInputs it is constructed from do.