### PR TITLE
chore: API cleanup

### DIFF
--- a/crates/context/interface/src/cfg.rs
+++ b/crates/context/interface/src/cfg.rs
@@ -6,7 +6,7 @@ use specification::hardfork::SpecId;
 
 #[auto_impl(&, &mut, Box, Arc)]
 pub trait Cfg {
-    type Spec: Into<SpecId>;
+    type Spec: Into<SpecId> + Clone;
 
     fn chain_id(&self) -> u64;
 

--- a/crates/handler/src/precompile_provider.rs
+++ b/crates/handler/src/precompile_provider.rs
@@ -9,7 +9,7 @@ use specification::hardfork::SpecId;
 use std::boxed::Box;
 
 #[auto_impl(&mut, Box)]
-pub trait PrecompileProvider: Clone {
+pub trait PrecompileProvider {
     type Context: ContextTrait;
     type Output;
 

--- a/crates/revm/src/mainnet_exec_inspect.rs
+++ b/crates/revm/src/mainnet_exec_inspect.rs
@@ -11,8 +11,7 @@ use handler::inspector::JournalExt;
 use handler::PrecompileProvider;
 use handler::{handler::EvmTrait, inspector::EthInspectorHandler};
 use handler::{
-    inspector::Inspector, instructions::EthInstructions, EthFrame, EthHandler, EthPrecompiles,
-    MainnetHandler,
+    inspector::Inspector, instructions::EthInstructions, EthFrame, EthHandler, MainnetHandler,
 };
 use interpreter::interpreter::EthInterpreter;
 
@@ -64,12 +63,13 @@ where
     }
 }
 
-impl<CTX, INSP> InspectEvm
-    for Evm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, EthPrecompiles<CTX>>
+impl<CTX, INSP, PRECOMPILES> InspectEvm
+    for Evm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, PRECOMPILES>
 where
     CTX: ContextSetters
         + ContextTrait<Journal: Journal<FinalOutput = (EvmState, Vec<Log>)> + JournalExt>,
     INSP: Inspector<CTX, EthInterpreter>,
+    PRECOMPILES: PrecompileProvider<Context = CTX, Output = InterpreterResult>,
 {
     type Inspector = INSP;
 
@@ -86,8 +86,8 @@ where
     }
 }
 
-impl<CTX, INSP> InspectCommitEvm
-    for Evm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, EthPrecompiles<CTX>>
+impl<CTX, INSP, PRECOMPILES> InspectCommitEvm
+    for Evm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, PRECOMPILES>
 where
     CTX: ContextSetters
         + ContextTrait<
@@ -95,6 +95,7 @@ where
             Db: DatabaseCommit,
         >,
     INSP: Inspector<CTX, EthInterpreter>,
+    PRECOMPILES: PrecompileProvider<Context = CTX, Output = InterpreterResult>,
 {
     fn inspect_commit_previous(&mut self) -> Self::CommitOutput {
         self.inspect_previous().map(|r| {

--- a/crates/revm/src/mainnet_exec_inspect.rs
+++ b/crates/revm/src/mainnet_exec_inspect.rs
@@ -8,6 +8,7 @@ use context_interface::{
 };
 use database_interface::DatabaseCommit;
 use handler::inspector::JournalExt;
+use handler::PrecompileProvider;
 use handler::{handler::EvmTrait, inspector::EthInspectorHandler};
 use handler::{
     inspector::Inspector, instructions::EthInstructions, EthFrame, EthHandler, EthPrecompiles,
@@ -15,16 +16,18 @@ use handler::{
 };
 use interpreter::interpreter::EthInterpreter;
 
+use interpreter::InterpreterResult;
 use primitives::Log;
 use state::EvmState;
 use std::vec::Vec;
 
-impl<CTX, INSP> ExecuteEvm
-    for Evm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, EthPrecompiles<CTX>>
+impl<CTX, INSP, PRECOMPILES> ExecuteEvm
+    for Evm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, PRECOMPILES>
 where
     CTX: ContextSetters
         + ContextTrait<Journal: Journal<FinalOutput = (EvmState, Vec<Log>)> + JournalExt>,
     INSP: Inspector<CTX, EthInterpreter>,
+    PRECOMPILES: PrecompileProvider<Context = CTX, Output = InterpreterResult>,
 {
     type Output = Result<
         ResultAndState<HaltReason>,
@@ -37,8 +40,8 @@ where
     }
 }
 
-impl<CTX, INSP> ExecuteCommitEvm
-    for Evm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, EthPrecompiles<CTX>>
+impl<CTX, INSP, PRECOMPILES> ExecuteCommitEvm
+    for Evm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, PRECOMPILES>
 where
     CTX: ContextSetters
         + ContextTrait<
@@ -46,6 +49,7 @@ where
             Db: DatabaseCommit,
         >,
     INSP: Inspector<CTX, EthInterpreter>,
+    PRECOMPILES: PrecompileProvider<Context = CTX, Output = InterpreterResult>,
 {
     type CommitOutput = Result<
         ExecutionResult<HaltReason>,


### PR DESCRIPTION
* Cfg::Spec is clonable
* PrecompileProvider does not need Clone
* Evm is now generic over Precompiles. In future we could potentially do the same for Instructions.