### PR TITLE
feat: support selfdestruct for dummyhost

### DIFF
--- a/crates/interpreter/src/host/dummy.rs
+++ b/crates/interpreter/src/host/dummy.rs
@@ -65,12 +65,12 @@ impl Host for DummyHost {
     }
 
     #[inline]
-    fn code_hash(&mut self, __address: Address) -> Option<(B256, bool)> {
+    fn code_hash(&mut self, _address: Address) -> Option<(B256, bool)> {
         Some((KECCAK_EMPTY, false))
     }
 
     #[inline]
-    fn sload(&mut self, __address: Address, index: U256) -> Option<(U256, bool)> {
+    fn sload(&mut self, _address: Address, index: U256) -> Option<(U256, bool)> {
         match self.storage.entry(index) {
             Entry::Occupied(entry) => Some((*entry.get(), false)),
             Entry::Vacant(entry) => {
@@ -82,19 +82,12 @@ impl Host for DummyHost {
 
     #[inline]
     fn sstore(&mut self, _address: Address, index: U256, value: U256) -> Option<SStoreResult> {
-        let (present, is_cold) = match self.storage.entry(index) {
-            Entry::Occupied(mut entry) => (entry.insert(value), false),
-            Entry::Vacant(entry) => {
-                entry.insert(value);
-                (U256::ZERO, true)
-            }
-        };
-
+        let present = self.storage.insert(index, value);
         Some(SStoreResult {
             original_value: U256::ZERO,
-            present_value: present,
+            present_value: present.unwrap_or(U256::ZERO),
             new_value: value,
-            is_cold,
+            is_cold: present.is_none(),
         })
     }
 
@@ -118,6 +111,6 @@ impl Host for DummyHost {
 
     #[inline]
     fn selfdestruct(&mut self, _address: Address, _target: Address) -> Option<SelfDestructResult> {
-        panic!("Selfdestruct is not supported for this host")
+        Some(SelfDestructResult::default())
     }
 }


### PR DESCRIPTION
Return a dummy result instead of panicking.

I've also simplified `sstore`.