### PR TITLE
chore: cast block number to u64 and not usize

### DIFF
--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -6,7 +6,7 @@ use alloy_primitives::{address, Address};
 pub const MAX_CODE_SIZE: usize = 0x6000;
 
 /// Number of block hashes that EVM can access in the past (pre-Prague).
-pub const BLOCK_HASH_HISTORY: usize = 256;
+pub const BLOCK_HASH_HISTORY: u64 = 256;
 
 /// EIP-2935: Serve historical block hashes from state
 ///

--- a/crates/revm/src/context.rs
+++ b/crates/revm/src/context.rs
@@ -8,7 +8,7 @@ pub use context_precompiles::{
 };
 pub use evm_context::EvmContext;
 pub use inner_evm_context::InnerEvmContext;
-use revm_interpreter::as_usize_saturated;
+use revm_interpreter::{as_u64_saturated, as_usize_saturated};
 
 use crate::{
     db::{Database, EmptyDB},
@@ -109,8 +109,8 @@ impl<EXT, DB: Database> Host for Context<EXT, DB> {
     }
 
     fn block_hash(&mut self, number: u64) -> Option<B256> {
-        let block_number = as_usize_saturated!(self.env().block.number);
-        let requested_number = usize::try_from(number).unwrap_or(usize::MAX);
+        let block_number = as_u64_saturated!(self.env().block.number);
+        let requested_number = u64::try_from(number).unwrap_or(u64::MAX);
 
         let Some(diff) = block_number.checked_sub(requested_number) else {
             return Some(B256::ZERO);

--- a/crates/revm/src/context.rs
+++ b/crates/revm/src/context.rs
@@ -8,7 +8,7 @@ pub use context_precompiles::{
 };
 pub use evm_context::EvmContext;
 pub use inner_evm_context::InnerEvmContext;
-use revm_interpreter::{as_u64_saturated, as_usize_saturated};
+use revm_interpreter::as_u64_saturated;
 
 use crate::{
     db::{Database, EmptyDB},
@@ -108,9 +108,8 @@ impl<EXT, DB: Database> Host for Context<EXT, DB> {
         &mut self.evm.env
     }
 
-    fn block_hash(&mut self, number: u64) -> Option<B256> {
+    fn block_hash(&mut self, requested_number: u64) -> Option<B256> {
         let block_number = as_u64_saturated!(self.env().block.number);
-        let requested_number = u64::try_from(number).unwrap_or(u64::MAX);
 
         let Some(diff) = block_number.checked_sub(requested_number) else {
             return Some(B256::ZERO);
@@ -124,7 +123,7 @@ impl<EXT, DB: Database> Host for Context<EXT, DB> {
         if diff <= BLOCK_HASH_HISTORY {
             return self
                 .evm
-                .block_hash(number)
+                .block_hash(requested_number)
                 .map_err(|e| self.evm.error = Err(e))
                 .ok();
         }

--- a/crates/revm/src/db/states/state.rs
+++ b/crates/revm/src/db/states/state.rs
@@ -278,7 +278,7 @@ impl<DB: Database> Database for State<DB> {
                 let ret = *entry.insert(self.database.block_hash(number)?);
 
                 // prune all hashes that are older then BLOCK_HASH_HISTORY
-                let last_block = number.saturating_sub(BLOCK_HASH_HISTORY as u64);
+                let last_block = number.saturating_sub(BLOCK_HASH_HISTORY);
                 while let Some(entry) = self.block_hashes.first_entry() {
                     if *entry.key() < last_block {
                         entry.remove();
@@ -315,7 +315,7 @@ mod tests {
         state.block_hash(1u64).unwrap();
         state.block_hash(2u64).unwrap();
 
-        let test_number = BLOCK_HASH_HISTORY as u64 + 2;
+        let test_number = BLOCK_HASH_HISTORY + 2;
 
         let block1_hash = keccak256(U256::from(1).to_string().as_bytes());
         let block2_hash = keccak256(U256::from(2).to_string().as_bytes());


### PR DESCRIPTION
if the artificially big number is set for the block number it will have different values on 32 and 64 systems if the number is 2^32 < N < 2^64