### PR TITLE
chore: refactor `L1BlockInfo::tx_estimated_size_fjord`

### DIFF
--- a/crates/optimism/src/fast_lz.rs
+++ b/crates/optimism/src/fast_lz.rs
@@ -1,5 +1,7 @@
 /// Returns the length of the data after compression through FastLZ, based on
-// https://github.com/Vectorized/solady/blob/5315d937d79b335c668896d7533ac603adac5315/js/solady.js
+/// <https://github.com/Vectorized/solady/blob/5315d937d79b335c668896d7533ac603adac5315/js/solady.js>
+/// The u32s match op-geth's Go port:
+/// <https://github.com/ethereum-optimism/op-geth/blob/647c346e2bef36219cc7b47d76b1cb87e7ca29e4/core/types/rollup_cost.go#L411>
 pub(crate) fn flz_compress_len(input: &[u8]) -> u32 {
     let mut idx: u32 = 2;
 

--- a/crates/optimism/src/l1block.rs
+++ b/crates/optimism/src/l1block.rs
@@ -40,6 +40,16 @@ pub const BASE_FEE_RECIPIENT: Address = address!("420000000000000000000000000000
 /// The address of the L1Block contract.
 pub const L1_BLOCK_CONTRACT: Address = address!("4200000000000000000000000000000000000015");
 
+/// <https://github.com/ethereum-optimism/op-geth/blob/647c346e2bef36219cc7b47d76b1cb87e7ca29e4/core/types/rollup_cost.go#L79>
+const L1_COST_FASTLZ_COEF: u64 = 836_500;
+
+/// <https://github.com/ethereum-optimism/op-geth/blob/647c346e2bef36219cc7b47d76b1cb87e7ca29e4/core/types/rollup_cost.go#L78>
+/// Inverted to be used with `saturating_sub`.
+const L1_COST_INTERCEPT: u64 = 42_585_600;
+
+/// <https://github.com/ethereum-optimism/op-geth/blob/647c346e2bef36219cc7b47d76b1cb87e7ca29e4/core/types/rollup_cost.go#82>
+const MIN_TX_SIZE_SCALED: u64 = 100 * 1_000_000;
+
 /// L1 block info
 ///
 /// We can extract L1 epoch data from each L2 block, by looking at the `setL1BlockValues`
@@ -161,12 +171,14 @@ impl L1BlockInfo {
     // This value is computed based on the following formula:
     // max(minTransactionSize, intercept + fastlzCoef*fastlzSize)
     fn tx_estimated_size_fjord(&self, input: &[u8]) -> U256 {
-        let fastlz_size = U256::from(flz_compress_len(input));
+        let fastlz_size = flz_compress_len(input) as u64;
 
-        fastlz_size
-            .saturating_mul(U256::from(836_500))
-            .saturating_sub(U256::from(42_585_600))
-            .max(U256::from(100_000_000))
+        U256::from(
+            fastlz_size
+                .saturating_mul(L1_COST_FASTLZ_COEF)
+                .saturating_sub(L1_COST_INTERCEPT)
+                .max(MIN_TX_SIZE_SCALED),
+        )
     }
 
     /// Calculate the gas cost of a transaction based on L1 block data posted on L2, depending on the [OptimismSpecId] passed.


### PR DESCRIPTION
Found `tx_estimated_size_fjord` in our block-building pipeline's hot path so had a look.
![image](https://github.com/user-attachments/assets/02280f06-4152-44d3-a62d-20549699754d)

Apparently, it's taking a non-trivial 9% of the cake when `State::commit` takes 10% and `Evm::transact` itself only takes 38%.

This PR adds some info and constants around `tx_estimated_size_fjord`, and micro-optimizes it by removing redundant `U256` conversions. 91% of `tx_estimated_size_fjord` is still spent on `flz_compress_len` so we may need to optimize the current Rust port, or go with an Assembly binding. 