### PR TITLE
Remove unnecessary execution logic

### DIFF
--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -108,7 +108,7 @@ where
         // Make account warm and loaded
         let _ = context
             .journal()
-            .load_account_delegated(inputs.bytecode_address)?;
+            .load_account(inputs.bytecode_address)?;
 
         // Create subroutine checkpoint
         let checkpoint = context.journal().checkpoint();

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -106,9 +106,7 @@ where
         }
 
         // Make account warm and loaded
-        let _ = context
-            .journal()
-            .load_account(inputs.bytecode_address)?;
+        let _ = context.journal().load_account(inputs.bytecode_address)?;
 
         // Create subroutine checkpoint
         let checkpoint = context.journal().checkpoint();


### PR DESCRIPTION
It seems load_code is the only effective thing happening here since AccountLoad is not used. Just replaced load_account_delegated with load_code. 