### PR TITLE
Add essential EIP-7756 tracing fields

### DIFF
--- a/crates/bytecode/src/bytecode.rs
+++ b/crates/bytecode/src/bytecode.rs
@@ -142,22 +142,34 @@ impl Bytecode {
         }
     }
 
+    /// Pointer to the executable bytecode.
+    ///
+    /// Note: EOF will return the pointer to the start of the code section.
+    /// while legacy bytecode will point to the start of the bytes.
+    pub fn bytecode_ptr(&self) -> *const u8 {
+        self.bytecode().as_ptr()
+    }
+
     /// Returns bytes.
     #[inline]
     pub fn bytes(&self) -> Bytes {
+        self.bytes_ref().clone()
+    }
+
+    /// Returns bytes.
+    #[inline]
+    pub fn bytes_ref(&self) -> &Bytes {
         match self {
-            Self::LegacyAnalyzed(analyzed) => analyzed.bytecode().clone(),
-            _ => self.original_bytes(),
+            Self::LegacyAnalyzed(analyzed) => analyzed.bytecode(),
+            Self::Eof(eof) => &eof.raw,
+            Self::Eip7702(code) => code.raw(),
         }
     }
 
     /// Returns bytes slice.
     #[inline]
     pub fn bytes_slice(&self) -> &[u8] {
-        match self {
-            Self::LegacyAnalyzed(analyzed) => analyzed.bytecode(),
-            _ => self.original_byte_slice(),
-        }
+        self.bytes_ref()
     }
 
     /// Returns a reference to the original bytecode.

