### PR TITLE
feat: extract and export `estimate_tx_compressed_size`

### DIFF
--- a/crates/optimism/src/lib.rs
+++ b/crates/optimism/src/lib.rs
@@ -19,4 +19,4 @@ pub use l1block::{
 };
 pub use result::OptimismHaltReason;
 pub use spec::*;
-pub use transaction::{error::OpTransactionError, OpTransaction};
+pub use transaction::{error::OpTransactionError, OpTransaction, estimate_tx_compressed_size};

--- a/crates/optimism/src/transaction.rs
+++ b/crates/optimism/src/transaction.rs
@@ -4,3 +4,26 @@ pub mod error;
 
 pub use abstraction::{OpTransaction, OpTxTrait};
 pub use error::OpTransactionError;
+
+use crate::fast_lz::flz_compress_len;
+
+/// <https://github.com/ethereum-optimism/op-geth/blob/647c346e2bef36219cc7b47d76b1cb87e7ca29e4/core/types/rollup_cost.go#L79>
+const L1_COST_FASTLZ_COEF: u64 = 836_500;
+
+/// <https://github.com/ethereum-optimism/op-geth/blob/647c346e2bef36219cc7b47d76b1cb87e7ca29e4/core/types/rollup_cost.go#L78>
+/// Inverted to be used with `saturating_sub`.
+const L1_COST_INTERCEPT: u64 = 42_585_600;
+
+/// <https://github.com/ethereum-optimism/op-geth/blob/647c346e2bef36219cc7b47d76b1cb87e7ca29e4/core/types/rollup_cost.go#82>
+const MIN_TX_SIZE_SCALED: u64 = 100 * 1_000_000;
+
+
+/// Estimates the compressed size of a transaction.
+pub fn estimate_tx_compressed_size(input: &[u8]) -> u64 {
+    let fastlz_size = flz_compress_len(input) as u64;
+
+    fastlz_size
+        .saturating_mul(L1_COST_FASTLZ_COEF)
+        .saturating_sub(L1_COST_INTERCEPT)
+        .max(MIN_TX_SIZE_SCALED)
+}


### PR DESCRIPTION
This will allow calling `estimate_tx_compressed_size` for the purpose of adding DA size limits to the OP sequencer. Example usage here: https://github.com/paradigmxyz/reth/pull/13757/files#diff-fc959a93a8c46daf00cdff39ee39f8c1c18d36cd482a50a300294000cea38c37R82

I can also move this function to a separate file if that's desired - just lmk!