### PR TITLE
implement serde for interpreter

### DIFF
--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -295,7 +295,6 @@ mod tests {
     #[test]
     #[cfg(feature = "serde")]
     fn test_interpreter_serde() {
-
         type EXT = ();
         type MG = SharedMemory;
 
@@ -320,7 +319,15 @@ mod tests {
         let deserialized: Interpreter<EthInterpreter<EXT, MG>> =
             bincode::deserialize(&serialized).unwrap();
 
-        assert_eq!(interpreter.bytecode.pc(), deserialized.bytecode.pc());
-        assert_eq!(interpreter.stack.len(), deserialized.stack.len());
+        assert_eq!(
+            interpreter.bytecode.base.bytecode(),
+            deserialized.bytecode.base.bytecode(),
+            "Base bytecode content should be preserved"
+        );
+        assert_eq!(
+            interpreter.bytecode.pc(),
+            deserialized.bytecode.pc(),
+            "Program counter should be preserved"
+        );
     }
 }

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -29,6 +29,7 @@ use std::rc::Rc;
 use subroutine_stack::SubRoutineImpl;
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub struct Interpreter<WIRE: InterpreterTypes> {
     pub bytecode: WIRE::Bytecode,
     pub stack: WIRE::Stack,
@@ -284,4 +285,42 @@ mod tests {
     //         >();
     //     let _ = interp.run(EMPTY_SHARED_MEMORY, table, host);
     // }
+
+    use super::*;
+    use bytecode::Bytecode;
+    use primitives::{Address, Bytes, U256};
+    use specification::hardfork::SpecId;
+    use std::{cell::RefCell, rc::Rc};
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_interpreter_serde() {
+
+        type EXT = ();
+        type MG = SharedMemory;
+
+        let bytecode = Bytecode::new_raw(Bytes::from(&[0x60, 0x00, 0x60, 0x00, 0x01][..]));
+        let interpreter = Interpreter::<EthInterpreter<EXT, MG>>::new(
+            Rc::new(RefCell::new(SharedMemory::new())),
+            bytecode,
+            InputsImpl {
+                target_address: Address::ZERO,
+                caller_address: Address::ZERO,
+                input: Bytes::default(),
+                call_value: U256::ZERO,
+            },
+            false,
+            false,
+            SpecId::LATEST,
+            u64::MAX,
+        );
+
+        let serialized = bincode::serialize(&interpreter).unwrap();
+
+        let deserialized: Interpreter<EthInterpreter<EXT, MG>> =
+            bincode::deserialize(&serialized).unwrap();
+
+        assert_eq!(interpreter.bytecode.pc(), deserialized.bytecode.pc());
+        assert_eq!(interpreter.stack.len(), deserialized.stack.len());
+    }
 }

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -295,11 +295,8 @@ mod tests {
     #[test]
     #[cfg(feature = "serde")]
     fn test_interpreter_serde() {
-        type EXT = ();
-        type MG = SharedMemory;
-
         let bytecode = Bytecode::new_raw(Bytes::from(&[0x60, 0x00, 0x60, 0x00, 0x01][..]));
-        let interpreter = Interpreter::<EthInterpreter<EXT, MG>>::new(
+        let interpreter = Interpreter::<EthInterpreter>::new(
             Rc::new(RefCell::new(SharedMemory::new())),
             bytecode,
             InputsImpl {
@@ -316,8 +313,7 @@ mod tests {
 
         let serialized = bincode::serialize(&interpreter).unwrap();
 
-        let deserialized: Interpreter<EthInterpreter<EXT, MG>> =
-            bincode::deserialize(&serialized).unwrap();
+        let deserialized: Interpreter<EthInterpreter> = bincode::deserialize(&serialized).unwrap();
 
         assert_eq!(
             interpreter.bytecode.pc(),

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -320,11 +320,6 @@ mod tests {
             bincode::deserialize(&serialized).unwrap();
 
         assert_eq!(
-            interpreter.bytecode.base.bytecode(),
-            deserialized.bytecode.base.bytecode(),
-            "Base bytecode content should be preserved"
-        );
-        assert_eq!(
             interpreter.bytecode.pc(),
             deserialized.bytecode.pc(),
             "Program counter should be preserved"

--- a/crates/interpreter/src/interpreter/ext_bytecode.rs
+++ b/crates/interpreter/src/interpreter/ext_bytecode.rs
@@ -7,6 +7,9 @@ use primitives::Bytes;
 
 use super::{EofCodeInfo, EofContainer, EofData, Immediates, Jumps, LegacyBytecode};
 
+#[cfg(feature = "serde")]
+mod serde;
+
 #[derive(Debug)]
 pub struct ExtBytecode {
     pub base: Bytecode,

--- a/crates/interpreter/src/interpreter/ext_bytecode/serde.rs
+++ b/crates/interpreter/src/interpreter/ext_bytecode/serde.rs
@@ -1,0 +1,39 @@
+use crate::interpreter::Jumps;
+
+use super::ExtBytecode;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Serialize, Deserialize)]
+struct ExtBytecodeSerde {
+    base: bytecode::Bytecode,
+    program_counter: usize,
+}
+
+impl Serialize for ExtBytecode {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        ExtBytecodeSerde {
+            base: self.base.clone(),
+            program_counter: self.pc(),
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ExtBytecode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let ExtBytecodeSerde {
+            base,
+            program_counter,
+        } = ExtBytecodeSerde::deserialize(deserializer)?;
+
+        let mut bytecode = Self::new(base);
+        bytecode.absolute_jump(program_counter);
+        Ok(bytecode)
+    }
+}

--- a/crates/interpreter/src/interpreter/ext_bytecode/serde.rs
+++ b/crates/interpreter/src/interpreter/ext_bytecode/serde.rs
@@ -1,6 +1,5 @@
-use crate::interpreter::Jumps;
-
 use super::ExtBytecode;
+use crate::interpreter::Jumps;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Serialize, Deserialize)]
@@ -33,6 +32,10 @@ impl<'de> Deserialize<'de> for ExtBytecode {
         } = ExtBytecodeSerde::deserialize(deserializer)?;
 
         let mut bytecode = Self::new(base);
+
+        if program_counter >= bytecode.base.bytecode().len() {
+            panic!("serde pc: {program_counter} is less than bytecode len");
+        }
         bytecode.absolute_jump(program_counter);
         Ok(bytecode)
     }

--- a/crates/interpreter/src/interpreter/ext_bytecode/serde.rs
+++ b/crates/interpreter/src/interpreter/ext_bytecode/serde.rs
@@ -34,7 +34,7 @@ impl<'de> Deserialize<'de> for ExtBytecode {
         let mut bytecode = Self::new(base);
 
         if program_counter >= bytecode.base.bytecode().len() {
-            panic!("serde pc: {program_counter} is less than bytecode len");
+            panic!("serde pc: {program_counter} is greater than or equal to bytecode len");
         }
         bytecode.absolute_jump(program_counter);
         Ok(bytecode)

--- a/crates/interpreter/src/interpreter/input.rs
+++ b/crates/interpreter/src/interpreter/input.rs
@@ -1,6 +1,9 @@
 use crate::interpreter_types::InputsTrait;
 use primitives::{Address, Bytes, U256};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct InputsImpl {
     pub target_address: Address,
     pub caller_address: Address,

--- a/crates/interpreter/src/interpreter/loop_control.rs
+++ b/crates/interpreter/src/interpreter/loop_control.rs
@@ -1,6 +1,9 @@
 use crate::interpreter_types::LoopControl as LoopControlTrait;
 use crate::{Gas, InstructionResult, InterpreterAction};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LoopControl {
     /// The execution control flag. If this is not set to `Continue`, the interpreter will stop
     /// execution.

--- a/crates/interpreter/src/interpreter/return_data.rs
+++ b/crates/interpreter/src/interpreter/return_data.rs
@@ -1,6 +1,9 @@
 use crate::interpreter::ReturnData;
 use primitives::Bytes;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Default)]
 pub struct ReturnDataImpl(Bytes);
 

--- a/crates/interpreter/src/interpreter/runtime_flags.rs
+++ b/crates/interpreter/src/interpreter/runtime_flags.rs
@@ -1,7 +1,10 @@
 use specification::hardfork::SpecId;
 
 use super::RuntimeFlag;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RuntimeFlags {
     pub is_static: bool,
     pub is_eof_init: bool,


### PR DESCRIPTION
I tried to tackle https://github.com/bluealloy/revm/issues/1890

I am not sure this is correct. To my understanding the instruction_pointer is just a pointer and so i have replaced it with the program counter for serialization which i know is not the same but i also wonder what the value of that pointer is in a different context. To my understanding doing an absolute jump back to that offset should give us the correct instruction_pointer again when deserializing.

I probably need some guidance here, if this is too far from expecatiations please let me know i can also just let it go :)

In case this is correct i probably have to add a test where the instruction_pointer changes i.e a running execution. What is the best way to mock the host, do i have to implement a transaction, block etc. from scratch? @rakita thanks!