### PR TITLE
fix(Inspector): frame_end called multiple times

### DIFF
--- a/crates/handler/interface/src/item_or_result.rs
+++ b/crates/handler/interface/src/item_or_result.rs
@@ -1,5 +1,6 @@
 use crate::Frame;
 
+#[derive(Clone, Debug)]
 pub enum ItemOrResult<ITEM, RES> {
     Item(ITEM),
     Result(RES),

--- a/crates/inspector/src/inspector.rs
+++ b/crates/inspector/src/inspector.rs
@@ -266,14 +266,9 @@ where
             .handler
             .frame_init_first(context, frame_context, frame_input);
 
-        match &mut ret {
-            Ok(ItemOrResult::Result(res)) => {
-                context.frame_end(res);
-            }
-            Ok(ItemOrResult::Item(frame)) => {
-                context.initialize_interp(frame.interpreter());
-            }
-            _ => (),
+        // only if new frame is created call initialize_interp hook.
+        if let Ok(ItemOrResult::Item(frame)) = &mut ret {
+            context.initialize_interp(frame.interpreter());
         }
         ret
     }
@@ -297,14 +292,10 @@ where
         let mut ret = self
             .handler
             .frame_init(frame, context, frame_context, frame_input);
-        match &mut ret {
-            Ok(ItemOrResult::Result(res)) => {
-                context.frame_end(res);
-            }
-            Ok(ItemOrResult::Item(frame)) => {
-                context.initialize_interp(frame.interpreter());
-            }
-            _ => (),
+
+        // only if new frame is created call initialize_interp hook.
+        if let Ok(ItemOrResult::Item(frame)) = &mut ret {
+            context.initialize_interp(frame.interpreter());
         }
         ret
     }

--- a/crates/precompile/src/bn128.rs
+++ b/crates/precompile/src/bn128.rs
@@ -283,7 +283,7 @@ mod tests {
         .unwrap();
 
         let res = run_add(&input, BYZANTIUM_ADD_GAS_COST, 499);
-        println!("{:?}", res);
+
         assert!(matches!(
             res,
             Err(PrecompileErrors::Error(PrecompileError::OutOfGas))


### PR DESCRIPTION
frame_end is called twice in this setup.

https://github.com/bluealloy/revm/blob/03f84f3095c9c9b5cb2d216c65f0a9b1b4704826/crates/handler/src/handler.rs#L219-L245

Main execution loop will always call `frame_return_result` and `last_frame_result` so calling `frame_end` in those two places is enough