### PR TITLE
feat(EIP-7702): devnet-4 changes

### DIFF
--- a/crates/primitives/src/eip7702.rs
+++ b/crates/primitives/src/eip7702.rs
@@ -11,7 +11,7 @@ pub use bytecode::{
 };
 
 // Base cost of updating authorized account.
-pub const PER_AUTH_BASE_COST: u64 = 2500;
+pub const PER_AUTH_BASE_COST: u64 = 12500;
 
 /// Cost of creating authorized account that was previously empty.
 pub const PER_EMPTY_ACCOUNT_COST: u64 = 25000;
@@ -20,7 +20,7 @@ pub const PER_EMPTY_ACCOUNT_COST: u64 = 25000;
 /// to EIP-2 should have an S value less than or equal to this.
 ///
 /// `57896044618658097711785492504343953926418782139537452191302581570759080747168`
-const SECP256K1N_HALF: U256 = U256::from_be_bytes([
+pub const SECP256K1N_HALF: U256 = U256::from_be_bytes([
     0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
     0x5D, 0x57, 0x6E, 0x73, 0x57, 0xA4, 0x50, 0x1D, 0xDF, 0xE9, 0x2F, 0x46, 0x68, 0x1B, 0x20, 0xA0,
 ]);

--- a/crates/primitives/src/eip7702/authorization_list.rs
+++ b/crates/primitives/src/eip7702/authorization_list.rs
@@ -1,7 +1,6 @@
 pub use alloy_eip7702::{Authorization, SignedAuthorization};
 pub use alloy_primitives::{Parity, Signature};
 
-use super::SECP256K1N_HALF;
 use crate::Address;
 use core::{fmt, ops::Deref};
 use std::{boxed::Box, vec::Vec};
@@ -33,40 +32,6 @@ impl AuthorizationList {
             Self::Signed(signed) => signed.len(),
             Self::Recovered(recovered) => recovered.len(),
         }
-    }
-
-    /// Returns true if the authorization list is valid.
-    pub fn is_valid(&self, _chain_id: u64) -> Result<(), InvalidAuthorization> {
-        let validate = |auth: &SignedAuthorization| -> Result<(), InvalidAuthorization> {
-            // TODO Eip7702. Check chain_id
-            // Pending: https://github.com/ethereum/EIPs/pull/8833/files
-            // let auth_chain_id: u64 = auth.chain_id().try_into().unwrap_or(u64::MAX);
-            // if auth_chain_id != 0 && auth_chain_id != chain_id {
-            //     return Err(InvalidAuthorization::InvalidChainId);
-            // }
-
-            // Check y_parity, Parity::Parity means that it was 0 or 1.
-            if !matches!(auth.signature().v(), Parity::Parity(_)) {
-                return Err(InvalidAuthorization::InvalidYParity);
-            }
-
-            // Check s-value
-            if auth.signature().s() > SECP256K1N_HALF {
-                return Err(InvalidAuthorization::Eip2InvalidSValue);
-            }
-
-            Ok(())
-        };
-
-        match self {
-            Self::Signed(signed) => signed.iter().try_for_each(validate)?,
-            Self::Recovered(recovered) => recovered
-                .iter()
-                .map(|recovered| &recovered.inner)
-                .try_for_each(validate)?,
-        };
-
-        Ok(())
     }
 
     /// Return empty authorization list.

--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -202,9 +202,6 @@ impl Env {
                 return Err(InvalidTransaction::EmptyAuthorizationList);
             }
 
-            // Check validity of authorization_list
-            auth_list.is_valid(self.cfg.chain_id)?;
-
             // Check if other fields are unset.
             if self.tx.max_fee_per_blob_gas.is_some() || !self.tx.blob_hashes.is_empty() {
                 return Err(InvalidTransaction::AuthorizationListInvalidFields);

--- a/crates/revm/src/handler/mainnet/pre_execution.rs
+++ b/crates/revm/src/handler/mainnet/pre_execution.rs
@@ -8,7 +8,7 @@ use crate::{
         db::Database,
         eip7702, Account, Bytecode, EVMError, Env, Spec,
         SpecId::{CANCUN, PRAGUE, SHANGHAI},
-        TxKind, BLOCKHASH_STORAGE_ADDRESS, U256,
+        TxKind, BLOCKHASH_STORAGE_ADDRESS, KECCAK_EMPTY, U256,
     },
     Context, ContextPrecompiles,
 };
@@ -114,28 +114,33 @@ pub fn apply_eip7702_auth_list<SPEC: Spec, EXT, DB: Database>(
 
     let mut refunded_accounts = 0;
     for authorization in authorization_list.recovered_iter() {
-        // 1. recover authority and authorized addresses.
-        // authority = ecrecover(keccak(MAGIC || rlp([chain_id, address, nonce])), y_parity, r, s]
-        let Some(authority) = authorization.authority() else {
-            continue;
-        };
-
-        // 2. Verify the chain id is either 0 or the chain's current ID.
+        // 1. Verify the chain id is either 0 or the chain's current ID.
         if !authorization.chain_id().is_zero()
             && authorization.chain_id() != U256::from(context.evm.inner.env.cfg.chain_id)
         {
             continue;
         }
 
+        // 2. Verify the `nonce` is less than `2**64 - 1`.
+        if authorization.nonce() < u64::MAX {
+            continue;
+        }
+
+        // recover authority and authorized addresses.
+        // 3. `authority = ecrecover(keccak(MAGIC || rlp([chain_id, address, nonce])), y_parity, r, s]`
+        let Some(authority) = authorization.authority() else {
+            continue;
+        };
+
         // warm authority account and check nonce.
-        // 3. Add authority to accessed_addresses (as defined in EIP-2929.)
+        // 4. Add `authority` to `accessed_addresses` (as defined in [EIP-2929](./eip-2929.md).)
         let mut authority_acc = context
             .evm
             .inner
             .journaled_state
             .load_code(authority, &mut context.evm.inner.db)?;
 
-        // 4. Verify the code of authority is either empty or already delegated.
+        // 5. Verify the code of `authority` is either empty or already delegated.
         if let Some(bytecode) = &authority_acc.info.code {
             // if it is not empty and it is not eip7702
             if !bytecode.is_empty() && !bytecode.is_eip7702() {
@@ -143,22 +148,29 @@ pub fn apply_eip7702_auth_list<SPEC: Spec, EXT, DB: Database>(
             }
         }
 
-        // 5. Verify the nonce of authority is equal to nonce.
+        // 6. Verify the nonce of `authority` is equal to `nonce`. In case `authority` does not exist in the trie, verify that `nonce` is equal to `0`.
         if authorization.nonce() != authority_acc.info.nonce {
             continue;
         }
 
-        // 6. Refund the sender PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST gas if authority exists in the trie.
+        // 7. Add `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST` gas to the global refund counter if `authority` exists in the trie.
         if !authority_acc.is_empty() {
             refunded_accounts += 1;
         }
 
-        // 7. Set the code of authority to be 0xef0100 || address. This is a delegation designation.
-        let bytecode = Bytecode::new_eip7702(authorization.address);
-        authority_acc.info.code_hash = bytecode.hash_slow();
+        // 8. Set the code of `authority` to be `0xef0100 || address`. This is a delegation designation.
+        //  * As a special case, if `address` is `0x0000000000000000000000000000000000000000` do not write the designation. Clear the accounts code and reset the account's code hash to the empty hash `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`.
+        let (bytecode, hash) = if authorization.address.is_zero() {
+            (Bytecode::default(), KECCAK_EMPTY)
+        } else {
+            let bytecode = Bytecode::new_eip7702(authorization.address);
+            let hash = bytecode.hash_slow();
+            (bytecode, hash)
+        };
+        authority_acc.info.code_hash = hash;
         authority_acc.info.code = Some(bytecode);
 
-        // 8. Increase the nonce of authority by one.
+        // 9. Increase the nonce of `authority` by one.
         authority_acc.info.nonce = authority_acc.info.nonce.saturating_add(1);
         authority_acc.mark_touch();
     }


### PR DESCRIPTION
* EIP-7702 field validation was removed:
  * There is edge case for parity as it is specified as `assert auth.y_parity < 2**8`, alloy signature use u64 for parity.
* New gas specified.  (First here: https://github.com/ethereum/EIPs/commit/8628167f34d9022380db5039a0e9d483888d5c4a than revised here: https://github.com/ethereum/EIPs/commit/0b5d3a653b27cd473d2a66269d878fca55c1e8a5) 
* Clear the accounts code is added for address `0x00...000`
