### PR TITLE
Optimize gas cost subtraction using signed integer check #1884

### DIFF
--- a/crates/interpreter/src/gas.rs
+++ b/crates/interpreter/src/gas.rs
@@ -137,12 +137,12 @@ impl Gas {
     #[inline]
     #[must_use = "prefer using `gas!` instead to return an out-of-gas error on failure"]
     pub fn record_cost(&mut self, cost: u64) -> bool {
-        let (remaining, overflow) = self.remaining.overflowing_sub(cost);
-        let success = !overflow;
-        if success {
-            self.remaining = remaining;
+        let remaining = self.remaining as i64 - cost as i64;
+        if remaining < 0 {
+            return false; // OOG
         }
-        success
+        self.remaining = remaining as u64;
+        true
     }
 
     /// Record memory expansion


### PR DESCRIPTION
This being pr :- Link((https://github.com/bluealloy/revm/issues/1884))
- Switched to i64 for gas computation to simplify OOG (Out of Gas) checks.
- Replaced `overflowing_sub` with direct subtraction and a signed check.
@rakita 