### PR TITLE
feat: add isthmus spec

### DIFF
--- a/crates/optimism/src/handler/precompiles.rs
+++ b/crates/optimism/src/handler/precompiles.rs
@@ -87,7 +87,12 @@ where
                 | SpecId::CANCUN,
             )
             | OpSpec::Op(
-                OpSpecId::BEDROCK | OpSpecId::REGOLITH | OpSpecId::CANYON | OpSpecId::ECOTONE,
+                OpSpecId::BEDROCK
+                | OpSpecId::REGOLITH
+                | OpSpecId::CANYON
+                | OpSpecId::ECOTONE
+                | OpSpecId::HOLOCENE
+                | OpSpecId::ISTHMUS,
             )) => Self::new(Precompiles::new(spec.into_eth_spec().into())),
             OpSpec::Op(OpSpecId::FJORD) => Self::new(fjord()),
             OpSpec::Op(OpSpecId::GRANITE)

--- a/crates/optimism/src/spec.rs
+++ b/crates/optimism/src/spec.rs
@@ -19,6 +19,8 @@ pub enum OpSpecId {
     ECOTONE,
     FJORD,
     GRANITE,
+    HOLOCENE,
+    ISTHMUS,
 }
 
 impl OpSpecId {
@@ -27,7 +29,9 @@ impl OpSpecId {
         match self {
             Self::BEDROCK | Self::REGOLITH => SpecId::MERGE,
             Self::CANYON => SpecId::SHANGHAI,
-            Self::ECOTONE | Self::FJORD | Self::GRANITE => SpecId::CANCUN,
+            Self::ECOTONE | Self::FJORD | Self::GRANITE | Self::HOLOCENE | Self::ISTHMUS => {
+                SpecId::CANCUN
+            }
         }
     }
 
@@ -73,6 +77,8 @@ impl From<OpSpecId> for &'static str {
             OpSpecId::ECOTONE => name::ECOTONE,
             OpSpecId::FJORD => name::FJORD,
             OpSpecId::GRANITE => name::GRANITE,
+            OpSpecId::HOLOCENE => name::HOLOCENE,
+            OpSpecId::ISTHMUS => name::ISTHMUS,
         }
     }
 }
@@ -85,6 +91,8 @@ pub mod name {
     pub const ECOTONE: &str = "Ecotone";
     pub const FJORD: &str = "Fjord";
     pub const GRANITE: &str = "Granite";
+    pub const HOLOCENE: &str = "Holocene";
+    pub const ISTHMUS: &str = "Isthmus";
 }
 
 impl OpSpec {


### PR DESCRIPTION
Just adding `HOLOCENE` and `ISTHMUS` to `OpSpecId`.

It will be needed for https://github.com/ethereum-optimism/specs/discussions/373, and more precisely I would need it to be able to [handle Isthmus in op-reth](https://github.com/paradigmxyz/reth/blob/82af17068721ee8e6025b41279a15c55cd2a50b1/crates/optimism/evm/src/config.rs#L16).

Closes #1874 

