### PR TITLE
feat(op): Isthmus precompiles

### DIFF
--- a/bins/revme/src/cmd.rs
+++ b/bins/revme/src/cmd.rs
@@ -40,17 +40,16 @@ pub enum Error {
 impl MainCmd {
     pub fn run(&self) -> Result<(), Error> {
         match self {
-            Self::Statetest(cmd) => cmd.run().map_err(Into::into),
-            Self::EofValidation(cmd) => cmd.run().map_err(Into::into),
-            Self::Evm(cmd) => cmd.run().map_err(Into::into),
+            Self::Statetest(cmd) => cmd.run()?,
+            Self::EofValidation(cmd) => cmd.run()?,
+            Self::Evm(cmd) => cmd.run()?,
             Self::Bytecode(cmd) => {
                 cmd.run();
-                Ok(())
             }
             Self::Bench(cmd) => {
                 cmd.run();
-                Ok(())
             }
         }
+        Ok(())
     }
 }

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -388,7 +388,7 @@ pub fn execute_test_suite(
                         access_list
                             .iter()
                             .map(|item| (item.address, item.storage_keys.clone()))
-                            .collect::<Vec<_>>()
+                            .collect()
                     })
                     .unwrap_or_default();
 

--- a/crates/optimism/src/handler/precompiles.rs
+++ b/crates/optimism/src/handler/precompiles.rs
@@ -1,6 +1,6 @@
 use crate::{OpSpec, OpSpecId};
 use once_cell::race::OnceBox;
-use precompile::{bls12_381, secp256r1, PrecompileErrors, Precompiles};
+use precompile::{secp256r1, PrecompileErrors, Precompiles};
 use revm::{
     context::Cfg,
     context_interface::ContextTrait,
@@ -98,7 +98,7 @@ pub fn isthumus() -> &'static Precompiles {
         #[cfg(feature = "blst")]
         let precompiles = {
             let mut precompiles = precompiles;
-            precompiles.extend(bls12_381::precompiles());
+            precompiles.extend(precompile::bls12_381::precompiles());
             precompiles
         };
         Box::new(precompiles)

--- a/crates/optimism/src/handler/precompiles.rs
+++ b/crates/optimism/src/handler/precompiles.rs
@@ -1,6 +1,6 @@
 use crate::{OpSpec, OpSpecId};
 use once_cell::race::OnceBox;
-use precompile::{secp256r1, PrecompileErrors, Precompiles};
+use precompile::{bls12_381, secp256r1, PrecompileErrors, Precompiles};
 use revm::{
     context::Cfg,
     context_interface::ContextTrait,
@@ -35,7 +35,6 @@ impl<CTX> OpPrecompileProvider<CTX> {
     #[inline]
     pub fn new_with_spec(spec: OpSpec) -> Self {
         match spec {
-            // No changes
             spec @ (OpSpec::Eth(
                 SpecId::FRONTIER
                 | SpecId::FRONTIER_THAWING
@@ -57,16 +56,12 @@ impl<CTX> OpPrecompileProvider<CTX> {
                 | SpecId::CANCUN,
             )
             | OpSpec::Op(
-                OpSpecId::BEDROCK
-                | OpSpecId::REGOLITH
-                | OpSpecId::CANYON
-                | OpSpecId::ECOTONE
-                | OpSpecId::HOLOCENE
-                | OpSpecId::ISTHMUS,
+                OpSpecId::BEDROCK | OpSpecId::REGOLITH | OpSpecId::CANYON | OpSpecId::ECOTONE,
             )) => Self::new(Precompiles::new(spec.into_eth_spec().into())),
             OpSpec::Op(OpSpecId::FJORD) => Self::new(fjord()),
-            OpSpec::Op(OpSpecId::GRANITE)
-            | OpSpec::Eth(SpecId::PRAGUE | SpecId::OSAKA | SpecId::LATEST) => Self::new(granite()),
+            OpSpec::Op(OpSpecId::GRANITE | OpSpecId::HOLOCENE) => Self::new(granite()),
+            OpSpec::Op(OpSpecId::ISTHMUS)
+            | OpSpec::Eth(SpecId::PRAGUE | SpecId::OSAKA | SpecId::LATEST) => Self::new(isthumus()),
         }
     }
 }
@@ -89,6 +84,23 @@ pub fn granite() -> &'static Precompiles {
         let mut precompiles = Precompiles::cancun().clone();
         // Restrict bn256Pairing input size
         precompiles.extend([secp256r1::P256VERIFY]);
+        Box::new(precompiles)
+    })
+}
+
+/// Returns precompiles for isthumus spec.
+pub fn isthumus() -> &'static Precompiles {
+    static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
+    INSTANCE.get_or_init(|| {
+        let precompiles = granite().clone();
+        // Prague bls12 precompiles
+        // Don't include BLS12-381 precompiles in no_std builds.
+        #[cfg(feature = "blst")]
+        let precompiles = {
+            let mut precompiles = precompiles;
+            precompiles.extend(bls12_381::precompiles());
+            precompiles
+        };
         Box::new(precompiles)
     })
 }

--- a/crates/optimism/src/spec.rs
+++ b/crates/optimism/src/spec.rs
@@ -29,9 +29,8 @@ impl OpSpecId {
         match self {
             Self::BEDROCK | Self::REGOLITH => SpecId::MERGE,
             Self::CANYON => SpecId::SHANGHAI,
-            Self::ECOTONE | Self::FJORD | Self::GRANITE | Self::HOLOCENE | Self::ISTHMUS => {
-                SpecId::CANCUN
-            }
+            Self::ECOTONE | Self::FJORD | Self::GRANITE | Self::HOLOCENE => SpecId::CANCUN,
+            Self::ISTHMUS => SpecId::PRAGUE,
         }
     }
 


### PR DESCRIPTION
Part of https://github.com/bluealloy/revm/issues/1896
Backports: https://github.com/bluealloy/revm/pull/2000

Fix a bug where ECOTONE, HOLOCENE and ISTHMUS was creating fjord precompiles.

And add blst prague precompiles for Isthmus