### PR TITLE
feat(example): deploy bytecode from scratch

### DIFF
--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -133,6 +133,11 @@ name = "db_by_ref"
 path = "../../examples/db_by_ref.rs"
 required-features = ["std", "serde-json"]
 
+[[example]]
+name = "deploy"
+path = "../../examples/deploy.rs"
+required-features = []
+
 #[[example]]
 #name = "uniswap_v2_usdc_swap"
 #path = "../../examples/uniswap_v2_usdc_swap.rs"

--- a/examples/deploy.rs
+++ b/examples/deploy.rs
@@ -1,19 +1,41 @@
 use anyhow::{anyhow, bail};
 use revm::{
+    interpreter::opcode,
     primitives::{bytes::Bytes, hex, EthereumWiring, ExecutionResult, Output, TxKind, U256},
     Evm, InMemoryDB,
 };
 
-/// [ PUSH1, 0x01, PUSH1, 0x17, PUSH1, 0x1f, CODECOPY, PUSH0, MLOAD, PUSH0, SSTORE ]
+/// Load number parameter and set to storage with slot 0
 const INIT_CODE: &[u8] = &[
-    0x60, 0x01, 0x60, 0x17, 0x60, 0x1f, 0x39, 0x5f, 0x51, 0x5f, 0x55,
+    opcode::PUSH1,
+    0x01,
+    opcode::PUSH1,
+    0x17,
+    opcode::PUSH1,
+    0x1f,
+    opcode::CODECOPY,
+    opcode::PUSH0,
+    opcode::MLOAD,
+    opcode::PUSH0,
+    opcode::SSTORE,
 ];
 
-/// [ PUSH1, 0x02, PUSH1, 0x15, PUSH0, CODECOPY, PUSH1, 0x02, PUSH0, RETURN]
-const RET: &[u8] = &[0x60, 0x02, 0x60, 0x15, 0x5f, 0x39, 0x60, 0x02, 0x5f, 0xf3];
+/// Copy runtime bytecode to memory and return
+const RET: &[u8] = &[
+    opcode::PUSH1,
+    0x02,
+    opcode::PUSH1,
+    0x15,
+    opcode::PUSH0,
+    opcode::CODECOPY,
+    opcode::PUSH1,
+    0x02,
+    opcode::PUSH0,
+    opcode::RETURN,
+];
 
