### PR TITLE
feat: couple convenience functions for nested cache dbs

### DIFF
--- a/crates/database/src/in_memory_db.rs
+++ b/crates/database/src/in_memory_db.rs
@@ -39,7 +39,38 @@ impl<ExtDB: Default> Default for CacheDB<ExtDB> {
     }
 }
 
+impl<ExtDb> CacheDB<CacheDB<ExtDb>> {
+    /// Flatten a nested cache by applying the outer cache to the inner cache.
+    ///
+    /// The behavior is as follows:
+    /// - Accounts are overridden with outer accounts
+    /// - Contracts are overridden with outer contracts
+    /// - Logs are appended
+    /// - Block hashes are overridden with outer block hashes
+    pub fn flatten(self) -> CacheDB<ExtDb> {
+        let CacheDB {
+            accounts,
+            contracts,
+            logs,
+            block_hashes,
+            db: mut inner,
+        } = self;
+
+        inner.accounts.extend(accounts);
+        inner.contracts.extend(contracts);
+        inner.logs.extend(logs);
+        inner.block_hashes.extend(block_hashes);
+        inner
+    }
+
+    /// Discard the outer cache and return the inner cache.
+    pub fn discard_outer(self) -> CacheDB<ExtDb> {
+        self.db
+    }
+}
+
 impl<ExtDB> CacheDB<ExtDB> {
+    /// Create a new cache with the given external database.
     pub fn new(db: ExtDB) -> Self {
         let mut contracts = HashMap::default();
         contracts.insert(KECCAK_EMPTY, Bytecode::default());
@@ -78,6 +109,11 @@ impl<ExtDB> CacheDB<ExtDB> {
     pub fn insert_account_info(&mut self, address: Address, mut info: AccountInfo) {
         self.insert_contract(&mut info);
         self.accounts.entry(address).or_default().info = info;
+    }
+
+    /// Wrap the cache in a [CacheDB], creating a nested cache.
+    pub fn nest(self) -> CacheDB<Self> {
+        CacheDB::new(self)
     }
 }
 


### PR DESCRIPTION
Adds a couple simple convenience functions for working with nested `CacheDb` instances. No particular motivation, just seemed like sensible things to have