### PR TITLE
fix(eip7702): Trigger selfdestruct if Loaded to empty change happens

### DIFF
--- a/crates/revm/src/db/states/cache.rs
+++ b/crates/revm/src/db/states/cache.rs
@@ -125,7 +125,8 @@ impl CacheState {
         let is_created = account.is_created();
         let is_empty = account.is_empty();
 
-        // EIP-7702 possible to have Changed/Loaded state that goes to empty state.
+        // first version of EIP-7702 makes it possible to have Changed/Loaded state that goes to empty state.
+        // If Delegated contract sends all balance to other account.
         if is_empty
             && matches!(
                 this_account.status,


### PR DESCRIPTION
EIP-7702 introduces a new transition that an already Changed account can become empty after the transaction finishes. In this case, we have an empty account that is touched and the assumption is that it needs to be destroyed.