### PR TITLE
fix: typos in documentation files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,7 +235,7 @@ Bigger release. Cancun support, revm State added and some cleanup refactoring.
 # v24 tag
 date: 03.05.2023
 
-Cosnensus bug inside journal and some small changes.
+Consensus bug inside journal and some small changes.
 
 * revm: v3.3.0
 * revm-precompile: v2.0.3

--- a/bins/revme/CHANGELOG.md
+++ b/bins/revme/CHANGELOG.md
@@ -115,7 +115,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.1](https://github.com/bluealloy/revm/compare/revme-v0.2.0...revme-v0.2.1) - 2024-02-07
 
 ### Added
-- tweeks for v4.0 revm release ([#1048](https://github.com/bluealloy/revm/pull/1048))
+- tweaks for v4.0 revm release ([#1048](https://github.com/bluealloy/revm/pull/1048))
 - *(revme)* make it runnable by goevmlab ([#990](https://github.com/bluealloy/revm/pull/990))
 - EvmBuilder and External Contexts ([#888](https://github.com/bluealloy/revm/pull/888))
 - Loop call stack ([#851](https://github.com/bluealloy/revm/pull/851))

--- a/documentation/src/crates/primitives.md
+++ b/documentation/src/crates/primitives.md
@@ -15,7 +15,7 @@ It is set up to be compatible with environments that do not include Rust's stand
 - [specification](./primitives/specifications.md): This module defines types related to Ethereum specifications (also known as hard forks).
 - [state](./primitives/state.md): This module provides types and functions for managing Ethereum state, including accounts and storage.
 - [utilities](./primitives/utils.md): This module provides utility functions used in multiple places across the EVM implementation.
-- [kzg](./primitives/kzg.md): This module provides types and functions related to KZG commitment, it is empolyed visibly in the Point Evaluation Precompile.
+- [kzg](./primitives/kzg.md): This module provides types and functions related to KZG commitment, it is employed visibly in the Point Evaluation Precompile.
 
 ### External Crates:
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `Cosnensus` to `Consensus`
Corrected `tweeks` to `tweaks`
Corrected `empolyed` to `employed`

Please review the changes and let me know if any additional changes are needed.

