### PR TITLE
fix: make macro crate-agnostic

### DIFF
--- a/crates/interpreter/src/instruction_result.rs
+++ b/crates/interpreter/src/instruction_result.rs
@@ -151,58 +151,58 @@ impl From<HaltReason> for InstructionResult {
 #[macro_export]
 macro_rules! return_ok {
     () => {
-        InstructionResult::Continue
-            | InstructionResult::Stop
-            | InstructionResult::Return
-            | InstructionResult::SelfDestruct
-            | InstructionResult::ReturnContract
+        $crate::InstructionResult::Continue
+            | $crate::InstructionResult::Stop
+            | $crate::InstructionResult::Return
+            | $crate::InstructionResult::SelfDestruct
+            | $crate::InstructionResult::ReturnContract
     };
 }
 
 #[macro_export]
 macro_rules! return_revert {
     () => {
-        InstructionResult::Revert
-            | InstructionResult::CallTooDeep
-            | InstructionResult::OutOfFunds
-            | InstructionResult::InvalidEOFInitCode
-            | InstructionResult::CreateInitCodeStartingEF00
-            | InstructionResult::InvalidExtDelegateCallTarget
+        $crate::InstructionResult::Revert
+            | $crate::InstructionResult::CallTooDeep
+            | $crate::InstructionResult::OutOfFunds
+            | $crate::InstructionResult::InvalidEOFInitCode
+            | $crate::InstructionResult::CreateInitCodeStartingEF00
+            | $crate::InstructionResult::InvalidExtDelegateCallTarget
     };
 }
 
 #[macro_export]
 macro_rules! return_error {
     () => {
-        InstructionResult::OutOfGas
-            | InstructionResult::MemoryOOG
-            | InstructionResult::MemoryLimitOOG
-            | InstructionResult::PrecompileOOG
-            | InstructionResult::InvalidOperandOOG
-            | InstructionResult::ReentrancySentryOOG
-            | InstructionResult::OpcodeNotFound
-            | InstructionResult::CallNotAllowedInsideStatic
-            | InstructionResult::StateChangeDuringStaticCall
-            | InstructionResult::InvalidFEOpcode
-            | InstructionResult::InvalidJump
-            | InstructionResult::NotActivated
-            | InstructionResult::StackUnderflow
-            | InstructionResult::StackOverflow
-            | InstructionResult::OutOfOffset
-            | InstructionResult::CreateCollision
-            | InstructionResult::OverflowPayment
-            | InstructionResult::PrecompileError
-            | InstructionResult::NonceOverflow
-            | InstructionResult::CreateContractSizeLimit
-            | InstructionResult::CreateContractStartingWithEF
-            | InstructionResult::CreateInitCodeSizeLimit
-            | InstructionResult::FatalExternalError
-            | InstructionResult::ReturnContractInNotInitEOF
-            | InstructionResult::EOFOpcodeDisabledInLegacy
-            | InstructionResult::EOFFunctionStackOverflow
-            | InstructionResult::EofAuxDataTooSmall
-            | InstructionResult::EofAuxDataOverflow
-            | InstructionResult::InvalidEXTCALLTarget
+        $crate::InstructionResult::OutOfGas
+            | $crate::InstructionResult::MemoryOOG
+            | $crate::InstructionResult::MemoryLimitOOG
+            | $crate::InstructionResult::PrecompileOOG
+            | $crate::InstructionResult::InvalidOperandOOG
+            | $crate::InstructionResult::ReentrancySentryOOG
+            | $crate::InstructionResult::OpcodeNotFound
+            | $crate::InstructionResult::CallNotAllowedInsideStatic
+            | $crate::InstructionResult::StateChangeDuringStaticCall
+            | $crate::InstructionResult::InvalidFEOpcode
+            | $crate::InstructionResult::InvalidJump
+            | $crate::InstructionResult::NotActivated
+            | $crate::InstructionResult::StackUnderflow
+            | $crate::InstructionResult::StackOverflow
+            | $crate::InstructionResult::OutOfOffset
+            | $crate::InstructionResult::CreateCollision
+            | $crate::InstructionResult::OverflowPayment
+            | $crate::InstructionResult::PrecompileError
+            | $crate::InstructionResult::NonceOverflow
+            | $crate::InstructionResult::CreateContractSizeLimit
+            | $crate::InstructionResult::CreateContractStartingWithEF
+            | $crate::InstructionResult::CreateInitCodeSizeLimit
+            | $crate::InstructionResult::FatalExternalError
+            | $crate::InstructionResult::ReturnContractInNotInitEOF
+            | $crate::InstructionResult::EOFOpcodeDisabledInLegacy
+            | $crate::InstructionResult::EOFFunctionStackOverflow
+            | $crate::InstructionResult::EofAuxDataTooSmall
+            | $crate::InstructionResult::EofAuxDataOverflow
+            | $crate::InstructionResult::InvalidEXTCALLTarget
     };
 }
 

--- a/crates/optimism/src/handler_register.rs
+++ b/crates/optimism/src/handler_register.rs
@@ -12,7 +12,7 @@ use revm::{
         mainnet::{self, deduct_caller_inner},
         register::EvmHandler,
     },
-    interpreter::{return_ok, return_revert, Gas, InstructionResult},
+    interpreter::{return_ok, return_revert, Gas},
     precompile::{secp256r1, PrecompileSpecId},
     primitives::{HashMap, U256},
     state::Account,
@@ -432,7 +432,7 @@ mod tests {
     use database::InMemoryDB;
     use revm::{
         database_interface::EmptyDB,
-        interpreter::{CallOutcome, InterpreterResult},
+        interpreter::{CallOutcome, InstructionResult, InterpreterResult},
         primitives::{bytes, Address, Bytes, B256},
         state::AccountInfo,
     };

--- a/crates/revm/src/handler/mainnet/execution.rs
+++ b/crates/revm/src/handler/mainnet/execution.rs
@@ -5,8 +5,8 @@ use crate::{
 use core::mem;
 use interpreter::{
     return_ok, return_revert, table::InstructionTables, CallInputs, CallOutcome, CreateInputs,
-    CreateOutcome, EOFCreateInputs, Gas, InstructionResult, InterpreterAction, InterpreterResult,
-    SharedMemory, EMPTY_SHARED_MEMORY,
+    CreateOutcome, EOFCreateInputs, Gas, InterpreterAction, InterpreterResult, SharedMemory,
+    EMPTY_SHARED_MEMORY,
 };
 use specification::hardfork::Spec;
 use std::boxed::Box;
@@ -194,6 +194,7 @@ pub fn insert_eofcreate_outcome<EvmWiringT: EvmWiring>(
 mod tests {
     use super::*;
     use crate::handler::mainnet::refund;
+    use interpreter::InstructionResult;
     use primitives::Bytes;
     use specification::hardfork::CancunSpec;
     use wiring::{default::EnvWiring, DefaultEthereumWiring};


### PR DESCRIPTION
This allows usage of the macros in external crates without needing to include `InstructionResult` beforehand.