### PR TITLE
refactor: remove OpSpec

### DIFF
--- a/crates/optimism/src/api/builder.rs
+++ b/crates/optimism/src/api/builder.rs
@@ -1,4 +1,4 @@
-use crate::{evm::OpEvm, transaction::OpTxTrait, L1BlockInfo, OpSpec, OpTransaction};
+use crate::{evm::OpEvm, transaction::OpTxTrait, L1BlockInfo, OpSpecId, OpTransaction};
 use precompile::Log;
 use revm::{
     context::{BlockEnv, Cfg, CfgEnv, TxEnv},
@@ -27,7 +27,7 @@ impl<BLOCK, TX, CFG, DB, JOURNAL> OpBuilder for Context<BLOCK, TX, CFG, DB, JOUR
 where
     BLOCK: Block,
     TX: OpTxTrait,
-    CFG: Cfg<Spec = OpSpec>,
+    CFG: Cfg<Spec = OpSpecId>,
     DB: Database,
     JOURNAL: Journal<Database = DB, FinalOutput = (EvmState, Vec<Log>)>,
 {
@@ -48,4 +48,4 @@ where
 }
 
 pub type OpContext<DB> =
-    Context<BlockEnv, OpTransaction<TxEnv>, CfgEnv<OpSpec>, DB, JournaledState<DB>, L1BlockInfo>;
+    Context<BlockEnv, OpTransaction<TxEnv>, CfgEnv<OpSpecId>, DB, JournaledState<DB>, L1BlockInfo>;

--- a/crates/optimism/src/api/default_ctx.rs
+++ b/crates/optimism/src/api/default_ctx.rs
@@ -1,4 +1,4 @@
-use crate::{L1BlockInfo, OpSpec, OpSpecId, OpTransaction};
+use crate::{L1BlockInfo, OpSpecId, OpTransaction};
 use revm::{
     context::{BlockEnv, CfgEnv, TxEnv},
     database_interface::EmptyDB,
@@ -9,7 +9,7 @@ pub trait DefaultOp {
     fn op() -> Context<
         BlockEnv,
         OpTransaction<TxEnv>,
-        CfgEnv<OpSpec>,
+        CfgEnv<OpSpecId>,
         EmptyDB,
         JournaledState<EmptyDB>,
         L1BlockInfo,
@@ -20,7 +20,7 @@ impl DefaultOp
     for Context<
         BlockEnv,
         OpTransaction<TxEnv>,
-        CfgEnv<OpSpec>,
+        CfgEnv<OpSpecId>,
         EmptyDB,
         JournaledState<EmptyDB>,
         L1BlockInfo,
@@ -29,7 +29,7 @@ impl DefaultOp
     fn op() -> Self {
         Context::mainnet()
             .with_tx(OpTransaction::default())
-            .with_cfg(CfgEnv::new().with_spec(OpSpec::Op(OpSpecId::BEDROCK)))
+            .with_cfg(CfgEnv::new().with_spec(OpSpecId::BEDROCK))
             .with_chain(L1BlockInfo::default())
     }
 }

--- a/crates/optimism/src/api/exec.rs
+++ b/crates/optimism/src/api/exec.rs
@@ -1,5 +1,5 @@
 use crate::{
-    evm::OpEvm, handler::OpHandler, transaction::OpTxTrait, L1BlockInfo, OpHaltReason, OpSpec,
+    evm::OpEvm, handler::OpHandler, transaction::OpTxTrait, L1BlockInfo, OpHaltReason, OpSpecId,
     OpTransactionError,
 };
 use precompile::Log;
@@ -29,7 +29,7 @@ impl<BLOCK, TX, CFG, DB, JOURNAL, INSP> ExecuteEvm
 where
     BLOCK: Block,
     TX: OpTxTrait,
-    CFG: Cfg<Spec = OpSpec>,
+    CFG: Cfg<Spec = OpSpecId>,
     DB: Database,
     JOURNAL: Journal<Database = DB, FinalOutput = (EvmState, Vec<Log>)> + JournalExt,
     INSP: Inspector<Context<BLOCK, TX, CFG, DB, JOURNAL, L1BlockInfo>, EthInterpreter>,
@@ -52,7 +52,7 @@ impl<BLOCK, TX, CFG, DB, JOURNAL, INSP> ExecuteCommitEvm
 where
     BLOCK: Block,
     TX: OpTxTrait,
-    CFG: Cfg<Spec = OpSpec>,
+    CFG: Cfg<Spec = OpSpecId>,
     DB: Database + DatabaseCommit,
     JOURNAL: Journal<Database = DB, FinalOutput = (EvmState, Vec<Log>)> + JournalExt,
     INSP: Inspector<Context<BLOCK, TX, CFG, DB, JOURNAL, L1BlockInfo>, EthInterpreter>,
@@ -79,7 +79,7 @@ impl<BLOCK, TX, CFG, DB, JOURNAL, INSP> InspectEvm
 where
     BLOCK: Block,
     TX: OpTxTrait,
-    CFG: Cfg<Spec = OpSpec>,
+    CFG: Cfg<Spec = OpSpecId>,
     DB: Database,
     JOURNAL: Journal<Database = DB, FinalOutput = (EvmState, Vec<Log>)> + JournalExt,
     INSP: Inspector<Context<BLOCK, TX, CFG, DB, JOURNAL, L1BlockInfo>, EthInterpreter>,
@@ -105,7 +105,7 @@ impl<BLOCK, TX, CFG, DB, JOURNAL, INSP> InspectCommitEvm
 where
     BLOCK: Block,
     TX: OpTxTrait,
-    CFG: Cfg<Spec = OpSpec>,
+    CFG: Cfg<Spec = OpSpecId>,
     DB: Database + DatabaseCommit,
     JOURNAL: Journal<Database = DB, FinalOutput = (EvmState, Vec<Log>)> + JournalExt,
     INSP: Inspector<Context<BLOCK, TX, CFG, DB, JOURNAL, L1BlockInfo>, EthInterpreter>,

--- a/crates/optimism/src/handler.rs
+++ b/crates/optimism/src/handler.rs
@@ -8,7 +8,7 @@ use crate::{
         deposit::{DepositTransaction, DEPOSIT_TRANSACTION_TYPE},
         OpTransactionError, OpTxTrait,
     },
-    L1BlockInfo, OpHaltReason, OpSpec, OpSpecId,
+    L1BlockInfo, OpHaltReason, OpSpecId,
 };
 use precompile::Log;
 use revm::{
@@ -66,7 +66,7 @@ where
         Context: ContextTrait<
             Journal: Journal<FinalOutput = (EvmState, Vec<Log>)>,
             Tx: OpTxTrait,
-            Cfg: Cfg<Spec = OpSpec>,
+            Cfg: Cfg<Spec = OpSpecId>,
             Chain = L1BlockInfo,
         >,
     >,
@@ -290,9 +290,13 @@ where
         // Prior to Regolith, deposit transactions did not receive gas refunds.
         let is_gas_refund_disabled = is_deposit && !is_regolith;
         if !is_gas_refund_disabled {
-            exec_result
-                .gas_mut()
-                .set_final_refund(evm.ctx().cfg().spec().is_enabled_in(SpecId::LONDON));
+            exec_result.gas_mut().set_final_refund(
+                evm.ctx()
+                    .cfg()
+                    .spec()
+                    .into_eth_spec()
+                    .is_enabled_in(SpecId::LONDON),
+            );
         }
     }
 
@@ -444,7 +448,7 @@ where
         Context: ContextTrait<
             Journal: Journal<FinalOutput = (EvmState, Vec<Log>)>,
             Tx: OpTxTrait,
-            Cfg: Cfg<Spec = OpSpec>,
+            Cfg: Cfg<Spec = OpSpecId>,
             Chain = L1BlockInfo,
         >,
         Inspector: Inspector<<<Self as EthHandler>::Evm as EvmTrait>::Context, EthInterpreter>,

--- a/crates/optimism/src/handler.rs
+++ b/crates/optimism/src/handler.rs
@@ -511,7 +511,7 @@ mod tests {
                 tx.base.gas_limit = 100;
                 tx.enveloped_tx = None;
             })
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::BEDROCK.into());
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::BEDROCK);
 
         let gas = call_last_frame_return(ctx, InstructionResult::Revert, Gas::new(90));
         assert_eq!(gas.remaining(), 90);
