### PR TITLE
doc(memory): remove dead link

### DIFF
--- a/documentation/src/crates/interpreter/memory.md
+++ b/documentation/src/crates/interpreter/memory.md
@@ -2,7 +2,7 @@
 
 Is a memory localized to the current Interpreter context. Interpreter context is a call or create frame. It is used by opcodes to store or format data that are more than 32 bytes long, for example calls to format input, return output or for logs data. Revm has a shared memory between all the Interpreters but Interpreter loop only see the part it is allocated to it.
 
-Extending memory is paid by the gas. It consumes 3 gas per word plus square of the number of words added divided by `512` (`3*N+ N^2/512`). There is no limit on the size of the memory, but it is limited by logarithmic growth of the gas cost. For 30M there is a calculated max memory of 32MB (Blog post by ramco: [Upper bound for transaction memory](https://xn--2-umb.com/22/eth-max-mem/)).
+Extending memory is paid by the gas. It consumes 3 gas per word plus square of the number of words added divided by `512` (`3*N+ N^2/512`). There is no limit on the size of the memory, but it is limited by logarithmic growth of the gas cost. For 30M there is a calculated max memory of 32MB (by [Remco](https://xn--2-umb.com/) in 2022).
 
 ## Opcodes
 


### PR DESCRIPTION
The blog post was unfortunately removed: https://xn--2-umb.com/22/eth-max-mem/, cannot find it on Remco's homepage as well: https://xn--2-umb.com/.