### PR TITLE
chore: bump kzg-rs version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2196,9 +2196,9 @@ dependencies = [
 
 [[package]]
 name = "kzg-rs"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b4bb3bc9aea7619189db05005d378385ccfd7f12b31891c3a2647035294443f"
+checksum = "0850eb19206463a61bede4f7b7e6b21731807137619044b1f3c287ebcfe2b3b0"
 dependencies = [
  "ff",
  "hex",

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -50,7 +50,7 @@ c-kzg = { version = "1.0.3", default-features = false, optional = true, features
 ] }
 
 # Optionally use `kzg-rs` for a pure Rust implementation of KZG point evaluation.
-kzg-rs = { version = "0.2.2", default-features = false, optional = true }
+kzg-rs = { version = "0.2.3", default-features = false, optional = true }
 
 # BLS12-381 precompiles
 blst = { version = "0.3.13", optional = true }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -37,7 +37,7 @@ c-kzg = { version = "1.0.3", default-features = false, optional = true, features
 ] }
 
 # Optionally use `kzg-rs` for a pure Rust implementation of KZG.
-kzg-rs = { version = "0.2.2", default-features = false, optional = true }
+kzg-rs = { version = "0.2.3", default-features = false, optional = true }
 
 # utility
 enumn = "0.1"


### PR DESCRIPTION
- Build `g1.bin`, `g2.bin`, `roots_of_unity.bin` in `OUT_DIR`.
- Should not build binaries when building docs