### PR TITLE
perf(`TransitionAccount`): remove unneeded clone

### DIFF
--- a/crates/database/src/states/transition_account.rs
+++ b/crates/database/src/states/transition_account.rs
@@ -73,7 +73,7 @@ impl TransitionAccount {
     /// Update new values of transition. Don't override old values.
     /// Both account info and old storages need to be left intact.
     pub fn update(&mut self, other: Self) {
-        self.info.clone_from(&other.info);
+        self.info = other.info;
         self.status = other.status;
 
         // if transition is from some to destroyed drop the storage.


### PR DESCRIPTION
Found it in the hot path here:
![image](https://github.com/user-attachments/assets/df2cd667-e665-483a-98fe-d888190193a3)
