### PR TITLE
chore: migrate off alloy-eips

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.3.0"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159eab0e4e15b88571f55673af37314f4b8f17630dc1b393c3d70f2128a1d494"
+checksum = "f923dd5fca5f67a43d81ed3ebad0880bd41f6dd0ada930030353ac356c54cd0f"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -114,6 +114,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "c-kzg",
+ "derive_more 1.0.0",
  "once_cell",
  "serde",
  "sha2",
@@ -2970,7 +2971,8 @@ dependencies = [
 name = "revm-specification"
 version = "1.0.0"
 dependencies = [
- "alloy-eips",
+ "alloy-eip2930",
+ "alloy-eip7702",
  "alloy-primitives",
  "enumn",
  "revm-primitives",

--- a/crates/specification/Cargo.toml
+++ b/crates/specification/Cargo.toml
@@ -25,7 +25,8 @@ all = "warn"
 primitives = { path = "../primitives", package = "revm-primitives", version = "9.0.1", default-features = false }
 
 # alloy
-alloy-eips = { version = "0.3", default-features = false, features = ["k256"] }
+alloy-eip2930 = { version = "0.1.0", default-features = false }
+alloy-eip7702 = { version = "0.1.0", default-features = false, features = ["k256"] }
 alloy-primitives = { version = "0.8.2", default-features = false, features = [
     "rlp",
 ] }
@@ -44,6 +45,6 @@ serde = { version = "1.0", default-features = false, features = [
 
 [features]
 default = ["std"]
-std = ["serde?/std"]
-serde = ["dep:serde", "alloy-eips/serde", "alloy-primitives/serde"]
+std = ["serde?/std", "alloy-eip2930/std", "alloy-eip7702/std", "alloy-primitives/std"]
+serde = ["dep:serde", "alloy-eip2930/serde", "alloy-eip7702/serde", "alloy-primitives/serde"]
 serde-json = ["serde"]

--- a/crates/specification/src/eip2930.rs
+++ b/crates/specification/src/eip2930.rs
@@ -1,1 +1,1 @@
-pub use alloy_eips::eip2930::{AccessList, AccessListItem};
+pub use alloy_eip2930::{AccessList, AccessListItem};

--- a/crates/specification/src/eip7702.rs
+++ b/crates/specification/src/eip7702.rs
@@ -6,4 +6,4 @@ pub use authorization_list::*;
 pub use constants::*;
 pub use recovered_authorization::*;
 
-pub use alloy_eips::eip7702::{Authorization, SignedAuthorization};
+pub use alloy_eip7702::{Authorization, SignedAuthorization};


### PR DESCRIPTION
Re-work of #1723 , now that #1695 has been merged. 

Removes the dep on `alloy-eips` in `revm-specification` in favor of depending on `alloy-eip2930` and `alloy-7702`.

This should be a change only to the dep graph, as the types are already re-exports