### PR TITLE
fix(revme): Statetest stop exec when print output is true

### DIFF
--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -434,7 +434,7 @@ pub fn execute_test_suite(
                                 .with_tx(&tx)
                                 .with_cfg(&cfg)
                                 .with_db(&mut state),
-                            TracerEip3155::new(Box::new(stderr())),
+                            TracerEip3155::new(Box::new(stderr())).without_summary(),
                         ),
                         inspector_handler(),
                     );
@@ -510,7 +510,7 @@ pub fn execute_test_suite(
                             .with_block(&block)
                             .with_tx(&tx)
                             .with_cfg(&cfg),
-                        TracerEip3155::new(Box::new(stderr())),
+                        TracerEip3155::new(Box::new(stderr())).without_summary(),
                     ),
                     inspector_handler(),
                 );

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -482,10 +482,10 @@ pub fn execute_test_suite(
                     (e, res)
                 };
 
-                // Print only once or
-                // if we are already in trace mode, just return error
+                // Print only once or if we are already in trace mode, just return error
+                // If trace is true that print_json_outcome will be also true.
                 static FAILED: AtomicBool = AtomicBool::new(false);
-                if trace || FAILED.swap(true, Ordering::SeqCst) {
+                if print_json_outcome || FAILED.swap(true, Ordering::SeqCst) {
                     return Err(TestError {
                         name: name.clone(),
                         path: path.clone(),

--- a/bins/revme/src/main.rs
+++ b/bins/revme/src/main.rs
@@ -2,5 +2,5 @@ use clap::Parser;
 use revme::cmd::{Error, MainCmd};
 
 fn main() -> Result<(), Error> {
-    MainCmd::parse().run().inspect_err(|e| eprintln!("{e:?}"))
+    MainCmd::parse().run().inspect_err(|e| println!("{e:?}"))
 }


### PR DESCRIPTION
Additional lines are redirected to std output: https://github.com/bluealloy/revm/issues/1977