### PR TITLE
chore: add `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+assets/** linguist-vendored
+documentation/** linguist-vendored


### PR DESCRIPTION
## Description

Add `.gitattributes` to ignore the language in contents of `assets/` and `documentation/` folders.