### PR TITLE
chore: bump alloy deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,8 +56,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.1.4"
-source = "git+https://github.com/alloy-rs/alloy.git?rev=678617e#678617e1e4c9928b14c27477d8dd5aa25bb67f11"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58047cc851e58c26224521d1ecda466e3d746ebca0274cd5427aa660a88c353"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -69,25 +70,26 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.1.4"
-source = "git+https://github.com/alloy-rs/alloy.git?rev=678617e#678617e1e4c9928b14c27477d8dd5aa25bb67f11"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32a3e14fa0d152d00bd8daf605eb74ad397efb0f54bd7155585823dddb4401e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
  "arbitrary",
  "c-kzg",
+ "k256",
  "once_cell",
- "proptest",
- "proptest-derive",
  "serde",
  "sha2",
 ]
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.1.4"
-source = "git+https://github.com/alloy-rs/alloy.git?rev=678617e#678617e1e4c9928b14c27477d8dd5aa25bb67f11"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a9feec2352c78545d1a37415699817bae8dc41654bd1bfe57d6cdd5433bd"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -98,8 +100,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.1.4"
-source = "git+https://github.com/alloy-rs/alloy.git?rev=678617e#678617e1e4c9928b14c27477d8dd5aa25bb67f11"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3223d71dc78f464b2743418d0be8b5c894313e272105a6206ad5e867d67b3ce2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -144,8 +147,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.1.4"
-source = "git+https://github.com/alloy-rs/alloy.git?rev=678617e#678617e1e4c9928b14c27477d8dd5aa25bb67f11"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29da7457d853cb8199ec04b227d5d2ef598be3e59fc2bbad70c8be213292f32"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -197,8 +201,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.1.4"
-source = "git+https://github.com/alloy-rs/alloy.git?rev=678617e#678617e1e4c9928b14c27477d8dd5aa25bb67f11"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a9e609524fa31c2c70eb24c0da60796809193ad4787a6dfe6d0db0d3ac112d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -217,8 +222,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.1.4"
-source = "git+https://github.com/alloy-rs/alloy.git?rev=678617e#678617e1e4c9928b14c27477d8dd5aa25bb67f11"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605fa8462732bb8fd0645a9941e12961e079d45ae6a44634c826f8229c187bdf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -234,21 +240,21 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.1.4"
-source = "git+https://github.com/alloy-rs/alloy.git?rev=678617e#678617e1e4c9928b14c27477d8dd5aa25bb67f11"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c5b9057acc02aee1b8aac2b5a0729cb0f73d080082c111313e5d1f92a96630"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
- "proptest",
- "proptest-derive",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-signer"
-version = "0.1.4"
-source = "git+https://github.com/alloy-rs/alloy.git?rev=678617e#678617e1e4c9928b14c27477d8dd5aa25bb67f11"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37f10592696f4ab8b687d5a8ab55e998a14ea0ca5f8eb20ad74a96ad671bb54a"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -319,8 +325,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.1.4"
-source = "git+https://github.com/alloy-rs/alloy.git?rev=678617e#678617e1e4c9928b14c27477d8dd5aa25bb67f11"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b44b0f6f4a2593b258fa7b6cae8968e6a4c404d9ef4f5bc74401f2d04fa23fa"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -337,8 +344,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.1.4"
-source = "git+https://github.com/alloy-rs/alloy.git?rev=678617e#678617e1e4c9928b14c27477d8dd5aa25bb67f11"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d8f1eefa8cb9e7550740ee330feba4fed303a77ad3085707546f9152a88c380"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,3 @@ debug = true
 [profile.ethtests]
 inherits = "test"
 opt-level = 3
-
-[patch.crates-io]
-alloy-eips = { git = "https://github.com/alloy-rs/alloy.git", rev = "678617e" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy.git", rev = "678617e" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy.git", rev = "678617e" }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -22,7 +22,7 @@ rust_2018_idioms = "deny"
 all = "warn"
 
 [dependencies]
-alloy-eips = { version = "0.1", default-features = false, features = ["k256"] }
+alloy-eips = { version = "0.2", default-features = false, features = ["k256"] }
 alloy-primitives = { version = "0.7.7", default-features = false, features = [
     "rlp",
 ] }

--- a/crates/primitives/src/env/eip7702.rs
+++ b/crates/primitives/src/env/eip7702.rs
@@ -13,6 +13,18 @@ pub enum AuthorizationList {
     Recovered(Vec<RecoveredAuthorization>),
 }
 
