### PR TITLE
feat: use batch bn256 pair operation

### DIFF
--- a/crates/precompile/src/bn128.rs
+++ b/crates/precompile/src/bn128.rs
@@ -179,7 +179,7 @@ pub fn run_pair(
     } else {
         let elements = input.len() / PAIR_ELEMENT_LEN;
 
-        let mut points = vec![];
+        let mut points = Vec::with_capacity(elements);
 
         // read points
         for idx in 0..elements {

--- a/crates/precompile/src/bn128.rs
+++ b/crates/precompile/src/bn128.rs
@@ -179,7 +179,9 @@ pub fn run_pair(
     } else {
         let elements = input.len() / PAIR_ELEMENT_LEN;
 
-        let mut mul = Gt::one();
+        let mut points = vec![];
+
+        // read points
         for idx in 0..elements {
             let read_fq_at = |n: usize| {
                 debug_assert!(n < PAIR_ELEMENT_LEN / 32);
@@ -200,6 +202,7 @@ pub fn run_pair(
             let b = {
                 let ba = Fq2::new(bax, bay);
                 let bb = Fq2::new(bbx, bby);
+                // TODO: check whether or not we need these zero checks
                 if ba.is_zero() && bb.is_zero() {
                     G2::zero()
                 } else {
@@ -207,8 +210,10 @@ pub fn run_pair(
                 }
             };
 
-            mul = mul * bn::pairing(a, b);
+            points.push((a, b));
         }
+
+        let mul = bn::pairing_batch(&points);
 
         mul == Gt::one()
     };

--- a/crates/precompile/src/bn128.rs
+++ b/crates/precompile/src/bn128.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use bn::{AffineG1, AffineG2, Fq, Fq2, Group, Gt, G1, G2};
 use revm_primitives::PrecompileOutput;
+use std::vec::Vec;
 
 pub mod add {
     use super::*;


### PR DESCRIPTION
We are currently not taking advantage of the batch pair operation from the `bn` library for the pairing check precompile.

This yields a ~27% speedup on the existing bench:
```
Crypto Precompile benchmarks/precompile bench | ecpairing precompile
                        time:   [2.2389 ms 2.2441 ms 2.2495 ms]
                        change: [-27.689% -27.469% -27.227%] (p = 0.00 < 0.05)
                        Performance has improved.
```