@@ -527,7 +527,7 @@ mod tests {
                 tx.deposit.source_hash = B256::ZERO;
                 tx.base.tx_type = DEPOSIT_TRANSACTION_TYPE;
             })
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::REGOLITH.into());
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::REGOLITH);
 
         let gas = call_last_frame_return(ctx, InstructionResult::Stop, Gas::new(90));
         assert_eq!(gas.remaining(), 90);
@@ -543,7 +543,7 @@ mod tests {
                 tx.base.tx_type = DEPOSIT_TRANSACTION_TYPE;
                 tx.deposit.source_hash = B256::ZERO;
             })
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::REGOLITH.into());
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::REGOLITH);
 
         let mut ret_gas = Gas::new(90);
         ret_gas.record_refund(20);
@@ -567,7 +567,7 @@ mod tests {
                 tx.base.gas_limit = 100;
                 tx.deposit.source_hash = B256::ZERO;
             })
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::BEDROCK.into());
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::BEDROCK);
         let gas = call_last_frame_return(ctx, InstructionResult::Stop, Gas::new(90));
         assert_eq!(gas.remaining(), 0);
         assert_eq!(gas.spent(), 100);
@@ -594,7 +594,7 @@ mod tests {
                 l1_base_fee_scalar: U256::from(1_000),
                 ..Default::default()
             })
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::REGOLITH.into());
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::REGOLITH);
         ctx.modify_tx(|tx| {
             tx.base.tx_type = DEPOSIT_TRANSACTION_TYPE;
             tx.deposit.source_hash = B256::ZERO;
@@ -630,7 +630,7 @@ mod tests {
                 l1_base_fee_scalar: U256::from(1_000),
                 ..Default::default()
             })
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::REGOLITH.into())
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::REGOLITH)
             .modify_tx_chained(|tx| {
                 tx.base.gas_limit = 100;
                 tx.base.tx_type = DEPOSIT_TRANSACTION_TYPE;
@@ -668,7 +668,7 @@ mod tests {
                 l1_base_fee_scalar: U256::from(1_000),
                 ..Default::default()
             })
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::REGOLITH.into())
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::REGOLITH)
             .modify_tx_chained(|tx| {
                 tx.base.gas_limit = 100;
                 tx.deposit.source_hash = B256::ZERO;
@@ -704,7 +704,7 @@ mod tests {
                 operator_fee_constant: Some(U256::from(50)),
                 ..Default::default()
             })
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ISTHMUS.into())
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ISTHMUS)
             .modify_tx_chained(|tx| {
                 tx.base.gas_limit = 10;
                 tx.enveloped_tx = Some(bytes!("FACADE"));
@@ -741,7 +741,7 @@ mod tests {
                 l1_base_fee_scalar: U256::from(1_000),
                 ..Default::default()
             })
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::REGOLITH.into())
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::REGOLITH)
             .modify_tx_chained(|tx| {
                 tx.enveloped_tx = Some(bytes!("FACADE"));
             });
