### PR TITLE
feat(statetest): enable EOF in Prague tests

### DIFF
--- a/bins/revme/src/cmd/statetest/models/spec.rs
+++ b/bins/revme/src/cmd/statetest/models/spec.rs
@@ -25,7 +25,6 @@ pub enum SpecName {
     Shanghai,
     Cancun,
     Prague,
-    PragueEOF,
     Osaka, // SKIPPED
     #[serde(other)]
     Unknown,
@@ -49,7 +48,6 @@ impl SpecName {
             Self::Shanghai => SpecId::SHANGHAI,
             Self::Cancun => SpecId::CANCUN,
             Self::Prague => SpecId::PRAGUE,
-            Self::PragueEOF => SpecId::PRAGUE_EOF,
             Self::ByzantiumToConstantinopleAt5 | Self::Constantinople => {
                 panic!("Overridden with PETERSBURG")
             }

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -334,7 +334,12 @@ pub fn execute_test_suite(
                 continue;
             }
 
-            let spec_id = spec_name.to_spec_id();
+            // Enable EOF in Prague tests.
+            let spec_id = if spec_name == SpecName::Prague {
+                SpecId::PRAGUE_EOF
+            } else {
+                spec_name.to_spec_id()
+            };
 
             if spec_id.is_enabled_in(SpecId::MERGE) && env.block.prevrandao.is_none() {
                 // if spec is merge and prevrandao is not set, set it to default


### PR DESCRIPTION
This is the easiest way for test purposes to handle EOF and Prague differences in spec.

to have EOF disable for devnets but enabled in tests