### PR TITLE
chore: add ReentrancySentryOOG for SSTORE

### DIFF
--- a/crates/interpreter/src/gas/calc.rs
+++ b/crates/interpreter/src/gas/calc.rs
@@ -185,29 +185,22 @@ pub const fn sload_cost(spec_id: SpecId, is_cold: bool) -> u64 {
 
 /// `SSTORE` opcode cost calculation.
 #[inline]
-pub fn sstore_cost(spec_id: SpecId, vals: &SStoreResult, gas: u64, is_cold: bool) -> Option<u64> {
-    // EIP-1706 Disable SSTORE with gasleft lower than call stipend
-    if spec_id.is_enabled_in(SpecId::ISTANBUL) && gas <= CALL_STIPEND {
-        return None;
-    }
-
-    if spec_id.is_enabled_in(SpecId::BERLIN) {
+pub fn sstore_cost(spec_id: SpecId, vals: &SStoreResult, is_cold: bool) -> Option<u64> {
+    Some(if spec_id.is_enabled_in(SpecId::BERLIN) {
         // Berlin specification logic
         let mut gas_cost = istanbul_sstore_cost::<WARM_STORAGE_READ_COST, WARM_SSTORE_RESET>(vals);
 
         if is_cold {
             gas_cost += COLD_SLOAD_COST;
         }
-        Some(gas_cost)
+        gas_cost
     } else if spec_id.is_enabled_in(SpecId::ISTANBUL) {
         // Istanbul logic
-        Some(istanbul_sstore_cost::<INSTANBUL_SLOAD_GAS, SSTORE_RESET>(
-            vals,
-        ))
+        istanbul_sstore_cost::<INSTANBUL_SLOAD_GAS, SSTORE_RESET>(vals)
     } else {
         // Frontier logic
-        Some(frontier_sstore_cost(vals))
-    }
+        frontier_sstore_cost(vals)
+    })
 }
 
 /// EIP-2200: Structured Definitions for Net Gas Metering

--- a/crates/interpreter/src/gas/calc.rs
+++ b/crates/interpreter/src/gas/calc.rs
@@ -185,8 +185,8 @@ pub const fn sload_cost(spec_id: SpecId, is_cold: bool) -> u64 {
 
 /// `SSTORE` opcode cost calculation.
 #[inline]
-pub fn sstore_cost(spec_id: SpecId, vals: &SStoreResult, is_cold: bool) -> Option<u64> {
-    Some(if spec_id.is_enabled_in(SpecId::BERLIN) {
+pub fn sstore_cost(spec_id: SpecId, vals: &SStoreResult, is_cold: bool) -> u64 {
+    if spec_id.is_enabled_in(SpecId::BERLIN) {
         // Berlin specification logic
         let mut gas_cost = istanbul_sstore_cost::<WARM_STORAGE_READ_COST, WARM_SSTORE_RESET>(vals);
 
@@ -200,7 +200,7 @@ pub fn sstore_cost(spec_id: SpecId, vals: &SStoreResult, is_cold: bool) -> Optio
     } else {
         // Frontier logic
         frontier_sstore_cost(vals)
-    })
+    }
 }
 
 /// EIP-2200: Structured Definitions for Net Gas Metering

--- a/crates/interpreter/src/instruction_result.rs
+++ b/crates/interpreter/src/instruction_result.rs
@@ -50,6 +50,8 @@ pub enum InstructionResult {
     PrecompileOOG,
     /// Out of gas error encountered while calling an invalid operand.
     InvalidOperandOOG,
+    /// Out of gas error encountered while checking for reentrancy sentry.
+    ReentrancySentryOOG,
     /// Unknown or invalid opcode.
     OpcodeNotFound,
     /// Invalid `CALL` with value transfer in static context.
@@ -118,6 +120,7 @@ impl From<HaltReason> for InstructionResult {
                 OutOfGasError::Memory => Self::MemoryOOG,
                 OutOfGasError::MemoryLimit => Self::MemoryLimitOOG,
                 OutOfGasError::Precompile => Self::PrecompileOOG,
+                OutOfGasError::ReentrancySentry => Self::ReentrancySentryOOG,
             },
             HaltReason::OpcodeNotFound => Self::OpcodeNotFound,
             HaltReason::InvalidFEOpcode => Self::InvalidFEOpcode,
@@ -176,6 +179,7 @@ macro_rules! return_error {
             | InstructionResult::MemoryLimitOOG
             | InstructionResult::PrecompileOOG
             | InstructionResult::InvalidOperandOOG
+            | InstructionResult::ReentrancySentryOOG
             | InstructionResult::OpcodeNotFound
             | InstructionResult::CallNotAllowedInsideStatic
             | InstructionResult::StateChangeDuringStaticCall
@@ -308,6 +312,9 @@ impl<HaltReasonT: HaltReasonTrait> From<InstructionResult> for SuccessOrHalt<Hal
             }
             InstructionResult::InvalidOperandOOG => {
                 Self::Halt(HaltReason::OutOfGas(OutOfGasError::InvalidOperand).into())
+            }
+            InstructionResult::ReentrancySentryOOG => {
+                Self::Halt(HaltReason::OutOfGas(OutOfGasError::ReentrancySentry).into())
             }
             InstructionResult::OpcodeNotFound | InstructionResult::ReturnContractInNotInitEOF => {
                 Self::Halt(HaltReason::OpcodeNotFound.into())

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -1,5 +1,5 @@
 use crate::{
-    gas::{self, warm_cold_cost, warm_cold_cost_with_delegation},
+    gas::{self, warm_cold_cost, warm_cold_cost_with_delegation, CALL_STIPEND},
     interpreter::Interpreter,
     Host, InstructionResult,
 };
@@ -136,14 +136,14 @@ pub fn sstore<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host:
         interpreter.instruction_result = InstructionResult::FatalExternalError;
         return;
     };
+
+    // EIP-1706 Disable SSTORE with gasleft lower than call stipend
+    if SPEC::SPEC_ID.is_enabled_in(ISTANBUL) && interpreter.gas.remaining() <= CALL_STIPEND {
+        interpreter.instruction_result = InstructionResult::ReentrancySentryOOG;
+        return;
+    }
     gas_or_fail!(interpreter, {
-        let remaining_gas = interpreter.gas.remaining();
-        gas::sstore_cost(
-            SPEC::SPEC_ID,
-            &state_load.data,
-            remaining_gas,
-            state_load.is_cold,
-        )
+        gas::sstore_cost(SPEC::SPEC_ID, &state_load.data, state_load.is_cold)
     });
     refund!(
         interpreter,

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -142,9 +142,7 @@ pub fn sstore<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host:
         interpreter.instruction_result = InstructionResult::ReentrancySentryOOG;
         return;
     }
-    gas_or_fail!(interpreter, {
-        gas::sstore_cost(SPEC::SPEC_ID, &state_load.data, state_load.is_cold)
-    });
+    gas::sstore_cost(SPEC::SPEC_ID, &state_load.data, state_load.is_cold);
     refund!(
         interpreter,
         gas::sstore_refund(SPEC::SPEC_ID, &state_load.data)

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -142,7 +142,10 @@ pub fn sstore<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host:
         interpreter.instruction_result = InstructionResult::ReentrancySentryOOG;
         return;
     }
-    gas::sstore_cost(SPEC::SPEC_ID, &state_load.data, state_load.is_cold);
+    gas!(
+        interpreter,
+        gas::sstore_cost(SPEC::SPEC_ID, &state_load.data, state_load.is_cold)
+    );
     refund!(
         interpreter,
         gas::sstore_refund(SPEC::SPEC_ID, &state_load.data)

--- a/crates/interpreter/src/instructions/macros.rs
+++ b/crates/interpreter/src/instructions/macros.rs
@@ -250,7 +250,7 @@ macro_rules! pop_top {
 /// Pushes `B256` values onto the stack. Fails the instruction if the stack is full.
 #[macro_export]
 macro_rules! push_b256 {
-	($interp:expr, $($x:expr),* $(,)?) => ($(
+    ($interp:expr, $($x:expr),* $(,)?) => ($(
         match $interp.stack.push_b256($x) {
             Ok(()) => {},
             Err(e) => {

--- a/crates/wiring/src/result.rs
+++ b/crates/wiring/src/result.rs
@@ -463,4 +463,6 @@ pub enum OutOfGasError {
     // When performing something that takes a U256 and casts down to a u64, if its too large this would fire
     // i.e. in `as_usize_or_fail`
     InvalidOperand,
+    // When performing SSTORE the gasleft is less than or equal to 2300
+    ReentrancySentry,
 }


### PR DESCRIPTION
Currently reth's trace results 

Geth returns a special oog error when gasleft in sstore < 2300, https://github.com/ethereum/go-ethereum/blob/564b6161637fe7e7c28e7c10a1f1978a22861bd2/core/vm/gas_table.go#L184-L188, 

```go
func gasSStoreEIP2200(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
	// If we fail the minimum gas availability invariant, fail (0)
	if contract.Gas <= params.SstoreSentryGasEIP2200 {
		return 0, errors.New("not enough gas for reentrancy sentry")
	}
```

so the trace result of reth's is differ to geth's, eg this tx: https://etherscan.io/tx/0x87a19142a638f981a923a6b76859cd4a6d443c430435a1aedf5c9cb35c955768


diff as below: 
<img width="1611" alt="image" src="https://github.com/user-attachments/assets/0e44325c-aa0d-4c4a-a11f-e30d11fe1dd6">