+impl From<Vec<SignedAuthorization>> for AuthorizationList {
+    fn from(signed: Vec<SignedAuthorization>) -> Self {
+        Self::Signed(signed)
+    }
+}
+
+impl From<Vec<RecoveredAuthorization>> for AuthorizationList {
+    fn from(recovered: Vec<RecoveredAuthorization>) -> Self {
+        Self::Recovered(recovered)
+    }
+}
+
 impl AuthorizationList {
     /// Returns length of the authorization list.
     pub fn len(&self) -> usize {

--- a/crates/primitives/src/env/eip7702.rs
+++ b/crates/primitives/src/env/eip7702.rs
@@ -1,6 +1,8 @@
-pub use alloy_eips::eip7702::{Authorization, RecoveredAuthorization, SignedAuthorization};
+pub use alloy_eips::eip7702::{Authorization, SignedAuthorization};
 pub use alloy_primitives::Signature;
 
+use crate::Address;
+use core::ops::Deref;
 use std::{boxed::Box, vec::Vec};
 
 /// Authorization list for EIP-7702 transaction type.
@@ -33,9 +35,7 @@ impl AuthorizationList {
     /// Returns iterator of recovered Authorizations.
     pub fn recovered_iter<'a>(&'a self) -> Box<dyn Iterator<Item = RecoveredAuthorization> + 'a> {
         match self {
-            Self::Signed(signed) => {
-                Box::new(signed.iter().map(|signed| signed.clone().into_recovered()))
-            }
+            Self::Signed(signed) => Box::new(signed.iter().map(|signed| signed.clone().into())),
             Self::Recovered(recovered) => Box::new(recovered.clone().into_iter()),
         }
     }
@@ -45,11 +45,50 @@ impl AuthorizationList {
         let Self::Signed(signed) = self else {
             return self;
         };
-        Self::Recovered(
-            signed
-                .into_iter()
-                .map(|signed| signed.into_recovered())
-                .collect(),
-        )
+        Self::Recovered(signed.into_iter().map(|signed| signed.into()).collect())
+    }
+}
+
+/// A recovered authorization.
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RecoveredAuthorization {
+    #[cfg_attr(feature = "serde", serde(flatten))]
+    inner: Authorization,
+    authority: Option<Address>,
+}
+
+impl RecoveredAuthorization {
+    /// Instantiate without performing recovery. This should be used carefully.
+    pub const fn new_unchecked(inner: Authorization, authority: Option<Address>) -> Self {
+        Self { inner, authority }
+    }
+
+    /// Get the `authority` for the authorization.
+    ///
+    /// If this is `None`, then the authority could not be recovered.
+    pub const fn authority(&self) -> Option<Address> {
+        self.authority
+    }
+
+    /// Splits the authorization into parts.
+    pub const fn into_parts(self) -> (Authorization, Option<Address>) {
+        (self.inner, self.authority)
+    }
+}
+
+impl From<SignedAuthorization> for RecoveredAuthorization {
+    fn from(signed_auth: SignedAuthorization) -> Self {
+        let authority = signed_auth.recover_authority().ok();
+        let (authorization, _) = signed_auth.into_parts();
+        Self::new_unchecked(authorization, authority)
+    }
+}
+
+impl Deref for RecoveredAuthorization {
+    type Target = Authorization;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -49,9 +49,9 @@ ethers-providers = { version = "2.0", optional = true }
 ethers-core = { version = "2.0", optional = true }
 
 # alloydb
-alloy-provider = { version = "0.1", optional = true, default-features = false }
-alloy-eips = { version = "0.1", optional = true, default-features = false }
-alloy-transport = { version = "0.1", optional = true, default-features = false }
+alloy-provider = { version = "0.2", optional = true, default-features = false }
+alloy-eips = { version = "0.2", optional = true, default-features = false }
+alloy-transport = { version = "0.2", optional = true, default-features = false }
 
 [dev-dependencies]
 alloy-sol-types = { version = "0.7.7", default-features = false, features = [
@@ -64,7 +64,7 @@ indicatif = "0.17"
 reqwest = { version = "0.12" }
 rstest = "0.21.0"
 
-alloy-provider = "0.1"
+alloy-provider = "0.2"
 
 [features]
 default = ["std", "c-kzg", "secp256k1", "portable", "blst"]


### PR DESCRIPTION
Backported the `RecoveredAuthorization` to minimize breaking changes.

Another option considered is to have: `Recovered(Vec<Option<RecoveredAuthorization>>), in place of `Recovered(Vec<RecoveredAuthorization>),` but this loses information on invalid Authorization that some hooks/handler/inspector maybe want to have. 