### PR TITLE
rfc: Lazy-load fee beneficiary in mainnet handler

### DIFF
--- a/crates/optimism/src/handler_register.rs
+++ b/crates/optimism/src/handler_register.rs
@@ -278,10 +278,12 @@ pub fn reward_beneficiary<EvmWiringT: OptimismWiring, SPEC: OptimismSpec>(
 ) -> EVMResultGeneric<(), EvmWiringT> {
     let is_deposit = context.evm.inner.env.tx.source_hash().is_some();
 
-    // transfer fee to coinbase/beneficiary if the transaction is not a deposit.
+    // transfer fee to coinbase/beneficiary.
     if !is_deposit {
         mainnet::reward_beneficiary::<EvmWiringT, SPEC>(context, gas)?;
+    }
 
+    if !is_deposit {
         // If the transaction is not a deposit transaction, fees are paid out
         // to both the Base Fee Vault as well as the L1 Fee Vault.
         let l1_block_info = context
@@ -297,36 +299,32 @@ pub fn reward_beneficiary<EvmWiringT: OptimismWiring, SPEC: OptimismSpec>(
         };
 
         let l1_cost = l1_block_info.calculate_tx_l1_cost(enveloped_tx, SPEC::OPTIMISM_SPEC_ID);
-        if l1_cost.gt(&U256::ZERO) {
-            // Send the L1 cost of the transaction to the L1 Fee Vault.
-            let mut l1_fee_vault_account = context
-                .evm
-                .inner
-                .journaled_state
-                .load_account(L1_FEE_RECIPIENT, &mut context.evm.inner.db)
-                .map_err(EVMError::Database)?;
-            l1_fee_vault_account.mark_touch();
-            l1_fee_vault_account.info.balance += l1_cost;
-        }
+
+        // Send the L1 cost of the transaction to the L1 Fee Vault.
+        let mut l1_fee_vault_account = context
+            .evm
+            .inner
+            .journaled_state
+            .load_account(L1_FEE_RECIPIENT, &mut context.evm.inner.db)
+            .map_err(EVMError::Database)?;
+        l1_fee_vault_account.mark_touch();
+        l1_fee_vault_account.info.balance += l1_cost;
 
         // Send the base fee of the transaction to the Base Fee Vault.
-        let reward = context
+        let mut base_fee_vault_account = context
+            .evm
+            .inner
+            .journaled_state
+            .load_account(BASE_FEE_RECIPIENT, &mut context.evm.inner.db)
+            .map_err(EVMError::Database)?;
+        base_fee_vault_account.mark_touch();
+        base_fee_vault_account.info.balance += context
             .evm
             .inner
             .env
             .block
             .basefee()
             .mul(U256::from(gas.spent() - gas.refunded() as u64));
-        if reward.gt(&U256::ZERO) {
-            let mut base_fee_vault_account = context
-                .evm
-                .inner
-                .journaled_state
-                .load_account(BASE_FEE_RECIPIENT, &mut context.evm.inner.db)
-                .map_err(EVMError::Database)?;
-            base_fee_vault_account.mark_touch();
-            base_fee_vault_account.info.balance += reward;
-        }
     }
     Ok(())
 }

--- a/crates/revm/src/handler/mainnet/post_execution.rs
+++ b/crates/revm/src/handler/mainnet/post_execution.rs
@@ -2,7 +2,8 @@ use crate::{
     interpreter::{Gas, SuccessOrHalt},
     primitives::{
         Block, EVMError, EVMResult, EVMResultGeneric, ExecutionResult, ResultAndState, Spec,
-        SpecId, SpecId::LONDON, Transaction, U256,
+        SpecId::{self, LONDON},
+        Transaction, U256,
     },
     Context, EvmWiring, FrameResult,
 };

--- a/crates/revm/src/handler/mainnet/post_execution.rs
+++ b/crates/revm/src/handler/mainnet/post_execution.rs
@@ -37,24 +37,36 @@ pub fn reward_beneficiary<EvmWiringT: EvmWiring, SPEC: Spec>(
     // transfer fee to coinbase/beneficiary.
     // EIP-1559 discard basefee for coinbase transfer. Basefee amount of gas is discarded.
     let coinbase_gas_price = if SPEC::enabled(LONDON) {
-        effective_gas_price.saturating_sub(*context.evm.env.block.basefee())
+        let basefee = *context.evm.env.block.basefee();
+
+        // Skip the transfer if basefee and max priority fee per gas is zero, like geth.
+        if basefee.is_zero()
+            && context
+                .evm
+                .env
+                .tx
+                .max_priority_fee_per_gas()
+                .unwrap_or(&U256::ZERO)
+                .is_zero()
+        {
+            return Ok(());
+        }
+
+        effective_gas_price.saturating_sub(basefee)
     } else {
         effective_gas_price
     };
 
     let reward = coinbase_gas_price * U256::from(gas.spent() - gas.refunded() as u64);
-    if reward.gt(&U256::ZERO) {
-        let coinbase_account = context
-            .evm
-            .inner
-            .journaled_state
-            .load_account(beneficiary, &mut context.evm.inner.db)
-            .map_err(EVMError::Database)?;
+    let coinbase_account = context
+        .evm
+        .inner
+        .journaled_state
+        .load_account(beneficiary, &mut context.evm.inner.db)
+        .map_err(EVMError::Database)?;
 
-        coinbase_account.data.mark_touch();
-        coinbase_account.data.info.balance =
-            coinbase_account.data.info.balance.saturating_add(reward);
-    }
+    coinbase_account.data.mark_touch();
+    coinbase_account.data.info.balance = coinbase_account.data.info.balance.saturating_add(reward);
 
     Ok(())
 }


### PR DESCRIPTION
## Overview

Lazy-loads the fee beneficiaries like `geth`'s EVM does. In the case where no value is transferred to the fee beneficiary, the account is not actually loaded from state in `geth`. This is a small semantic difference between the two implementations that does not actually affect the outcome of the STF, but does make execution witnesses generated by `geth` incompatible with `reth` due to the lack of a MPT proof for the fee beneficiary account.

Because `load_account` hits the DB via `Database::basic`, a proof to the beneficiary account in the trie is required to complete execution.

This edge case shows up in empty L1/L2 blocks, specifically for the 4788 transaction, where `gas_price == 0`, no value is transferred, and no other transactions load the fee recipient.

Note that the fee recipients on Optimism are always loaded, so that logic remains untouched: https://github.com/ethereum-optimism/op-geth/blob/21010bb6b78b8478ff0121778b781411263e160d/core/state_transition.go#L585-L597

### Refs

https://github.com/ethereum/go-ethereum/blob/ae707445f54972f4fddc7c6cf8ba2de083636e50/core/state_transition.go#L468-L471