-/// [ PUSH0 SLOAD ]
-const RUNTIME_BYTECODE: &[u8] = &[0x5f, 0x54];
+/// Load storage from slot zero to memory
+const RUNTIME_BYTECODE: &[u8] = &[opcode::PUSH0, opcode::SLOAD];
 
 fn main() -> anyhow::Result<()> {
     let param = 0x42;

--- a/examples/deploy.rs
+++ b/examples/deploy.rs
@@ -1,23 +1,23 @@
 use anyhow::{anyhow, bail};
 use revm::{
-    primitives::{bytes::Bytes, hex, EthereumWiring, ExecutionResult, Output, TxKind},
+    primitives::{bytes::Bytes, hex, EthereumWiring, ExecutionResult, Output, TxKind, U256},
     Evm, InMemoryDB,
 };
 
-/// [ PUSH1, 0x01, PUSH0, SSTORE ]
-const INIT_CODE: &[u8] = &[0x60, 0x01, 0x5f, 0x55];
+/// [ PUSH1, 0x01, PUSH1, 0x17, PUSH1, 0x1f, CODECOPY, PUSH0, MLOAD, PUSH0, SSTORE ]
+const INIT_CODE: &[u8] = &[
+    0x60, 0x01, 0x60, 0x17, 0x60, 0x1f, 0x39, 0x5f, 0x51, 0x5f, 0x55,
+];
 
-/// [ PUSH1, 0x02, PUSH1, 0x0e, PUSH0, CODECOPY, PUSH1, 0x02, PUSH0, RETURN]
-const RET: &[u8] = &[0x60, 0x02, 0x60, 0x0e, 0x5f, 0x39, 0x60, 0x02, 0x5f, 0xf3];
+/// [ PUSH1, 0x02, PUSH1, 0x15, PUSH0, CODECOPY, PUSH1, 0x02, PUSH0, RETURN]
+const RET: &[u8] = &[0x60, 0x02, 0x60, 0x15, 0x5f, 0x39, 0x60, 0x02, 0x5f, 0xf3];
 
 /// [ PUSH0 SLOAD ]
 const RUNTIME_BYTECODE: &[u8] = &[0x5f, 0x54];
 
-/// []
-const PARAMS: &[u8] = &hex!("");
-
 fn main() -> anyhow::Result<()> {
-    let bytecode: Bytes = [INIT_CODE, RET, RUNTIME_BYTECODE, PARAMS].concat().into();
+    let param = 0x42;
+    let bytecode: Bytes = [INIT_CODE, RET, RUNTIME_BYTECODE, &[param]].concat().into();
     let mut evm: Evm<'_, EthereumWiring<InMemoryDB, ()>> =
         Evm::<EthereumWiring<InMemoryDB, ()>>::builder()
             .with_default_db()
@@ -35,14 +35,14 @@ fn main() -> anyhow::Result<()> {
         ..
     } = ref_tx
     else {
-        bail!("Failed to create contract");
+        bail!("Failed to create contract: {ref_tx:#?}");
     };
 
     println!("Created contract at {address}");
     evm = evm
         .modify()
         .modify_tx_env(|tx| {
-            tx.transact_to = TxKind::Call(address.clone());
+            tx.transact_to = TxKind::Call(address);
             *tx.data = Default::default();
             tx.nonce += 1;
         })
@@ -54,12 +54,12 @@ fn main() -> anyhow::Result<()> {
         .get(&address)
         .ok_or_else(|| anyhow!("Contract not found"))?
         .storage
-        .get(&Default::default())
+        .get::<U256>(&Default::default())
     else {
-        bail!("Failed to write storage in the init code");
+        bail!("Failed to write storage in the init code: {result:#?}");
     };
 
     println!("storage U256(0) at{address}:  {storage0:#?}");
-    assert_eq!(storage0.present_value(), 1.try_into()?);
+    assert_eq!(storage0.present_value(), param.try_into()?, "{result:#?}");
     Ok(())
 }

--- a/examples/deploy.rs
+++ b/examples/deploy.rs
@@ -1,0 +1,65 @@
+use anyhow::{anyhow, bail};
+use revm::{
+    primitives::{bytes::Bytes, hex, EthereumWiring, ExecutionResult, Output, TxKind},
+    Evm, InMemoryDB,
+};
+
+/// [ PUSH1, 0x01, PUSH0, SSTORE ]
+const INIT_CODE: &[u8] = &[0x60, 0x01, 0x5f, 0x55];
+
+/// [ PUSH1, 0x02, PUSH1, 0x0e, PUSH0, CODECOPY, PUSH1, 0x02, PUSH0, RETURN]
+const RET: &[u8] = &[0x60, 0x02, 0x60, 0x0e, 0x5f, 0x39, 0x60, 0x02, 0x5f, 0xf3];
+
+/// [ PUSH0 SLOAD ]
+const RUNTIME_BYTECODE: &[u8] = &[0x5f, 0x54];
+
+/// []
+const PARAMS: &[u8] = &hex!("");
+
+fn main() -> anyhow::Result<()> {
+    let bytecode: Bytes = [INIT_CODE, RET, RUNTIME_BYTECODE, PARAMS].concat().into();
+    let mut evm: Evm<'_, EthereumWiring<InMemoryDB, ()>> =
+        Evm::<EthereumWiring<InMemoryDB, ()>>::builder()
+            .with_default_db()
+            .with_default_ext_ctx()
+            .modify_tx_env(|tx| {
+                tx.transact_to = TxKind::Create;
+                *tx.data = bytecode.clone();
+            })
+            .build();
+
+    println!("bytecode: {}", hex::encode(bytecode));
+    let ref_tx = evm.transact_commit()?;
+    let ExecutionResult::Success {
+        output: Output::Create(_, Some(address)),
+        ..
+    } = ref_tx
+    else {
+        bail!("Failed to create contract");
+    };
+
+    println!("Created contract at {address}");
+    evm = evm
+        .modify()
+        .modify_tx_env(|tx| {
+            tx.transact_to = TxKind::Call(address.clone());
+            *tx.data = Default::default();
+            tx.nonce += 1;
+        })
+        .build();
+
+    let result = evm.transact()?;
+    let Some(storage0) = result
+        .state
+        .get(&address)
+        .ok_or_else(|| anyhow!("Contract not found"))?
+        .storage
+        .get(&Default::default())
+    else {
+        bail!("Failed to write storage in the init code");
+    };
+
+    println!("storage U256(0) at{address}:  {storage0:#?}");
+    assert_eq!(storage0.present_value(), 1.try_into()?);
+    Ok(())
+}

--- a/examples/uniswap_v2_usdc_swap.rs
+++ b/examples/uniswap_v2_usdc_swap.rs
@@ -275,4 +275,3 @@ fn transfer(
 
     Ok(())
 }
-B

--- a/examples/uniswap_v2_usdc_swap.rs
+++ b/examples/uniswap_v2_usdc_swap.rs
@@ -275,3 +275,4 @@ fn transfer(
 
     Ok(())
 }
+B


### PR DESCRIPTION

Introduces an example about deploying raw bytecode with revm with storage operations as example, it includes:

- [x] set up a basic REVM from scratch
- [x] concat [init_code, runtime_bytecode, constructor_params ] as bytecode
- [x] deploy the bytecode with REVM
- [x] verify the storage operation from init_code in the deployed contract
- [x] passing params to `constructor` with codecopy