### PR TITLE
fix: allow non-static lifetime in HandleRegisterBox

### DIFF
--- a/crates/revm/src/builder.rs
+++ b/crates/revm/src/builder.rs
@@ -329,7 +329,7 @@ impl<'a, BuilderStage, EXT, DB: Database> EvmBuilder<'a, BuilderStage, EXT, DB> 
     /// When called, EvmBuilder will transition from SetGenericStage to HandlerStage.
     pub fn append_handler_register_box(
         mut self,
-        handle_register: register::HandleRegisterBox<EXT, DB>,
+        handle_register: register::HandleRegisterBox<'a, EXT, DB>,
     ) -> EvmBuilder<'a, HandlerStage, EXT, DB> {
         self.handler
             .append_handler_register(register::HandleRegisters::Box(handle_register));

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -27,7 +27,7 @@ pub struct Handler<'a, H: Host + 'a, EXT, DB: Database> {
     /// Instruction table type.
     pub instruction_table: InstructionTables<'a, H>,
     /// Registers that will be called on initialization.
-    pub registers: Vec<HandleRegisters<EXT, DB>>,
+    pub registers: Vec<HandleRegisters<'a, EXT, DB>>,
     /// Validity handles.
     pub validation: ValidationHandler<'a, EXT, DB>,
     /// Pre execution handle.
@@ -154,7 +154,7 @@ impl<'a, EXT, DB: Database> EvmHandler<'a, EXT, DB> {
     }
 
     /// Append handle register.
-    pub fn append_handler_register(&mut self, register: HandleRegisters<EXT, DB>) {
+    pub fn append_handler_register(&mut self, register: HandleRegisters<'a, EXT, DB>) {
         register.register(self);
         self.registers.push(register);
     }
@@ -166,13 +166,13 @@ impl<'a, EXT, DB: Database> EvmHandler<'a, EXT, DB> {
     }
 
     /// Append boxed handle register.
-    pub fn append_handler_register_box(&mut self, register: HandleRegisterBox<EXT, DB>) {
+    pub fn append_handler_register_box(&mut self, register: HandleRegisterBox<'a, EXT, DB>) {
         register(self);
         self.registers.push(HandleRegisters::Box(register));
     }
 
     /// Pop last handle register and reapply all registers that are left.
-    pub fn pop_handle_register(&mut self) -> Option<HandleRegisters<EXT, DB>> {
+    pub fn pop_handle_register(&mut self) -> Option<HandleRegisters<'a, EXT, DB>> {
         let out = self.registers.pop();
         if out.is_some() {
             let registers = core::mem::take(&mut self.registers);
@@ -227,7 +227,7 @@ mod test {
 
     #[test]
     fn test_handler_register_pop() {
-        let register = |inner: &Rc<RefCell<i32>>| -> HandleRegisterBox<(), EmptyDB> {
+        let register = |inner: &Rc<RefCell<i32>>| -> HandleRegisterBox<'_, (), EmptyDB> {
             let inner = inner.clone();
             Box::new(move |h| {
                 *inner.borrow_mut() += 1;

--- a/crates/revm/src/handler/register.rs
+++ b/crates/revm/src/handler/register.rs
@@ -8,18 +8,21 @@ pub type EvmHandler<'a, EXT, DB> = Handler<'a, Context<EXT, DB>, EXT, DB>;
 pub type HandleRegister<EXT, DB> = for<'a> fn(&mut EvmHandler<'a, EXT, DB>);
 
 // Boxed handle register
-pub type HandleRegisterBox<EXT, DB> = Box<dyn for<'a> Fn(&mut EvmHandler<'a, EXT, DB>)>;
+pub type HandleRegisterBox<'a, EXT, DB> = Box<dyn for<'e> Fn(&mut EvmHandler<'e, EXT, DB>) + 'a>;
 
-pub enum HandleRegisters<EXT, DB: Database> {
+pub enum HandleRegisters<'a, EXT, DB: Database> {
     /// Plain function register
     Plain(HandleRegister<EXT, DB>),
     /// Boxed function register.
-    Box(HandleRegisterBox<EXT, DB>),
+    Box(HandleRegisterBox<'a, EXT, DB>),
 }
 
-impl<EXT, DB: Database> HandleRegisters<EXT, DB> {
+impl<'register, EXT, DB: Database> HandleRegisters<'register, EXT, DB> {
     /// Call register function to modify EvmHandler.
-    pub fn register(&self, handler: &mut EvmHandler<'_, EXT, DB>) {
+    pub fn register<'evm>(&self, handler: &mut EvmHandler<'evm, EXT, DB>)
+    where
+        'evm: 'register,
+    {
         match self {
             HandleRegisters::Plain(f) => f(handler),
             HandleRegisters::Box(f) => f(handler),


### PR DESCRIPTION
When using `append_handler_register_box` Rust was always assigning the static lifetime to the `Box`, which is the default behaviour of Rust when a lifetime is not specified.

This change allows custom lifetimes for the box.