### PR TITLE
chore: inline more `AccountInfo` fns and add docs

### DIFF
--- a/crates/state/src/account_info.rs
+++ b/crates/state/src/account_info.rs
@@ -45,6 +45,8 @@ impl Hash for AccountInfo {
 }
 
 impl AccountInfo {
+    /// Creates a new [`AccountInfo`] with the given fields.
+    #[inline]
     pub fn new(balance: U256, nonce: u64, code_hash: B256, code: Bytecode) -> Self {
         Self {
             balance,
@@ -63,6 +65,7 @@ impl AccountInfo {
     /// This is distinct from [`AccountInfo::without_code`] in that it returns
     /// a new `AccountInfo` instance with the code removed.
     /// [`AccountInfo::without_code`] will modify and return the same instance.
+    #[inline]
     pub fn copy_without_code(&self) -> Self {
         Self {
             balance: self.balance,
@@ -92,23 +95,27 @@ impl AccountInfo {
     /// - code hash is zero or set to the Keccak256 hash of the empty string `""`
     /// - balance is zero
     /// - nonce is zero
+    #[inline]
     pub fn is_empty(&self) -> bool {
         let code_empty = self.is_empty_code_hash() || self.code_hash.is_zero();
         code_empty && self.balance.is_zero() && self.nonce == 0
     }
 
     /// Returns `true` if the account is not empty.
+    #[inline]
     pub fn exists(&self) -> bool {
         !self.is_empty()
     }
 
     /// Returns `true` if account has no nonce and code.
+    #[inline]
     pub fn has_no_code_and_nonce(&self) -> bool {
         self.is_empty_code_hash() && self.nonce == 0
     }
 
     /// Return bytecode hash associated with this account.
     /// If account does not have code, it returns `KECCAK_EMPTY` hash.
+    #[inline]
     pub fn code_hash(&self) -> B256 {
         self.code_hash
     }
@@ -120,10 +127,14 @@ impl AccountInfo {
     }
 
     /// Take bytecode from account. Code will be set to None.
+    #[inline]
     pub fn take_bytecode(&mut self) -> Option<Bytecode> {
         self.code.take()
     }
 
+    /// Initialize an [`AccountInfo`] with the given balance, setting all other fields to their
+    /// default values.
+    #[inline]
     pub fn from_balance(balance: U256) -> Self {
         AccountInfo {
             balance,
@@ -131,6 +142,9 @@ impl AccountInfo {
         }
     }
 
+    /// Initialize an [`AccountInfo`] with the given bytecode, setting its balance to zero, its
+    /// nonce to `1`, and calculating the code hash from the given bytecode.
+    #[inline]
     pub fn from_bytecode(bytecode: Bytecode) -> Self {
         let hash = bytecode.hash_slow();
 


### PR DESCRIPTION
Adds more docs for `AccountInfo` constructors and inlines the rest of its pub functions