### PR TITLE
chore(revm): expose convenience cache state for preimages

### DIFF
--- a/crates/interpreter/src/function_stack.rs
+++ b/crates/interpreter/src/function_stack.rs
@@ -51,9 +51,8 @@ impl FunctionStack {
 
     /// Pops a frame from the stack and sets current_code_idx to the popped frame's idx.
     pub fn pop(&mut self) -> Option<FunctionReturnFrame> {
-        self.return_stack.pop().map(|frame| {
+        self.return_stack.pop().inspect(|frame| {
             self.current_code_idx = frame.idx;
-            frame
         })
     }
 

--- a/crates/revm/src/db/states/state.rs
+++ b/crates/revm/src/db/states/state.rs
@@ -213,6 +213,11 @@ impl<DB: Database> State<DB> {
     pub fn take_bundle(&mut self) -> BundleState {
         core::mem::take(&mut self.bundle_state)
     }
+
+    /// Takes the [`CacheState`] from the [`State`], replacing it with an empty one.
+    pub fn take_cache(&mut self) -> CacheState {
+        core::mem::take(&mut self.cache)
+    }
 }
 
 impl<DB: Database> Database for State<DB> {

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -199,9 +199,8 @@ impl<EXT, DB: Database> Evm<'_, EXT, DB> {
             .handler
             .validation()
             .initial_tx_gas(&self.context.evm.env)
-            .map_err(|e| {
+            .inspect_err(|_e| {
                 self.clear();
-                e
             })?;
         let output = self.transact_preverified_inner(initial_gas_spend);
         let output = self.handler.post_execution().end(&mut self.context, output);
@@ -228,9 +227,8 @@ impl<EXT, DB: Database> Evm<'_, EXT, DB> {
     /// This function will validate the transaction.
     #[inline]
     pub fn transact(&mut self) -> EVMResult<DB::Error> {
-        let initial_gas_spend = self.preverify_transaction_inner().map_err(|e| {
+        let initial_gas_spend = self.preverify_transaction_inner().inspect_err(|_e| {
             self.clear();
-            e
         })?;
 
         let output = self.transact_preverified_inner(initial_gas_spend);


### PR DESCRIPTION
## Description

expose cache state for getting preimages, its initial user will be debug_execution_witness in reth. Reference PR here: https://github.com/paradigmxyz/reth/pull/10736/files