@@ -771,7 +771,7 @@ mod tests {
                 tx.base.tx_type = DEPOSIT_TRANSACTION_TYPE;
                 tx.deposit.is_system_transaction = true;
             })
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::REGOLITH.into());
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::REGOLITH);
 
         let mut evm = ctx.build_op();
         let handler = OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<_, _, _>>::new();
@@ -783,8 +783,7 @@ mod tests {
             ))
         );
 
-        evm.ctx()
-            .modify_cfg(|cfg| cfg.spec = OpSpecId::BEDROCK.into());
+        evm.ctx().modify_cfg(|cfg| cfg.spec = OpSpecId::BEDROCK);
 
         // Pre-regolith system transactions should be allowed.
         assert!(handler.validate_env(&mut evm).is_ok());
@@ -798,7 +797,7 @@ mod tests {
                 tx.base.tx_type = DEPOSIT_TRANSACTION_TYPE;
                 tx.deposit.source_hash = B256::ZERO;
             })
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::REGOLITH.into());
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::REGOLITH);
 
         let mut evm = ctx.build_op();
         let handler = OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<_, _, _>>::new();
@@ -814,7 +813,7 @@ mod tests {
                 tx.base.tx_type = DEPOSIT_TRANSACTION_TYPE;
                 tx.deposit.source_hash = B256::ZERO;
             })
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::REGOLITH.into());
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::REGOLITH);
 
         let mut evm = ctx.build_op();
         let handler = OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<_, _, _>>::new();

