### PR TITLE
chore: make clippy happy

### DIFF
--- a/crates/interpreter/src/function_stack.rs
+++ b/crates/interpreter/src/function_stack.rs
@@ -51,10 +51,9 @@ impl FunctionStack {
 
     /// Pops a frame from the stack and sets current_code_idx to the popped frame's idx.
     pub fn pop(&mut self) -> Option<FunctionReturnFrame> {
-        self.return_stack.pop().map(|frame| {
-            self.current_code_idx = frame.idx;
-            frame
-        })
+        self.return_stack
+            .pop()
+            .inspect(|frame| self.current_code_idx = frame.idx)
     }
 
     /// Sets current_code_idx, this is needed for JUMPF opcode.

--- a/crates/interpreter/src/instructions/arithmetic.rs
+++ b/crates/interpreter/src/instructions/arithmetic.rs
@@ -69,6 +69,8 @@ pub fn exp<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &
     *op2 = op1.pow(*op2);
 }
 
+/// Implements the `SIGNEXTEND` opcode as defined in the Ethereum Yellow Paper.
+///
 /// In the yellow paper `SIGNEXTEND` is defined to take two inputs, we will call them
 /// `x` and `y`, and produce one output. The first `t` bits of the output (numbering from the
 /// left, starting from 0) are equal to the `t`-th bit of `y`, where `t` is equal to

