### PR TITLE
feat(testing): support symbolic accounts with fresh storage

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -24,7 +24,7 @@ all = "warn"
 [dependencies]
 alloy-eips = { version = "0.3", default-features = false, features = ["k256"] }
 alloy-primitives = { version = "0.8.0", default-features = false, features = [
-    "rlp",
+    "rlp", "rand"
 ] }
 hashbrown = "0.14"
 auto_impl = "1.2"

--- a/crates/primitives/src/state.rs
+++ b/crates/primitives/src/state.rs
@@ -20,6 +20,8 @@ pub struct Account {
     pub storage: EvmStorage,
     /// Account status flags.
     pub status: AccountStatus,
+    /// Whether account is symbolic or not.
+    pub symbolic: bool,
 }
 
 // The `bitflags!` macro generates `struct`s that manage a set of flags.
@@ -59,6 +61,7 @@ impl Account {
             info: AccountInfo::default(),
             storage: HashMap::new(),
             status: AccountStatus::LoadedAsNotExisting,
+            symbolic: false,
         }
     }
 
@@ -129,6 +132,12 @@ impl Account {
         }
     }
 
+    /// Mark account as symbolic in order to generate random values for slots
+    /// that are not written yet.
+    pub fn mark_symbolic(&mut self) {
+        self.symbolic = true;
+    }
+
     /// Is account loaded as not existing from database
     /// This is needed for pre spurious dragon hardforks where
     /// existing and empty were two separate states.
@@ -160,6 +169,7 @@ impl From<AccountInfo> for Account {
             info,
             storage: HashMap::new(),
             status: AccountStatus::Loaded,
+            symbolic: false,
         }
     }
 }

--- a/crates/revm/src/journaled_state.rs
+++ b/crates/revm/src/journaled_state.rs
@@ -3,9 +3,9 @@ use revm_interpreter::Eip7702CodeLoad;
 use crate::{
     interpreter::{AccountLoad, InstructionResult, SStoreResult, SelfDestructResult, StateLoad},
     primitives::{
-        db::Database, hash_map::Entry, Account, Address, Bytecode, EVMError, EvmState,
-        EvmStorageSlot, HashMap, HashSet, Log, SpecId, SpecId::*, TransientStorage, B256,
-        KECCAK_EMPTY, PRECOMPILE3, U256,
+        alloy_primitives::private::rand::random, db::Database, hash_map::Entry, Account, Address,
+        Bytecode, EVMError, EvmState, EvmStorageSlot, HashMap, HashSet, Log, SpecId, SpecId::*,
+        TransientStorage, B256, KECCAK_EMPTY, PRECOMPILE3, U256,
     },
 };
 use core::mem;
@@ -693,7 +693,11 @@ impl JournaledState {
             Entry::Vacant(vac) => {
                 // if storage was cleared, we don't need to ping db.
                 let value = if is_newly_created {
-                    U256::ZERO
+                    if account.symbolic {
+                        random()
+                    } else {
+                        U256::ZERO
+                    }
                 } else {
                     db.storage(address, key).map_err(EVMError::Database)?
                 };


### PR DESCRIPTION
(opening this draft PR to get initial thoughts and if OK to have this impl in revm, thank you!)

## Motivation
Re symbolic testing (atm with Kontrol) in foundry https://github.com/foundry-rs/foundry/issues/4072#issuecomment-1456844543

There's a need for a new `freshStorage(address target)` cheatcode where storage of target contract should follow rules below:
- Every SSTORE that comes through is handled as a normal write.
- On SLOAD:
  - If storage slot was already written, then written value is returned.
  - If storage slot wasn't already written, a random uint256 is generated and written to storage.

For example, for a contract like:
```Solidity
contract Counter {
    address[] public owners;

    function getOwner(uint256 pos) public view returns (address) {
        return owners[pos];
    }

    function setOwner(uint256 pos, address owner) public {
        owners[pos] = owner;
    }
}
```

a test like the one bellow should result in PASS

```Solidity
function test_fresh_storage(uint256 a) public {
    a = bound(a, 0, 100);

    Counter counter = new Counter();
    vm.freshStorage(address(counter));

    // Next call would fail with array out of bounds without freshStorage
    address owner = counter.getOwner(a);
    // Subsequent calls should retrieve same value
    assertEq(counter.getOwner(a), owner);
    // Change slot and make sure new value retrieved
    counter.setOwner(a, address(111));
    assertEq(counter.getOwner(a), address(111));
}
```

## Solution
- add a new `symbolic` bool in `Account` struct, default false
- expose `Account.mark_symbolic` fn to enable symbolic storage
- in `JournaledState.sload` generate random value if account newly created and symbolic
