### PR TITLE
feat: expose precompile address in Journal, DB::Error: StdError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,6 +1460,7 @@ name = "example-database-components"
 version = "0.0.0"
 dependencies = [
  "auto_impl",
+ "derive_more 1.0.0",
  "revm",
 ]
 

--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -1,6 +1,6 @@
 use core::ops::{Deref, DerefMut};
 use database_interface::{Database, DatabaseGetter};
-use primitives::{Address, Log, B256, U256};
+use primitives::{Address, HashSet, Log, B256, U256};
 use specification::hardfork::SpecId;
 use state::{Account, Bytecode};
 use std::boxed::Box;
@@ -62,6 +62,10 @@ pub trait Journal {
     ) -> Result<(), <Self::Database as Database>::Error>;
 
     fn warm_account(&mut self, address: Address);
+
+    fn warm_precompiles(&mut self, addresses: HashSet<Address>);
+
+    fn contains_precompile(&self, address: &Address) -> bool;
 
     fn set_spec_id(&mut self, spec_id: SpecId);
 

--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -17,10 +17,10 @@ pub trait Journal {
     fn new(database: Self::Database) -> Self;
 
     /// Returns the database.
-    fn db(&self) -> &Self::Database;
+    fn db_ref(&self) -> &Self::Database;
 
     /// Returns the mutable database.
-    fn db_mut(&mut self) -> &mut Self::Database;
+    fn db(&mut self) -> &mut Self::Database;
 
     /// Returns the storage value from Journal state.
     ///

--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -65,7 +65,7 @@ pub trait Journal {
 
     fn warm_precompiles(&mut self, addresses: HashSet<Address>);
 
-    fn contains_precompile(&self, address: &Address) -> bool;
+    fn precompile_addresses(&self) -> &HashSet<Address>;
 
     fn set_spec_id(&mut self, spec_id: SpecId);
 

--- a/crates/context/interface/src/result.rs
+++ b/crates/context/interface/src/result.rs
@@ -54,6 +54,15 @@ impl<HaltReasonT: HaltReasonTrait> ExecutionResult<HaltReasonT> {
         matches!(self, Self::Success { .. })
     }
 
+    /// Returns created address if execution is Create transaction
+    /// and Contract was created.
+    pub fn created_address(&self) -> Option<Address> {
+        match self {
+            Self::Success { output, .. } => output.address().cloned(),
+            _ => None,
+        }
+    }
+
     /// Returns true if execution result is a Halt.
     pub fn is_halt(&self) -> bool {
         matches!(self, Self::Halt { .. })

--- a/crates/context/interface/src/result.rs
+++ b/crates/context/interface/src/result.rs
@@ -175,9 +175,9 @@ impl<DB, TX> FromStringError for EVMError<DB, TX> {
     }
 }
 
-impl<DB, TXERROR: From<InvalidTransaction>> From<InvalidTransaction> for EVMError<DB, TXERROR> {
+impl<DB> From<InvalidTransaction> for EVMError<DB, InvalidTransaction> {
     fn from(value: InvalidTransaction) -> Self {
-        Self::Transaction(value.into())
+        Self::Transaction(value)
     }
 }
 

--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -313,7 +313,7 @@ where
     where
         F: FnOnce(&mut DB),
     {
-        f(self.journaled_state.db_mut());
+        f(self.journaled_state.db());
     }
 
     pub fn modify_journal<F>(&mut self, f: F)
@@ -395,7 +395,7 @@ where
         if diff <= BLOCK_HASH_HISTORY {
             return self
                 .journaled_state
-                .db_mut()
+                .db()
                 .block_hash(requested_number)
                 .map_err(|e| self.error = Err(e))
                 .ok();
@@ -508,7 +508,11 @@ where
     type Database = DB;
 
     fn db(&mut self) -> &mut Self::Database {
-        self.journaled_state.db_mut()
+        self.journaled_state.db()
+    }
+
+    fn db_ref(&self) -> &Self::Database {
+        self.journaled_state.db_ref()
     }
 }
 

--- a/crates/context/src/journaled_state.rs
+++ b/crates/context/src/journaled_state.rs
@@ -52,6 +52,8 @@ pub struct JournaledState<DB> {
     /// Note that this not include newly loaded accounts, account and storage
     /// is considered warm if it is found in the `State`.
     pub warm_preloaded_addresses: HashSet<Address>,
+    /// Precompile addresses
+    pub precompiles: HashSet<Address>,
 }
 
 impl<DB: Database> Journal for JournaledState<DB> {
@@ -110,6 +112,17 @@ impl<DB: Database> Journal for JournaledState<DB> {
 
     fn warm_account(&mut self, address: Address) {
         self.warm_preloaded_addresses.insert(address);
+    }
+
+    fn warm_precompiles(&mut self, address: HashSet<Address>) {
+        self.precompiles = address;
+        self.warm_preloaded_addresses
+            .extend(self.precompiles.iter());
+    }
+
+    #[inline]
+    fn contains_precompile(&self, address: &Address) -> bool {
+        self.precompiles.contains(address)
     }
 
     /// Returns call depth.
@@ -212,6 +225,7 @@ impl<DB: Database> Journal for JournaledState<DB> {
             spec: _,
             database: _,
             warm_preloaded_addresses: _,
+            precompiles: _,
         } = self;
 
         *transient_storage = TransientStorage::default();
@@ -243,6 +257,7 @@ impl<DB: Database> JournaledState<DB> {
             depth: 0,
             spec,
             warm_preloaded_addresses: HashSet::default(),
+            precompiles: HashSet::default(),
         }
     }
 

--- a/crates/context/src/journaled_state.rs
+++ b/crates/context/src/journaled_state.rs
@@ -121,8 +121,8 @@ impl<DB: Database> Journal for JournaledState<DB> {
     }
 
     #[inline]
-    fn contains_precompile(&self, address: &Address) -> bool {
-        self.precompiles.contains(address)
+    fn precompile_addresses(&self) -> &HashSet<Address> {
+        &self.precompiles
     }
 
     /// Returns call depth.

--- a/crates/context/src/journaled_state.rs
+++ b/crates/context/src/journaled_state.rs
@@ -63,11 +63,11 @@ impl<DB: Database> Journal for JournaledState<DB> {
         Self::new(SpecId::LATEST, database)
     }
 
-    fn db(&self) -> &Self::Database {
+    fn db_ref(&self) -> &Self::Database {
         &self.database
     }
 
-    fn db_mut(&mut self) -> &mut Self::Database {
+    fn db(&mut self) -> &mut Self::Database {
         &mut self.database
     }
 

--- a/crates/database/interface/src/async_db.rs
+++ b/crates/database/interface/src/async_db.rs
@@ -1,10 +1,10 @@
 use core::future::Future;
 
+use crate::{DBErrorMarker, Database, DatabaseRef};
+use core::error::Error;
 use primitives::{Address, B256, U256};
 use state::{AccountInfo, Bytecode};
 use tokio::runtime::{Handle, Runtime};
-
-use crate::{DBErrorMarker, Database, DatabaseRef};
 
 /// The async EVM database interface
 ///
@@ -13,7 +13,7 @@ use crate::{DBErrorMarker, Database, DatabaseRef};
 /// Use [WrapDatabaseAsync] to provide [Database] implementation for a type that only implements this trait.
 pub trait DatabaseAsync {
     /// The database error type
-    type Error: Send + DBErrorMarker;
+    type Error: Send + DBErrorMarker + Error;
 
     /// Gets basic account information.
     fn basic_async(
@@ -48,7 +48,7 @@ pub trait DatabaseAsync {
 /// Use [WrapDatabaseAsync] to provide [DatabaseRef] implementation for a type that only implements this trait.
 pub trait DatabaseAsyncRef {
     /// The database error type
-    type Error: Send + DBErrorMarker;
+    type Error: Send + DBErrorMarker + Error;
 
     /// Gets basic account information.
     fn basic_async_ref(

--- a/crates/database/interface/src/empty_db.rs
+++ b/crates/database/interface/src/empty_db.rs
@@ -1,4 +1,5 @@
 use crate::{DBErrorMarker, Database, DatabaseRef};
+use core::error::Error;
 use core::{convert::Infallible, fmt, marker::PhantomData};
 use primitives::{keccak256, Address, B256, U256};
 use state::{AccountInfo, Bytecode};
@@ -52,7 +53,7 @@ impl<E> EmptyDBTyped<E> {
     }
 }
 
-impl<E: DBErrorMarker> Database for EmptyDBTyped<E> {
+impl<E: DBErrorMarker + Error> Database for EmptyDBTyped<E> {
     type Error = E;
 
     #[inline]
@@ -76,7 +77,7 @@ impl<E: DBErrorMarker> Database for EmptyDBTyped<E> {
     }
 }
 
-impl<E: DBErrorMarker> DatabaseRef for EmptyDBTyped<E> {
+impl<E: DBErrorMarker + Error> DatabaseRef for EmptyDBTyped<E> {
     type Error = E;
 
     #[inline]

--- a/crates/database/interface/src/lib.rs
+++ b/crates/database/interface/src/lib.rs
@@ -8,6 +8,7 @@ extern crate alloc as std;
 use core::convert::Infallible;
 
 use auto_impl::auto_impl;
+use core::error::Error;
 use primitives::{Address, HashMap, B256, U256};
 use state::{Account, AccountInfo, Bytecode};
 use std::string::String;
@@ -35,7 +36,7 @@ impl DBErrorMarker for String {}
 #[auto_impl(&mut, Box)]
 pub trait Database {
     /// The database error type.
-    type Error: DBErrorMarker;
+    type Error: DBErrorMarker + Error;
     //type Bytecode: BytecodeTrait;
 
     /// Gets basic account information.
@@ -67,7 +68,7 @@ pub trait DatabaseCommit {
 #[auto_impl(&, &mut, Box, Rc, Arc)]
 pub trait DatabaseRef {
     /// The database error type.
-    type Error: DBErrorMarker;
+    type Error: DBErrorMarker + Error;
 
     /// Gets basic account information.
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error>;

--- a/crates/database/interface/src/lib.rs
+++ b/crates/database/interface/src/lib.rs
@@ -130,4 +130,6 @@ pub trait DatabaseGetter {
     type Database: Database;
 
     fn db(&mut self) -> &mut Self::Database;
+
+    fn db_ref(&self) -> &Self::Database;
 }

--- a/crates/database/src/alloydb.rs
+++ b/crates/database/src/alloydb.rs
@@ -7,14 +7,24 @@ use alloy_provider::{
     Network, Provider,
 };
 use alloy_transport::{Transport, TransportError};
+use core::error::Error;
 use database_interface::{async_db::DatabaseAsyncRef, DBErrorMarker};
 use primitives::{Address, B256, U256};
 use state::{AccountInfo, Bytecode};
+use std::fmt::Display;
 
 #[derive(Debug)]
 pub struct DBTransportError(pub TransportError);
 
 impl DBErrorMarker for DBTransportError {}
+
+impl Display for DBTransportError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Transport error: {}", self.0)
+    }
+}
+
+impl Error for DBTransportError {}
 
 impl From<TransportError> for DBTransportError {
     fn from(e: TransportError) -> Self {

--- a/crates/database/src/states/state_builder.rs
+++ b/crates/database/src/states/state_builder.rs
@@ -85,7 +85,7 @@ impl<DB: Database> StateBuilder<DB> {
     }
 
     /// With boxed version of database.
-    pub fn with_database_boxed<Error: DBErrorMarker>(
+    pub fn with_database_boxed<Error: DBErrorMarker + core::error::Error>(
         self,
         database: DBBox<'_, Error>,
     ) -> StateBuilder<DBBox<'_, Error>> {

--- a/crates/handler/interface/src/execution.rs
+++ b/crates/handler/interface/src/execution.rs
@@ -32,7 +32,7 @@ pub trait ExecutionHandler {
             let frame = frame_stack.last_mut().unwrap();
             let call_or_result = frame.run(context)?;
 
-            let result = match call_or_result {
+            let mut result = match call_or_result {
                 FrameOrResultGen::Frame(init) => match frame.init(context, init)? {
                     FrameOrResultGen::Frame(new_frame) => {
                         frame_stack.push(new_frame);
@@ -49,6 +49,7 @@ pub trait ExecutionHandler {
             };
 
             let Some(frame) = frame_stack.last_mut() else {
+                Self::Frame::final_return(context, &mut result)?;
                 return self.last_frame_result(context, result);
             };
             frame.return_result(context, result)?;

--- a/crates/handler/interface/src/frame.rs
+++ b/crates/handler/interface/src/frame.rs
@@ -13,7 +13,6 @@ pub trait Frame: Sized {
     ) -> Result<FrameOrResultGen<Self, Self::FrameResult>, Self::Error>;
 
     fn final_return(
-        self,
         context: &mut Self::Context,
         result: &mut Self::FrameResult,
     ) -> Result<(), Self::Error>;

--- a/crates/handler/interface/src/frame.rs
+++ b/crates/handler/interface/src/frame.rs
@@ -12,6 +12,12 @@ pub trait Frame: Sized {
         frame_input: Self::FrameInit,
     ) -> Result<FrameOrResultGen<Self, Self::FrameResult>, Self::Error>;
 
+    fn final_return(
+        self,
+        context: &mut Self::Context,
+        result: &mut Self::FrameResult,
+    ) -> Result<(), Self::Error>;
+
     fn init(
         &self,
         context: &mut Self::Context,

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -484,7 +484,6 @@ where
     }
 
     fn final_return(
-        self,
         _context: &mut Self::Context,
         _result: &mut Self::FrameResult,
     ) -> Result<(), Self::Error> {

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -483,6 +483,14 @@ where
         Self::init_with_context(0, frame_input, memory, precompiles, instructions, context)
     }
 
+    fn final_return(
+        self,
+        _context: &mut Self::Context,
+        _result: &mut Self::FrameResult,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
     fn init(
         &self,
         context: &mut CTX,

--- a/crates/inspector/src/inspector.rs
+++ b/crates/inspector/src/inspector.rs
@@ -716,8 +716,16 @@ where
             }
             _ => (),
         }
-
         ret
+    }
+
+    fn final_return(
+        self,
+        context: &mut Self::Context,
+        result: &mut Self::FrameResult,
+    ) -> Result<(), Self::Error> {
+        context.frame_end(result);
+        Ok(())
     }
 
     fn init(
@@ -736,9 +744,6 @@ where
         if let Ok(FrameOrResultGen::Frame(frame)) = &mut ret {
             context.initialize_interp(&mut frame.eth_frame.interpreter);
         }
-
-        // TODO : Handle last frame_end. MAKE a separate function for `last_return_result`.
-
         ret
     }
 

--- a/crates/inspector/src/inspector.rs
+++ b/crates/inspector/src/inspector.rs
@@ -27,6 +27,7 @@ use revm::{
     },
     precompile::PrecompileErrors,
     primitives::{Address, Bytes, Log, B256, U256},
+    state::EvmState,
     Context, Error, Evm, JournalEntry,
 };
 use std::{rc::Rc, vec::Vec};
@@ -396,6 +397,10 @@ where
     fn db(&mut self) -> &mut Self::Database {
         self.inner.db()
     }
+
+    fn db_ref(&self) -> &Self::Database {
+        self.inner.db_ref()
+    }
 }
 
 impl<INSP, DB, CTX> ErrorGetter for InspectorContext<INSP, DB, CTX>
@@ -527,6 +532,10 @@ pub trait JournalExt {
     fn logs(&self) -> &[Log];
 
     fn last_journal(&self) -> &[JournalEntry];
+
+    fn evm_state(&self) -> &EvmState;
+
+    fn evm_state_mut(&mut self) -> &mut EvmState;
 }
 
 impl<DB: Database> JournalExt for JournaledState<DB> {
@@ -536,6 +545,14 @@ impl<DB: Database> JournalExt for JournaledState<DB> {
 
     fn last_journal(&self) -> &[JournalEntry] {
         self.journal.last().expect("Journal is never empty")
+    }
+
+    fn evm_state(&self) -> &EvmState {
+        &self.state
+    }
+
+    fn evm_state_mut(&mut self) -> &mut EvmState {
+        &mut self.state
     }
 }
 

--- a/crates/inspector/src/inspector.rs
+++ b/crates/inspector/src/inspector.rs
@@ -720,7 +720,6 @@ where
     }
 
     fn final_return(
-        self,
         context: &mut Self::Context,
         result: &mut Self::FrameResult,
     ) -> Result<(), Self::Error> {

--- a/crates/optimism/src/handler.rs
+++ b/crates/optimism/src/handler.rs
@@ -70,7 +70,6 @@ where
         if tx_type == OpTransactionType::Deposit {
             let tx = context.op_tx().deposit();
             // Do not allow for a system transaction to be processed if Regolith is enabled.
-            // TODO : Check if this is correct.
             if tx.is_system_transaction() && context.cfg().spec().is_enabled_in(OpSpecId::REGOLITH)
             {
                 return Err(OpTransactionError::DepositSystemTxPostRegolith.into());

--- a/crates/revm/src/exec.rs
+++ b/crates/revm/src/exec.rs
@@ -10,10 +10,20 @@ pub trait EvmExec {
     fn set_tx(&mut self, tx: Self::Transaction);
 
     fn exec(&mut self) -> Self::Output;
+
+    fn exec_with_tx(&mut self, tx: Self::Transaction) -> Self::Output {
+        self.set_tx(tx);
+        self.exec()
+    }
 }
 
 pub trait EvmCommit: EvmExec {
     type CommitOutput;
 
     fn exec_commit(&mut self) -> Self::CommitOutput;
+
+    fn exec_commit_with_tx(&mut self, tx: Self::Transaction) -> Self::CommitOutput {
+        self.set_tx(tx);
+        self.exec_commit()
+    }
 }

--- a/examples/database_components/Cargo.toml
+++ b/examples/database_components/Cargo.toml
@@ -27,3 +27,4 @@ revm.workspace = true
 
 # mics
 auto_impl.workspace = true
+derive_more = { version = "1.0", default-features = false }

--- a/examples/database_components/src/block_hash.rs
+++ b/examples/database_components/src/block_hash.rs
@@ -1,13 +1,13 @@
 //! BlockHash database component from [`revm::Database`]
 
 use auto_impl::auto_impl;
-use core::ops::Deref;
+use core::{error::Error as StdError, ops::Deref};
 use revm::primitives::B256;
 use std::sync::Arc;
 
 #[auto_impl(&mut, Box)]
 pub trait BlockHash {
-    type Error;
+    type Error: StdError;
 
     /// Gets block hash by block number.
     fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error>;
@@ -15,7 +15,7 @@ pub trait BlockHash {
 
 #[auto_impl(&, &mut, Box, Rc, Arc)]
 pub trait BlockHashRef {
-    type Error;
+    type Error: StdError;
 
     /// Gets block hash by block number.
     fn block_hash(&self, number: u64) -> Result<B256, Self::Error>;

--- a/examples/database_components/src/lib.rs
+++ b/examples/database_components/src/lib.rs
@@ -8,6 +8,8 @@ pub mod state;
 pub use block_hash::{BlockHash, BlockHashRef};
 pub use state::{State, StateRef};
 
+use core::{error::Error as StdError, fmt::Debug};
+use derive_more::Display;
 use revm::{
     database_interface::{DBErrorMarker, Database, DatabaseCommit, DatabaseRef},
     primitives::{Address, HashMap, B256, U256},
@@ -20,11 +22,13 @@ pub struct DatabaseComponents<S, BH> {
     pub block_hash: BH,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Display)]
 pub enum DatabaseComponentError<SE, BHE> {
     State(SE),
     BlockHash(BHE),
 }
+
+impl<SE: Debug + Display, BHE: Debug + Display> StdError for DatabaseComponentError<SE, BHE> {}
 
 impl<SE, BHE> DBErrorMarker for DatabaseComponentError<SE, BHE> {}
 

--- a/examples/database_components/src/state.rs
+++ b/examples/database_components/src/state.rs
@@ -6,11 +6,11 @@ use revm::{
     primitives::{Address, B256, U256},
     state::{AccountInfo, Bytecode},
 };
-use std::sync::Arc;
+use std::{error::Error as StdError, sync::Arc};
 
 #[auto_impl(&mut, Box)]
 pub trait State {
-    type Error;
+    type Error: StdError;
 
     /// Gets basic account information.
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error>;
@@ -24,7 +24,7 @@ pub trait State {
 
 #[auto_impl(&, &mut, Box, Rc, Arc)]
 pub trait StateRef {
-    type Error;
+    type Error: StdError;
 
     /// Gets basic account information.
     fn basic(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error>;


### PR DESCRIPTION
There are few places were precompile addresses are needed, so we will copying them inside journal.


Additionally Database::Error is now requiring `std::error::Error`.