### PR TITLE
Fix typos in code and documentation

### DIFF
--- a/crates/bytecode/src/eof/types_section.rs
+++ b/crates/bytecode/src/eof/types_section.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use std::vec::Vec;
 
-/// Non returning function has a output `0x80`
+/// Non returning function has an output `0x80`
 const EOF_NON_RETURNING_FUNCTION: u8 = 0x80;
 
 /// Types section that contains stack information for matching code section

--- a/crates/context/interface/src/block.rs
+++ b/crates/context/interface/src/block.rs
@@ -12,7 +12,7 @@ pub trait Block {
     /// The number of ancestor blocks of this block (block height).
     fn number(&self) -> u64;
 
-    /// Beneficiary (Coinbase, miner) is a address that have signed the block.
+    /// Beneficiary (Coinbase, miner) is an address that have signed the block.
     ///
     /// This is the receiver address of priority gas rewards.
     fn beneficiary(&self) -> Address;

--- a/crates/context/interface/src/cfg.rs
+++ b/crates/context/interface/src/cfg.rs
@@ -10,7 +10,7 @@ pub trait Cfg {
 
     fn chain_id(&self) -> u64;
 
-    // TODO : Make SpecId a associated type but for faster development we use impl Into.
+    // TODO : Make SpecId an associated type but for faster development we use impl Into.
     fn spec(&self) -> Self::Spec;
 
     fn max_code_size(&self) -> usize;

--- a/crates/context/src/block.rs
+++ b/crates/context/src/block.rs
@@ -7,7 +7,7 @@ use primitives::{Address, B256, U256};
 pub struct BlockEnv {
     /// The number of ancestor blocks of this block (block height)
     pub number: u64,
-    /// Beneficiary (Coinbase or miner) is a address that have signed the block
+    /// Beneficiary (Coinbase or miner) is an address that have signed the block
     ///
     /// This is the receiver address of all the gas spent in the block.
     pub beneficiary: Address,

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -126,7 +126,7 @@ where
         }
     }
 
-    // TODO : Make impl a associate type. With this associate type we can implement.
+    // TODO : Make impl an associate type. With this associate type we can implement.
     // InspectorInstructionProvider over generic type.
     fn table(&mut self) -> &[impl CustomInstruction<Wire = Self::WIRE, Host = Self::Host>; 256] {
         self.instruction_table.as_ref()

--- a/documentation/src/crates/revm/evm.md
+++ b/documentation/src/crates/revm/evm.md
@@ -6,7 +6,7 @@
 
 It is consisting of two main parts the `Context` and the `Handler`. `Context` represent the state that is needed for execution and `Handler` contains list of functions that act as a logic.
 
-`Context` is additionally split between `EvmContext` and `External` context. `EvmContext` is internal and contains `Database`, `Environment`, `JournaledState` and `Precompiles`. And `External` context is fully generic without any trait restrains and its purpose is to allow custom handlers to save state in runtime or allows hooks to be added (For example external contexts can be a Inspector), more on its usage can be seen in [`EvmBuilder`](./builder.md).
+`Context` is additionally split between `EvmContext` and `External` context. `EvmContext` is internal and contains `Database`, `Environment`, `JournaledState` and `Precompiles`. And `External` context is fully generic without any trait restrains and its purpose is to allow custom handlers to save state in runtime or allows hooks to be added (For example external contexts can be an Inspector), more on its usage can be seen in [`EvmBuilder`](./builder.md).
 
 `Evm` implements the [`Host`](./../interpreter/host.md) trait, which defines an interface for the interaction of the EVM Interpreter with its environment (or "host"), encompassing essential operations such as account and storage access, creating logs, and invoking sub calls and selfdestruct.
 


### PR DESCRIPTION
This pull request fixes several grammatical and typographical errors across multiple code files and documentation, ensuring improved clarity and consistency.

### Summary of Changes:
1. **Corrected "a" to "an"** in appropriate contexts:
   - `types_section.rs`: Updated "a output" to "an output."
   - `block.rs` (two instances): Updated "a address" to "an address."
   - `cfg.rs`: Updated "a associated type" to "an associated type."
   - `interpreter.rs`: Updated "a associate type" to "an associate type."
   - `evm.md`: Fixed "a Inspector" to "an Inspector."

2. **Files Modified**:
   - `crates/bytecode/src/eof/types_section.rs`
   - `crates/context/interface/src/block.rs`
   - `crates/context/interface/src/cfg.rs`
   - `crates/context/src/block.rs`
   - `crates/interpreter/src/interpreter.rs`
   - `documentation/src/crates/revm/evm.md`