### PR TITLE
fix(EOF): returning to non-returning jumpf, enable validation error

### DIFF
--- a/bins/revme/src/cmd.rs
+++ b/bins/revme/src/cmd.rs
@@ -34,6 +34,11 @@ pub enum Error {
     KzgErrors(#[from] format_kzg_setup::KzgErrors),
     #[error(transparent)]
     EvmRunnerErrors(#[from] evmrunner::Errors),
+    #[error("Eof validation failed: {:?}/{total_tests}", total_tests-failed_test)]
+    EofValidation {
+        failed_test: usize,
+        total_tests: usize,
+    },
     #[error("Custom error: {0}")]
     Custom(&'static str),
 }

--- a/bins/revme/src/cmd/eofvalidation.rs
+++ b/bins/revme/src/cmd/eofvalidation.rs
@@ -23,12 +23,11 @@ impl Cmd {
         if !self.path.exists() {
             return Err(Error::Custom("The specified path does not exist"));
         }
-        run_test(&self.path);
-        Ok(())
+        run_test(&self.path)
     }
 }
 
-pub fn run_test(path: &Path) {
+pub fn run_test(path: &Path) -> Result<(), Error> {
     let test_files = find_all_json_tests(path);
     let mut test_sum = 0;
     let mut passed_tests = 0;
@@ -73,6 +72,14 @@ pub fn run_test(path: &Path) {
             }
         }
     }
-    println!("Types of error: {:#?}", types_of_error);
     println!("Passed tests: {}/{}", passed_tests, test_sum);
+    if passed_tests != test_sum {
+        println!("Types of error: {:#?}", types_of_error);
+        Err(Error::EofValidation {
+            failed_test: test_sum - passed_tests,
+            total_tests: test_sum,
+        })
+    } else {
+        Ok(())
+    }
 }


### PR DESCRIPTION
Fixing last commit and confirming this rule in EOF spec:
```
section type has 0x80 as outputs value, and is non-returning, if and only if this section contains neither RETF instructions nor JUMPF into returning (outputs <= 0x7f) sections.
     * in particular, section having only JUMPFs to non-returning sections is non-returning itself.
```