### PR TITLE
EIP-7742: Uncouple blob count between CL and EL

### DIFF
--- a/bins/revme/src/cmd/statetest/models/mod.rs
+++ b/bins/revme/src/cmd/statetest/models/mod.rs
@@ -106,6 +106,7 @@ pub struct Env {
     pub parent_blob_gas_used: Option<U256>,
     pub parent_excess_blob_gas: Option<U256>,
     pub current_excess_blob_gas: Option<U256>,
+    pub target_blobs_per_block: Option<U256>,
 }
 
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/bins/revme/src/cmd/statetest/models/mod.rs
+++ b/bins/revme/src/cmd/statetest/models/mod.rs
@@ -106,7 +106,7 @@ pub struct Env {
     pub parent_blob_gas_used: Option<U256>,
     pub parent_excess_blob_gas: Option<U256>,
     pub current_excess_blob_gas: Option<U256>,
-    pub target_blobs_per_block: Option<U256>,
+    pub parent_target_blobs_per_block: Option<U256>,
 }
 
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -295,7 +295,7 @@ pub fn execute_test_suite(
                     parent_blob_gas_used.to(),
                     parent_excess_blob_gas.to(),
                     unit.env
-                        .target_blobs_per_block
+                        .parent_target_blobs_per_block
                         .map(|i| i.to())
                         .unwrap_or(TARGET_BLOB_GAS_PER_BLOCK),
                 ));

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -11,7 +11,7 @@ use revm::{
     interpreter::analysis::to_analysed,
     primitives::{
         calc_excess_blob_gas, keccak256, Bytecode, Bytes, EVMResultGeneric, Env, ExecutionResult,
-        SpecId, TxKind, B256, TARGET_BLOB_GAS_PER_BLOCK, U256,
+        SpecId, TxKind, B256, TARGET_BLOB_GAS_PER_BLOCK,
     },
     Evm, State,
 };

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -11,7 +11,7 @@ use revm::{
     interpreter::analysis::to_analysed,
     primitives::{
         calc_excess_blob_gas, keccak256, Bytecode, Bytes, EVMResultGeneric, Env, ExecutionResult,
-        SpecId, TxKind, B256,
+        SpecId, TxKind, B256, TARGET_BLOB_GAS_PER_BLOCK, U256,
     },
     Evm, State,
 };
@@ -294,6 +294,10 @@ pub fn execute_test_suite(
                 .set_blob_excess_gas_and_price(calc_excess_blob_gas(
                     parent_blob_gas_used.to(),
                     parent_excess_blob_gas.to(),
+                    unit.env
+                        .target_blobs_per_block
+                        .map(|i| i.to())
+                        .unwrap_or(TARGET_BLOB_GAS_PER_BLOCK),
                 ));
         }
 

--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -4,8 +4,8 @@ pub use handler_cfg::{CfgEnvWithHandlerCfg, EnvWithHandlerCfg, HandlerCfg};
 
 use crate::{
     calc_blob_gasprice, calc_excess_blob_gas, AccessListItem, Account, Address, AuthorizationList,
-    Bytes, InvalidHeader, InvalidTransaction, Spec, SpecId, B256, GAS_PER_BLOB,
-    MAX_BLOB_NUMBER_PER_BLOCK, MAX_CODE_SIZE, MAX_INITCODE_SIZE, U256, VERSIONED_HASH_VERSION_KZG,
+    Bytes, InvalidHeader, InvalidTransaction, Spec, SpecId, B256, GAS_PER_BLOB, MAX_CODE_SIZE,
+    MAX_INITCODE_SIZE, U256, VERSIONED_HASH_VERSION_KZG,
 };
 use alloy_primitives::TxKind;
 use core::cmp::{min, Ordering};
