### PR TITLE
chore: switch gas check order in blake2 precompile

### DIFF
--- a/crates/precompile/src/blake2.rs
+++ b/crates/precompile/src/blake2.rs
@@ -17,18 +17,18 @@ pub fn run(input: &Bytes, gas_limit: u64) -> PrecompileResult {
         return Err(Error::Blake2WrongLength.into());
     }
 
-    let f = match input[212] {
-        1 => true,
-        0 => false,
-        _ => return Err(Error::Blake2WrongFinalIndicatorFlag.into()),
-    };
-
     // rounds 4 bytes
     let rounds = u32::from_be_bytes(input[..4].try_into().unwrap()) as usize;
     let gas_used = rounds as u64 * F_ROUND;
     if gas_used > gas_limit {
         return Err(Error::OutOfGas.into());
     }
+
+    let f = match input[212] {
+        1 => true,
+        0 => false,
+        _ => return Err(Error::Blake2WrongFinalIndicatorFlag.into()),
+    };
 
     let mut h = [0u64; 8];
     let mut m = [0u64; 16];


### PR DESCRIPTION
Go-ethereum always check gas before checking the detailed flag in [1]:
```go
func RunPrecompiledContract(p PrecompiledContract, input []byte, suppliedGas uint64, logger *tracing.Hooks) (ret []byte, remainingGas uint64, err error) {
	gasCost := p.RequiredGas(input)
	if suppliedGas < gasCost {
		return nil, 0, ErrOutOfGas
	}
	if logger != nil && logger.OnGasChange != nil {
		logger.OnGasChange(suppliedGas, suppliedGas-gasCost, tracing.GasChangeCallPrecompiledContract)
	}
	suppliedGas -= gasCost
	output, err := p.Run(input)
	return output, suppliedGas, err
}
```
[1]https://github.com/ethereum/go-ethereum/blob/941ae33d7e0b36afc2f8551884f555d963de7c6b/core/vm/contracts.go#L190-L206

Therefore, when the final flag is invalid (neither 1 nor 0) in blake2 precompile, and the gas limit is below the minimum requirement, the behavior differs between revm and go-ethereum.