--- a/crates/optimism/src/handler/precompiles.rs
+++ b/crates/optimism/src/handler/precompiles.rs
@@ -1,4 +1,4 @@
-use crate::{OpSpec, OpSpecId};
+use crate::OpSpecId;
 use once_cell::race::OnceBox;
 use precompile::{secp256r1, PrecompileErrors, Precompiles};
 use revm::{
@@ -6,7 +6,6 @@ use revm::{
     context_interface::ContextTrait,
     handler::{EthPrecompiles, PrecompileProvider},
     interpreter::InterpreterResult,
-    specification::hardfork::SpecId,
 };
 use std::boxed::Box;
 
@@ -33,35 +32,15 @@ impl<CTX> OpPrecompileProvider<CTX> {
     }
 
     #[inline]
-    pub fn new_with_spec(spec: OpSpec) -> Self {
+    pub fn new_with_spec(spec: OpSpecId) -> Self {
         match spec {
-            spec @ (OpSpec::Eth(
-                SpecId::FRONTIER
-                | SpecId::FRONTIER_THAWING
-                | SpecId::HOMESTEAD
-                | SpecId::DAO_FORK
-                | SpecId::TANGERINE
-                | SpecId::SPURIOUS_DRAGON
-                | SpecId::BYZANTIUM
-                | SpecId::CONSTANTINOPLE
-                | SpecId::PETERSBURG
-                | SpecId::ISTANBUL
-                | SpecId::MUIR_GLACIER
-                | SpecId::BERLIN
-                | SpecId::LONDON
-                | SpecId::ARROW_GLACIER
-                | SpecId::GRAY_GLACIER
-                | SpecId::MERGE
-                | SpecId::SHANGHAI
-                | SpecId::CANCUN,
-            )
-            | OpSpec::Op(
-                OpSpecId::BEDROCK | OpSpecId::REGOLITH | OpSpecId::CANYON | OpSpecId::ECOTONE,
-            )) => Self::new(Precompiles::new(spec.into_eth_spec().into())),
-            OpSpec::Op(OpSpecId::FJORD) => Self::new(fjord()),
-            OpSpec::Op(OpSpecId::GRANITE | OpSpecId::HOLOCENE) => Self::new(granite()),
-            OpSpec::Op(OpSpecId::ISTHMUS)
-            | OpSpec::Eth(SpecId::PRAGUE | SpecId::OSAKA | SpecId::LATEST) => Self::new(isthumus()),
+            spec @ (OpSpecId::BEDROCK
+            | OpSpecId::REGOLITH
+            | OpSpecId::CANYON
+            | OpSpecId::ECOTONE) => Self::new(Precompiles::new(spec.into_eth_spec().into())),
+            OpSpecId::FJORD => Self::new(fjord()),
+            OpSpecId::GRANITE | OpSpecId::HOLOCENE => Self::new(granite()),
+            OpSpecId::ISTHMUS => Self::new(isthumus()),
         }
     }
 }
@@ -107,7 +86,7 @@ pub fn isthumus() -> &'static Precompiles {
 
 impl<CTX> PrecompileProvider for OpPrecompileProvider<CTX>
 where
-    CTX: ContextTrait<Cfg: Cfg<Spec = OpSpec>>,
+    CTX: ContextTrait<Cfg: Cfg<Spec = OpSpecId>>,
 {
     type Context = CTX;
     type Output = InterpreterResult;
@@ -142,6 +121,6 @@ where
 
 impl<CTX> Default for OpPrecompileProvider<CTX> {
     fn default() -> Self {
-        Self::new_with_spec(OpSpec::Op(OpSpecId::ISTHMUS))
+        Self::new_with_spec(OpSpecId::ISTHMUS)
     }
 }

--- a/crates/optimism/src/l1block.rs
+++ b/crates/optimism/src/l1block.rs
@@ -220,7 +220,7 @@ impl L1BlockInfo {
         U256::from(estimate_tx_compressed_size(input))
     }
 
-    /// Calculate the gas cost of a transaction based on L1 block data posted on L2, depending on the [OpSpec] passed.
+    /// Calculate the gas cost of a transaction based on L1 block data posted on L2, depending on the [OpSpecId] passed.
     pub fn calculate_tx_l1_cost(&self, input: &[u8], spec_id: OpSpecId) -> U256 {
         // If the input is a deposit transaction or empty, the default value is zero.
         if input.is_empty() || input.first() == Some(&0x7F) {
@@ -321,17 +321,17 @@ mod tests {
         // gas cost = 3 non-zero bytes * NON_ZERO_BYTE_COST + NON_ZERO_BYTE_COST * 68
         // gas cost = 3 * 16 + 68 * 16 = 1136
         let input = bytes!("FACADE");
-        let bedrock_data_gas = l1_block_info.data_gas(&input, OpSpecId::BEDROCK.into());
+        let bedrock_data_gas = l1_block_info.data_gas(&input, OpSpecId::BEDROCK);
         assert_eq!(bedrock_data_gas, U256::from(1136));
 
         // Regolith has no added 68 non zero bytes
         // gas cost = 3 * 16 = 48
-        let regolith_data_gas = l1_block_info.data_gas(&input, OpSpecId::REGOLITH.into());
+        let regolith_data_gas = l1_block_info.data_gas(&input, OpSpecId::REGOLITH);
         assert_eq!(regolith_data_gas, U256::from(48));
 
         // Fjord has a minimum compressed size of 100 bytes
         // gas cost = 100 * 16 = 1600
-        let fjord_data_gas = l1_block_info.data_gas(&input, OpSpecId::FJORD.into());
+        let fjord_data_gas = l1_block_info.data_gas(&input, OpSpecId::FJORD);
         assert_eq!(fjord_data_gas, U256::from(1600));
     }
 
@@ -351,17 +351,17 @@ mod tests {
         // gas cost = 3 non-zero * NON_ZERO_BYTE_COST + 2 * ZERO_BYTE_COST + NON_ZERO_BYTE_COST * 68
         // gas cost = 3 * 16 + 2 * 4 + 68 * 16 = 1144
         let input = bytes!("FA00CA00DE");
-        let bedrock_data_gas = l1_block_info.data_gas(&input, OpSpecId::BEDROCK.into());
+        let bedrock_data_gas = l1_block_info.data_gas(&input, OpSpecId::BEDROCK);
         assert_eq!(bedrock_data_gas, U256::from(1144));
 
         // Regolith has no added 68 non zero bytes
         // gas cost = 3 * 16 + 2 * 4 = 56
-        let regolith_data_gas = l1_block_info.data_gas(&input, OpSpecId::REGOLITH.into());
+        let regolith_data_gas = l1_block_info.data_gas(&input, OpSpecId::REGOLITH);
         assert_eq!(regolith_data_gas, U256::from(56));
 
         // Fjord has a minimum compressed size of 100 bytes
         // gas cost = 100 * 16 = 1600
-        let fjord_data_gas = l1_block_info.data_gas(&input, OpSpecId::FJORD.into());
+        let fjord_data_gas = l1_block_info.data_gas(&input, OpSpecId::FJORD);
         assert_eq!(fjord_data_gas, U256::from(1600));
     }
 
@@ -375,17 +375,17 @@ mod tests {
         };
 
         let input = bytes!("FACADE");
-        let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::REGOLITH.into());
+        let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::REGOLITH);
         assert_eq!(gas_cost, U256::from(1048));
 
         // Zero rollup data gas cost should result in zero
         let input = bytes!("");
-        let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::REGOLITH.into());
+        let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::REGOLITH);
         assert_eq!(gas_cost, U256::ZERO);
 
         // Deposit transactions with the EIP-2718 type of 0x7F should result in zero
         let input = bytes!("7FFACADE");
-        let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::REGOLITH.into());
+        let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::REGOLITH);
         assert_eq!(gas_cost, U256::ZERO);
     }
 
@@ -404,23 +404,23 @@ mod tests {
         // = (16 * 3) * (1000 * 16 * 1000 + 1000 * 1000) / (16 * 1e6)
         // = 51
         let input = bytes!("FACADE");
-        let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::ECOTONE.into());
+        let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::ECOTONE);
         assert_eq!(gas_cost, U256::from(51));
 
         // Zero rollup data gas cost should result in zero
         let input = bytes!("");
-        let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::ECOTONE.into());
+        let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::ECOTONE);
         assert_eq!(gas_cost, U256::ZERO);
 
         // Deposit transactions with the EIP-2718 type of 0x7F should result in zero
         let input = bytes!("7FFACADE");
-        let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::ECOTONE.into());
+        let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::ECOTONE);
         assert_eq!(gas_cost, U256::ZERO);
 
         // If the scalars are empty, the bedrock cost function should be used.
         l1_block_info.empty_ecotone_scalars = true;
         let input = bytes!("FACADE");
-        let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::ECOTONE.into());
+        let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::ECOTONE);
         assert_eq!(gas_cost, U256::from(1048));
     }
 
@@ -459,11 +459,11 @@ mod tests {
 
         // test
 
-        let gas_used = l1_block_info.data_gas(TX, OpSpecId::ECOTONE.into());
+        let gas_used = l1_block_info.data_gas(TX, OpSpecId::ECOTONE);
 
         assert_eq!(gas_used, expected_l1_gas_used);
 
-        let l1_fee = l1_block_info.calculate_tx_l1_cost_ecotone(TX, OpSpecId::ECOTONE.into());
+        let l1_fee = l1_block_info.calculate_tx_l1_cost_ecotone(TX, OpSpecId::ECOTONE);
 
         assert_eq!(l1_fee, expected_l1_fee)
     }
