### PR TITLE
refactor: make ChainSpec associated type on EvmWiring

### DIFF
--- a/crates/inspector/src/gas.rs
+++ b/crates/inspector/src/gas.rs
@@ -79,8 +79,9 @@ mod tests {
         bytecode::Bytecode,
         interpreter::{opcode, Interpreter},
         primitives::{address, Bytes, Log, TxKind},
-        wiring::EvmWiring as PrimitiveEvmWiring,
-        wiring::{DefaultEthereumWiring, EthereumWiring},
+        wiring::{
+            ChainSpec, DefaultEthereumWiring, EthereumWiring, EvmWiring as PrimitiveEvmWiring,
+        },
         Evm, EvmWiring,
     };
 
@@ -181,7 +182,7 @@ mod tests {
             .with_db(BenchmarkDB::new_bytecode(bytecode.clone()))
             .with_default_ext_ctx()
             .modify_tx_env(|tx| {
-                *tx = <TestEvmWiring as PrimitiveEvmWiring>::Transaction::default();
+                *tx = <<TestEvmWiring as PrimitiveEvmWiring>::ChainSpec as ChainSpec>::Transaction::default();
 
                 tx.caller = address!("1000000000000000000000000000000000000000");
                 tx.transact_to = TxKind::Call(address!("0000000000000000000000000000000000000000"));

--- a/crates/inspector/src/handler_register.rs
+++ b/crates/inspector/src/handler_register.rs
@@ -269,7 +269,9 @@ mod tests {
         database_interface::EmptyDB,
         interpreter::{opcode, CallInputs, CallOutcome, CreateInputs, CreateOutcome},
         primitives::{address, Bytes, TxKind},
-        wiring::{DefaultEthereumWiring, EthereumWiring, EvmWiring as PrimitiveEvmWiring},
+        wiring::{
+            ChainSpec, DefaultEthereumWiring, EthereumWiring, EvmWiring as PrimitiveEvmWiring,
+        },
         Evm, EvmContext, EvmWiring,
     };
 
@@ -374,7 +376,7 @@ mod tests {
             .with_db(BenchmarkDB::new_bytecode(bytecode.clone()))
             .with_external_context(StackInspector::default())
             .modify_tx_env(|tx| {
-                *tx = <TestEvmWiring as PrimitiveEvmWiring>::Transaction::default();
+                *tx = <<TestEvmWiring as PrimitiveEvmWiring>::ChainSpec as ChainSpec>::Transaction::default();
 
                 tx.caller = address!("1000000000000000000000000000000000000000");
                 tx.transact_to = TxKind::Call(address!("0000000000000000000000000000000000000000"));

--- a/crates/interpreter/src/host/dummy.rs
+++ b/crates/interpreter/src/host/dummy.rs
@@ -2,20 +2,17 @@ use crate::{Host, SStoreResult, SelfDestructResult};
 use derive_where::derive_where;
 use primitives::{hash_map::Entry, Address, Bytes, HashMap, Log, B256, KECCAK_EMPTY, U256};
 use std::vec::Vec;
-use wiring::{
-    default::{Env, EnvWiring},
-    EvmWiring,
-};
+use wiring::{default::EnvWiring, ChainSpec, EvmWiring};
 
 use super::{AccountLoad, Eip7702CodeLoad, StateLoad};
 
 /// A dummy [Host] implementation.
-#[derive_where(Clone, Debug, Default; EvmWiringT::Block, EvmWiringT::Transaction)]
+#[derive_where(Clone, Debug, Default; <EvmWiringT::ChainSpec as ChainSpec>::Block, <EvmWiringT::ChainSpec as ChainSpec>::Transaction)]
 pub struct DummyHost<EvmWiringT>
 where
     EvmWiringT: EvmWiring,
 {
-    pub env: Env<EvmWiringT::Block, EvmWiringT::Transaction>,
+    pub env: EnvWiring<EvmWiringT>,
     pub storage: HashMap<U256, U256>,
     pub transient_storage: HashMap<U256, U256>,
     pub log: Vec<Log>,
@@ -25,7 +22,7 @@ impl<EvmWiringT> DummyHost<EvmWiringT>
 where
     EvmWiringT: EvmWiring,
 {
-    /// Create a new dummy host with the given [`Env`].
+    /// Create a new dummy host with the given [`EnvWiring`].
     #[inline]
     pub fn new(env: EnvWiring<EvmWiringT>) -> Self {
         Self {

--- a/crates/interpreter/src/interpreter_action/eof_create_inputs.rs
+++ b/crates/interpreter/src/interpreter_action/eof_create_inputs.rs
@@ -1,6 +1,6 @@
 use bytecode::Eof;
 use primitives::{Address, Bytes, U256};
-use wiring::{EvmWiring, Transaction};
+use wiring::{ChainSpec, EvmWiring, Transaction};
 
 /// EOF create can be called from two places:
 /// * EOFCREATE opcode
@@ -75,7 +75,10 @@ impl EOFCreateInputs {
     }
 
     /// Creates new EOFCreateInputs from transaction.
-    pub fn new_tx<EvmWiringT: EvmWiring>(tx: &EvmWiringT::Transaction, gas_limit: u64) -> Self {
+    pub fn new_tx<EvmWiringT: EvmWiring>(
+        tx: &<EvmWiringT::ChainSpec as ChainSpec>::Transaction,
+        gas_limit: u64,
+    ) -> Self {
         EOFCreateInputs::new(
             *tx.caller(),
             *tx.value(),

--- a/crates/optimism/src/lib.rs
+++ b/crates/optimism/src/lib.rs
@@ -22,7 +22,7 @@ pub use l1block::{L1BlockInfo, BASE_FEE_RECIPIENT, L1_BLOCK_CONTRACT, L1_FEE_REC
 pub use result::{OptimismHaltReason, OptimismInvalidTransaction};
 use revm::{
     primitives::{Bytes, B256},
-    wiring::TransactionValidation,
+    wiring::{ChainSpec, TransactionValidation},
 };
 pub use spec::*;
 
@@ -63,8 +63,8 @@ pub trait OptimismTransaction {
 }
 
 /// Trait for an Optimism chain spec.
-pub trait OptimismWiring:
-    revm::EvmWiring<
+pub trait OptimismChainSpec:
+    ChainSpec<
     ChainContext: OptimismContext,
     Hardfork = OptimismSpecId,
     HaltReason = OptimismHaltReason,
@@ -74,13 +74,21 @@ pub trait OptimismWiring:
 {
 }
 
-impl<EvmWiringT> OptimismWiring for EvmWiringT where
-    EvmWiringT: revm::EvmWiring<
+impl<ChainSpecT> OptimismChainSpec for ChainSpecT where
+    ChainSpecT: ChainSpec<
         ChainContext: OptimismContext,
         Hardfork = OptimismSpecId,
         HaltReason = OptimismHaltReason,
         Transaction: OptimismTransaction
                          + TransactionValidation<ValidationError = OptimismInvalidTransaction>,
     >
+{
+}
+
+/// Trait for Optimism `EvmWiring`.
+pub trait OptimismWiring: revm::EvmWiring<ChainSpec: OptimismChainSpec> {}
+
+impl<EvmWiringT> OptimismWiring for EvmWiringT where
+    EvmWiringT: revm::EvmWiring<ChainSpec: OptimismChainSpec>
 {
 }

--- a/crates/optimism/src/spec.rs
+++ b/crates/optimism/src/spec.rs
@@ -8,27 +8,34 @@ use revm::{
     precompile::PrecompileSpecId,
     specification::hardfork::{Spec, SpecId},
     wiring::default::block::BlockEnv,
-    wiring::EvmWiring,
+    wiring::{ChainSpec, EvmWiring},
     EvmHandler,
 };
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct OptimismChainSpec;
+
+impl ChainSpec for OptimismChainSpec {
+    type Block = BlockEnv;
+    type ChainContext = Context;
+    type Transaction = TxEnv;
+    type Hardfork = OptimismSpecId;
+    type HaltReason = OptimismHaltReason;
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct OptimismEvmWiring<DB: Database, EXT> {
-    _phantom: PhantomData<(DB, EXT)>,
+    phantom: PhantomData<(DB, EXT)>,
 }
 
 impl<DB: Database, EXT> EvmWiring for OptimismEvmWiring<DB, EXT> {
-    type Block = BlockEnv;
+    type ChainSpec = OptimismChainSpec;
     type Database = DB;
-    type ChainContext = Context;
     type ExternalContext = EXT;
-    type Hardfork = OptimismSpecId;
-    type HaltReason = OptimismHaltReason;
-    type Transaction = TxEnv;
 }
 
 impl<DB: Database, EXT> revm::EvmWiring for OptimismEvmWiring<DB, EXT> {
-    fn handler<'evm>(hardfork: Self::Hardfork) -> EvmHandler<'evm, Self>
+    fn handler<'evm>(hardfork: <Self::ChainSpec as ChainSpec>::Hardfork) -> EvmHandler<'evm, Self>
     where
         DB: Database,
     {

--- a/crates/revm/src/context.rs
+++ b/crates/revm/src/context.rs
@@ -18,10 +18,10 @@ use interpreter::{
 };
 use primitives::{Address, Bytes, Log, B256, BLOCK_HASH_HISTORY, U256};
 use std::boxed::Box;
-use wiring::{default::EnvWiring, Block, EthereumWiring};
+use wiring::{default::EnvWiring, Block, ChainSpec, EthereumWiring};
 
 /// Main Context structure that contains both EvmContext and External context.
-#[derive_where(Clone; EvmWiringT::Block, EvmWiringT::ChainContext, EvmWiringT::Transaction, EvmWiringT::Database, <EvmWiringT::Database as Database>::Error, EvmWiringT::ExternalContext)]
+#[derive_where(Clone; <EvmWiringT::ChainSpec as ChainSpec>::Block, <EvmWiringT::ChainSpec as ChainSpec>::ChainContext, <EvmWiringT::ChainSpec as ChainSpec>::Transaction, EvmWiringT::Database, <EvmWiringT::Database as Database>::Error, EvmWiringT::ExternalContext)]
 pub struct Context<EvmWiringT: EvmWiring> {
     /// Evm Context (internal context).
     pub evm: EvmContext<EvmWiringT>,
@@ -40,8 +40,11 @@ impl Default for Context<EthereumWiring<EmptyDB, ()>> {
 
 impl<DB: Database, EvmWiringT> Context<EvmWiringT>
 where
-    EvmWiringT:
-        EvmWiring<Block: Default, Transaction: Default, ExternalContext = (), Database = DB>,
+    EvmWiringT: EvmWiring<
+        ChainSpec: ChainSpec<Block: Default, Transaction: Default>,
+        ExternalContext = (),
+        Database = DB,
+    >,
 {
     /// Creates new context with database.
     pub fn new_with_db(db: DB) -> Context<EvmWiringT> {
@@ -63,17 +66,20 @@ impl<EvmWiringT: EvmWiring> Context<EvmWiringT> {
 }
 
 /// Context with handler configuration.
-#[derive_where(Clone; EvmWiringT::Block, EvmWiringT::ChainContext, EvmWiringT::Transaction,EvmWiringT::Database, <EvmWiringT::Database as Database>::Error, EvmWiringT::ExternalContext)]
+#[derive_where(Clone; <EvmWiringT::ChainSpec as ChainSpec>::Block, <EvmWiringT::ChainSpec as ChainSpec>::ChainContext, <EvmWiringT::ChainSpec as ChainSpec>::Transaction, EvmWiringT::Database, <EvmWiringT::Database as Database>::Error, EvmWiringT::ExternalContext)]
 pub struct ContextWithEvmWiring<EvmWiringT: EvmWiring> {
     /// Context of execution.
     pub context: Context<EvmWiringT>,
     /// Handler configuration.
-    pub spec_id: EvmWiringT::Hardfork,
+    pub spec_id: <EvmWiringT::ChainSpec as ChainSpec>::Hardfork,
 }
 
 impl<EvmWiringT: EvmWiring> ContextWithEvmWiring<EvmWiringT> {
     /// Creates new context with handler configuration.
-    pub fn new(context: Context<EvmWiringT>, spec_id: EvmWiringT::Hardfork) -> Self {
+    pub fn new(
+        context: Context<EvmWiringT>,
+        spec_id: <EvmWiringT::ChainSpec as ChainSpec>::Hardfork,
+    ) -> Self {
         Self { spec_id, context }
     }
 }

--- a/crates/revm/src/context/evm_context.rs
+++ b/crates/revm/src/context/evm_context.rs
@@ -16,11 +16,11 @@ use std::{boxed::Box, sync::Arc};
 use wiring::{
     default::{CreateScheme, EnvWiring},
     result::{EVMError, EVMResultGeneric},
-    Transaction,
+    ChainSpec, Transaction,
 };
 
 /// EVM context that contains the inner EVM context and precompiles.
-#[derive_where(Clone, Debug; EvmWiringT::Block, EvmWiringT::ChainContext, EvmWiringT::Transaction, EvmWiringT::Database, <EvmWiringT::Database as Database>::Error)]
+#[derive_where(Clone, Debug; <EvmWiringT::ChainSpec as ChainSpec>::Block, <EvmWiringT::ChainSpec as ChainSpec>::ChainContext, <EvmWiringT::ChainSpec as ChainSpec>::Transaction, EvmWiringT::Database, <EvmWiringT::Database as Database>::Error)]
 pub struct EvmContext<EvmWiringT: EvmWiring> {
     /// Inner EVM context.
     pub inner: InnerEvmContext<EvmWiringT>,
@@ -44,7 +44,7 @@ impl<EvmWiringT: EvmWiring> DerefMut for EvmContext<EvmWiringT> {
 
 impl<EvmWiringT> EvmContext<EvmWiringT>
 where
-    EvmWiringT: EvmWiring<Block: Default, Transaction: Default>,
+    EvmWiringT: EvmWiring<ChainSpec: ChainSpec<Block: Default, Transaction: Default>>,
 {
     /// Create new context with database.
     pub fn new(db: EvmWiringT::Database) -> Self {
@@ -73,7 +73,12 @@ where
     /// Note that this will ignore the previous `error` if set.
     #[inline]
     pub fn with_db<
-        OEvmWiring: EvmWiring<Block = EvmWiringT::Block, Transaction = EvmWiringT::Transaction>,
+        OEvmWiring: EvmWiring<
+            ChainSpec: ChainSpec<
+                Block = <EvmWiringT::ChainSpec as ChainSpec>::Block,
+                Transaction = <EvmWiringT::ChainSpec as ChainSpec>::Transaction,
+            >,
+        >,
     >(
         self,
         db: OEvmWiring::Database,

--- a/crates/revm/src/evm_wiring.rs
+++ b/crates/revm/src/evm_wiring.rs
@@ -7,15 +7,15 @@ use interpreter::opcode::InstructionTables;
 use specification::spec_to_generic;
 use std::fmt::Debug;
 use std::vec::Vec;
-use wiring::{EthereumWiring, EvmWiring as PrimitiveEvmWiring};
+use wiring::{ChainSpec, EthereumWiring, EvmWiring as PrimitiveEvmWiring};
 
 pub trait EvmWiring: PrimitiveEvmWiring {
     /// Creates a new handler with the given hardfork.
-    fn handler<'evm>(hardfork: Self::Hardfork) -> EvmHandler<'evm, Self>;
+    fn handler<'evm>(hardfork: <Self::ChainSpec as ChainSpec>::Hardfork) -> EvmHandler<'evm, Self>;
 }
 
 impl<DB: Database, EXT: Debug> EvmWiring for EthereumWiring<DB, EXT> {
-    fn handler<'evm>(hardfork: Self::Hardfork) -> EvmHandler<'evm, Self>
+    fn handler<'evm>(hardfork: <Self::ChainSpec as ChainSpec>::Hardfork) -> EvmHandler<'evm, Self>
     where
         DB: Database,
     {

--- a/crates/revm/src/handler/handle_types/post_execution.rs
+++ b/crates/revm/src/handler/handle_types/post_execution.rs
@@ -3,7 +3,10 @@ use crate::{handler::mainnet, Context, EvmWiring, FrameResult};
 use interpreter::Gas;
 use specification::hardfork::Spec;
 use std::sync::Arc;
-use wiring::result::{EVMResult, EVMResultGeneric, ResultAndState};
+use wiring::{
+    result::{EVMResult, EVMResultGeneric, ResultAndState},
+    ChainSpec,
+};
 
 /// Reimburse the caller with ethereum it didn't spent.
 pub type ReimburseCallerHandle<'a, EvmWiringT> =
@@ -98,7 +101,10 @@ impl<'a, EvmWiringT: EvmWiring> PostExecutionHandler<'a, EvmWiringT> {
     pub fn end(
         &self,
         context: &mut Context<EvmWiringT>,
-        end_output: EVMResultGeneric<ResultAndState<EvmWiringT::HaltReason>, EvmWiringT>,
+        end_output: EVMResultGeneric<
+            ResultAndState<<EvmWiringT::ChainSpec as ChainSpec>::HaltReason>,
+            EvmWiringT,
+        >,
     ) -> EVMResult<EvmWiringT> {
         (self.end)(context, end_output)
     }

--- a/crates/revm/src/handler/handle_types/validation.rs
+++ b/crates/revm/src/handler/handle_types/validation.rs
@@ -5,6 +5,7 @@ use wiring::{
     default::EnvWiring,
     result::{EVMResultGeneric, InvalidTransaction},
     transaction::TransactionValidation,
+    ChainSpec,
 };
 
 /// Handle that validates env.
@@ -32,7 +33,8 @@ pub struct ValidationHandler<'a, EvmWiringT: EvmWiring> {
 
 impl<'a, EvmWiringT: EvmWiring + 'a> ValidationHandler<'a, EvmWiringT>
 where
-    <EvmWiringT::Transaction as TransactionValidation>::ValidationError: From<InvalidTransaction>,
+    <<EvmWiringT::ChainSpec as ChainSpec>::Transaction as TransactionValidation>::ValidationError:
+        From<InvalidTransaction>,
 {
     /// Create new ValidationHandles
     pub fn new<SPEC: Spec + 'a>() -> Self {

--- a/crates/revm/src/handler/mainnet/post_execution.rs
+++ b/crates/revm/src/handler/mainnet/post_execution.rs
@@ -4,7 +4,7 @@ use primitives::U256;
 use specification::hardfork::{Spec, SpecId};
 use wiring::{
     result::{EVMError, EVMResult, EVMResultGeneric, ExecutionResult, ResultAndState},
-    Block, Transaction,
+    Block, ChainSpec, Transaction,
 };
 
 /// Mainnet end handle does not change the output.
@@ -112,7 +112,9 @@ pub fn output<EvmWiringT: EvmWiring>(
     // reset journal and return present state.
     let (state, logs) = context.evm.journaled_state.finalize();
 
-    let result = match SuccessOrHalt::<EvmWiringT::HaltReason>::from(instruction_result.result) {
+    let result = match SuccessOrHalt::<<EvmWiringT::ChainSpec as ChainSpec>::HaltReason>::from(
+        instruction_result.result,
+    ) {
         SuccessOrHalt::Success(reason) => ExecutionResult::Success {
             reason,
             gas_used: final_gas_used,

--- a/crates/revm/src/handler/mainnet/validation.rs
+++ b/crates/revm/src/handler/mainnet/validation.rs
@@ -5,6 +5,7 @@ use wiring::{
     default::EnvWiring,
     result::{EVMError, EVMResultGeneric, InvalidTransaction},
     transaction::{Transaction, TransactionValidation},
+    ChainSpec,
 };
 
 /// Validate environment for the mainnet.
@@ -12,7 +13,8 @@ pub fn validate_env<EvmWiringT: EvmWiring, SPEC: Spec>(
     env: &EnvWiring<EvmWiringT>,
 ) -> EVMResultGeneric<(), EvmWiringT>
 where
-    <EvmWiringT::Transaction as TransactionValidation>::ValidationError: From<InvalidTransaction>,
+    <<EvmWiringT::ChainSpec as ChainSpec>::Transaction as TransactionValidation>::ValidationError:
+        From<InvalidTransaction>,
 {
     // Important: validate block before tx.
     env.validate_block_env::<SPEC>()?;
@@ -26,7 +28,8 @@ pub fn validate_tx_against_state<EvmWiringT: EvmWiring, SPEC: Spec>(
     context: &mut Context<EvmWiringT>,
 ) -> EVMResultGeneric<(), EvmWiringT>
 where
-    <EvmWiringT::Transaction as TransactionValidation>::ValidationError: From<InvalidTransaction>,
+    <<EvmWiringT::ChainSpec as ChainSpec>::Transaction as TransactionValidation>::ValidationError:
+        From<InvalidTransaction>,
 {
     // load acc
     let tx_caller = *context.evm.env.tx.caller();
@@ -52,7 +55,8 @@ pub fn validate_initial_tx_gas<EvmWiringT: EvmWiring, SPEC: Spec>(
     env: &EnvWiring<EvmWiringT>,
 ) -> EVMResultGeneric<u64, EvmWiringT>
 where
-    <EvmWiringT::Transaction as TransactionValidation>::ValidationError: From<InvalidTransaction>,
+    <<EvmWiringT::ChainSpec as ChainSpec>::Transaction as TransactionValidation>::ValidationError:
+        From<InvalidTransaction>,
 {
     let input = &env.tx.data();
     let is_create = env.tx.kind().is_create();

--- a/crates/wiring/src/default.rs
+++ b/crates/wiring/src/default.rs
@@ -4,6 +4,7 @@ pub mod transaction;
 use crate::block::blob::calc_blob_gasprice;
 use crate::result::InvalidHeader;
 use crate::transaction::TransactionValidation;
+use crate::ChainSpec;
 use crate::{result::InvalidTransaction, Block, EvmWiring, Transaction};
 use core::cmp::{min, Ordering};
 use core::fmt::Debug;
@@ -22,8 +23,10 @@ use std::boxed::Box;
 use std::vec::Vec;
 
 /// Subtype
-pub type EnvWiring<EvmWiringT> =
-    Env<<EvmWiringT as EvmWiring>::Block, <EvmWiringT as EvmWiring>::Transaction>;
+pub type EnvWiring<EvmWiringT> = Env<
+    <<EvmWiringT as EvmWiring>::ChainSpec as ChainSpec>::Block,
+    <<EvmWiringT as EvmWiring>::ChainSpec as ChainSpec>::Transaction,
+>;
 
 #[derive(Clone, Debug, Default)]
 /// EVM environment configuration.

--- a/crates/wiring/src/evm_wiring.rs
+++ b/crates/wiring/src/evm_wiring.rs
@@ -22,15 +22,9 @@ impl<HaltReasonT> HaltReasonTrait for HaltReasonT where
 {
 }
 
-pub trait EvmWiring: Sized {
-    /// External context type
-    type ExternalContext: Sized;
-
+pub trait ChainSpec: Sized {
     /// Chain context type.
     type ChainContext: Sized + Default + Debug;
-
-    /// Database type.
-    type Database: Database;
 
     /// The type that contains all block information.
     type Block: Block;
@@ -45,19 +39,37 @@ pub trait EvmWiring: Sized {
     type HaltReason: HaltReasonTrait;
 }
 
+pub trait EvmWiring: Sized {
+    /// Chain specification type.
+    type ChainSpec: ChainSpec;
+
+    /// External context type
+    type ExternalContext: Sized;
+
+    /// Database type.
+    type Database: Database;
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct EthereumChainSpec;
+
+impl ChainSpec for EthereumChainSpec {
+    type ChainContext = ();
+    type Block = crate::default::block::BlockEnv;
+    type Transaction = crate::default::TxEnv;
+    type Hardfork = SpecId;
+    type HaltReason = crate::result::HaltReason;
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct EthereumWiring<DB: Database, EXT> {
     phantom: core::marker::PhantomData<(DB, EXT)>,
 }
 
 impl<DB: Database, EXT: Debug> EvmWiring for EthereumWiring<DB, EXT> {
+    type ChainSpec = EthereumChainSpec;
     type Database = DB;
     type ExternalContext = EXT;
-    type ChainContext = ();
-    type Block = crate::default::block::BlockEnv;
-    type Transaction = crate::default::TxEnv;
-    type Hardfork = SpecId;
-    type HaltReason = crate::result::HaltReason;
 }
 
 pub type DefaultEthereumWiring = EthereumWiring<EmptyDB, ()>;

--- a/crates/wiring/src/lib.rs
+++ b/crates/wiring/src/lib.rs
@@ -13,7 +13,9 @@ pub mod result;
 pub mod transaction;
 
 pub use block::Block;
-pub use evm_wiring::{DefaultEthereumWiring, EthereumWiring, EvmWiring, HaltReasonTrait};
+pub use evm_wiring::{
+    ChainSpec, DefaultEthereumWiring, EthereumWiring, EvmWiring, HaltReasonTrait,
+};
 pub use transaction::{Transaction, TransactionValidation};
 
 // KZG


### PR DESCRIPTION
This PR proposes a separation between the `EvmWiring` and `ChainSpec` such that the associated types of a `ChainSpec` can be used without the `ExternalContext` and `Database` that are only required for the `Evm`.

This allows re-usage of chain specs for other use cases.