### PR TITLE
Fix Consistency and Spelling in Documentation

### DIFF
--- a/crates/precompile/README.md
+++ b/crates/precompile/README.md
@@ -1,3 +1,3 @@
 ### REVM Precompiles - Ethereum compatible precompiled contracts
 
-Used inside REVM and passes all eth/tests. It supports all Ethereum hardforks.
+Used inside REVM and passes all eth/tests. It supports all Ethereum hard forks.

--- a/documentation/src/introduction.md
+++ b/documentation/src/introduction.md
@@ -15,7 +15,7 @@ The project has 4 main crates that are used to build revm. These are:
 
 There are two binaries both of which are used for testing. To install them run `cargo install --path bins/<binary-name>`. The binaries are:
 
-- `revme`: A CLI binary, used for running state test json. Currently it is used to run [ethereum tests](https://github.com/ethereum/tests) to check if revm is compliant. For example if you have the eth tests cloned into a directory called eth tests and the EIP tests in the following directories you can run 
+- `revme`: A CLI binary, used for running state test json. Currently it is used to run [ethereum tests](https://github.com/ethereum/tests) to check if revm is compliant. For example if you have the eth-tests cloned into a directory called eth-tests and the EIP tests in the following directories you can run 
 ```bash
 cargo run --profile ethtests -p revme -- \
     statetest \


### PR DESCRIPTION
Description: This PR addresses the following improvements for consistency and clarity:

Changed "eth tests" to "eth-tests" for consistent naming style.
Corrected the spelling of "hardforks" to "hard forks" to align with the proper term.