### PR TITLE
perf: Add static Optimism precompiles for Fjord & Granite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3013,6 +3013,7 @@ dependencies = [
  "criterion",
  "enumn",
  "indicatif",
+ "once_cell",
  "revm",
  "revm-database",
  "revm-precompile",

--- a/crates/optimism/Cargo.toml
+++ b/crates/optimism/Cargo.toml
@@ -28,6 +28,7 @@ precompile = { workspace = true, features = ["secp256r1"] }
 
 # misc
 enumn = { version = "0.1" }
+once_cell = { version = "1.19", default-features = false, features = ["alloc"] }
 
 # Optional
 serde = { version = "1.0", default-features = false, features = [

--- a/crates/optimism/src/lib.rs
+++ b/crates/optimism/src/lib.rs
@@ -9,6 +9,7 @@ pub mod bn128;
 pub mod fast_lz;
 pub mod handler_register;
 pub mod l1block;
+pub mod precompile;
 pub mod result;
 pub mod spec;
 pub mod transaction;

--- a/crates/optimism/src/precompile.rs
+++ b/crates/optimism/src/precompile.rs
@@ -1,0 +1,32 @@
+use once_cell::race::OnceBox;
+use revm::precompile::{secp256r1, Precompiles};
+
+/// Returns precompiles for Fjord spec.
+pub fn fjord() -> &'static Precompiles {
+    static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
+    INSTANCE.get_or_init(|| {
+        let mut precompiles = Precompiles::cancun().clone();
+
+        precompiles.extend([
+            // EIP-7212: secp256r1 P256verify
+            secp256r1::P256VERIFY,
+        ]);
+
+        Box::new(precompiles)
+    })
+}
+
+/// Returns precompiles for Granite spec.
+pub fn granite() -> &'static Precompiles {
+    static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
+    INSTANCE.get_or_init(|| {
+        let mut precompiles = fjord().clone();
+
+        precompiles.extend([
+            // Restrict bn256Pairing input size
+            crate::bn128::pair::GRANITE,
+        ]);
+
+        Box::new(precompiles)
+    })
+}


### PR DESCRIPTION
As `ContextPrecompiles::extend` is quite expensive:

![image](https://github.com/user-attachments/assets/1f11ea3e-f6e8-4cb2-b1ba-fa1d7a8e66db)
