### PR TITLE
Chore: some no_std cleanup

### DIFF
--- a/crates/bytecode/src/eof/printer.rs
+++ b/crates/bytecode/src/eof/printer.rs
@@ -1,4 +1,5 @@
-#[cfg(feature = "std")]
+#![cfg(feature = "std")]
+
 pub fn print(code: &[u8]) {
     use crate::{opcode::*, utils::read_i16};
     use primitives::hex;
@@ -60,7 +61,6 @@ pub fn print(code: &[u8]) {
 mod test {
     use primitives::hex;
 
-    #[cfg(feature = "std")]
     #[test]
     fn sanity_test() {
         super::print(&hex!("6001e200ffff00"));

--- a/crates/revm/src/builder.rs
+++ b/crates/revm/src/builder.rs
@@ -463,13 +463,16 @@ where
 
 #[cfg(test)]
 mod test {
+    extern crate alloc;
+
     use crate::{Context, Evm};
+    use alloc::{boxed::Box, rc::Rc};
     use bytecode::Bytecode;
+    use core::cell::RefCell;
     use database::InMemoryDB;
     use interpreter::Interpreter;
     use primitives::{address, TxKind, U256};
     use state::AccountInfo;
-    use std::{cell::RefCell, rc::Rc};
     use wiring::EthereumWiring;
 
     /// Custom evm context

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -168,6 +168,9 @@ impl<'a, EvmWiringT: EvmWiring> EvmHandler<'a, EvmWiringT> {
 
 #[cfg(test)]
 mod test {
+    extern crate alloc;
+
+    use alloc::boxed::Box;
     use core::cell::RefCell;
     use database_interface::EmptyDB;
     use std::{rc::Rc, sync::Arc};

--- a/crates/wiring/src/result.rs
+++ b/crates/wiring/src/result.rs
@@ -185,14 +185,13 @@ impl<DBError, TransactionValidationErrorT> EVMError<DBError, TransactionValidati
     }
 }
 
-#[cfg(feature = "std")]
-impl<DBError, TransactionValidationErrorT> std::error::Error
+impl<DBError, TransactionValidationErrorT> core::error::Error
     for EVMError<DBError, TransactionValidationErrorT>
 where
-    DBError: std::error::Error + 'static,
-    TransactionValidationErrorT: std::error::Error + 'static,
+    DBError: core::error::Error + 'static,
+    TransactionValidationErrorT: core::error::Error + 'static,
 {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
             Self::Transaction(e) => Some(e),
             Self::Header(e) => Some(e),


### PR DESCRIPTION

- moves `printer` cfg flag to module level, instead of annotating every item in the module
- adds some missing imports to tests in `no_std`
- changes an impl from feature-gated `std::error::Error` to non-gated `core::error::Error`