### PR TITLE
chore: use alloy type instead of re-defining

### DIFF
--- a/crates/primitives/src/env/eip7702.rs
+++ b/crates/primitives/src/env/eip7702.rs
@@ -1,6 +1,4 @@
-pub use alloy_eips::eip7702::{
-    Authorization, RecoveredAuthority, RecoveredAuthorization, SignedAuthorization,
-};
+pub use alloy_eips::eip7702::{Authorization, RecoveredAuthorization, SignedAuthorization};
 pub use alloy_primitives::Signature;
 
 use std::{boxed::Box, vec::Vec};

--- a/crates/primitives/src/env/eip7702.rs
+++ b/crates/primitives/src/env/eip7702.rs
@@ -1,8 +1,8 @@
-pub use alloy_eips::eip7702::{Authorization, SignedAuthorization};
+pub use alloy_eips::eip7702::{
+    Authorization, RecoveredAuthority, RecoveredAuthorization, SignedAuthorization,
+};
 pub use alloy_primitives::Signature;
 
-use crate::Address;
-use core::ops::Deref;
 use std::{boxed::Box, vec::Vec};
 
 /// Authorization list for EIP-7702 transaction type.
@@ -58,49 +58,5 @@ impl AuthorizationList {
             return self;
         };
         Self::Recovered(signed.into_iter().map(|signed| signed.into()).collect())
-    }
-}
-
-/// A recovered authorization.
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct RecoveredAuthorization {
-    #[cfg_attr(feature = "serde", serde(flatten))]
-    inner: Authorization,
-    authority: Option<Address>,
-}
-
-impl RecoveredAuthorization {
-    /// Instantiate without performing recovery. This should be used carefully.
-    pub const fn new_unchecked(inner: Authorization, authority: Option<Address>) -> Self {
-        Self { inner, authority }
-    }
-
-    /// Get the `authority` for the authorization.
-    ///
-    /// If this is `None`, then the authority could not be recovered.
-    pub const fn authority(&self) -> Option<Address> {
-        self.authority
-    }
-
-    /// Splits the authorization into parts.
-    pub const fn into_parts(self) -> (Authorization, Option<Address>) {
-        (self.inner, self.authority)
-    }
-}
-
-impl From<SignedAuthorization> for RecoveredAuthorization {
-    fn from(signed_auth: SignedAuthorization) -> Self {
-        let authority = signed_auth.recover_authority().ok();
-        let (authorization, _) = signed_auth.into_parts();
-        Self::new_unchecked(authorization, authority)
-    }
-}
-
-impl Deref for RecoveredAuthorization {
-    type Target = Authorization;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
     }
 }


### PR DESCRIPTION
The [`RecoveredAuthorization`](https://github.com/alloy-rs/alloy/blob/main/crates/eips/src/eip7702/auth_list.rs#L233) type is already defined in alloy-eips, the only difference being that the `into_parts` method returns a tuple of `(Authorization, RecoveredAuthority)` instead of `(Authorization, Option<Address>)`. However, the `RecoveredAuthority` itself exposes an `address(&self)` method that returns the `Option<Address>`.