### PR TITLE
perf(precompile): use secp256k1 global context for ecrecover

### DIFF
--- a/crates/precompile/src/secp256k1.rs
+++ b/crates/precompile/src/secp256k1.rs
@@ -49,7 +49,7 @@ mod secp256k1 {
     use primitives::{alloy_primitives::B512, keccak256, B256};
     use secp256k1::{
         ecdsa::{RecoverableSignature, RecoveryId},
-        Message, Secp256k1,
+        Message, SECP256K1,
     };
 
     // Silence the unused crate dependency warning.
@@ -59,7 +59,7 @@ mod secp256k1 {
         let recid = RecoveryId::from_i32(recid as i32).expect("recovery ID is valid");
         let sig = RecoverableSignature::from_compact(sig.as_slice(), recid)?;
 
-        let secp = Secp256k1::new();
+        let secp = &SECP256K1;
         let msg = Message::from_digest(msg.0);
         let public = secp.recover_ecdsa(&msg, &sig)?;
 

--- a/crates/precompile/src/secp256k1.rs
+++ b/crates/precompile/src/secp256k1.rs
@@ -59,9 +59,8 @@ mod secp256k1 {
         let recid = RecoveryId::from_i32(recid as i32).expect("recovery ID is valid");
         let sig = RecoverableSignature::from_compact(sig.as_slice(), recid)?;
 
-        let secp = &SECP256K1;
         let msg = Message::from_digest(msg.0);
-        let public = secp.recover_ecdsa(&msg, &sig)?;
+        let public = SECP256K1.recover_ecdsa(&msg, &sig)?;
 
         let mut hash = keccak256(&public.serialize_uncompressed()[1..]);
         hash[..12].fill(0);


### PR DESCRIPTION
Initializing a new `Secp256k1` instance ever ecrecover call ends up dominating execution time, because of the randomization. This now uses the global context, avoiding randomization overhead.

Samply profiles from https://share.firefox.dev/4hwBrXj
<img width="1512" alt="Screenshot 2024-11-01 at 4 19 08 PM" src="https://github.com/user-attachments/assets/4444ab08-92f3-49ee-99ae-5cfc3c9827e4">
<img width="1512" alt="Screenshot 2024-11-01 at 4 19 39 PM" src="https://github.com/user-attachments/assets/ede99f6b-2406-4d5e-9607-0502583a98f0">
<img width="1512" alt="Screenshot 2024-11-01 at 4 21 40 PM" src="https://github.com/user-attachments/assets/d0028d8f-a8b4-4848-b8a3-94501ee6ec84">
