### PR TITLE
chore: remove analysis bench inner loops

### DIFF
--- a/bins/revme/src/cmd/bench/analysis.rs
+++ b/bins/revme/src/cmd/bench/analysis.rs
@@ -5,7 +5,6 @@ use revm::{
     primitives::{address, bytes, hex, Bytes, TxKind},
     Context, MainEvm,
 };
-use std::time::Instant;
 
 const BYTES: &str = include_str!("analysis.hex");
 
@@ -23,16 +22,5 @@ pub fn run() {
             tx.data = bytes!("8035F0CE");
         });
     let mut evm = MainEvm::new(context, EthHandler::default());
-
-    // Just to warm up the processor.
-    for _ in 0..10000 {
-        let _ = evm.transact().unwrap();
-    }
-
-    let timer = Instant::now();
-    for _ in 0..30000 {
-        let _ = evm.transact().unwrap();
-    }
-    let time = timer.elapsed();
-    println!("Elapsed time: {:?}", time);
+    let _ = evm.transact().unwrap();
 }


### PR DESCRIPTION
Doesn't make a difference when in valgrind