### PR TITLE
fix: missing kzg_settings if kzg-rs feature enabled

### DIFF
--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -395,7 +395,7 @@ impl Default for CfgEnv {
             chain_id: 1,
             perf_analyse_created_bytecodes: AnalysisKind::default(),
             limit_contract_code_size: None,
-            #[cfg(feature = "c-kzg")]
+            #[cfg(any(feature = "c-kzg", feature = "kzg-rs"))]
             kzg_settings: crate::kzg::EnvKzgSettings::Default,
             #[cfg(feature = "memory_limit")]
             memory_limit: (1 << 32) - 1,


### PR DESCRIPTION
Makes sure `kzg_settings` is still in `CfgEnv` even if the `kzg-rs` feature is used.