### PR TITLE
refactor: make stricter database trait bounds for user ergonomics

### DIFF
--- a/crates/database/interface/Cargo.toml
+++ b/crates/database/interface/Cargo.toml
@@ -34,7 +34,7 @@ serde = { version = "1.0", default-features = false, features = [
 ], optional = true }
 
 # asyncdb
-tokio = { version = "1.40", optional = true }
+tokio = { version = "1.40", optional = true, features = ["rt", "rt-multi-thread"] }
 
 
 [dev-dependencies]

--- a/crates/database/interface/src/async_db.rs
+++ b/crates/database/interface/src/async_db.rs
@@ -13,7 +13,7 @@ use crate::{Database, DatabaseRef};
 /// Use [WrapDatabaseAsync] to provide [Database] implementation for a type that only implements this trait.
 pub trait DatabaseAsync {
     /// The database error type.
-    type Error: Send;
+    type Error: core::error::Error + Send;
 
     /// Get basic account information.
     fn basic_async(
@@ -48,7 +48,7 @@ pub trait DatabaseAsync {
 /// Use [WrapDatabaseAsync] to provide [DatabaseRef] implementation for a type that only implements this trait.
 pub trait DatabaseAsyncRef {
     /// The database error type.
-    type Error: Send;
+    type Error: core::error::Error + Send;
 
     /// Get basic account information.
     fn basic_async_ref(

--- a/crates/database/interface/src/empty_db.rs
+++ b/crates/database/interface/src/empty_db.rs
@@ -52,7 +52,7 @@ impl<E> EmptyDBTyped<E> {
     }
 }
 
-impl<E> Database for EmptyDBTyped<E> {
+impl<E: core::error::Error> Database for EmptyDBTyped<E> {
     type Error = E;
 
     #[inline]
@@ -76,7 +76,7 @@ impl<E> Database for EmptyDBTyped<E> {
     }
 }
 
-impl<E> DatabaseRef for EmptyDBTyped<E> {
+impl<E: core::error::Error> DatabaseRef for EmptyDBTyped<E> {
     type Error = E;
 
     #[inline]

--- a/crates/database/interface/src/lib.rs
+++ b/crates/database/interface/src/lib.rs
@@ -21,7 +21,7 @@ pub use empty_db::{EmptyDB, EmptyDBTyped};
 #[auto_impl(&mut, Box)]
 pub trait Database {
     /// The database error type.
-    type Error;
+    type Error: core::error::Error;
 
     /// Get basic account information.
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error>;
@@ -38,7 +38,7 @@ pub trait Database {
 
 /// EVM database commit interface.
 #[auto_impl(&mut, Box)]
-pub trait DatabaseCommit {
+pub trait DatabaseCommit: Database {
     /// Commit changes to the database.
     fn commit(&mut self, changes: HashMap<Address, Account>);
 }
@@ -52,7 +52,7 @@ pub trait DatabaseCommit {
 #[auto_impl(&, &mut, Box, Rc, Arc)]
 pub trait DatabaseRef {
     /// The database error type.
-    type Error;
+    type Error: core::error::Error;
 
     /// Get basic account information.
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error>;

--- a/crates/database/src/in_memory_db.rs
+++ b/crates/database/src/in_memory_db.rs
@@ -125,7 +125,7 @@ impl<ExtDB: DatabaseRef> CacheDB<ExtDB> {
     }
 }
 
-impl<ExtDB> DatabaseCommit for CacheDB<ExtDB> {
+impl<ExtDB: DatabaseRef> DatabaseCommit for CacheDB<ExtDB> {
     fn commit(&mut self, changes: HashMap<Address, Account>) {
         for (address, mut account) in changes {
             if !account.is_touched() {

--- a/crates/database/src/states/state_builder.rs
+++ b/crates/database/src/states/state_builder.rs
@@ -81,7 +81,7 @@ impl<DB: Database> StateBuilder<DB> {
     }
 
     /// With boxed version of database.
-    pub fn with_database_boxed<Error>(
+    pub fn with_database_boxed<Error: core::error::Error>(
         self,
         database: DBBox<'_, Error>,
     ) -> StateBuilder<DBBox<'_, Error>> {

--- a/examples/database_components/src/block_hash.rs
+++ b/examples/database_components/src/block_hash.rs
@@ -42,23 +42,3 @@ where
         self.deref().block_hash(number)
     }
 }
-
-/// Wraps a [`BlockHashRef`] to provide a [`BlockHash`] implementation.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct WrapBlockHashRef<T: BlockHashRef>(pub T);
-
-impl<F: BlockHashRef> From<F> for WrapBlockHashRef<F> {
-    #[inline]
-    fn from(f: F) -> Self {
-        WrapBlockHashRef(f)
-    }
-}
-
-impl<T: BlockHashRef> BlockHash for WrapBlockHashRef<T> {
-    type Error = T::Error;
-
-    #[inline]
-    fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error> {
-        self.0.block_hash(number)
-    }
-}

--- a/examples/database_components/src/lib.rs
+++ b/examples/database_components/src/lib.rs
@@ -4,7 +4,6 @@
 pub mod block_hash;
 pub mod state;
 
-use block_hash::WrapBlockHashRef;
 pub use block_hash::{BlockHash, BlockHashRef};
 pub use state::{State, StateRef};
 
@@ -72,7 +71,7 @@ impl<S: State, BH: BlockHashRef> Database for DatabaseComponents<S, BH> {
     }
 
     fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error> {
-        WrapBlockHashRef(&self.block_hash)
+        self.block_hash
             .block_hash(number)
             .map_err(Self::Error::BlockHash)
     }

--- a/examples/database_components/src/state.rs
+++ b/examples/database_components/src/state.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 #[auto_impl(&mut, Box)]
 pub trait State {
-    type Error;
+    type Error: core::error::Error + 'static;
 
     /// Get basic account information.
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error>;
@@ -24,7 +24,7 @@ pub trait State {
 
 #[auto_impl(&, &mut, Box, Rc, Arc)]
 pub trait StateRef {
-    type Error;
+    type Error: core::error::Error + 'static;
 
     /// Get basic account information.
     fn basic(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error>;


### PR DESCRIPTION
Two quick ergonomics changes for downstream users. Intended to simplify bounds writing

This is a breaking change, as downstream implementors of these traits may need to be updated

----

## `Error` bounds for database errors

Adds an error bound for `Database::Error` and `DatabaseRef::Error`, and the async versions. This closes #1674. This prevents propagation of complex bounds for upstream wrapper structs, particularly error types that might wrap EVM output. 

motivation: 
simplify bounds writing for users by ensuring they don't need to manually write out error bounds. This is particulartly a problem when holding an instance of `EVMError<Db>`

Before:
```rust
use revm::{primitives::EVMError, Database};

pub struct Error<Db: Database<Error: core::error::Error>>(EVMError<Db::Error>);

impl<Db: Database<Error: core::error::Error>> From<EVMError<Db::Error>> for Error<Db>
{
    fn from(e: EVMError<Db::Error>) -> Self {
        Self(e)
    }
}

impl<Db: Database<Error: core::error::Error>> core::error::Error for Error<Db> {
    fn source(&self) -> Option<&(dyn Error + 'static)> {
        Some(&self.0)
    }
}
```

After:
```rust
use revm::{primitives::EVMError, Database};

pub struct Error<Db: Database>(EVMError<Db::Error>);

impl<Db> From<EVMError<Db::Error>> for Error<Db>
where
    Db: Database,
{
    fn from(e: EVMError<Db::Error>) -> Self {
        Self(e)
    }
}

impl<Db: Database> core::error::Error for Error<Db> {
    fn source(&self) -> Option<&(dyn Error + 'static)> {
        Some(&self.0)
    }
}
```

----

##  Add `Database` as a supertrait of `DatabaseCommit`

This does not close a current issue, but I'm happy to make one. This causes some bounds changes in the `database_components` examples

motivation: simplify bounds writing for users by allowing them to avoid specifying `Database`

alternate approach: a `trait CommitableDatabase: Database + DatabaseCommit` with a blanket `impl<T> CommittableDatabase for T where T: Database + DatabaseCommit`

Code before:
```rust
use revm::{Database, DatabaseCommit};
pub fn make_writable_evm<Db: Database + DatabaseCommit>(db: Db) -> Evm<'static, (), Db> { ... } 
```

Code after:
```rust
use revm::{DatabaseCommit};
pub fn make_writable_evm<Db: DatabaseCommit>(db: Db) -> Evm<'static, (), Db> { ... } 
```

----

## Add `WrapBlockHashRef` to example

Add a wrapper struct like `WrapDatabaseRef` to `BlockHashRef` to allow relaxing the bounds on the database components in the `database_components` example

----

Drive-by:
The asyncdb is cfged out when running `cargo c --all-features`. And running `cargo c -p revm-database-interface --features asyncdb` produced compilation errors due to disabled tokio features. I have enabled the necessary features. When running with `--workspace` it appears some other package enabled the features, and covered up the dep specification issue