--- a/crates/precompile/src/hash.rs
+++ b/crates/precompile/src/hash.rs
@@ -16,7 +16,7 @@ pub const RIPEMD160: PrecompileWithAddress = PrecompileWithAddress(
 /// This function follows specifications defined in the following references:
 /// - [Ethereum Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf)
 /// - [Solidity Documentation on Mathematical and Cryptographic Functions](https://docs.soliditylang.org/en/develop/units-and-global-variables.html#mathematical-and-cryptographic-functions)
-/// - [Address 0x02][(https://etherscan.io/address/0000000000000000000000000000000000000002)
+/// - [Address 0x02](https://etherscan.io/address/0000000000000000000000000000000000000002)
 pub fn sha256_run(input: &Bytes, gas_limit: u64) -> PrecompileResult {
     let cost = calc_linear_cost_u32(input.len(), 60, 12);
     if cost > gas_limit {
@@ -32,7 +32,7 @@ pub fn sha256_run(input: &Bytes, gas_limit: u64) -> PrecompileResult {
 /// This function follows specifications defined in the following references:
 /// - [Ethereum Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf)
 /// - [Solidity Documentation on Mathematical and Cryptographic Functions](https://docs.soliditylang.org/en/develop/units-and-global-variables.html#mathematical-and-cryptographic-functions)
-/// - [Address 03](https://etherscan.io/address/0000000000000000000000000000000000000003))
+/// - [Address 03](https://etherscan.io/address/0000000000000000000000000000000000000003)
 pub fn ripemd160_run(input: &Bytes, gas_limit: u64) -> PrecompileResult {
     let gas_used = calc_linear_cost_u32(input.len(), 600, 120);
     if gas_used > gas_limit {

--- a/crates/precompile/src/hash.rs
+++ b/crates/precompile/src/hash.rs
@@ -11,9 +11,12 @@ pub const RIPEMD160: PrecompileWithAddress = PrecompileWithAddress(
     Precompile::Standard(ripemd160_run),
 );
 
-/// See: <https://ethereum.github.io/yellowpaper/paper.pdf>
-/// See: <https://docs.soliditylang.org/en/develop/units-and-global-variables.html#mathematical-and-cryptographic-functions>
-/// See: <https://etherscan.io/address/0000000000000000000000000000000000000002>
+/// Computes the SHA-256 hash of the input data.
+///
+/// This function follows specifications defined in the following references:
+/// - [Ethereum Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf)
+/// - [Solidity Documentation on Mathematical and Cryptographic Functions](https://docs.soliditylang.org/en/develop/units-and-global-variables.html#mathematical-and-cryptographic-functions)
+/// - [Address 0x02][(https://etherscan.io/address/0000000000000000000000000000000000000002)
 pub fn sha256_run(input: &Bytes, gas_limit: u64) -> PrecompileResult {
     let cost = calc_linear_cost_u32(input.len(), 60, 12);
     if cost > gas_limit {
@@ -24,9 +27,12 @@ pub fn sha256_run(input: &Bytes, gas_limit: u64) -> PrecompileResult {
     }
 }
 
-/// See: <https://ethereum.github.io/yellowpaper/paper.pdf>
-/// See: <https://docs.soliditylang.org/en/develop/units-and-global-variables.html#mathematical-and-cryptographic-functions>
-/// See: <https://etherscan.io/address/0000000000000000000000000000000000000003>
+/// Computes the RIPEMD-160 hash of the input data.
+///
+/// This function follows specifications defined in the following references:
+/// - [Ethereum Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf)
+/// - [Solidity Documentation on Mathematical and Cryptographic Functions](https://docs.soliditylang.org/en/develop/units-and-global-variables.html#mathematical-and-cryptographic-functions)
+/// - [Address 03](https://etherscan.io/address/0000000000000000000000000000000000000003))
 pub fn ripemd160_run(input: &Bytes, gas_limit: u64) -> PrecompileResult {
     let gas_used = calc_linear_cost_u32(input.len(), 600, 120);
     if gas_used > gas_limit {

--- a/crates/revm/src/context/context_precompiles.rs
+++ b/crates/revm/src/context/context_precompiles.rs
@@ -95,7 +95,7 @@ impl<DB: Database> ContextPrecompiles<DB> {
 
     /// Returns precompiles addresses.
     #[inline]
-    pub fn addresses<'a>(&'a self) -> Box<dyn ExactSizeIterator<Item = &Address> + 'a> {
+    pub fn addresses<'a>(&'a self) -> Box<dyn ExactSizeIterator<Item = &'a Address> + 'a> {
         match self.inner {
             PrecompilesCow::StaticRef(inner) => Box::new(inner.addresses()),
             PrecompilesCow::Owned(ref inner) => Box::new(inner.keys()),

--- a/crates/revm/src/db/states/account_status.rs
+++ b/crates/revm/src/db/states/account_status.rs
@@ -1,6 +1,19 @@
+/// AccountStatus represents the various states an account can be in after being loaded from the database.
+///
 /// After account get loaded from database it can be in a lot of different states
 /// while we execute multiple transaction and even blocks over account that is in memory.
 /// This structure models all possible states that account can be in.
+///
+/// # Variants
+///
+/// - `LoadedNotExisting`: the account has been loaded but does not exist.
+/// - `Loaded`: the account has been loaded and exists.
+/// - `LoadedEmptyEIP161`: the account is loaded and empty, as per EIP-161.
+/// - `InMemoryChange`: there are changes in the account that exist only in memory.
+/// - `Changed`: the account has been modified.
+/// - `Destroyed`: the account has been destroyed.
+/// - `DestroyedChanged`: the account has been destroyed and then modified.
+/// - `DestroyedAgain`: the account has been destroyed again.
 #[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AccountStatus {

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -199,10 +199,7 @@ impl<EXT, DB: Database> Evm<'_, EXT, DB> {
             .handler
             .validation()
             .initial_tx_gas(&self.context.evm.env)
-            .map_err(|e| {
-                self.clear();
-                e
-            })?;
+            .inspect_err(|_e| self.clear())?;
         let output = self.transact_preverified_inner(initial_gas_spend);
         let output = self.handler.post_execution().end(&mut self.context, output);
         self.clear();
@@ -228,10 +225,9 @@ impl<EXT, DB: Database> Evm<'_, EXT, DB> {
     /// This function will validate the transaction.
     #[inline]
     pub fn transact(&mut self) -> EVMResult<DB::Error> {
-        let initial_gas_spend = self.preverify_transaction_inner().map_err(|e| {
-            self.clear();
-            e
-        })?;
+        let initial_gas_spend = self
+            .preverify_transaction_inner()
+            .inspect_err(|_e| self.clear())?;
 
         let output = self.transact_preverified_inner(initial_gas_spend);
         let output = self.handler.post_execution().end(&mut self.context, output);


### PR DESCRIPTION
when running with `cargo check --release` with warning as below:

```
warning: elided lifetime has a name
  --> crates/revm/src/context/context_precompiles.rs:98:72
   |
98 |     pub fn addresses<'a>(&'a self) -> Box<dyn ExactSizeIterator<Item = &Address> + 'a> {
   |                      -- lifetime `'a` declared here                    ^ this elided lifetime gets resolved as `'a`
   |
   = note: `#[warn(elided_named_lifetimes)]` on by default
```
