### PR TITLE
fix(op-isthmus): missing granite precompiles and disable eof

### DIFF
--- a/crates/primitives/src/specification.rs
+++ b/crates/primitives/src/specification.rs
@@ -68,8 +68,8 @@ pub enum SpecId {
     GRANITE = 23,
     HOLOCENE = 24,
     PRAGUE = 25,
-    OSAKA = 26,
-    ISTHMUS = 27,
+    ISTHMUS = 26,
+    OSAKA = 27,
     #[default]
     LATEST = u8::MAX,
 }

--- a/crates/revm/src/optimism/handler_register.rs
+++ b/crates/revm/src/optimism/handler_register.rs
@@ -355,25 +355,21 @@ pub fn deduct_caller<SPEC: Spec, EXT, DB: Database>(
             ));
         };
 
-        let tx_l1_cost = context
+        let l1_block = context
             .evm
             .inner
             .l1_block_info
             .as_mut()
-            .expect("L1BlockInfo should be loaded")
-            .calculate_tx_l1_cost(enveloped_tx, SPEC::SPEC_ID);
+            .expect("L1BlockInfo should be loaded");
+
+        let tx_l1_cost = l1_block.calculate_tx_l1_cost(enveloped_tx, SPEC::SPEC_ID);
         caller_account.info.balance = caller_account.info.balance.saturating_sub(tx_l1_cost);
 
         // Deduct the operator fee from the caller's account.
         let gas_limit = U256::from(context.evm.inner.env.tx.gas_limit);
 
-        let operator_fee_charge = context
-            .evm
-            .inner
-            .l1_block_info
-            .as_ref()
-            .expect("L1BlockInfo should be loaded")
-            .operator_fee_charge(enveloped_tx, gas_limit, SPEC::SPEC_ID);
+        let operator_fee_charge =
+            l1_block.operator_fee_charge(enveloped_tx, gas_limit, SPEC::SPEC_ID);
 
         caller_account.info.balance = caller_account
             .info

--- a/crates/revm/src/optimism/precompile.rs
+++ b/crates/revm/src/optimism/precompile.rs
@@ -38,7 +38,7 @@ pub(crate) fn granite() -> &'static Precompiles {
 pub(crate) fn isthmus() -> &'static Precompiles {
     static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
     INSTANCE.get_or_init(|| {
-        let precompiles = Precompiles::cancun().clone();
+        let precompiles = granite().clone();
 
         // Don't include BLS12-381 precompiles in no_std builds.
         #[cfg(feature = "blst")]


### PR DESCRIPTION
Two fixes for upcoming isthmus hardfork.