### PR TITLE
fix(eof): don't fail if offset overflows `usize` in `RETURNDATALOAD`

### DIFF
--- a/crates/interpreter/src/instructions/system.rs
+++ b/crates/interpreter/src/instructions/system.rs
@@ -162,7 +162,7 @@ pub fn returndataload<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &m
     require_eof!(interpreter);
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, offset);
-    let offset_usize = as_usize_or_fail!(interpreter, offset);
+    let offset_usize = as_usize_saturated!(offset);
 
     let mut output = [0u8; 32];
     if let Some(available) = interpreter


### PR DESCRIPTION
As per the spec:
> if offset + 32 > len(returndata buffer) the result is zero-padded (same behavior as CALLDATALOAD)

Doesn't matter if 1 above or 2^255 above the length, it's always zero-padded