@@ -661,7 +661,7 @@ impl BlobExcessGasAndPrice {
     /// Calculate this block excess gas and price from the parent excess gas and gas used
     /// and the target blob gas per block.
     ///
-    /// This fields will be used to calculate `excess_blob_gas` with [`calc_excess_blob_gas`].
+    /// This fields will be used to calculate `excess_blob_gas` with [`calc_excess_blob_gas`] func.
     pub fn from_parent_and_target(
         parent_excess_blob_gas: u64,
         parent_blob_gas_used: u64,

--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -174,27 +174,6 @@ impl Env {
                     return Err(InvalidTransaction::BlobVersionNotSupported);
                 }
             }
-
-            // EIP-7742: Uncouple blob count between CL and EL
-            // Max number of blobs are not a header field but it is set by CL on block building.
-            let max_blob_num_per_block = if SPEC::enabled(SpecId::PRAGUE) {
-                self.block.max_blobs_per_block
-            } else {
-                Some(MAX_BLOB_NUMBER_PER_BLOCK)
-            };
-
-            if let Some(max_blob_num_per_block) = max_blob_num_per_block {
-                let max_blob_num_per_block = max_blob_num_per_block as usize;
-                let num_blobs = self.tx.blob_hashes.len();
-                // ensure the total blob gas spent is at most equal to the limit
-                // assert blob_gas_used <= MAX_BLOB_GAS_PER_BLOCK
-                if num_blobs > max_blob_num_per_block {
-                    return Err(InvalidTransaction::TooManyBlobs {
-                        have: num_blobs,
-                        max: max_blob_num_per_block,
-                    });
-                }
-            }
         } else {
             // if max_fee_per_blob_gas is not set, then blob_hashes must be empty
             if !self.tx.blob_hashes.is_empty() {

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -410,8 +410,6 @@ pub enum InvalidHeader {
     PrevrandaoNotSet,
     /// `excess_blob_gas` is not set for Cancun and above.
     ExcessBlobGasNotSet,
-    /// `target_blobs_per_block` is not set for Prague and above.
-    TargetBlobNotSet,
 }
 
 #[cfg(feature = "std")]
@@ -422,7 +420,6 @@ impl fmt::Display for InvalidHeader {
         match self {
             Self::PrevrandaoNotSet => write!(f, "`prevrandao` not set"),
             Self::ExcessBlobGasNotSet => write!(f, "`excess_blob_gas` not set"),
-            Self::TargetBlobNotSet => write!(f, "`target_blobs_per_block` not set"),
         }
     }
 }

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -298,7 +298,7 @@ pub enum InvalidTransaction {
     /// Blob transaction can't be a create transaction.
     /// `to` must be present
     BlobCreateTransaction,
-    /// Transaction has more then [`crate::MAX_BLOB_NUMBER_PER_BLOCK`] blobs
+    /// Transaction has more then `max_blob_num_per_block` blobs.
     TooManyBlobs {
         max: usize,
         have: usize,
@@ -410,6 +410,8 @@ pub enum InvalidHeader {
     PrevrandaoNotSet,
     /// `excess_blob_gas` is not set for Cancun and above.
     ExcessBlobGasNotSet,
+    /// `target_blobs_per_block` is not set for Prague and above.
+    TargetBlobNotSet,
 }
 
 #[cfg(feature = "std")]
@@ -420,6 +422,7 @@ impl fmt::Display for InvalidHeader {
         match self {
             Self::PrevrandaoNotSet => write!(f, "`prevrandao` not set"),
             Self::ExcessBlobGasNotSet => write!(f, "`excess_blob_gas` not set"),
+            Self::TargetBlobNotSet => write!(f, "`target_blobs_per_block` not set"),
         }
     }
 }

--- a/crates/primitives/src/utilities.rs
+++ b/crates/primitives/src/utilities.rs
@@ -11,9 +11,16 @@ pub const KECCAK_EMPTY: B256 =
 ///
 /// See also [the EIP-4844 helpers]<https://eips.ethereum.org/EIPS/eip-4844#helpers>
 /// (`calc_excess_blob_gas`).
+///
+/// EIP-7742: Uncouple blob count between CL and EL
+/// Removes hardcoded constants and uses the `target_blob_gas_per_block` from the header.
 #[inline]
-pub fn calc_excess_blob_gas(parent_excess_blob_gas: u64, parent_blob_gas_used: u64) -> u64 {
-    (parent_excess_blob_gas + parent_blob_gas_used).saturating_sub(TARGET_BLOB_GAS_PER_BLOCK)
+pub fn calc_excess_blob_gas(
+    parent_excess_blob_gas: u64,
+    parent_blob_gas_used: u64,
+    target_blob_gas_per_block: u64,
+) -> u64 {
+    (parent_excess_blob_gas + parent_blob_gas_used).saturating_sub(target_blob_gas_per_block)
 }
 
 /// Calculates the blob gas price from the header's excess blob gas field.
@@ -113,7 +120,8 @@ mod tests {
                 0,
             ),
         ] {
-            let actual = calc_excess_blob_gas(excess, blobs * GAS_PER_BLOB);
+            let actual =
+                calc_excess_blob_gas(excess, blobs * GAS_PER_BLOB, TARGET_BLOB_GAS_PER_BLOCK);
             assert_eq!(actual, expected, "test: {t:?}");
         }
     }

--- a/crates/primitives/src/utilities.rs
+++ b/crates/primitives/src/utilities.rs
@@ -11,14 +11,14 @@ pub const KECCAK_EMPTY: B256 =
 /// (`calc_excess_blob_gas`).
 ///
 /// EIP-7742: Uncouple blob count between CL and EL
-/// Removes hardcoded constants and uses the `target_blob_gas_per_block` from the header.
+/// Removes hardcoded constants and uses the `target_blob_gas_per_block` from the parent header.
 #[inline]
 pub fn calc_excess_blob_gas(
     parent_excess_blob_gas: u64,
     parent_blob_gas_used: u64,
-    target_blob_gas_per_block: u64,
+    parent_target_blob_gas_per_block: u64,
 ) -> u64 {
-    (parent_excess_blob_gas + parent_blob_gas_used).saturating_sub(target_blob_gas_per_block)
+    (parent_excess_blob_gas + parent_blob_gas_used).saturating_sub(parent_target_blob_gas_per_block)
 }
 
 /// Calculates the blob gas price from the header's excess blob gas field.

--- a/crates/primitives/src/utilities.rs
+++ b/crates/primitives/src/utilities.rs
@@ -1,6 +1,4 @@
-use crate::{
-    b256, B256, BLOB_GASPRICE_UPDATE_FRACTION, MIN_BLOB_GASPRICE, TARGET_BLOB_GAS_PER_BLOCK,
-};
+use crate::{b256, B256, BLOB_GASPRICE_UPDATE_FRACTION, MIN_BLOB_GASPRICE};
 pub use alloy_primitives::keccak256;
 
 /// The Keccak-256 hash of the empty string `""`.
@@ -69,7 +67,7 @@ pub fn fake_exponential(factor: u64, numerator: u64, denominator: u64) -> u128 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::GAS_PER_BLOB;
+    use crate::{GAS_PER_BLOB, TARGET_BLOB_GAS_PER_BLOCK};
 
     // https://github.com/ethereum/go-ethereum/blob/28857080d732857030eda80c69b9ba2c8926f221/consensus/misc/eip4844/eip4844_test.go#L27
     #[test]


### PR DESCRIPTION
The only meaningful change is that the `calc_excess_blob_gas` func now takes `target_blob_gas_per_block` as input.

Check to make sure that tx blob num is smaller than the block blob num is removed, this needs to be checked on block level.