### PR TITLE
chore: simplify some generics

### DIFF
--- a/crates/context/interface/src/result.rs
+++ b/crates/context/interface/src/result.rs
@@ -14,7 +14,7 @@ impl<HaltReasonT> HaltReasonTrait for HaltReasonT where
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ResultAndState<HaltReasonT: HaltReasonTrait> {
+pub struct ResultAndState<HaltReasonT: HaltReasonTrait = HaltReason> {
     /// Status of execution
     pub result: ExecutionResult<HaltReasonT>,
     /// State that got updated
@@ -37,7 +37,7 @@ impl<HaltReasonT: HaltReasonTrait> ResultAndState<HaltReasonT> {
 /// Result of a transaction execution
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum ExecutionResult<HaltReasonT: HaltReasonTrait> {
+pub enum ExecutionResult<HaltReasonT: HaltReasonTrait = HaltReason> {
     /// Returned successfully
     Success {
         reason: SuccessReason,
@@ -192,7 +192,7 @@ impl Output {
 /// Main EVM error
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum EVMError<DBError, TransactionError> {
+pub enum EVMError<DBError, TransactionError = InvalidTransaction> {
     /// Transaction validation error
     Transaction(TransactionError),
     /// Header validation error

--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -8,7 +8,7 @@ use std::{vec, vec::Vec};
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
-pub struct CfgEnv<SPEC: Into<SpecId> = SpecId> {
+pub struct CfgEnv<SPEC = SpecId> {
     /// Chain ID of the EVM
     ///
     /// `chain_id` will be compared to the transaction's Chain ID.
@@ -77,7 +77,14 @@ pub struct CfgEnv<SPEC: Into<SpecId> = SpecId> {
     pub disable_base_fee: bool,
 }
 
-impl<SPEC: Into<SpecId>> CfgEnv<SPEC> {
+impl CfgEnv {
+    /// Creates new `CfgEnv` with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<SPEC> CfgEnv<SPEC> {
     pub fn with_chain_id(mut self, chain_id: u64) -> Self {
         self.chain_id = chain_id;
         self
@@ -196,12 +203,12 @@ impl<SPEC: Into<SpecId> + Copy> Cfg for CfgEnv<SPEC> {
     }
 }
 
-impl Default for CfgEnv {
+impl<SPEC: Default> Default for CfgEnv<SPEC> {
     fn default() -> Self {
         Self {
             chain_id: 1,
             limit_contract_code_size: None,
-            spec: SpecId::PRAGUE,
+            spec: Default::default(),
             disable_nonce_check: false,
             blob_target_and_max_count: vec![(SpecId::CANCUN, 3, 6), (SpecId::PRAGUE, 6, 9)],
             #[cfg(feature = "memory_limit")]
@@ -226,7 +233,7 @@ mod test {
 
     #[test]
     fn blob_max_and_target_count() {
-        let cfg = CfgEnv::default();
+        let cfg: CfgEnv = Default::default();
         assert_eq!(cfg.blob_max_count(SpecId::BERLIN), (6));
         assert_eq!(cfg.blob_max_count(SpecId::CANCUN), (6));
         assert_eq!(cfg.blob_max_count(SpecId::PRAGUE), (9));

--- a/crates/inspector/src/exec.rs
+++ b/crates/inspector/src/exec.rs
@@ -22,7 +22,7 @@ use revm::{
 };
 use std::vec::Vec;
 
-pub trait InspectEvm<CTX, INTR: InterpreterTypes>: ExecuteEvm {
+pub trait InspectEvm<INTR: InterpreterTypes>: ExecuteEvm {
     fn inspect<'a, 'b, INSP>(&'a mut self, tx: Self::Transaction, inspector: INSP) -> Self::Output
     where
         INSP: Inspector<&'a mut Self, INTR> + 'b,
@@ -45,7 +45,7 @@ impl<
         DB: Database,
         JOURNAL: Journal<Database = DB, FinalOutput = (EvmState, Vec<Log>)> + JournalExt,
         CHAIN,
-    > InspectEvm<&mut Self, EthInterpreter> for Context<BLOCK, TX, CFG, DB, JOURNAL, CHAIN>
+    > InspectEvm<EthInterpreter> for Context<BLOCK, TX, CFG, DB, JOURNAL, CHAIN>
 {
     fn inspect_previous<'a, 'b, INSP>(&'a mut self, inspector: INSP) -> Self::Output
     where
@@ -56,9 +56,7 @@ impl<
     }
 }
 
-pub trait InspectCommitEvm<CTX, INTR: InterpreterTypes>:
-    InspectEvm<CTX, INTR> + ExecuteCommitEvm
-{
+pub trait InspectCommitEvm<INTR: InterpreterTypes>: InspectEvm<INTR> + ExecuteCommitEvm {
     fn inspect_commit<'a, 'b, INSP>(
         &'a mut self,
         tx: Self::Transaction,
@@ -83,7 +81,7 @@ impl<
         DB: Database + DatabaseCommit,
         JOURNAL: Journal<Database = DB, FinalOutput = (EvmState, Vec<Log>)> + JournalExt,
         CHAIN,
-    > InspectCommitEvm<&mut Self, EthInterpreter> for Context<BLOCK, TX, CFG, DB, JOURNAL, CHAIN>
+    > InspectCommitEvm<EthInterpreter> for Context<BLOCK, TX, CFG, DB, JOURNAL, CHAIN>
 {
     fn inspect_commit_previous<'a, 'b, INSP>(&'a mut self, inspector: INSP) -> Self::CommitOutput
     where

--- a/crates/optimism/src/api/inspect.rs
+++ b/crates/optimism/src/api/inspect.rs
@@ -32,7 +32,7 @@ impl<
         CFG: Cfg<Spec = crate::OpSpec>,
         DB: Database,
         JOURNAL: Journal<Database = DB, FinalOutput = (EvmState, Vec<Log>)> + JournalExt,
-    > InspectEvm<&mut Self, EthInterpreter> for OpContext<BLOCK, TX, CFG, DB, JOURNAL>
+    > InspectEvm<EthInterpreter> for OpContext<BLOCK, TX, CFG, DB, JOURNAL>
 {
     fn inspect_previous<'a, 'b, INSP>(&'a mut self, inspector: INSP) -> Self::Output
     where
@@ -43,9 +43,7 @@ impl<
     }
 }
 
-pub trait InspectCommitEvm<CTX, INTR: InterpreterTypes>:
-    InspectEvm<CTX, INTR> + ExecuteCommitEvm
-{
+pub trait InspectCommitEvm<INTR: InterpreterTypes>: InspectEvm<INTR> + ExecuteCommitEvm {
     fn inspect_commit<'a, 'b, INSP>(
         &'a mut self,
         tx: Self::Transaction,
@@ -69,7 +67,7 @@ impl<
         CFG: Cfg<Spec = OpSpec>,
         DB: Database + DatabaseCommit,
         JOURNAL: Journal<Database = DB, FinalOutput = (EvmState, Vec<Log>)> + JournalExt,
-    > InspectCommitEvm<&mut Self, EthInterpreter> for OpContext<BLOCK, TX, CFG, DB, JOURNAL>
+    > InspectCommitEvm<EthInterpreter> for OpContext<BLOCK, TX, CFG, DB, JOURNAL>
 {
     fn inspect_commit_previous<'a, 'b, INSP>(&'a mut self, inspector: INSP) -> Self::CommitOutput
     where

--- a/crates/optimism/src/api/into_optimism.rs
+++ b/crates/optimism/src/api/into_optimism.rs
@@ -52,7 +52,7 @@ impl DefaultOp
     fn default_op() -> Self {
         Context::default()
             .with_tx(OpTransaction::default())
-            .with_cfg(CfgEnv::default().with_spec(OpSpec::Op(OpSpecId::BEDROCK)))
+            .with_cfg(CfgEnv::new().with_spec(OpSpec::Op(OpSpecId::BEDROCK)))
             .with_chain(L1BlockInfo::default())
     }
 }

--- a/crates/optimism/src/context.rs
+++ b/crates/optimism/src/context.rs
@@ -38,7 +38,7 @@ impl Default for OpContext {
         Self(
             Context::default()
                 .with_tx(OpTransaction::default())
-                .with_cfg(CfgEnv::default().with_spec(OpSpec::Op(OpSpecId::BEDROCK)))
+                .with_cfg(CfgEnv::new().with_spec(OpSpec::Op(OpSpecId::BEDROCK)))
                 .with_chain(L1BlockInfo::default()),
         )
     }
@@ -55,7 +55,7 @@ impl OpContext {
     > {
         Context::default()
             .with_tx(OpTransaction::default())
-            .with_cfg(CfgEnv::default().with_spec(OpSpec::Op(OpSpecId::BEDROCK)))
+            .with_cfg(CfgEnv::new().with_spec(OpSpec::Op(OpSpecId::BEDROCK)))
             .with_chain(L1BlockInfo::default())
     }
 }


### PR DESCRIPTION
Adds default generics for `EvmError`, `ResultAndState`, `ExecutionResult`.

Removes CTX generic from `InspectEvm` and `InspectCommitEvm` as it's unused.

Removes `Spec: Into<SpecId>` bound from `CfgEnv` struct definition