--- a/crates/bytecode/src/eof.rs
+++ b/crates/bytecode/src/eof.rs
@@ -43,6 +43,7 @@ impl Default for Eof {
             code_section: vec![1],
             // One code section with a STOP byte.
             code: Bytes::from_static(&[0x00]),
+            code_offset: 0,
             container_section: vec![],
             data_section: Bytes::new(),
             is_data_filled: true,

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -153,6 +153,7 @@ where
 
         // ExtDelegateCall is not allowed to call non-EOF contracts.
         if is_ext_delegate_call && !bytecode.bytes_slice().starts_with(&EOF_MAGIC_BYTES) {
+            context.journal().checkpoint_revert(checkpoint);
             return return_result(InstructionResult::InvalidExtDelegateCallTarget);
         }
 

--- a/crates/inspector/src/eip3155.rs
+++ b/crates/inspector/src/eip3155.rs
@@ -1,4 +1,5 @@
 use crate::{inspectors::GasInspector, Inspector};
+use revm::interpreter::interpreter_types::{RuntimeFlag, SubRoutineStack};
 use revm::{
     bytecode::opcode::OpCode,
     context::Cfg,
@@ -21,6 +22,8 @@ pub struct TracerEip3155<CTX, INTR> {
     print_summary: bool,
     stack: Vec<U256>,
     pc: usize,
+    section: Option<u64>,
+    function_depth: Option<u64>,
     opcode: u8,
     gas: u64,
     refunded: i64,
@@ -39,6 +42,9 @@ struct Output {
     // Required fields:
     /// Program counter
     pc: u64,
+    /// EOF code section
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    section: Option<u64>,
     /// OpCode
     op: u8,
     /// Gas left before executing this operation
@@ -49,6 +55,9 @@ struct Output {
     stack: Vec<String>,
     /// Depth of the call stack
     depth: u64,
+    /// Depth of the EOF function call stack
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    function_depth: Option<u64>,
     /// Data returned by the function call
     return_data: String,
     /// Amount of **global** gas refunded
@@ -140,6 +149,8 @@ where
             stack: Default::default(),
             memory: Default::default(),
             pc: 0,
+            section: None,
+            function_depth: None,
             opcode: 0,
             gas: 0,
             refunded: 0,
@@ -213,7 +224,17 @@ where
         } else {
             None
         };
-        self.pc = interp.bytecode.pc();
+        self.pc = interp.bytecode.trace_pc();
+        self.section = if interp.runtime_flag.is_eof() {
+            Some(interp.sub_routine.routine_idx() as u64)
+        } else {
+            None
+        };
+        self.function_depth = if interp.runtime_flag.is_eof() {
+            Some(interp.sub_routine.len() as u64 + 1)
+        } else {
+            None
+        };
         self.opcode = interp.bytecode.opcode();
         self.mem_size = interp.memory.size();
         self.gas = interp.control.gas().remaining();
@@ -229,11 +250,13 @@ where
 
         let value = Output {
             pc: self.pc as u64,
+            section: self.section,
             op: self.opcode,
             gas: hex_number(self.gas),
             gas_cost: hex_number(self.gas_inspector.last_gas_cost()),
             stack: self.stack.iter().map(hex_number_u256).collect(),
             depth: context.journal().depth() as u64,
+            function_depth: self.function_depth,
             return_data: "0x".to_string(),
             refund: hex_number(self.refunded as u64),
             mem_size: self.mem_size.to_string(),

--- a/crates/inspector/src/eip3155.rs
+++ b/crates/inspector/src/eip3155.rs
@@ -21,7 +21,7 @@ pub struct TracerEip3155<CTX, INTR> {
     /// Print summary of the execution.
     print_summary: bool,
     stack: Vec<U256>,
-    pc: usize,
+    pc: u64,
     section: Option<u64>,
     function_depth: Option<u64>,
     opcode: u8,
@@ -224,7 +224,7 @@ where
         } else {
             None
         };
-        self.pc = interp.bytecode.trace_pc();
+        self.pc = interp.bytecode.pc() as u64;
         self.section = if interp.runtime_flag.is_eof() {
             Some(interp.sub_routine.routine_idx() as u64)
         } else {
@@ -249,7 +249,7 @@ where
         }
 
         let value = Output {
-            pc: self.pc as u64,
+            pc: self.pc,
             section: self.section,
             op: self.opcode,
             gas: hex_number(self.gas),

--- a/crates/interpreter/src/interpreter/ext_bytecode.rs
+++ b/crates/interpreter/src/interpreter/ext_bytecode.rs
@@ -30,7 +30,7 @@ impl Deref for ExtBytecode {
 impl ExtBytecode {
     /// Create new extended bytecode and set the instruction pointer to the start of the bytecode.
     pub fn new(base: Bytecode) -> Self {
-        let instruction_pointer = base.bytecode().as_ptr();
+        let instruction_pointer = base.bytecode_ptr();
         Self {
             base,
             instruction_pointer,
@@ -40,7 +40,7 @@ impl ExtBytecode {
 
     /// Creates new `ExtBytecode` with the given hash.
     pub fn new_with_hash(base: Bytecode, hash: B256) -> Self {
-        let instruction_pointer = base.bytecode().as_ptr();
+        let instruction_pointer = base.bytecode_ptr();
         Self {
             base,
             instruction_pointer,
@@ -66,10 +66,12 @@ impl Jumps for ExtBytecode {
     fn relative_jump(&mut self, offset: isize) {
         self.instruction_pointer = unsafe { self.instruction_pointer.offset(offset) };
     }
+
     #[inline]
     fn absolute_jump(&mut self, offset: usize) {
-        self.instruction_pointer = unsafe { self.base.bytecode().as_ptr().add(offset) };
+        self.instruction_pointer = unsafe { self.base.bytes_ref().as_ptr().add(offset) };
     }
+
     #[inline]
     fn is_valid_legacy_jump(&mut self, offset: usize) -> bool {
         self.base

--- a/crates/interpreter/src/interpreter/ext_bytecode.rs
+++ b/crates/interpreter/src/interpreter/ext_bytecode.rs
@@ -92,6 +92,18 @@ impl Jumps for ExtBytecode {
                 .offset_from(self.base.bytecode().as_ptr()) as usize
         }
     }
+    #[inline]
+    fn trace_pc(&self) -> usize {
+        match &self.base {
+            Bytecode::Eof(_) => unsafe {
+                // SAFETY: `instruction_pointer` should be at an offset from the start of the bytecode.
+                // In practice this is always true unless a caller modifies the `instruction_pointer` field manually.
+                self.instruction_pointer
+                    .offset_from(self.base.eof().unwrap().raw.as_ptr()) as usize
+            },
+            _ => self.pc(),
+        }
+    }
 }
 
 impl Immediates for ExtBytecode {

--- a/crates/interpreter/src/interpreter/ext_bytecode.rs
+++ b/crates/interpreter/src/interpreter/ext_bytecode.rs
@@ -88,16 +88,12 @@ impl Jumps for ExtBytecode {
 
     #[inline]
     fn pc(&self) -> usize {
-        let bytecode = match &self.base {
-            Bytecode::LegacyAnalyzed(ref analyzed) => analyzed.bytecode(),
-            Bytecode::Eof(ref eof) => &eof.raw,
-            Bytecode::Eip7702(eip7702) => eip7702.raw(),
-        };
-        // SAFETY: `instruction_pointer` should be at an offset from the start of the bytecode.
+        // SAFETY: `instruction_pointer` should be at an offset from the start of the bytes.
         // In practice this is always true unless a caller modifies the `instruction_pointer` field manually.
-        //
-        // For EOF bytecode, code bytes should be part of the raw bytes.
-        unsafe { self.instruction_pointer.offset_from(bytecode.as_ptr()) as usize }
+        unsafe {
+            self.instruction_pointer
+                .offset_from(self.base.bytes_ref().as_ptr()) as usize
+        }
     }
 }
 

--- a/crates/interpreter/src/interpreter_types.rs
+++ b/crates/interpreter/src/interpreter_types.rs
@@ -42,8 +42,6 @@ pub trait Jumps {
     fn is_valid_legacy_jump(&mut self, offset: usize) -> bool;
     /// Returns current program counter.
     fn pc(&self) -> usize;
-    /// Returns the pc offset for tracing
-    fn trace_pc(&self) -> usize;
     /// Returns instruction opcode.
     fn opcode(&self) -> u8;
 }

--- a/crates/interpreter/src/interpreter_types.rs
+++ b/crates/interpreter/src/interpreter_types.rs
@@ -42,6 +42,8 @@ pub trait Jumps {
     fn is_valid_legacy_jump(&mut self, offset: usize) -> bool;
     /// Returns current program counter.
     fn pc(&self) -> usize;
+    /// Returns the pc offset for tracing
+    fn trace_pc(&self) -> usize;
     /// Returns instruction opcode.
     fn opcode(&self) -> u8;
 }


### PR DESCRIPTION
Add (for eof) section and funcion depth fields, and make pc container relative instead of code section relative.