### PR TITLE
chore: bump alloy-eip7702 and remove `Parity` re-export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,18 @@ checksum = "c15873ee28dfe5a1aeddd762483bc7f378b465ec49bdce8165c4c46b4f55cb0a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "derive_more 1.0.0",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fb9fd842fdf10a524bbf2c4de6942ad869c1c8c3d128a1b09e67ed5f7cedbd"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
  "arbitrary",
  "derive_more 1.0.0",
  "k256",
@@ -117,7 +129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "769da342b6bcd945013925ef4c40763cc82f11e002c60702dba8b444bb60e5a7"
 dependencies = [
  "alloy-eip2930",
- "alloy-eip7702",
+ "alloy-eip7702 0.3.1",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
@@ -190,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f35429a652765189c1c5092870d8360ee7b7769b09b06d89ebaefd34676446"
+checksum = "8edae627382349b56cd6a7a2106f4fd69b243a9233e560c55c2e03cabb7e1d3c"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -3240,7 +3252,7 @@ name = "revm-primitives"
 version = "13.0.0"
 dependencies = [
  "alloy-eip2930",
- "alloy-eip7702",
+ "alloy-eip7702 0.4.0",
  "alloy-primitives",
  "auto_impl",
  "bitflags 2.6.0",

--- a/crates/interpreter/src/opcode/tables.rs
+++ b/crates/interpreter/src/opcode/tables.rs
@@ -27,7 +27,7 @@ pub enum InstructionTables<'a, H: ?Sized> {
     Boxed(BoxedInstructionTable<'a, H>),
 }
 
-impl<'a, H: Host + ?Sized> InstructionTables<'a, H> {
+impl<H: Host + ?Sized> InstructionTables<'_, H> {
     /// Creates a plain instruction table for the given spec. See [`make_instruction_table`].
     #[inline]
     pub const fn new_plain<SPEC: Spec>() -> Self {

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -41,7 +41,7 @@ use once_cell::race::OnceBox;
 use std::{boxed::Box, vec::Vec};
 
 pub fn calc_linear_cost_u32(len: usize, base: u64, word: u64) -> u64 {
-    (len as u64 + 32 - 1) / 32 * word + base
+    (len as u64).div_ceil(32) * word + base
 }
 
 #[derive(Clone, Default, Debug)]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -24,7 +24,7 @@ all = "warn"
 [dependencies]
 # alloy
 alloy-eip2930 = { version = "0.1", default-features = false }
-alloy-eip7702 = { version = "0.3", default-features = false, features = [
+alloy-eip7702 = { version = "0.4", default-features = false, features = [
     "k256",
 ] }
 alloy-primitives = { version = "0.8.8", default-features = false, features = [

--- a/crates/primitives/src/eip7702/authorization_list.rs
+++ b/crates/primitives/src/eip7702/authorization_list.rs
@@ -1,7 +1,7 @@
 pub use alloy_eip7702::{
     Authorization, RecoveredAuthority, RecoveredAuthorization, SignedAuthorization,
 };
-pub use alloy_primitives::{Parity, Signature};
+pub use alloy_primitives::Signature;
 
 use std::{boxed::Box, vec::Vec};
 

--- a/crates/revm/src/handler/handle_types/execution.rs
+++ b/crates/revm/src/handler/handle_types/execution.rs
@@ -162,7 +162,7 @@ impl<'a, EXT: 'a, DB: Database + 'a> ExecutionHandler<'a, EXT, DB> {
     }
 }
 
-impl<'a, EXT, DB: Database> ExecutionHandler<'a, EXT, DB> {
+impl<EXT, DB: Database> ExecutionHandler<'_, EXT, DB> {
     /// Executes single frame.
     #[inline]
     pub fn execute_frame(

--- a/crates/revm/src/handler/handle_types/post_execution.rs
+++ b/crates/revm/src/handler/handle_types/post_execution.rs
@@ -74,7 +74,7 @@ impl<'a, EXT: 'a, DB: Database + 'a> PostExecutionHandler<'a, EXT, DB> {
     }
 }
 
-impl<'a, EXT, DB: Database> PostExecutionHandler<'a, EXT, DB> {
+impl<EXT, DB: Database> PostExecutionHandler<'_, EXT, DB> {
     /// Calculate final refund
     pub fn refund(&self, context: &mut Context<EXT, DB>, gas: &mut Gas, eip7702_refund: i64) {
         (self.refund)(context, gas, eip7702_refund)

--- a/crates/revm/src/handler/handle_types/pre_execution.rs
+++ b/crates/revm/src/handler/handle_types/pre_execution.rs
@@ -45,7 +45,7 @@ impl<'a, EXT: 'a, DB: Database + 'a> PreExecutionHandler<'a, EXT, DB> {
     }
 }
 
-impl<'a, EXT, DB: Database> PreExecutionHandler<'a, EXT, DB> {
+impl<EXT, DB: Database> PreExecutionHandler<'_, EXT, DB> {
     /// Deduct caller to its limit.
     pub fn deduct_caller(&self, context: &mut Context<EXT, DB>) -> Result<(), EVMError<DB::Error>> {
         (self.deduct_caller)(context)

--- a/crates/revm/src/handler/handle_types/validation.rs
+++ b/crates/revm/src/handler/handle_types/validation.rs
@@ -39,7 +39,7 @@ impl<'a, EXT: 'a, DB: Database + 'a> ValidationHandler<'a, EXT, DB> {
     }
 }
 
-impl<'a, EXT, DB: Database> ValidationHandler<'a, EXT, DB> {
+impl<EXT, DB: Database> ValidationHandler<'_, EXT, DB> {
     /// Validate env.
     pub fn env(&self, env: &Env) -> Result<(), EVMError<DB::Error>> {
         (self.env)(env)


### PR DESCRIPTION
This enum will no longer exist after https://github.com/alloy-rs/core/pull/796

Also fixed some clippy lints