### PR TITLE
chore: Rename gas_price to gas_limit for precompile args

### DIFF
--- a/crates/revm/src/builder.rs
+++ b/crates/revm/src/builder.rs
@@ -612,7 +612,7 @@ mod test {
             fn call(
                 &self,
                 _input: &Bytes,
-                _gas_price: u64,
+                _gas_limit: u64,
                 _context: &mut InnerEvmContext<EmptyDB>,
             ) -> PrecompileResult {
                 Ok(PrecompileOutput::new(10, Bytes::new()))

--- a/crates/revm/src/context/context_precompiles.rs
+++ b/crates/revm/src/context/context_precompiles.rs
@@ -119,15 +119,15 @@ impl<DB: Database> ContextPrecompiles<DB> {
         &mut self,
         address: &Address,
         bytes: &Bytes,
-        gas_price: u64,
+        gas_limit: u64,
         evmctx: &mut InnerEvmContext<DB>,
     ) -> Option<PrecompileResult> {
         Some(match self.inner {
-            PrecompilesCow::StaticRef(p) => p.get(address)?.call_ref(bytes, gas_price, &evmctx.env),
+            PrecompilesCow::StaticRef(p) => p.get(address)?.call_ref(bytes, gas_limit, &evmctx.env),
             PrecompilesCow::Owned(ref mut owned) => match owned.get_mut(address)? {
-                ContextPrecompile::Ordinary(p) => p.call(bytes, gas_price, &evmctx.env),
-                ContextPrecompile::ContextStateful(p) => p.call(bytes, gas_price, evmctx),
-                ContextPrecompile::ContextStatefulMut(p) => p.call_mut(bytes, gas_price, evmctx),
+                ContextPrecompile::Ordinary(p) => p.call(bytes, gas_limit, &evmctx.env),
+                ContextPrecompile::ContextStateful(p) => p.call(bytes, gas_limit, evmctx),
+                ContextPrecompile::ContextStatefulMut(p) => p.call_mut(bytes, gas_limit, evmctx),
             },
         })
     }
@@ -199,7 +199,7 @@ pub trait ContextStatefulPrecompile<DB: Database>: Sync + Send {
     fn call(
         &self,
         bytes: &Bytes,
-        gas_price: u64,
+        gas_limit: u64,
         evmctx: &mut InnerEvmContext<DB>,
     ) -> PrecompileResult;
 }
@@ -210,7 +210,7 @@ pub trait ContextStatefulPrecompileMut<DB: Database>: DynClone + Send + Sync {
     fn call_mut(
         &mut self,
         bytes: &Bytes,
-        gas_price: u64,
+        gas_limit: u64,
         evmctx: &mut InnerEvmContext<DB>,
     ) -> PrecompileResult;
 }

--- a/documentation/src/crates/revm/builder.md
+++ b/documentation/src/crates/revm/builder.md
@@ -125,7 +125,7 @@ impl ContextStatefulPrecompile<EvmContext<EmptyDB>, ()> for CustomPrecompile {
     fn call(
         &self,
         _input: &Bytes,
-        _gas_price: u64,
+        _gas_limit: u64,
         _context: &mut EvmContext<EmptyDB>,
         _extctx: &mut (),
     ) -> PrecompileResult {


### PR DESCRIPTION
The comments refer to the relevant arguments as gas limit
```rust
    /// Stateful precompile that is Arc over [`ContextStatefulPrecompile`] trait.
    /// It takes a reference to input, gas limit and Context.
    ContextStateful(ContextStatefulPrecompileArc<DB>),
```

but the source names the argument `gas_price`
```rust
pub trait ContextStatefulPrecompile<DB: Database>: Sync + Send {
    fn call(
        &self,
        bytes: &Bytes,
        gas_price: u64,
```

My understanding is that gas price is not relevant to precompiles in general, just gas limit. In which case the variable name `gas_price` is incorrect.

Thanks!