### PR TITLE
Use HandleOrRuntime to allow alloydb/ethersdb to hold a custom runtime

### DIFF
--- a/crates/revm/src/db.rs
+++ b/crates/revm/src/db.rs
@@ -1,5 +1,8 @@
 //! [Database] implementations.
 
+#[cfg(any(feature = "alloydb", feature = "ethersdb"))]
+mod utils;
+
 #[cfg(feature = "alloydb")]
 mod alloydb;
 pub mod emptydb;

--- a/crates/revm/src/db/alloydb.rs
+++ b/crates/revm/src/db/alloydb.rs
@@ -6,7 +6,8 @@ use alloy_eips::BlockId;
 use alloy_provider::{Network, Provider};
 use alloy_transport::{Transport, TransportError};
 use std::future::IntoFuture;
-use tokio::runtime::Handle;
+
+use super::utils::HandleOrRuntime;
 
 /// An alloy-powered REVM [Database].
 ///
@@ -18,28 +19,42 @@ pub struct AlloyDB<T: Transport + Clone, N: Network, P: Provider<T, N>> {
     /// The block number on which the queries will be based on.
     block_number: BlockId,
     /// handle to the tokio runtime
-    handle: Handle,
+    rt: HandleOrRuntime,
     _marker: std::marker::PhantomData<fn() -> (T, N)>,
 }
 
 impl<T: Transport + Clone, N: Network, P: Provider<T, N>> AlloyDB<T, N, P> {
-    /// Create a new AlloyDB instance, with a [Provider] and a block (Use None for latest).
+    /// Create a new AlloyDB instance, with a [Provider] and a block.
     ///
     /// Returns `None` if no tokio runtime is available or if the current runtime is a current-thread runtime.
     pub fn new(provider: P, block_number: BlockId) -> Option<Self> {
-        let handle = match Handle::try_current() {
+        let rt = match Handle::try_current() {
             Ok(handle) => match handle.runtime_flavor() {
                 tokio::runtime::RuntimeFlavor::CurrentThread => return None,
-                _ => handle,
+                _ => HandleOrRuntime::Handle(handle),
             },
             Err(_) => return None,
         };
         Some(Self {
             provider,
             block_number,
-            handle,
+            rt,
             _marker: std::marker::PhantomData,
         })
+    }
+
+    // Create a new AlloyDB instance, with a provider and a block and a runtime.
+    //
+    // Refer to [tokio::runtime::Builder] how to create a runtime if you are in synchronous world.
+    // If you are already using something like [tokio::main], call AlloyDB::new instead.
+    pub fn with_runtime(provider: P, block_number: BlockId, runtime: Runtime) -> Self {
+        let rt = HandleOrRuntime::Runtime(runtime);
+        Self {
+            provider,
+            block_number,
+            rt,
+            _marker: std::marker::PhantomData,
+        }
     }
 
     /// Internal utility function that allows us to block on a future regardless of the runtime flavor.
@@ -49,7 +64,7 @@ impl<T: Transport + Clone, N: Network, P: Provider<T, N>> AlloyDB<T, N, P> {
         F: std::future::Future + Send,
         F::Output: Send,
     {
-        tokio::task::block_in_place(move || self.handle.block_on(f))
+        self.rt.block_on(f)
     }
 
     /// Set the block number on which the queries will be based on.

--- a/crates/revm/src/db/alloydb.rs
+++ b/crates/revm/src/db/alloydb.rs
@@ -6,13 +6,14 @@ use alloy_eips::BlockId;
 use alloy_provider::{Network, Provider};
 use alloy_transport::{Transport, TransportError};
 use std::future::IntoFuture;
+use tokio::runtime::{Handle, Runtime};
 
 use super::utils::HandleOrRuntime;
 
 /// An alloy-powered REVM [Database].
 ///
 /// When accessing the database, it'll use the given provider to fetch the corresponding account's data.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct AlloyDB<T: Transport + Clone, N: Network, P: Provider<T, N>> {
     /// The provider to fetch the data from.
     provider: P,

--- a/crates/revm/src/db/alloydb.rs
+++ b/crates/revm/src/db/alloydb.rs
@@ -60,8 +60,8 @@ impl<T: Transport + Clone, N: Network, P: Provider<T, N>> AlloyDB<T, N, P> {
 
     // Create a new AlloyDB instance, with a provider and a block and a runtime handle.
     //
-    // Refer to [tokio::runtime::Builder] how to create a runtime if you are in synchronous world.
-    // If you are already using something like [tokio::main], call AlloyDB::new instead.
+    // This generally allows you to pass any valid runtime handle, refer to [tokio::runtime::Handle] on how
+    // to obtain a handle. If you are already in asynchronous world, like [tokio::main], use AlloyDB::new instead.
     pub fn with_handle(provider: P, block_number: BlockId, handle: Handle) -> Self {
         let rt = HandleOrRuntime::Handle(handle);
         Self {

--- a/crates/revm/src/db/alloydb.rs
+++ b/crates/revm/src/db/alloydb.rs
@@ -44,10 +44,10 @@ impl<T: Transport + Clone, N: Network, P: Provider<T, N>> AlloyDB<T, N, P> {
         })
     }
 
-    // Create a new AlloyDB instance, with a provider and a block and a runtime.
-    //
-    // Refer to [tokio::runtime::Builder] on how to create a runtime if you are in synchronous world.
-    // If you are already using something like [tokio::main], call AlloyDB::new instead.
+    /// Create a new AlloyDB instance, with a provider and a block and a runtime.
+    ///
+    /// Refer to [tokio::runtime::Builder] on how to create a runtime if you are in synchronous world.
+    /// If you are already using something like [tokio::main], call AlloyDB::new instead.
     pub fn with_runtime(provider: P, block_number: BlockId, runtime: Runtime) -> Self {
         let rt = HandleOrRuntime::Runtime(runtime);
         Self {
@@ -58,10 +58,10 @@ impl<T: Transport + Clone, N: Network, P: Provider<T, N>> AlloyDB<T, N, P> {
         }
     }
 
-    // Create a new AlloyDB instance, with a provider and a block and a runtime handle.
-    //
-    // This generally allows you to pass any valid runtime handle, refer to [tokio::runtime::Handle] on how
-    // to obtain a handle. If you are already in asynchronous world, like [tokio::main], use AlloyDB::new instead.
+    /// Create a new AlloyDB instance, with a provider and a block and a runtime handle.
+    ///
+    /// This generally allows you to pass any valid runtime handle, refer to [tokio::runtime::Handle] on how
+    /// to obtain a handle. If you are already in asynchronous world, like [tokio::main], use AlloyDB::new instead.
     pub fn with_handle(provider: P, block_number: BlockId, handle: Handle) -> Self {
         let rt = HandleOrRuntime::Handle(handle);
         Self {

--- a/crates/revm/src/db/alloydb.rs
+++ b/crates/revm/src/db/alloydb.rs
@@ -46,10 +46,24 @@ impl<T: Transport + Clone, N: Network, P: Provider<T, N>> AlloyDB<T, N, P> {
 
     // Create a new AlloyDB instance, with a provider and a block and a runtime.
     //
-    // Refer to [tokio::runtime::Builder] how to create a runtime if you are in synchronous world.
+    // Refer to [tokio::runtime::Builder] on how to create a runtime if you are in synchronous world.
     // If you are already using something like [tokio::main], call AlloyDB::new instead.
     pub fn with_runtime(provider: P, block_number: BlockId, runtime: Runtime) -> Self {
         let rt = HandleOrRuntime::Runtime(runtime);
+        Self {
+            provider,
+            block_number,
+            rt,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    // Create a new AlloyDB instance, with a provider and a block and a runtime handle.
+    //
+    // Refer to [tokio::runtime::Builder] how to create a runtime if you are in synchronous world.
+    // If you are already using something like [tokio::main], call AlloyDB::new instead.
+    pub fn with_handle(provider: P, block_number: BlockId, handle: Handle) -> Self {
+        let rt = HandleOrRuntime::Handle(handle);
         Self {
             provider,
             block_number,

--- a/crates/revm/src/db/ethersdb.rs
+++ b/crates/revm/src/db/ethersdb.rs
@@ -72,8 +72,8 @@ impl<M: Middleware> EthersDB<M> {
 
     // Create a new EthersDB instance, with a provider and a block (None for latest) and a handle.
     //
-    // Refer to [tokio::runtime::Builder] how to create a runtime if you are in synchronous world.
-    // If you are already using something like [tokio::main], call EthersDB::new instead.
+    // This generally allows you to pass any valid runtime handle, refer to [tokio::runtime::Handle] on how
+    // to obtain a handle. If you are already in asynchronous world, like [tokio::main], use EthersDB::new instead.
     pub fn with_handle(
         client: Arc<M>,
         block_number: Option<BlockId>,

--- a/crates/revm/src/db/ethersdb.rs
+++ b/crates/revm/src/db/ethersdb.rs
@@ -48,10 +48,10 @@ impl<M: Middleware> EthersDB<M> {
         }
     }
 
-    // Create a new EthersDB instance, with a provider and a block (None for latest) and a runtime.
-    //
-    // Refer to [tokio::runtime::Builder] how to create a runtime if you are in synchronous world.
-    // If you are already using something like [tokio::main], call EthersDB::new instead.
+    /// Create a new EthersDB instance, with a provider and a block (None for latest) and a runtime.
+    ///
+    /// Refer to [tokio::runtime::Builder] how to create a runtime if you are in synchronous world.
+    /// If you are already using something like [tokio::main], call EthersDB::new instead.
     pub fn with_runtime(
         client: Arc<M>,
         block_number: Option<BlockId>,
@@ -70,10 +70,10 @@ impl<M: Middleware> EthersDB<M> {
         Some(instance)
     }
 
-    // Create a new EthersDB instance, with a provider and a block (None for latest) and a handle.
-    //
-    // This generally allows you to pass any valid runtime handle, refer to [tokio::runtime::Handle] on how
-    // to obtain a handle. If you are already in asynchronous world, like [tokio::main], use EthersDB::new instead.
+    /// Create a new EthersDB instance, with a provider and a block (None for latest) and a handle.
+    ///
+    /// This generally allows you to pass any valid runtime handle, refer to [tokio::runtime::Handle] on how
+    /// to obtain a handle. If you are already in asynchronous world, like [tokio::main], use EthersDB::new instead.
     pub fn with_handle(
         client: Arc<M>,
         block_number: Option<BlockId>,

--- a/crates/revm/src/db/ethersdb.rs
+++ b/crates/revm/src/db/ethersdb.rs
@@ -37,7 +37,7 @@ impl<M: Middleware> EthersDB<M> {
             })
         } else {
             let mut instance = Self {
-                client: client,
+                client,
                 block_number: None,
                 rt,
             };

--- a/crates/revm/src/db/ethersdb.rs
+++ b/crates/revm/src/db/ethersdb.rs
@@ -70,6 +70,28 @@ impl<M: Middleware> EthersDB<M> {
         Some(instance)
     }
 
+    // Create a new EthersDB instance, with a provider and a block (None for latest) and a handle.
+    //
+    // Refer to [tokio::runtime::Builder] how to create a runtime if you are in synchronous world.
+    // If you are already using something like [tokio::main], call EthersDB::new instead.
+    pub fn with_handle(
+        client: Arc<M>,
+        block_number: Option<BlockId>,
+        handle: Handle,
+    ) -> Option<Self> {
+        let rt = HandleOrRuntime::Handle(handle);
+        let mut instance = Self {
+            client,
+            block_number,
+            rt,
+        };
+
+        instance.block_number = Some(BlockId::from(
+            instance.block_on(instance.client.get_block_number()).ok()?,
+        ));
+        Some(instance)
+    }
+
     /// Internal utility function to call tokio feature and wait for output
     #[inline]
     fn block_on<F>(&self, f: F) -> F::Output

--- a/crates/revm/src/db/utils.rs
+++ b/crates/revm/src/db/utils.rs
@@ -1,6 +1,7 @@
 use tokio::runtime::{Handle, Runtime};
 
 // Hold a tokio runtime handle or full runtime
+#[derive(Debug)]
 pub(crate) enum HandleOrRuntime {
     Handle(Handle),
     Runtime(Runtime),
@@ -8,7 +9,7 @@ pub(crate) enum HandleOrRuntime {
 
 impl HandleOrRuntime {
     #[inline]
-    pub fn block_on<F>(&self, f: F) -> F::Output
+    pub(crate) fn block_on<F>(&self, f: F) -> F::Output
     where
         F: std::future::Future + Send,
         F::Output: Send,

--- a/crates/revm/src/db/utils.rs
+++ b/crates/revm/src/db/utils.rs
@@ -1,0 +1,21 @@
+use tokio::runtime::{Handle, Runtime};
+
+// Hold a tokio runtime handle or full runtime
+pub(crate) enum HandleOrRuntime {
+    Handle(Handle),
+    Runtime(Runtime),
+}
+
+impl HandleOrRuntime {
+    #[inline]
+    pub fn block_on<F>(&self, f: F) -> F::Output
+    where
+        F: std::future::Future + Send,
+        F::Output: Send,
+    {
+        match self {
+            Self::Handle(handle) => tokio::task::block_in_place(move || handle.block_on(f)),
+            Self::Runtime(rt) => rt.block_on(f),
+        }
+    }
+}


### PR DESCRIPTION
Following advice from @DaniPopes, this PR introduce `HandleOrRuntime` for both `EthersDB` and `AlloyDB` to avoid creating runtime for every call. Compared to #1557, this implementation also allows synchronous code to continue using both implementation by calling `AlloyDB::with_runtime(..., ..., new_current_thread())`, which reduces break changes.

This PR shall address the concerns of @DaniPopes while keeping the compatibility.

- If we are already in a tokio runtime, like foundry, the handle will be perfectly valid, and no runtime is created.
- If we are in synchronous code, users are responsible for creating the runtime only _once_ for `with_runtime`.

Note with this PR, we could also support current thread runtime now.