### PR TITLE
feat(precompiles): `no_std` BLS12-381 Precompiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,6 +875,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "bls12_381"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
+dependencies = [
+ "ff",
+ "group",
+ "pairing",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "blst"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,6 +1568,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
+ "bitvec",
  "byteorder",
  "ff_derive",
  "rand_core",
@@ -3288,6 +3302,7 @@ name = "revm-precompile"
 version = "16.0.0"
 dependencies = [
  "aurora-engine-modexp",
+ "bls12_381",
  "blst",
  "c-kzg",
  "cfg-if",

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -19,7 +19,8 @@ revm = { path = "../../crates/revm", version = "19.4.0", default-features = fals
     "std",
     "serde-json",
     "c-kzg",
-    "blst",
+    # "blst",
+    "bls-no-std",
 ] }
 alloy-rlp = { version = "0.3", default-features = false, features = [
     "arrayvec",

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -55,6 +55,9 @@ kzg-rs = { version = "0.2.3", default-features = false, optional = true }
 # BLS12-381 precompiles
 blst = { version = "0.3.13", optional = true }
 
+# no_std BLS12-381 precompiles
+bls12_381 = { version = "0.8.0", optional = true }
+
 # p256verify precompile
 p256 = { version = "0.13.2", optional = true, default-features = false, features = [
     "ecdsa",
@@ -115,6 +118,9 @@ secp256k1 = ["dep:secp256k1"]
 
 # Enables the BLS12-381 precompiles.
 blst = ["dep:blst"]
+
+# Enables no_std support for the BLS12-381 precompiles.
+bls-no-std = ["dep:bls12_381"]
 
 [[bench]]
 name = "bench"

--- a/crates/precompile/src/bls12_381_no_std.rs
+++ b/crates/precompile/src/bls12_381_no_std.rs
@@ -1,101 +1,10 @@
-//! BLS12-381 precompile with input size limits for Optimism.
+//! `no_std` BLS12-381 Precompiles
 
-use crate::primitives::{address, Address, Bytes, B256};
-use bls12_381::{G1Affine, G2Affine, G2Prepared, Gt, MillerLoopResult};
-use crate::{
-    Precompile, PrecompileError, PrecompileOutput, PrecompileResult, PrecompileWithAddress,
-};
+use crate::PrecompileWithAddress;
 
-pub(crate) mod pair {
-    use super::*;
+pub mod pairing;
 
-    /// BLS12_PAIRING precompile address.
-    const ADDRESS: Address = address!("000000000000000000000000000000000000000f");
-
-    /// Multiplier gas fee for BLS12-381 pairing operation.
-    const PAIRING_MULTIPLIER_BASE: u64 = 32600;
-
-    /// Offset gas fee for BLS12-381 pairing operation.
-    const PAIRING_OFFSET_BASE: u64 = 37700;
-
-    /// Input length of pairing operation.
-    const INPUT_LENGTH: usize = 384;
-
-    /// The maximum input size for isthmus.
-    const ISTHMUS_MAX_INPUT_SIZE: usize = 235008;
-
-    /// The isthmus precompile for BLS12-381 pairing check.
-    pub(crate) const ISTHMUS: PrecompileWithAddress = PrecompileWithAddress(
-        ADDRESS,
-        Precompile::Standard(|input, gas_limit| run_pair(input, gas_limit)),
-    );
-
-    /// Runs the pairing for the given input, limiting the input size.
-    fn run_pair(input: &[u8], gas_limit: u64) -> PrecompileResult {
-        if input.len() > ISTHMUS_MAX_INPUT_SIZE {
-            return Err(
-                PrecompileError::Other("BLS12-381 pairing input is too large".into()).into(),
-            );
-        }
-        let input = Bytes::copy_from_slice(input);
-        pairing(&input, gas_limit)
-    }
-
-    /// Pairing call expects 384*k (k being a positive integer) bytes as an inputs
-    /// that is interpreted as byte concatenation of k slices. Each slice has the
-    /// following structure:
-    ///    * 128 bytes of G1 point encoding
-    ///    * 256 bytes of G2 point encoding
-    ///
-    /// Each point is expected to be in the subgroup of order q.
-    /// Output is 32 bytes where first 31 bytes are equal to 0x00 and the last byte
-    /// is 0x01 if pairing result is equal to the multiplicative identity in a pairing
-    /// target field and 0x00 otherwise.
-    ///
-    /// See also: <https://eips.ethereum.org/EIPS/eip-2537#abi-for-pairing>
-    fn pairing(input: &Bytes, gas_limit: u64) -> PrecompileResult {
-        let input_len = input.len();
-        if input_len == 0 || input_len % INPUT_LENGTH != 0 {
-            return Err(PrecompileError::Other(format!(
-                "Pairing input length should be multiple of {INPUT_LENGTH}, was {input_len}"
-            ))
-            .into());
-        }
-
-        let k = input_len / INPUT_LENGTH;
-        let required_gas: u64 = PAIRING_MULTIPLIER_BASE * k as u64 + PAIRING_OFFSET_BASE;
-        if required_gas > gas_limit {
-            return Err(PrecompileError::OutOfGas.into());
-        }
-
-        // Accumulator for the Fp12 multiplications of the miller loops.
-        let mut acc = MillerLoopResult::default();
-        for i in 0..k {
-            // construct an array of len 96 and copy the input into it
-            let start = i * INPUT_LENGTH;
-            let end = start + 96;
-            let input_arr: [u8; 96] = input[start..end].try_into().unwrap();
-            let Some(g1_aff) = G1Affine::from_uncompressed(&input_arr).into_option() else {
-                return Err(PrecompileError::Other("Failed to parse G1 point".into()).into());
-            };
-            let input_arr: [u8; 192] = input[end..end + 192].try_into().unwrap();
-            let Some(g2_aff) = G2Affine::from_uncompressed(&input_arr).into_option() else {
-                return Err(PrecompileError::Other("Failed to parse G2 point".into()).into());
-            };
-            let g2_prep = G2Prepared::from(g2_aff);
-            let res = bls12_381::multi_miller_loop(&[(&g1_aff, &g2_prep)]);
-            acc += res;
-        }
-
-        let res = acc.final_exponentiation();
-
-        let mut result: u8 = 0;
-        if res == Gt::identity() {
-            result = 1;
-        }
-        Ok(PrecompileOutput::new(
-            required_gas,
-            B256::with_last_byte(result).into(),
-        ))
-    }
+/// Returns the `no_std` BLS12-381 precompiles with their addresses.
+pub fn precompiles() -> impl Iterator<Item = PrecompileWithAddress> {
+    [pairing::PRECOMPILE].into_iter()
 }

--- a/crates/precompile/src/bls12_381_no_std.rs
+++ b/crates/precompile/src/bls12_381_no_std.rs
@@ -4,9 +4,22 @@ use crate::PrecompileWithAddress;
 
 pub mod utils;
 pub mod g1_add;
+pub mod g1_msm;
+pub mod g2_add;
+pub mod g2_msm;
 pub mod pairing;
+pub mod map_fp_to_g1;
+pub mod map_fp2_to_g2;
 
 /// Returns the `no_std` BLS12-381 precompiles with their addresses.
 pub fn precompiles() -> impl Iterator<Item = PrecompileWithAddress> {
-    [pairing::PRECOMPILE].into_iter()
+    [
+        g1_add::PRECOMPILE,
+        g1_msm::PRECOMPILE,
+        g2_add::PRECOMPILE,
+        g2_msm::PRECOMPILE,
+        pairing::PRECOMPILE,
+        map_fp_to_g1::PRECOMPILE,
+        map_fp2_to_g2::PRECOMPILE,
+    ].into_iter()
 }

--- a/crates/precompile/src/bls12_381_no_std.rs
+++ b/crates/precompile/src/bls12_381_no_std.rs
@@ -1,0 +1,101 @@
+//! BLS12-381 precompile with input size limits for Optimism.
+
+use crate::primitives::{address, Address, Bytes, B256};
+use bls12_381::{G1Affine, G2Affine, G2Prepared, Gt, MillerLoopResult};
+use crate::{
+    Precompile, PrecompileError, PrecompileOutput, PrecompileResult, PrecompileWithAddress,
+};
+
+pub(crate) mod pair {
+    use super::*;
+
+    /// BLS12_PAIRING precompile address.
+    const ADDRESS: Address = address!("000000000000000000000000000000000000000f");
+
+    /// Multiplier gas fee for BLS12-381 pairing operation.
+    const PAIRING_MULTIPLIER_BASE: u64 = 32600;
+
+    /// Offset gas fee for BLS12-381 pairing operation.
+    const PAIRING_OFFSET_BASE: u64 = 37700;
+
+    /// Input length of pairing operation.
+    const INPUT_LENGTH: usize = 384;
+
+    /// The maximum input size for isthmus.
+    const ISTHMUS_MAX_INPUT_SIZE: usize = 235008;
+
+    /// The isthmus precompile for BLS12-381 pairing check.
+    pub(crate) const ISTHMUS: PrecompileWithAddress = PrecompileWithAddress(
+        ADDRESS,
+        Precompile::Standard(|input, gas_limit| run_pair(input, gas_limit)),
+    );
+
+    /// Runs the pairing for the given input, limiting the input size.
+    fn run_pair(input: &[u8], gas_limit: u64) -> PrecompileResult {
+        if input.len() > ISTHMUS_MAX_INPUT_SIZE {
+            return Err(
+                PrecompileError::Other("BLS12-381 pairing input is too large".into()).into(),
+            );
+        }
+        let input = Bytes::copy_from_slice(input);
+        pairing(&input, gas_limit)
+    }
+
+    /// Pairing call expects 384*k (k being a positive integer) bytes as an inputs
+    /// that is interpreted as byte concatenation of k slices. Each slice has the
+    /// following structure:
+    ///    * 128 bytes of G1 point encoding
+    ///    * 256 bytes of G2 point encoding
+    ///
+    /// Each point is expected to be in the subgroup of order q.
+    /// Output is 32 bytes where first 31 bytes are equal to 0x00 and the last byte
+    /// is 0x01 if pairing result is equal to the multiplicative identity in a pairing
+    /// target field and 0x00 otherwise.
+    ///
+    /// See also: <https://eips.ethereum.org/EIPS/eip-2537#abi-for-pairing>
+    fn pairing(input: &Bytes, gas_limit: u64) -> PrecompileResult {
+        let input_len = input.len();
+        if input_len == 0 || input_len % INPUT_LENGTH != 0 {
+            return Err(PrecompileError::Other(format!(
+                "Pairing input length should be multiple of {INPUT_LENGTH}, was {input_len}"
+            ))
+            .into());
+        }
+
+        let k = input_len / INPUT_LENGTH;
+        let required_gas: u64 = PAIRING_MULTIPLIER_BASE * k as u64 + PAIRING_OFFSET_BASE;
+        if required_gas > gas_limit {
+            return Err(PrecompileError::OutOfGas.into());
+        }
+
+        // Accumulator for the Fp12 multiplications of the miller loops.
+        let mut acc = MillerLoopResult::default();
+        for i in 0..k {
+            // construct an array of len 96 and copy the input into it
+            let start = i * INPUT_LENGTH;
+            let end = start + 96;
+            let input_arr: [u8; 96] = input[start..end].try_into().unwrap();
+            let Some(g1_aff) = G1Affine::from_uncompressed(&input_arr).into_option() else {
+                return Err(PrecompileError::Other("Failed to parse G1 point".into()).into());
+            };
+            let input_arr: [u8; 192] = input[end..end + 192].try_into().unwrap();
+            let Some(g2_aff) = G2Affine::from_uncompressed(&input_arr).into_option() else {
+                return Err(PrecompileError::Other("Failed to parse G2 point".into()).into());
+            };
+            let g2_prep = G2Prepared::from(g2_aff);
+            let res = bls12_381::multi_miller_loop(&[(&g1_aff, &g2_prep)]);
+            acc += res;
+        }
+
+        let res = acc.final_exponentiation();
+
+        let mut result: u8 = 0;
+        if res == Gt::identity() {
+            result = 1;
+        }
+        Ok(PrecompileOutput::new(
+            required_gas,
+            B256::with_last_byte(result).into(),
+        ))
+    }
+}

--- a/crates/precompile/src/bls12_381_no_std.rs
+++ b/crates/precompile/src/bls12_381_no_std.rs
@@ -2,6 +2,8 @@
 
 use crate::PrecompileWithAddress;
 
+pub mod utils;
+pub mod g1_add;
 pub mod pairing;
 
 /// Returns the `no_std` BLS12-381 precompiles with their addresses.

--- a/crates/precompile/src/bls12_381_no_std/g1_add.rs
+++ b/crates/precompile/src/bls12_381_no_std/g1_add.rs
@@ -1,0 +1,53 @@
+//! The BLS12-381 g1 addition precompile.
+
+use crate::{
+    Precompile, PrecompileError, PrecompileOutput, PrecompileResult, PrecompileWithAddress,
+    bls12_381_no_std::utils::{extract_g1_input, encode_g1_point, G1_INPUT_ITEM_LENGTH},
+};
+use bls12_381::{G1Projective, G1Affine};
+use revm_primitives::{address, Address, Bytes};
+
+/// [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#specification) BLS12_G1ADD precompile.
+pub const PRECOMPILE: PrecompileWithAddress =
+    PrecompileWithAddress(ADDRESS, Precompile::Standard(g1_add));
+
+/// BLS12_G1ADD precompile address.
+pub const ADDRESS: Address = address!("000000000000000000000000000000000000000b");
+
+/// Base gas fee for BLS12-381 g1_add operation.
+const BASE_GAS_FEE: u64 = 375;
+
+/// Input length of g1_add operation.
+const INPUT_LENGTH: usize = 256;
+
+/// G1 addition call expects `256` bytes as an input that is interpreted as byte
+/// concatenation of two G1 points (`128` bytes each).
+/// Output is an encoding of addition operation result - single G1 point (`128`
+/// bytes).
+/// See also: <https://eips.ethereum.org/EIPS/eip-2537#abi-for-g1-addition>
+pub fn g1_add(input: &Bytes, gas_limit: u64) -> PrecompileResult {
+    if BASE_GAS_FEE > gas_limit {
+        return Err(PrecompileError::OutOfGas.into());
+    }
+
+    if input.len() != INPUT_LENGTH {
+        return Err(PrecompileError::Other(format!(
+            "G1ADD input should be {INPUT_LENGTH} bytes, was {}",
+            input.len()
+        ))
+        .into());
+    }
+
+    // Extract G1 inputs from the input without subgroup check.
+    // G1 Addition precompile does _not_ require subgroup check.
+    let a_aff = &extract_g1_input(&input[..G1_INPUT_ITEM_LENGTH])?;
+    let b_aff = &extract_g1_input(&input[G1_INPUT_ITEM_LENGTH..])?;
+
+    // Perform the addition.
+    use core::ops::Add;
+    let b_proj: G1Projective = b_aff.into();
+    let out: G1Affine = a_aff.add(&b_proj).into();
+    let out = encode_g1_point(out);
+
+    Ok(PrecompileOutput::new(BASE_GAS_FEE, out))
+}

--- a/crates/precompile/src/bls12_381_no_std/g1_msm.rs
+++ b/crates/precompile/src/bls12_381_no_std/g1_msm.rs
@@ -1,0 +1,94 @@
+//! G1 MSM precopmile.
+
+use crate::{
+    Precompile, PrecompileError, PrecompileOutput, PrecompileResult, PrecompileWithAddress,
+    bls12_381_no_std::utils::{msm_required_gas, extract_scalar_input, SCALAR_LENGTH, extract_g1_input_subgroup_check, encode_g1_point, G1_INPUT_ITEM_LENGTH},
+};
+use bls12_381::G1Projective;
+use revm_primitives::{address, Address, Bytes};
+
+/// [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#specification) BLS12_G1MSM precompile.
+pub const PRECOMPILE: PrecompileWithAddress =
+    PrecompileWithAddress(ADDRESS, Precompile::Standard(g1_msm));
+
+/// BLS12_G1MSM precompile address.
+pub const ADDRESS: Address = address!("000000000000000000000000000000000000000c");
+
+/// Base gas fee for BLS12-381 g1_mul operation.
+pub const BASE_GAS_FEE: u64 = 12000;
+
+/// Input length of g1_mul operation.
+pub const INPUT_LENGTH: usize = 160;
+
+/// Discounts table for G1 MSM as a vector of pairs `[k, discount]`.
+pub static DISCOUNT_TABLE: [u16; 128] = [
+    1000, 949, 848, 797, 764, 750, 738, 728, 719, 712, 705, 698, 692, 687, 682, 677, 673, 669, 665,
+    661, 658, 654, 651, 648, 645, 642, 640, 637, 635, 632, 630, 627, 625, 623, 621, 619, 617, 615,
+    613, 611, 609, 608, 606, 604, 603, 601, 599, 598, 596, 595, 593, 592, 591, 589, 588, 586, 585,
+    584, 582, 581, 580, 579, 577, 576, 575, 574, 573, 572, 570, 569, 568, 567, 566, 565, 564, 563,
+    562, 561, 560, 559, 558, 557, 556, 555, 554, 553, 552, 551, 550, 549, 548, 547, 547, 546, 545,
+    544, 543, 542, 541, 540, 540, 539, 538, 537, 536, 536, 535, 534, 533, 532, 532, 531, 530, 529,
+    528, 528, 527, 526, 525, 525, 524, 523, 522, 522, 521, 520, 520, 519,
+];
+
+/// Implements EIP-2537 G1MSM precompile.
+/// G1 multi-scalar-multiplication call expects `160*k` bytes as an input that is interpreted
+/// as byte concatenation of `k` slices each of them being a byte concatenation
+/// of encoding of G1 point (`128` bytes) and encoding of a scalar value (`32`
+/// bytes).
+/// Output is an encoding of multi-scalar-multiplication operation result - single G1
+/// point (`128` bytes).
+/// See also: <https://eips.ethereum.org/EIPS/eip-2537#abi-for-g1-multiexponentiation>
+pub fn g1_msm(input: &Bytes, gas_limit: u64) -> PrecompileResult {
+    let input_len = input.len();
+    if input_len == 0 || input_len % INPUT_LENGTH != 0 {
+        return Err(PrecompileError::Other(format!(
+            "G1MSM input length should be multiple of {}, was {}",
+            INPUT_LENGTH, input_len
+        ))
+        .into());
+    }
+
+    let k = input_len / INPUT_LENGTH;
+    let required_gas = msm_required_gas(k, &DISCOUNT_TABLE, BASE_GAS_FEE);
+    if required_gas > gas_limit {
+        return Err(PrecompileError::OutOfGas.into());
+    }
+
+    let mut points: Vec<G1Projective> = Vec::with_capacity(k * SCALAR_LENGTH);
+    for i in 0..k {
+        let slice = &input[i * INPUT_LENGTH..i * INPUT_LENGTH + G1_INPUT_ITEM_LENGTH];
+
+        // BLST batch API for p1_affines blows up when you pass it a point at infinity, so we must
+        // filter points at infinity (and their corresponding scalars) from the input.
+        if slice.iter().all(|i| *i == 0) {
+            continue;
+        }
+
+        // Scalar multiplications, MSMs and pairings MUST perform a subgroup check.
+        let p0_aff = &extract_g1_input_subgroup_check(slice)?;
+        let p0: G1Projective = p0_aff.into();
+
+        let scalar = extract_scalar_input(
+            &input[i * INPUT_LENGTH + G1_INPUT_ITEM_LENGTH
+                ..i * INPUT_LENGTH + G1_INPUT_ITEM_LENGTH + SCALAR_LENGTH],
+        )?;
+
+        // TODO: actually use pippenger's algorithm here.
+        // EIP-2537 requires pippenger's algorithm to be used for MSM speedup that results in a discount.
+        // Multiply the affine by the scalar.
+        let projective = p0 * scalar;
+        points.push(projective);
+    }
+
+    // return infinity point if all points are infinity
+    if points.is_empty() {
+        return Ok(PrecompileOutput::new(required_gas, [0; 128].into()));
+    }
+
+    // Accumulate all the points.
+    let acc = points.iter().fold(G1Projective::default(), |acc, p| acc + p);
+
+    let out = encode_g1_point(acc.into());
+    Ok(PrecompileOutput::new(required_gas, out))
+}

--- a/crates/precompile/src/bls12_381_no_std/g2_add.rs
+++ b/crates/precompile/src/bls12_381_no_std/g2_add.rs
@@ -1,0 +1,54 @@
+//! The BLS12-381 g2 addition precompile.
+
+use crate::{
+    Precompile, PrecompileError, PrecompileOutput, PrecompileResult, PrecompileWithAddress,
+    bls12_381_no_std::utils::{extract_g2_input, encode_g2_point, G2_INPUT_ITEM_LENGTH},
+};
+use bls12_381::{G2Projective, G2Affine};
+use revm_primitives::{address, Address, Bytes};
+
+/// [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#specification) BLS12_G1ADD precompile.
+pub const PRECOMPILE: PrecompileWithAddress =
+    PrecompileWithAddress(ADDRESS, Precompile::Standard(g2_add));
+
+/// BLS12_G1ADD precompile address.
+pub const ADDRESS: Address = address!("000000000000000000000000000000000000000d");
+
+/// Base gas fee for BLS12-381 g2_add operation.
+const BASE_GAS_FEE: u64 = 600;
+
+/// Input length of g2_add operation.
+const INPUT_LENGTH: usize = 512;
+
+/// G2 addition call expects `512` bytes as an input that is interpreted as byte
+/// concatenation of two G2 points (`256` bytes each).
+/// Output is an encoding of addition operation result - single G2 point (`256`
+/// bytes).
+/// See also: <https://eips.ethereum.org/EIPS/eip-2537#abi-for-g2-addition>
+pub fn g2_add(input: &Bytes, gas_limit: u64) -> PrecompileResult {
+    if BASE_GAS_FEE > gas_limit {
+        return Err(PrecompileError::OutOfGas.into());
+    }
+
+    if input.len() != INPUT_LENGTH {
+        return Err(PrecompileError::Other(format!(
+            "G2ADD input should be {INPUT_LENGTH} bytes, was {}",
+            input.len()
+        ))
+        .into());
+    }
+
+    // Extract G2 inputs from the input without subgroup check.
+    // G2 Addition precompile does _not_ require subgroup check.
+    let a_aff = &extract_g2_input(&input[..G2_INPUT_ITEM_LENGTH])?;
+    let b_aff = &extract_g2_input(&input[G2_INPUT_ITEM_LENGTH..])?;
+
+    // Perform the addition.
+    use core::ops::Add;
+    let b_proj: G2Projective = b_aff.into();
+    let out: G2Affine = a_aff.add(&b_proj).into();
+    let out = encode_g2_point(out);
+
+    Ok(PrecompileOutput::new(BASE_GAS_FEE, out))
+}
+

--- a/crates/precompile/src/bls12_381_no_std/g2_msm.rs
+++ b/crates/precompile/src/bls12_381_no_std/g2_msm.rs
@@ -1,0 +1,98 @@
+//! G2 MSM precopmile.
+
+use crate::{
+    Precompile, PrecompileError, PrecompileOutput, PrecompileResult, PrecompileWithAddress,
+    bls12_381_no_std::utils::{
+        msm_required_gas, extract_scalar_input, SCALAR_LENGTH, extract_g2_input_subgroup_check,
+        encode_g2_point, G2_INPUT_ITEM_LENGTH,
+    },
+};
+use bls12_381::G2Projective;
+use revm_primitives::{address, Address, Bytes};
+
+/// [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#specification) BLS12_G2MSM precompile.
+pub const PRECOMPILE: PrecompileWithAddress =
+    PrecompileWithAddress(ADDRESS, Precompile::Standard(g2_msm));
+
+/// BLS12_G2MSM precompile address.
+pub const ADDRESS: Address = address!("000000000000000000000000000000000000000e");
+
+/// Base gas fee for BLS12-381 g2_mul operation.
+pub const BASE_GAS_FEE: u64 = 22500;
+
+/// Input length of g2_mul operation.
+pub const INPUT_LENGTH: usize = 288;
+
+// Discounts table for G2 MSM as a vector of pairs `[k, discount]`:
+pub static DISCOUNT_TABLE: [u16; 128] = [
+    1000, 1000, 923, 884, 855, 832, 812, 796, 782, 770, 759, 749, 740, 732, 724, 717, 711, 704,
+    699, 693, 688, 683, 679, 674, 670, 666, 663, 659, 655, 652, 649, 646, 643, 640, 637, 634, 632,
+    629, 627, 624, 622, 620, 618, 615, 613, 611, 609, 607, 606, 604, 602, 600, 598, 597, 595, 593,
+    592, 590, 589, 587, 586, 584, 583, 582, 580, 579, 578, 576, 575, 574, 573, 571, 570, 569, 568,
+    567, 566, 565, 563, 562, 561, 560, 559, 558, 557, 556, 555, 554, 553, 552, 552, 551, 550, 549,
+    548, 547, 546, 545, 545, 544, 543, 542, 541, 541, 540, 539, 538, 537, 537, 536, 535, 535, 534,
+    533, 532, 532, 531, 530, 530, 529, 528, 528, 527, 526, 526, 525, 524, 524,
+];
+
+/// Implements EIP-2537 G2MSM precompile.
+/// G2 multi-scalar-multiplication call expects `288*k` bytes as an input that is interpreted
+/// as byte concatenation of `k` slices each of them being a byte concatenation
+/// of encoding of G2 point (`256` bytes) and encoding of a scalar value (`32`
+/// bytes).
+/// Output is an encoding of multi-scalar-multiplication operation result - single G2
+/// point (`256` bytes).
+/// See also: <https://eips.ethereum.org/EIPS/eip-2537#abi-for-g2-multiexponentiation>
+pub fn g2_msm(input: &Bytes, gas_limit: u64) -> PrecompileResult {
+    let input_len = input.len();
+    if input_len == 0 || input_len % INPUT_LENGTH != 0 {
+        return Err(PrecompileError::Other(format!(
+            "G2MSM input length should be multiple of {}, was {}",
+            INPUT_LENGTH, input_len
+        ))
+        .into());
+    }
+
+    let k = input_len / INPUT_LENGTH;
+    let required_gas = msm_required_gas(k, &DISCOUNT_TABLE, BASE_GAS_FEE);
+    if required_gas > gas_limit {
+        return Err(PrecompileError::OutOfGas.into());
+    }
+
+    let mut points: Vec<G2Projective> = Vec::with_capacity(k * SCALAR_LENGTH);
+    for i in 0..k {
+        let slice = &input[i * INPUT_LENGTH..i * INPUT_LENGTH + G2_INPUT_ITEM_LENGTH];
+
+        // BLST batch API for p2_affines blows up when you pass it a point at infinity, so we must
+        // filter points at infinity (and their corresponding scalars) from the input.
+        if slice.iter().all(|i| *i == 0) {
+            continue;
+        }
+
+        // Scalar multiplications, MSMs and pairings MUST perform a subgroup check.
+        let p0_aff = &extract_g2_input_subgroup_check(slice)?;
+        let p0: G2Projective = p0_aff.into();
+
+        let scalar = extract_scalar_input(
+            &input[i * INPUT_LENGTH + G2_INPUT_ITEM_LENGTH
+                ..i * INPUT_LENGTH + G2_INPUT_ITEM_LENGTH + SCALAR_LENGTH],
+        )?;
+
+        // TODO: actually use pippenger's algorithm here.
+        // EIP-2537 requires pippenger's algorithm to be used for MSM speedup that results in a discount.
+        // Multiply the affine by the scalar.
+        let projective = p0 * scalar;
+        points.push(projective);
+    }
+
+    // return infinity point if all points are infinity
+    if points.is_empty() {
+        return Ok(PrecompileOutput::new(required_gas, [0; 128].into()));
+    }
+
+    // Accumulate all the points.
+    let acc = points.iter().fold(G2Projective::default(), |acc, p| acc + p);
+
+    let out = encode_g2_point(acc.into());
+    Ok(PrecompileOutput::new(required_gas, out))
+}
+

--- a/crates/precompile/src/bls12_381_no_std/map_fp2_to_g2.rs
+++ b/crates/precompile/src/bls12_381_no_std/map_fp2_to_g2.rs
@@ -1,0 +1,50 @@
+//! Map an element of Fp to a point on G2 curve.
+
+use crate::{
+    Precompile, PrecompileError, PrecompileOutput, PrecompileResult, PrecompileWithAddress,
+    bls12_381_no_std::utils::{PADDED_FP2_LENGTH, PADDED_FP_LENGTH, encode_g2_point, remove_padding},
+};
+use bls12_381::G2Affine;
+use revm_primitives::{address, Address, Bytes};
+
+/// [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#specification) BLS12_MAP_FP2_TO_G2 precompile.
+pub const PRECOMPILE: PrecompileWithAddress =
+    PrecompileWithAddress(ADDRESS, Precompile::Standard(map_fp2_to_g2));
+
+/// BLS12_MAP_FP_TO_G1 precompile address.
+pub const ADDRESS: Address = address!("0000000000000000000000000000000000000011");
+
+/// Base gas fee for BLS12-381 map_fp2_to_g2 operation.
+const BASE_GAS_FEE: u64 = 23800;
+
+/// Field-to-curve call expects 128 bytes as an input that is interpreted as
+/// an element of Fp2. Output of this call is 256 bytes and is an encoded G2
+/// point.
+/// See also: <https://eips.ethereum.org/EIPS/eip-2537#abi-for-mapping-fp2-element-to-g2-point>
+pub fn map_fp2_to_g2(input: &Bytes, gas_limit: u64) -> PrecompileResult {
+    if BASE_GAS_FEE > gas_limit {
+        return Err(PrecompileError::OutOfGas.into());
+    }
+
+    if input.len() != PADDED_FP2_LENGTH {
+        return Err(PrecompileError::Other(format!(
+            "MAP_FP_TO_G1 input should be {PADDED_FP_LENGTH} bytes, was {}",
+            input.len()
+        ))
+        .into());
+    }
+
+    let input_p0_x = remove_padding(&input[..PADDED_FP_LENGTH])?;
+    let input_p0_y = remove_padding(&input[PADDED_FP_LENGTH..PADDED_FP2_LENGTH])?;
+
+    // Copy the x and y inputs into the compressed buffer.
+    let mut compressed = [0u8; 96];
+    compressed[..48].copy_from_slice(&input_p0_x[..]);
+    compressed[48..].copy_from_slice(&input_p0_y[..]);
+    let aff = G2Affine::from_compressed(&compressed).into_option().ok_or_else(|| {
+        PrecompileError::Other("non-canonical fp value".to_string())
+    })?;
+
+    let out = encode_g2_point(aff);
+    Ok(PrecompileOutput::new(BASE_GAS_FEE, out))
+}

--- a/crates/precompile/src/bls12_381_no_std/map_fp_to_g1.rs
+++ b/crates/precompile/src/bls12_381_no_std/map_fp_to_g1.rs
@@ -1,0 +1,59 @@
+//! Map an element of Fp to a point on G1 curve.
+
+use crate::{
+    Precompile, PrecompileError, PrecompileOutput, PrecompileResult, PrecompileWithAddress,
+    bls12_381_no_std::utils::{PADDED_FP_LENGTH, encode_g1_point, remove_padding},
+};
+use bls12_381::G1Affine;
+use revm_primitives::{address, Address, Bytes};
+
+/// [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#specification) BLS12_MAP_FP_TO_G1 precompile.
+pub const PRECOMPILE: PrecompileWithAddress =
+    PrecompileWithAddress(ADDRESS, Precompile::Standard(map_fp_to_g1));
+
+/// BLS12_MAP_FP_TO_G1 precompile address.
+pub const ADDRESS: Address = address!("0000000000000000000000000000000000000010");
+
+/// Base gas fee for BLS12-381 map_fp_to_g1 operation.
+const MAP_FP_TO_G1_BASE: u64 = 5500;
+
+/// Field-to-curve call expects 64 bytes as an input that is interpreted as an
+/// element of Fp. Output of this call is 128 bytes and is an encoded G1 point.
+/// See also: <https://eips.ethereum.org/EIPS/eip-2537#abi-for-mapping-fp-element-to-g1-point>
+pub fn map_fp_to_g1(input: &Bytes, gas_limit: u64) -> PrecompileResult {
+    if MAP_FP_TO_G1_BASE > gas_limit {
+        return Err(PrecompileError::OutOfGas.into());
+    }
+
+    if input.len() != PADDED_FP_LENGTH {
+        return Err(PrecompileError::Other(format!(
+            "MAP_FP_TO_G1 input should be {PADDED_FP_LENGTH} bytes, was {}",
+            input.len()
+        ))
+        .into());
+    }
+
+    let input_p0 = remove_padding(input)?;
+    let aff = G1Affine::from_compressed(&input_p0).into_option().ok_or_else(|| {
+        PrecompileError::Other("non-canonical fp value".to_string())
+    })?;
+
+    let out = encode_g1_point(aff);
+    Ok(PrecompileOutput::new(MAP_FP_TO_G1_BASE, out))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::primitives::hex;
+
+    #[test]
+    fn sanity_test() {
+        let input = Bytes::from(hex!("000000000000000000000000000000006900000000000000636f6e7472616374595a603f343061cd305a03f40239f5ffff31818185c136bc2595f2aa18e08f17"));
+        let fail = map_fp_to_g1(&input, MAP_FP_TO_G1_BASE);
+        assert_eq!(
+            fail,
+            Err(PrecompileError::Other("non-canonical fp value".to_string()).into())
+        );
+    }
+}

--- a/crates/precompile/src/bls12_381_no_std/pairing.rs
+++ b/crates/precompile/src/bls12_381_no_std/pairing.rs
@@ -1,0 +1,93 @@
+//! BLS12-381 precompile with input size limits for Optimism.
+
+use crate::{
+    Precompile, PrecompileError, PrecompileOutput, PrecompileResult, PrecompileWithAddress,
+};
+use bls12_381::{G1Affine, G2Affine, G2Prepared, Gt, MillerLoopResult};
+use revm_primitives::{address, Address, Bytes, B256};
+
+/// The isthmus precompile for BLS12-381 pairing check.
+pub const PRECOMPILE: PrecompileWithAddress = PrecompileWithAddress(
+    ADDRESS,
+    Precompile::Standard(|input, gas_limit| run_pair(input, gas_limit)),
+);
+
+/// BLS12_PAIRING precompile address.
+pub const ADDRESS: Address = address!("000000000000000000000000000000000000000f");
+
+/// Multiplier gas fee for BLS12-381 pairing operation.
+const PAIRING_MULTIPLIER_BASE: u64 = 32600;
+/// Offset gas fee for BLS12-381 pairing operation.
+const PAIRING_OFFSET_BASE: u64 = 37700;
+/// Input length of pairing operation.
+const INPUT_LENGTH: usize = 384;
+
+/// The maximum input size for isthmus.
+const ISTHMUS_MAX_INPUT_SIZE: usize = 235008;
+
+/// Runs the pairing for the given input, limiting the input size.
+pub(super) fn run_pair(input: &[u8], gas_limit: u64) -> PrecompileResult {
+    if input.len() > ISTHMUS_MAX_INPUT_SIZE {
+        return Err(PrecompileError::Other("BLS12-381 pairing input is too large".into()).into());
+    }
+    let input = Bytes::copy_from_slice(input);
+    pairing(&input, gas_limit)
+}
+
+/// Pairing call expects 384*k (k being a positive integer) bytes as an inputs
+/// that is interpreted as byte concatenation of k slices. Each slice has the
+/// following structure:
+///    * 128 bytes of G1 point encoding
+///    * 256 bytes of G2 point encoding
+///
+/// Each point is expected to be in the subgroup of order q.
+/// Output is 32 bytes where first 31 bytes are equal to 0x00 and the last byte
+/// is 0x01 if pairing result is equal to the multiplicative identity in a pairing
+/// target field and 0x00 otherwise.
+///
+/// See also: <https://eips.ethereum.org/EIPS/eip-2537#abi-for-pairing>
+fn pairing(input: &Bytes, gas_limit: u64) -> PrecompileResult {
+    let input_len = input.len();
+    if input_len == 0 || input_len % INPUT_LENGTH != 0 {
+        return Err(PrecompileError::Other(format!(
+            "Pairing input length should be multiple of {INPUT_LENGTH}, was {input_len}"
+        ))
+        .into());
+    }
+
+    let k = input_len / INPUT_LENGTH;
+    let required_gas: u64 = PAIRING_MULTIPLIER_BASE * k as u64 + PAIRING_OFFSET_BASE;
+    if required_gas > gas_limit {
+        return Err(PrecompileError::OutOfGas.into());
+    }
+
+    // Accumulator for the Fp12 multiplications of the miller loops.
+    let mut acc = MillerLoopResult::default();
+    for i in 0..k {
+        // construct an array of len 96 and copy the input into it
+        let start = i * INPUT_LENGTH;
+        let end = start + 96;
+        let input_arr: [u8; 96] = input[start..end].try_into().unwrap();
+        let Some(g1_aff) = G1Affine::from_uncompressed(&input_arr).into_option() else {
+            return Err(PrecompileError::Other("Failed to parse G1 point".into()).into());
+        };
+        let input_arr: [u8; 192] = input[end..end + 192].try_into().unwrap();
+        let Some(g2_aff) = G2Affine::from_uncompressed(&input_arr).into_option() else {
+            return Err(PrecompileError::Other("Failed to parse G2 point".into()).into());
+        };
+        let g2_prep = G2Prepared::from(g2_aff);
+        let res = bls12_381::multi_miller_loop(&[(&g1_aff, &g2_prep)]);
+        acc += res;
+    }
+
+    let res = acc.final_exponentiation();
+
+    let mut result: u8 = 0;
+    if res == Gt::identity() {
+        result = 1;
+    }
+    Ok(PrecompileOutput::new(
+        required_gas,
+        B256::with_last_byte(result).into(),
+    ))
+}

--- a/crates/precompile/src/bls12_381_no_std/utils.rs
+++ b/crates/precompile/src/bls12_381_no_std/utils.rs
@@ -1,13 +1,22 @@
 //! Utilities for working with big endian and fp.
 
-use bls12_381::G1Affine;
+use bls12_381::{Scalar, G2Affine, G1Affine};
 use revm_primitives::{Bytes, PrecompileError};
+
+/// Number of bits used in the BLS12-381 curve finite field elements.
+pub const NBITS: usize = 256;
+
+/// Scalar length.
+pub const SCALAR_LENGTH: usize = 32;
 
 /// Finite field element input length.
 pub const FP_LENGTH: usize = 48;
 
 /// Finite field element padded input length.
 pub const PADDED_FP_LENGTH: usize = 64;
+
+/// Quadratic extension of finite field element input length.
+pub const PADDED_FP2_LENGTH: usize = 128;
 
 /// Input elements padding length.
 pub const PADDING_LENGTH: usize = 16;
@@ -17,6 +26,26 @@ pub const G1_INPUT_ITEM_LENGTH: usize = 128;
 
 /// Output length of a g1 operation.
 pub const G1_OUTPUT_LENGTH: usize = 128;
+
+/// Length of each of the elements in a g2 operation input.
+pub const G2_INPUT_ITEM_LENGTH: usize = 256;
+
+/// Output length of a g2 operation.
+pub const G2_OUTPUT_LENGTH: usize = 256;
+
+/// Amount used to calculate the multi-scalar-multiplication discount.
+pub const MSM_MULTIPLIER: u64 = 1000;
+
+/// Implements the gas schedule for G1/G2 Multiscalar-multiplication assuming 30
+/// MGas/second, see also: <https://eips.ethereum.org/EIPS/eip-2537#g1g2-multiexponentiation>
+pub fn msm_required_gas(k: usize, discount_table: &[u16], multiplication_cost: u64) -> u64 {
+    if k == 0 {
+        return 0;
+    }
+    let index = core::cmp::min(k - 1, discount_table.len() - 1);
+    let discount = discount_table[index] as u64;
+    (k as u64 * discount * multiplication_cost) / MSM_MULTIPLIER
+}
 
 /// Encodes a G1 point in affine format into byte slice with padded elements.
 pub fn encode_g1_point(input: G1Affine) -> Bytes {
@@ -28,10 +57,8 @@ pub fn encode_g1_point(input: G1Affine) -> Bytes {
 }
 
 /// Extracts a G1 point in Affine format from a 128 byte slice representation.
-///
-/// NOTE: This function will perform a G1 subgroup check if `subgroup_check` is set to `true`.
 pub fn extract_g1_input(input: &[u8]) -> Result<G1Affine, PrecompileError> {
-        if input.len() != G1_INPUT_ITEM_LENGTH {
+    if input.len() != G1_INPUT_ITEM_LENGTH {
         return Err(PrecompileError::Other(format!(
             "Input should be {G1_INPUT_ITEM_LENGTH} bytes, was {}",
             input.len()
@@ -46,7 +73,78 @@ pub fn extract_g1_input(input: &[u8]) -> Result<G1Affine, PrecompileError> {
     new_input[..48].copy_from_slice(input_p0_x);
     new_input[48..].copy_from_slice(input_p0_y);
 
-    G1Affine::from_uncompressed(&new_input).into_option().ok_or(PrecompileError::Other("Invalid G1 point".to_string()))
+    let g1_affine = G1Affine::from_uncompressed(&new_input).into_option().ok_or(PrecompileError::Other("Invalid G1 point".to_string()))?;
+
+    if g1_affine.is_on_curve().unwrap_u8() == 0 {
+        return Err(PrecompileError::Other("Element not on G1 Curve".to_string()));
+    }
+
+    Ok(g1_affine)
+}
+
+/// Extracts a G1 point in Affine format from a 128 byte slice representation.
+/// Performs a subgroup check.
+pub fn extract_g1_input_subgroup_check(input: &[u8]) -> Result<G1Affine, PrecompileError> {
+    let g1_affine = extract_g1_input(input)?;
+
+    if g1_affine.is_torsion_free().unwrap_u8() == 0 {
+        return Err(PrecompileError::Other("Element not in G1".to_string()));
+    }
+
+    Ok(g1_affine)
+}
+
+/// Encodes a G2 point in affine format into byte slice with padded elements.
+pub fn encode_g2_point(input: G2Affine) -> Bytes {
+    let uncompressed = input.to_uncompressed();
+    let mut out = vec![0u8; G2_OUTPUT_LENGTH];
+    out[16..64].copy_from_slice(&uncompressed[..48]);
+    out[80..128].copy_from_slice(&uncompressed[48..]);
+    out[144..192].copy_from_slice(&uncompressed[96..144]);
+    out[208..256].copy_from_slice(&uncompressed[144..]);
+    out.into()
+}
+
+/// Extracts a G2 point in Affine format from a 256 byte slice representation.
+pub fn extract_g2_input(input: &[u8]) -> Result<G2Affine, PrecompileError> {
+    if input.len() != G2_INPUT_ITEM_LENGTH {
+        return Err(PrecompileError::Other(format!(
+            "Input should be {G1_INPUT_ITEM_LENGTH} bytes, was {}",
+            input.len()
+        )));
+    }
+
+    let input_x0 = remove_padding(&input[..PADDED_FP_LENGTH])?;
+    let input_x1 = remove_padding(&input[PADDED_FP_LENGTH..PADDED_FP_LENGTH*2])?;
+    let input_y0 = remove_padding(&input[2*PADDED_FP_LENGTH..PADDED_FP_LENGTH*3])?;
+    let input_y1 = remove_padding(&input[3*PADDED_FP_LENGTH..PADDED_FP_LENGTH*4])?;
+
+    // Fill a new input array with the unpadded values
+    let mut new_input: [u8; 192] = [0; 192];
+    new_input[..48].copy_from_slice(input_x0);
+    new_input[48..96].copy_from_slice(input_x1);
+    new_input[96..144].copy_from_slice(input_y0);
+    new_input[144..].copy_from_slice(input_y1);
+
+    let g2_affine = G2Affine::from_uncompressed(&new_input).into_option().ok_or(PrecompileError::Other("Invalid G2 point".to_string()))?;
+
+    if g2_affine.is_on_curve().unwrap_u8() == 0 {
+        return Err(PrecompileError::Other("Element not on G2 Curve".to_string()));
+    }
+
+    Ok(g2_affine)
+}
+
+/// Extracts a G2 point in Affine format from a 256 byte slice representation.
+/// Performs a subgroup check.
+pub fn extract_g2_input_subgroup_check(input: &[u8]) -> Result<G2Affine, PrecompileError> {
+    let g2_affine = extract_g2_input(input)?;
+
+    if g2_affine.is_torsion_free().unwrap_u8() == 0 {
+        return Err(PrecompileError::Other("Element not in G2".to_string()));
+    }
+
+    Ok(g2_affine)
 }
 
 /// Removes zeros with which the precompile inputs are left padded to 64 bytes.
@@ -64,4 +162,27 @@ pub fn remove_padding(input: &[u8]) -> Result<&[u8; FP_LENGTH], PrecompileError>
         )));
     }
     Ok(unpadded.try_into().unwrap())
+}
+
+/// Extracts a scalar from a 32 byte slice representation, decoding the input as a big endian
+/// unsigned integer. If the input is not exactly 32 bytes long, an error is returned.
+///
+/// From [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537):
+/// * A scalar for the multiplication operation is encoded as 32 bytes by performing BigEndian
+///   encoding of the corresponding (unsigned) integer.
+///
+/// We do not check that the scalar is a canonical Fr element, because the EIP specifies:
+/// * The corresponding integer is not required to be less than or equal than main subgroup order
+///   `q`.
+pub(super) fn extract_scalar_input(input: &[u8]) -> Result<Scalar, PrecompileError> {
+    if input.len() != SCALAR_LENGTH {
+        return Err(PrecompileError::Other(format!(
+            "Input should be {SCALAR_LENGTH} bytes, was {}",
+            input.len()
+        )));
+    }
+
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(input);
+    Scalar::from_bytes(&arr).into_option().ok_or(PrecompileError::Other("Invalid scalar".to_string()))
 }

--- a/crates/precompile/src/bls12_381_no_std/utils.rs
+++ b/crates/precompile/src/bls12_381_no_std/utils.rs
@@ -1,0 +1,67 @@
+//! Utilities for working with big endian and fp.
+
+use bls12_381::G1Affine;
+use revm_primitives::{Bytes, PrecompileError};
+
+/// Finite field element input length.
+pub const FP_LENGTH: usize = 48;
+
+/// Finite field element padded input length.
+pub const PADDED_FP_LENGTH: usize = 64;
+
+/// Input elements padding length.
+pub const PADDING_LENGTH: usize = 16;
+
+/// Length of each of the elements in a g1 operation input.
+pub const G1_INPUT_ITEM_LENGTH: usize = 128;
+
+/// Output length of a g1 operation.
+pub const G1_OUTPUT_LENGTH: usize = 128;
+
+/// Encodes a G1 point in affine format into byte slice with padded elements.
+pub fn encode_g1_point(input: G1Affine) -> Bytes {
+    let uncompressed = input.to_uncompressed();
+    let mut out = vec![0u8; G1_OUTPUT_LENGTH];
+    out[16..64].copy_from_slice(&uncompressed[..48]);
+    out[80..128].copy_from_slice(&uncompressed[48..]);
+    out.into()
+}
+
+/// Extracts a G1 point in Affine format from a 128 byte slice representation.
+///
+/// NOTE: This function will perform a G1 subgroup check if `subgroup_check` is set to `true`.
+pub fn extract_g1_input(input: &[u8]) -> Result<G1Affine, PrecompileError> {
+        if input.len() != G1_INPUT_ITEM_LENGTH {
+        return Err(PrecompileError::Other(format!(
+            "Input should be {G1_INPUT_ITEM_LENGTH} bytes, was {}",
+            input.len()
+        )));
+    }
+
+    let input_p0_x = remove_padding(&input[..PADDED_FP_LENGTH])?;
+    let input_p0_y = remove_padding(&input[PADDED_FP_LENGTH..G1_INPUT_ITEM_LENGTH])?;
+
+    // Fill a new input array with the unpadded values
+    let mut new_input: [u8; 96] = [0; 96];
+    new_input[..48].copy_from_slice(input_p0_x);
+    new_input[48..].copy_from_slice(input_p0_y);
+
+    G1Affine::from_uncompressed(&new_input).into_option().ok_or(PrecompileError::Other("Invalid G1 point".to_string()))
+}
+
+/// Removes zeros with which the precompile inputs are left padded to 64 bytes.
+pub fn remove_padding(input: &[u8]) -> Result<&[u8; FP_LENGTH], PrecompileError> {
+    if input.len() != PADDED_FP_LENGTH {
+        return Err(PrecompileError::Other(format!(
+            "Padded input should be {PADDED_FP_LENGTH} bytes, was {}",
+            input.len()
+        )));
+    }
+    let (padding, unpadded) = input.split_at(PADDING_LENGTH);
+    if !padding.iter().all(|&x| x == 0) {
+        return Err(PrecompileError::Other(format!(
+            "{PADDING_LENGTH} top bytes of input are not zero",
+        )));
+    }
+    Ok(unpadded.try_into().unwrap())
+}

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -11,6 +11,8 @@ extern crate alloc as std;
 pub mod blake2;
 #[cfg(feature = "blst")]
 pub mod bls12_381;
+#[cfg(feature = "bls-no-std")]
+pub mod bls12_381_no_std;
 pub mod bn128;
 pub mod fatal_precompile;
 pub mod hash;
@@ -172,6 +174,14 @@ impl Precompiles {
             let precompiles = {
                 let mut precompiles = precompiles;
                 precompiles.extend(bls12_381::precompiles());
+                precompiles
+            };
+
+            // Only include the `no_std` BLS12-381 precompiles in no_std builds.
+            #[cfg(all(feature = "bls-no-std", not(feature = "blst")))]
+            let precompiles = {
+                let mut precompiles = precompiles;
+                precompiles.extend(bls12_381_no_std::precompiles());
                 precompiles
             };
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -135,6 +135,7 @@ c-kzg = ["revm-precompile/c-kzg"]
 # `kzg-rs` is not audited but useful for `no_std` environment, use it with causing and default to `c-kzg` if possible.
 kzg-rs = ["revm-precompile/kzg-rs"]
 blst = ["revm-precompile/blst"]
+bls-no-std = ["revm-precompile/bls-no-std"]
 
 [[example]]
 name = "fork_ref_transact"


### PR DESCRIPTION
### Description

> [!WARNING]
>
> Make sure to remove the `bls-no-std` feature flag from revm (this was only used to test with revme).

Adds support to revm's BLS12-381 precompiles for `no_std` using the [bls12_381](https://docs.rs/bls12_381/0.8.0/bls12_381/index.html) crate.