### PR TITLE
fix: error type return on `modexp`'s exp overflow

### DIFF
--- a/crates/precompile/src/modexp.rs
+++ b/crates/precompile/src/modexp.rs
@@ -79,7 +79,7 @@ where
 
     // Cast exponent length to usize, since it does not make sense to handle larger values.
     let Ok(exp_len) = usize::try_from(exp_len) else {
-        return Err(PrecompileError::ModexpModOverflow.into());
+        return Err(PrecompileError::ModexpExpOverflow.into());
     };
 
     // Used to extract ADJUSTED_EXPONENT_LENGTH.


### PR DESCRIPTION
Closes #1796.

Just replaces `PrecompileError` return variant.