### PR TITLE
Fix spelling errors in code

### DIFF
--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - add DATACOPY to OpCode::modifies_memory ([#1639](https://github.com/bluealloy/revm/pull/1639))
-- *(EOF)* returning to non-returning jumpf, enable valition error ([#1664](https://github.com/bluealloy/revm/pull/1664))
+- *(EOF)* returning to non-returning jumpf, enable validation error ([#1664](https://github.com/bluealloy/revm/pull/1664))
 - *(EOF)* Validate code access in stack ([#1659](https://github.com/bluealloy/revm/pull/1659))
 - *(eof)* deny static context in EOFCREATE ([#1644](https://github.com/bluealloy/revm/pull/1644))
 
@@ -92,7 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(EOF)* set CallOrCreate result in EOFCREATE ([#1535](https://github.com/bluealloy/revm/pull/1535))
 - *(EOF)* target needed for EOFCREATE created address ([#1536](https://github.com/bluealloy/revm/pull/1536))
 - *(EOF)* ext*call return values ([#1515](https://github.com/bluealloy/revm/pull/1515))
-- *(EOF)* Remove redundunt ext call gas cost ([#1513](https://github.com/bluealloy/revm/pull/1513))
+- *(EOF)* Remove redundant ext call gas cost ([#1513](https://github.com/bluealloy/revm/pull/1513))
 - *(EOF)* add DATACOPY copy gas ([#1510](https://github.com/bluealloy/revm/pull/1510))
 - *(EOF)* extstaticcall make static ([#1508](https://github.com/bluealloy/revm/pull/1508))
 - *(EOF)* jumpf gas was changes ([#1507](https://github.com/bluealloy/revm/pull/1507))
@@ -109,7 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - simplify Interpreter serde ([#1544](https://github.com/bluealloy/revm/pull/1544))
 - *(interpreter)* use U256::arithmetic_shr in SAR ([#1525](https://github.com/bluealloy/revm/pull/1525))
 - pluralize EOFCreateInput ([#1523](https://github.com/bluealloy/revm/pull/1523))
-- added simular to used-by ([#1521](https://github.com/bluealloy/revm/pull/1521))
+- added similar to used-by ([#1521](https://github.com/bluealloy/revm/pull/1521))
 - Removed .clone() in ExecutionHandler::call, and reusing output buffer in Interpreter ([#1512](https://github.com/bluealloy/revm/pull/1512))
 - *(revme)* add new line in revme EOF printer ([#1503](https://github.com/bluealloy/revm/pull/1503))
 - remove old deprecated items ([#1489](https://github.com/bluealloy/revm/pull/1489))
@@ -230,10 +230,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0](https://github.com/bluealloy/revm/compare/revm-interpreter-v1.3.0...revm-interpreter-v2.0.0) - 2024-02-07
 
-Iterpreter will not be called in recursive calls but would return Action ( CALL/CREATE) that will be executed by the main loop.
+Interpreter will not be called in recursive calls but would return Action ( CALL/CREATE) that will be executed by the main loop.
 
 ### Added
-- tweeks for v4.0 revm release ([#1048](https://github.com/bluealloy/revm/pull/1048))
+- tweaks for v4.0 revm release ([#1048](https://github.com/bluealloy/revm/pull/1048))
 - add `BytecodeLocked::original_bytecode` ([#1037](https://github.com/bluealloy/revm/pull/1037))
 - *(op)* Ecotone hardfork ([#1009](https://github.com/bluealloy/revm/pull/1009))
 - EvmBuilder and External Contexts ([#888](https://github.com/bluealloy/revm/pull/888))
@@ -377,7 +377,7 @@ Changelog:
 * d0038e3 - chore(deps): bump arbitrary from 1.2.3 to 1.3.0 (#428) (2 weeks ago) <dependabot[bot]>
 * dd0e227 - feat: Add all internals results to Halt (#413) (4 weeks ago) <rakita>
 * d8dc652 - fix(interpreter): halt on CreateInitcodeSizeLimit (#412) (4 weeks ago) <Roman Krasiuk>
-* a193d79 - chore: enabled primtive default feature in precompile (#409) (4 weeks ago) <Matthias Seitz>
+* a193d79 - chore: enabled primitive default feature in precompile (#409) (4 weeks ago) <Matthias Seitz>
 * 1720729 - chore: add display impl for Opcode (#406) (4 weeks ago) <Matthias Seitz>
 * 33bf8a8 - feat: use singular bytes for the jumpmap (#402) (4 weeks ago) <Bjerg>
 * 394e8e9 - feat: extend SuccessOrHalt (#405) (4 weeks ago) <Matthias Seitz>

--- a/crates/revm/CHANGELOG.md
+++ b/crates/revm/CHANGELOG.md
@@ -112,7 +112,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - avoid cloning precompiles ([#1486](https://github.com/bluealloy/revm/pull/1486))
 - add setters to `BundleBuilder` with `&mut self` ([#1527](https://github.com/bluealloy/revm/pull/1527))
 - pluralize EOFCreateInput ([#1523](https://github.com/bluealloy/revm/pull/1523))
-- added simular to used-by ([#1521](https://github.com/bluealloy/revm/pull/1521))
+- added similar to used-by ([#1521](https://github.com/bluealloy/revm/pull/1521))
 - Removed .clone() in ExecutionHandler::call, and reusing output buffer in Interpreter ([#1512](https://github.com/bluealloy/revm/pull/1512))
 - remove old deprecated items ([#1489](https://github.com/bluealloy/revm/pull/1489))
 - *(deps)* bump rstest from 0.19.0 to 0.21.0 ([#1482](https://github.com/bluealloy/revm/pull/1482))
@@ -904,5 +904,5 @@ Published v0.2.0, first initial version of code. London supported and all eth st
     * inspector: is what i wanted, full control on insides of EVM so that we can control it and modify it. will probably needs to add some small tweaks to interface but nothing major.
     * subroutines: Feels okay but it needs more scrutiny just to be sure that all corner cases are covered.
     * Test that are failing (~20) are mostly related to EIP-158: State clearing. For EIP-158 I will time to do it properly.
-    * There is probably benefit of replaing HashMap hasher with something simpler, but this is research for another time.
+    * There is probably benefit of replacing HashMap hasher with something simpler, but this is research for another time.
 ## Project structure:


### PR DESCRIPTION
1. `valition` → `validation`
2. `redundunt` → `redundant`
3. `simular` → `similar`
4. `Iterpreter` → `Interpreter`
5. `tweeks` → `tweaks`
6. `primtive` → `primitive`
7. `replaing` → `replacing`