### PR TITLE
remove duplicate instructions

### DIFF
--- a/crates/interpreter/src/instructions.rs
+++ b/crates/interpreter/src/instructions.rs
@@ -33,9 +33,6 @@ pub const fn instruction_table<WIRE: InterpreterTypes, H: Host + ?Sized>(
 
     table[STOP as usize] = control::stop;
     table[ADD as usize] = arithmetic::add;
-    table[STOP as usize] = control::stop;
-
-    table[ADD as usize] = arithmetic::add;
     table[MUL as usize] = arithmetic::mul;
     table[SUB as usize] = arithmetic::sub;
     table[DIV as usize] = arithmetic::div;


### PR DESCRIPTION
remove duplicate instructions (STOP, ADD) from instruction table