### PR TITLE
feature(revm): Optimism BLS12-381 Pairing Check Size Input Limit

### DIFF
--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -86,7 +86,7 @@ std = [
 hashbrown = ["revm-primitives/hashbrown"]
 asm-keccak = ["revm-primitives/asm-keccak"]
 
-optimism = ["revm-primitives/optimism", "secp256r1"]
+optimism = ["revm-primitives/optimism", "secp256r1", "blst"]
 # Optimism default handler enabled Optimism handler register by default in EvmBuilder.
 optimism-default-handler = [
     "optimism",

--- a/crates/precompile/src/bls12_381/pairing.rs
+++ b/crates/precompile/src/bls12_381/pairing.rs
@@ -33,7 +33,7 @@ const INPUT_LENGTH: usize = 384;
 /// target field and 0x00 otherwise.
 ///
 /// See also: <https://eips.ethereum.org/EIPS/eip-2537#abi-for-pairing>
-pub(super) fn pairing(input: &Bytes, gas_limit: u64) -> PrecompileResult {
+pub fn pairing(input: &Bytes, gas_limit: u64) -> PrecompileResult {
     let input_len = input.len();
     if input_len == 0 || input_len % INPUT_LENGTH != 0 {
         return Err(PrecompileError::Other(format!(

--- a/crates/revm/src/optimism.rs
+++ b/crates/revm/src/optimism.rs
@@ -1,5 +1,6 @@
 //! Optimism-specific constants, types, and helpers.
 
+mod bls12;
 mod bn128;
 mod fast_lz;
 mod handler_register;

--- a/crates/revm/src/optimism/bls12.rs
+++ b/crates/revm/src/optimism/bls12.rs
@@ -1,0 +1,26 @@
+//! BLS12-381 precompile with input size limits for Optimism.
+
+use crate::primitives::Bytes;
+use revm_precompile::{
+    bls12_381, Precompile, PrecompileError, PrecompileResult, PrecompileWithAddress,
+};
+
+pub(crate) mod pair {
+    use super::*;
+
+    pub(crate) const ISTHMUS_MAX_INPUT_SIZE: usize = 235008;
+    pub(crate) const ISTHMUS: PrecompileWithAddress = PrecompileWithAddress(
+        revm_precompile::u64_to_address(bls12_381::pairing::ADDRESS),
+        Precompile::Standard(|input, gas_limit| run_pair(input, gas_limit)),
+    );
+
+    pub(crate) fn run_pair(input: &[u8], gas_limit: u64) -> PrecompileResult {
+        if input.len() > ISTHMUS_MAX_INPUT_SIZE {
+            return Err(
+                PrecompileError::Other("BLS12-381 pairing input is too large".into()).into(),
+            );
+        }
+        let input = Bytes::copy_from_slice(input);
+        bls12_381::pairing::pairing(&input, gas_limit)
+    }
+}

--- a/crates/revm/src/optimism/precompile.rs
+++ b/crates/revm/src/optimism/precompile.rs
@@ -1,6 +1,4 @@
 use once_cell::race::OnceBox;
-#[cfg(feature = "blst")]
-use revm_precompile::bls12_381;
 use revm_precompile::{secp256r1, Precompiles};
 use std::boxed::Box;
 
@@ -38,15 +36,12 @@ pub(crate) fn granite() -> &'static Precompiles {
 pub(crate) fn isthmus() -> &'static Precompiles {
     static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
     INSTANCE.get_or_init(|| {
-        let precompiles = Precompiles::cancun().clone();
+        let mut precompiles = Precompiles::cancun().clone();
 
-        // Don't include BLS12-381 precompiles in no_std builds.
-        #[cfg(feature = "blst")]
-        let precompiles = {
-            let mut precompiles = precompiles;
-            precompiles.extend(bls12_381::precompiles());
-            precompiles
-        };
+        precompiles.extend([
+            // Restrict bls12 input size
+            crate::optimism::bls12::pair::ISTHMUS,
+        ]);
 
         Box::new(precompiles)
     })


### PR DESCRIPTION
### Description

> [!NOTE]
>
> Replaces #2038.

Modifies the optimism Isthmus hardfork Precompiles to limit the input size for the BLS12-381 pairing check. 

This size input limit is specified in https://github.com/ethereum-optimism/specs/pull/553.