### PR TITLE
fix(revme): use Osaka for state test results

### DIFF
--- a/bins/revme/src/cmd/eofvalidation.rs
+++ b/bins/revme/src/cmd/eofvalidation.rs
@@ -1,6 +1,6 @@
 mod test_suite;
 
-pub use test_suite::{PragueTestResult, TestResult, TestSuite, TestUnit, TestVector};
+pub use test_suite::{OsakaTestResult, TestResult, TestSuite, TestUnit, TestVector};
 
 use crate::{cmd::Error, dir_utils::find_all_json_tests};
 use clap::Parser;
@@ -82,12 +82,12 @@ pub fn run_test(path: &Path) -> Result<(), Error> {
                     Some(CodeType::ReturnOrStop)
                 };
                 let res = validate_raw_eof_inner(test_vector.code.clone(), kind);
-                if res.is_ok() != test_vector.results.prague.result {
+                if res.is_ok() != test_vector.results.osaka.result {
                     println!(
                         "\nTest failed: {} - {}\nresult:{:?}\nrevm err_result:{:#?}\nbytes:{:?}\n",
                         name,
                         vector_name,
-                        test_vector.results.prague,
+                        test_vector.results.osaka,
                         res.as_ref().err(),
                         test_vector.code
                     );

--- a/bins/revme/src/cmd/eofvalidation/test_suite.rs
+++ b/bins/revme/src/cmd/eofvalidation/test_suite.rs
@@ -19,14 +19,14 @@ pub struct TestUnit {
 pub struct TestVector {
     pub code: Bytes,
     pub container_kind: Option<String>,
-    pub results: PragueTestResult,
+    pub results: OsakaTestResult,
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct PragueTestResult {
-    #[serde(rename = "Prague")]
-    pub prague: TestResult,
+pub struct OsakaTestResult {
+    #[serde(rename = "Osaka")]
+    pub osaka: TestResult,
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize)]


### PR DESCRIPTION
These two `ethereum/tests` commits:
https://github.com/ethereum/tests/commit/6e878dffcabab64c7b8234d8204be06cc9b48b98 (adds osaka)
https://github.com/ethereum/tests/commit/4c87ebbf024a3e9ec842bcce90564f629a3bcd82 (removes prague)

changed the result key from `Prague` to `Osaka`, so we change it here as well