@@ -489,7 +489,7 @@ mod tests {
         // l1Cost = estimatedSize * l1FeeScaled / 1e12
         //        = 100e6 * 17 / 1e6
         //        = 1700
-        let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::FJORD.into());
+        let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::FJORD);
         assert_eq!(gas_cost, U256::from(1700));
 
         // fastLzSize = 202
@@ -500,17 +500,17 @@ mod tests {
         // l1Cost = estimatedSize * l1FeeScaled / 1e12
         //        = 126387400 * 17 / 1e6
         //        = 2148
-        let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::FJORD.into());
+        let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::FJORD);
         assert_eq!(gas_cost, U256::from(2148));
 
         // Zero rollup data gas cost should result in zero
         let input = bytes!("");
-        let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::FJORD.into());
+        let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::FJORD);
         assert_eq!(gas_cost, U256::ZERO);
 
         // Deposit transactions with the EIP-2718 type of 0x7F should result in zero
         let input = bytes!("7FFACADE");
-        let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::FJORD.into());
+        let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::FJORD);
         assert_eq!(gas_cost, U256::ZERO);
     }
 
@@ -541,7 +541,7 @@ mod tests {
 
         // test
 
-        let data_gas = l1_block_info.data_gas(TX, OpSpecId::FJORD.into());
+        let data_gas = l1_block_info.data_gas(TX, OpSpecId::FJORD);
 
         assert_eq!(data_gas, expected_data_gas);
 
@@ -562,7 +562,7 @@ mod tests {
             ..Default::default()
         };
 
-        let refunded = l1_block_info.operator_fee_refund(&gas, OpSpecId::ISTHMUS.into());
+        let refunded = l1_block_info.operator_fee_refund(&gas, OpSpecId::ISTHMUS);
 
         assert_eq!(refunded, U256::from(100))
     }

