### PR TITLE
fix ethersdb.rs forking

### DIFF
--- a/crates/revm/src/db/ethersdb.rs
+++ b/crates/revm/src/db/ethersdb.rs
@@ -64,9 +64,11 @@ impl<M: Middleware> EthersDB<M> {
             rt,
         };
 
-        instance.block_number = Some(BlockId::from(
-            instance.block_on(instance.client.get_block_number()).ok()?,
-        ));
+        if block_number.is_none() {
+            instance.block_number = Some(BlockId::from(
+                instance.block_on(instance.client.get_block_number()).ok()?,
+            ));
+        };
         Some(instance)
     }
 
@@ -86,9 +88,11 @@ impl<M: Middleware> EthersDB<M> {
             rt,
         };
 
-        instance.block_number = Some(BlockId::from(
-            instance.block_on(instance.client.get_block_number()).ok()?,
-        ));
+        if block_number.is_none() {
+            instance.block_number = Some(BlockId::from(
+                instance.block_on(instance.client.get_block_number()).ok()?,
+            ));
+        };
         Some(instance)
     }
 


### PR DESCRIPTION
EthersDB::with_runtime and EthersDB::with_handle were added in v11 for reasons involving async. Unlike EthersDB::new, these two functions always fork the latest block (even when a historical block is specified). This commit fixes that.