--- a/crates/optimism/src/spec.rs
+++ b/crates/optimism/src/spec.rs
@@ -17,7 +17,7 @@ pub enum OpSpecId {
 }
 
 impl OpSpecId {
-    /// Converts the [`OpSpec`] into a [`SpecId`].
+    /// Converts the [`OpSpecId`] into a [`SpecId`].
     pub const fn into_eth_spec(self) -> SpecId {
         match self {
             Self::BEDROCK | Self::REGOLITH => SpecId::MERGE,

--- a/crates/optimism/src/spec.rs
+++ b/crates/optimism/src/spec.rs
@@ -1,7 +1,7 @@
 use revm::specification::hardfork::SpecId;
 
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(non_camel_case_types)]
 pub enum OpSpecId {
@@ -12,6 +12,7 @@ pub enum OpSpecId {
     FJORD,
     GRANITE,
     HOLOCENE,
+    #[default]
     ISTHMUS,
 }
 

--- a/crates/optimism/src/spec.rs
+++ b/crates/optimism/src/spec.rs
@@ -1,15 +1,7 @@
 use revm::specification::hardfork::SpecId;
 
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum OpSpec {
-    Eth(SpecId),
-    Op(OpSpecId),
-}
-
-#[repr(u8)]
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(non_camel_case_types)]
 pub enum OpSpecId {
@@ -39,23 +31,9 @@ impl OpSpecId {
     }
 }
 
-impl From<OpSpecId> for OpSpec {
+impl From<OpSpecId> for SpecId {
     fn from(spec: OpSpecId) -> Self {
-        OpSpec::Op(spec)
-    }
-}
-
-impl From<SpecId> for OpSpec {
-    fn from(spec: SpecId) -> Self {
-        OpSpec::Eth(spec)
-    }
-}
-impl From<OpSpec> for SpecId {
-    fn from(spec: OpSpec) -> Self {
-        match spec {
-            OpSpec::Eth(spec) => spec,
-            OpSpec::Op(spec) => spec.into_eth_spec(),
-        }
+        spec.into_eth_spec()
     }
 }
 
@@ -102,106 +80,63 @@ pub mod name {
     pub const ISTHMUS: &str = "Isthmus";
 }
 
-impl OpSpec {
-    /// Returns `true` if the given specification ID is enabled in this spec.
-    #[inline]
-    pub fn is_enabled_in(self, other: impl Into<Self>) -> bool {
-        match (self, other.into()) {
-            (OpSpec::Eth(this), OpSpec::Eth(other)) => other as u8 <= this as u8,
-            (OpSpec::Op(this), OpSpec::Op(other)) => other as u8 <= this as u8,
-            (OpSpec::Eth(this), OpSpec::Op(other)) => other.into_eth_spec() as u8 <= this as u8,
-            (OpSpec::Op(this), OpSpec::Eth(other)) => other as u8 <= this.into_eth_spec() as u8,
-        }
-    }
-
-    /// Converts the [`OpSpec`] into a [`SpecId`].
-    pub const fn into_eth_spec(self) -> SpecId {
-        match self {
-            OpSpec::Eth(spec) => spec,
-            OpSpec::Op(spec) => spec.into_eth_spec(),
-        }
-    }
-}
-
-impl From<&str> for OpSpec {
-    fn from(name: &str) -> Self {
-        let eth = SpecId::from(name);
-        if eth != SpecId::LATEST {
-            return Self::Eth(eth);
-        }
-        match OpSpecId::try_from(name) {
-            Ok(op) => Self::Op(op),
-            Err(_) => Self::Eth(SpecId::LATEST),
-        }
-    }
-}
-
-impl From<OpSpec> for &'static str {
-    fn from(value: OpSpec) -> Self {
-        match value {
-            OpSpec::Eth(eth) => eth.into(),
-            OpSpec::Op(op) => op.into(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_bedrock_post_merge_hardforks() {
-        assert!(OpSpec::Op(OpSpecId::BEDROCK).is_enabled_in(SpecId::MERGE));
-        assert!(!OpSpec::Op(OpSpecId::BEDROCK).is_enabled_in(SpecId::SHANGHAI));
-        assert!(!OpSpec::Op(OpSpecId::BEDROCK).is_enabled_in(SpecId::CANCUN));
-        assert!(!OpSpec::Op(OpSpecId::BEDROCK).is_enabled_in(SpecId::LATEST));
-        assert!(OpSpec::Op(OpSpecId::BEDROCK).is_enabled_in(OpSpecId::BEDROCK));
-        assert!(!OpSpec::Op(OpSpecId::BEDROCK).is_enabled_in(OpSpecId::REGOLITH));
+        assert!(OpSpecId::BEDROCK.into_eth_spec().is_enabled_in(SpecId::MERGE));
+        assert!(!OpSpecId::BEDROCK.into_eth_spec().is_enabled_in(SpecId::SHANGHAI));
+        assert!(!OpSpecId::BEDROCK.into_eth_spec().is_enabled_in(SpecId::CANCUN));
+        assert!(!OpSpecId::BEDROCK.into_eth_spec().is_enabled_in(SpecId::LATEST));
+        assert!(OpSpecId::BEDROCK.is_enabled_in(OpSpecId::BEDROCK));
+        assert!(!OpSpecId::BEDROCK.is_enabled_in(OpSpecId::REGOLITH));
     }
 
     #[test]
     fn test_regolith_post_merge_hardforks() {
-        assert!(OpSpec::Op(OpSpecId::REGOLITH).is_enabled_in(SpecId::MERGE));
-        assert!(!OpSpec::Op(OpSpecId::REGOLITH).is_enabled_in(SpecId::SHANGHAI));
-        assert!(!OpSpec::Op(OpSpecId::REGOLITH).is_enabled_in(SpecId::CANCUN));
-        assert!(!OpSpec::Op(OpSpecId::REGOLITH).is_enabled_in(SpecId::LATEST));
-        assert!(OpSpec::Op(OpSpecId::REGOLITH).is_enabled_in(OpSpecId::BEDROCK));
-        assert!(OpSpec::Op(OpSpecId::REGOLITH).is_enabled_in(OpSpecId::REGOLITH));
+        assert!(OpSpecId::REGOLITH.into_eth_spec().is_enabled_in(SpecId::MERGE));
+        assert!(!OpSpecId::REGOLITH.into_eth_spec().is_enabled_in(SpecId::SHANGHAI));
+        assert!(!OpSpecId::REGOLITH.into_eth_spec().is_enabled_in(SpecId::CANCUN));
+        assert!(!OpSpecId::REGOLITH.into_eth_spec().is_enabled_in(SpecId::LATEST));
+        assert!(OpSpecId::REGOLITH.is_enabled_in(OpSpecId::BEDROCK));
+        assert!(OpSpecId::REGOLITH.is_enabled_in(OpSpecId::REGOLITH));
     }
 
     #[test]
     fn test_canyon_post_merge_hardforks() {
-        assert!(OpSpec::Op(OpSpecId::CANYON).is_enabled_in(SpecId::MERGE));
-        assert!(OpSpec::Op(OpSpecId::CANYON).is_enabled_in(SpecId::SHANGHAI));
-        assert!(!OpSpec::Op(OpSpecId::CANYON).is_enabled_in(SpecId::CANCUN));
-        assert!(!OpSpec::Op(OpSpecId::CANYON).is_enabled_in(SpecId::LATEST));
-        assert!(OpSpec::Op(OpSpecId::CANYON).is_enabled_in(OpSpecId::BEDROCK));
-        assert!(OpSpec::Op(OpSpecId::CANYON).is_enabled_in(OpSpecId::REGOLITH));
-        assert!(OpSpec::Op(OpSpecId::CANYON).is_enabled_in(OpSpecId::CANYON));
+        assert!(OpSpecId::CANYON.into_eth_spec().is_enabled_in(SpecId::MERGE));
+        assert!(OpSpecId::CANYON.into_eth_spec().is_enabled_in(SpecId::SHANGHAI));
+        assert!(!OpSpecId::CANYON.into_eth_spec().is_enabled_in(SpecId::CANCUN));
+        assert!(!OpSpecId::CANYON.into_eth_spec().is_enabled_in(SpecId::LATEST));
+        assert!(OpSpecId::CANYON.is_enabled_in(OpSpecId::BEDROCK));
+        assert!(OpSpecId::CANYON.is_enabled_in(OpSpecId::REGOLITH));
+        assert!(OpSpecId::CANYON.is_enabled_in(OpSpecId::CANYON));
     }
 
     #[test]
     fn test_ecotone_post_merge_hardforks() {
-        assert!(OpSpec::Op(OpSpecId::ECOTONE).is_enabled_in(SpecId::MERGE));
-        assert!(OpSpec::Op(OpSpecId::ECOTONE).is_enabled_in(SpecId::SHANGHAI));
-        assert!(OpSpec::Op(OpSpecId::ECOTONE).is_enabled_in(SpecId::CANCUN));
-        assert!(!OpSpec::Op(OpSpecId::ECOTONE).is_enabled_in(SpecId::LATEST));
-        assert!(OpSpec::Op(OpSpecId::ECOTONE).is_enabled_in(OpSpecId::BEDROCK));
-        assert!(OpSpec::Op(OpSpecId::ECOTONE).is_enabled_in(OpSpecId::REGOLITH));
-        assert!(OpSpec::Op(OpSpecId::ECOTONE).is_enabled_in(OpSpecId::CANYON));
-        assert!(OpSpec::Op(OpSpecId::ECOTONE).is_enabled_in(OpSpecId::ECOTONE));
+        assert!(OpSpecId::ECOTONE.into_eth_spec().is_enabled_in(SpecId::MERGE));
+        assert!(OpSpecId::ECOTONE.into_eth_spec().is_enabled_in(SpecId::SHANGHAI));
+        assert!(OpSpecId::ECOTONE.into_eth_spec().is_enabled_in(SpecId::CANCUN));
+        assert!(!OpSpecId::ECOTONE.into_eth_spec().is_enabled_in(SpecId::LATEST));
+        assert!(OpSpecId::ECOTONE.is_enabled_in(OpSpecId::BEDROCK));
+        assert!(OpSpecId::ECOTONE.is_enabled_in(OpSpecId::REGOLITH));
+        assert!(OpSpecId::ECOTONE.is_enabled_in(OpSpecId::CANYON));
+        assert!(OpSpecId::ECOTONE.is_enabled_in(OpSpecId::ECOTONE));
     }
 
     #[test]
     fn test_fjord_post_merge_hardforks() {
-        assert!(OpSpec::Op(OpSpecId::FJORD).is_enabled_in(SpecId::MERGE));
-        assert!(OpSpec::Op(OpSpecId::FJORD).is_enabled_in(SpecId::SHANGHAI));
-        assert!(OpSpec::Op(OpSpecId::FJORD).is_enabled_in(SpecId::CANCUN));
-        assert!(!OpSpec::Op(OpSpecId::FJORD).is_enabled_in(SpecId::LATEST));
-        assert!(OpSpec::Op(OpSpecId::FJORD).is_enabled_in(OpSpecId::BEDROCK));
-        assert!(OpSpec::Op(OpSpecId::FJORD).is_enabled_in(OpSpecId::REGOLITH));
-        assert!(OpSpec::Op(OpSpecId::FJORD).is_enabled_in(OpSpecId::CANYON));
-        assert!(OpSpec::Op(OpSpecId::FJORD).is_enabled_in(OpSpecId::ECOTONE));
-        assert!(OpSpec::Op(OpSpecId::FJORD).is_enabled_in(OpSpecId::FJORD));
+        assert!(OpSpecId::FJORD.into_eth_spec().is_enabled_in(SpecId::MERGE));
+        assert!(OpSpecId::FJORD.into_eth_spec().is_enabled_in(SpecId::SHANGHAI));
+        assert!(OpSpecId::FJORD.into_eth_spec().is_enabled_in(SpecId::CANCUN));
+        assert!(!OpSpecId::FJORD.into_eth_spec().is_enabled_in(SpecId::LATEST));
+        assert!(OpSpecId::FJORD.is_enabled_in(OpSpecId::BEDROCK));
+        assert!(OpSpecId::FJORD.is_enabled_in(OpSpecId::REGOLITH));
+        assert!(OpSpecId::FJORD.is_enabled_in(OpSpecId::CANYON));
+        assert!(OpSpecId::FJORD.is_enabled_in(OpSpecId::ECOTONE));
+        assert!(OpSpecId::FJORD.is_enabled_in(OpSpecId::FJORD));
     }
 }

--- a/crates/optimism/src/spec.rs
+++ b/crates/optimism/src/spec.rs
@@ -28,7 +28,7 @@ impl OpSpecId {
     }
 
     pub const fn is_enabled_in(self, other: OpSpecId) -> bool {
-        self as u8 <= other as u8
+        other as u8 <= self as u8
     }
 }
 

--- a/crates/optimism/src/spec.rs
+++ b/crates/optimism/src/spec.rs
@@ -87,30 +87,54 @@ mod tests {
 
     #[test]
     fn test_bedrock_post_merge_hardforks() {
-        assert!(OpSpecId::BEDROCK.into_eth_spec().is_enabled_in(SpecId::MERGE));
-        assert!(!OpSpecId::BEDROCK.into_eth_spec().is_enabled_in(SpecId::SHANGHAI));
-        assert!(!OpSpecId::BEDROCK.into_eth_spec().is_enabled_in(SpecId::CANCUN));
-        assert!(!OpSpecId::BEDROCK.into_eth_spec().is_enabled_in(SpecId::LATEST));
+        assert!(OpSpecId::BEDROCK
+            .into_eth_spec()
+            .is_enabled_in(SpecId::MERGE));
+        assert!(!OpSpecId::BEDROCK
+            .into_eth_spec()
+            .is_enabled_in(SpecId::SHANGHAI));
+        assert!(!OpSpecId::BEDROCK
+            .into_eth_spec()
+            .is_enabled_in(SpecId::CANCUN));
+        assert!(!OpSpecId::BEDROCK
+            .into_eth_spec()
+            .is_enabled_in(SpecId::LATEST));
         assert!(OpSpecId::BEDROCK.is_enabled_in(OpSpecId::BEDROCK));
         assert!(!OpSpecId::BEDROCK.is_enabled_in(OpSpecId::REGOLITH));
     }
 
     #[test]
     fn test_regolith_post_merge_hardforks() {
-        assert!(OpSpecId::REGOLITH.into_eth_spec().is_enabled_in(SpecId::MERGE));
-        assert!(!OpSpecId::REGOLITH.into_eth_spec().is_enabled_in(SpecId::SHANGHAI));
-        assert!(!OpSpecId::REGOLITH.into_eth_spec().is_enabled_in(SpecId::CANCUN));
-        assert!(!OpSpecId::REGOLITH.into_eth_spec().is_enabled_in(SpecId::LATEST));
+        assert!(OpSpecId::REGOLITH
+            .into_eth_spec()
+            .is_enabled_in(SpecId::MERGE));
+        assert!(!OpSpecId::REGOLITH
+            .into_eth_spec()
+            .is_enabled_in(SpecId::SHANGHAI));
+        assert!(!OpSpecId::REGOLITH
+            .into_eth_spec()
+            .is_enabled_in(SpecId::CANCUN));
+        assert!(!OpSpecId::REGOLITH
+            .into_eth_spec()
+            .is_enabled_in(SpecId::LATEST));
         assert!(OpSpecId::REGOLITH.is_enabled_in(OpSpecId::BEDROCK));
         assert!(OpSpecId::REGOLITH.is_enabled_in(OpSpecId::REGOLITH));
     }
 
     #[test]
     fn test_canyon_post_merge_hardforks() {
-        assert!(OpSpecId::CANYON.into_eth_spec().is_enabled_in(SpecId::MERGE));
-        assert!(OpSpecId::CANYON.into_eth_spec().is_enabled_in(SpecId::SHANGHAI));
-        assert!(!OpSpecId::CANYON.into_eth_spec().is_enabled_in(SpecId::CANCUN));
-        assert!(!OpSpecId::CANYON.into_eth_spec().is_enabled_in(SpecId::LATEST));
+        assert!(OpSpecId::CANYON
+            .into_eth_spec()
+            .is_enabled_in(SpecId::MERGE));
+        assert!(OpSpecId::CANYON
+            .into_eth_spec()
+            .is_enabled_in(SpecId::SHANGHAI));
+        assert!(!OpSpecId::CANYON
+            .into_eth_spec()
+            .is_enabled_in(SpecId::CANCUN));
+        assert!(!OpSpecId::CANYON
+            .into_eth_spec()
+            .is_enabled_in(SpecId::LATEST));
         assert!(OpSpecId::CANYON.is_enabled_in(OpSpecId::BEDROCK));
         assert!(OpSpecId::CANYON.is_enabled_in(OpSpecId::REGOLITH));
         assert!(OpSpecId::CANYON.is_enabled_in(OpSpecId::CANYON));
@@ -118,10 +142,18 @@ mod tests {
 
     #[test]
     fn test_ecotone_post_merge_hardforks() {
-        assert!(OpSpecId::ECOTONE.into_eth_spec().is_enabled_in(SpecId::MERGE));
-        assert!(OpSpecId::ECOTONE.into_eth_spec().is_enabled_in(SpecId::SHANGHAI));
-        assert!(OpSpecId::ECOTONE.into_eth_spec().is_enabled_in(SpecId::CANCUN));
-        assert!(!OpSpecId::ECOTONE.into_eth_spec().is_enabled_in(SpecId::LATEST));
+        assert!(OpSpecId::ECOTONE
+            .into_eth_spec()
+            .is_enabled_in(SpecId::MERGE));
+        assert!(OpSpecId::ECOTONE
+            .into_eth_spec()
+            .is_enabled_in(SpecId::SHANGHAI));
+        assert!(OpSpecId::ECOTONE
+            .into_eth_spec()
+            .is_enabled_in(SpecId::CANCUN));
+        assert!(!OpSpecId::ECOTONE
+            .into_eth_spec()
+            .is_enabled_in(SpecId::LATEST));
         assert!(OpSpecId::ECOTONE.is_enabled_in(OpSpecId::BEDROCK));
         assert!(OpSpecId::ECOTONE.is_enabled_in(OpSpecId::REGOLITH));
         assert!(OpSpecId::ECOTONE.is_enabled_in(OpSpecId::CANYON));
@@ -131,9 +163,15 @@ mod tests {
     #[test]
     fn test_fjord_post_merge_hardforks() {
         assert!(OpSpecId::FJORD.into_eth_spec().is_enabled_in(SpecId::MERGE));
-        assert!(OpSpecId::FJORD.into_eth_spec().is_enabled_in(SpecId::SHANGHAI));
-        assert!(OpSpecId::FJORD.into_eth_spec().is_enabled_in(SpecId::CANCUN));
-        assert!(!OpSpecId::FJORD.into_eth_spec().is_enabled_in(SpecId::LATEST));
+        assert!(OpSpecId::FJORD
+            .into_eth_spec()
+            .is_enabled_in(SpecId::SHANGHAI));
+        assert!(OpSpecId::FJORD
+            .into_eth_spec()
+            .is_enabled_in(SpecId::CANCUN));
+        assert!(!OpSpecId::FJORD
+            .into_eth_spec()
+            .is_enabled_in(SpecId::LATEST));
         assert!(OpSpecId::FJORD.is_enabled_in(OpSpecId::BEDROCK));
         assert!(OpSpecId::FJORD.is_enabled_in(OpSpecId::REGOLITH));
         assert!(OpSpecId::FJORD.is_enabled_in(OpSpecId::CANYON));


### PR DESCRIPTION
Removes `OpSpec` enum and uses `OpSpecId` directly 

Additionally derived `Default` on it