### PR TITLE
feat: integrate alloy-eips

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
+ "k256",
  "serde",
 ]
 
@@ -369,6 +370,22 @@ dependencies = [
  "auto_impl",
  "elliptic-curve",
  "k256",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "alloy-signer-local"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbdc63ce9eda1283fcbaca66ba4a414b841c0e3edbeef9c86a71242fc9e84ccc"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "async-trait",
+ "k256",
+ "rand",
  "thiserror 2.0.11",
 ]
 
@@ -3372,7 +3389,10 @@ dependencies = [
 name = "revm"
 version = "19.2.0"
 dependencies = [
+ "alloy-eip7702",
  "alloy-provider",
+ "alloy-signer",
+ "alloy-signer-local",
  "alloy-sol-types",
  "anyhow",
  "ethers-contract",
@@ -3408,6 +3428,8 @@ dependencies = [
 name = "revm-context"
 version = "1.0.0"
 dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
  "auto_impl",
  "cfg-if",
  "derive-where",
@@ -3589,6 +3611,8 @@ dependencies = [
 name = "revm-statetest-types"
 version = "1.0.0"
 dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
  "revm",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,11 @@ statetest-types = { path = "crates/statetest-types", package = "revm-statetest-t
 context = { path = "crates/context", package = "revm-context", version = "1.0.0", default-features = false }
 context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "1.0.0", default-features = false }
 handler = { path = "crates/handler", package = "revm-handler", version = "1.0.0", default-features = false }
+
+# alloy
+alloy-eip2930 = { version = "0.1.0", default-features = false }
+alloy-eip7702 = { version = "0.5.0", default-features = false }
+
 # misc
 cfg-if = { version = "1.0", default-features = false }
 auto_impl = { version = "1.2.0" }

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -383,13 +383,8 @@ pub fn execute_test_suite(
                     .transaction
                     .access_lists
                     .get(test.indexes.data)
-                    .and_then(Option::as_deref)
-                    .map(|access_list| {
-                        access_list
-                            .iter()
-                            .map(|item| (item.address, item.storage_keys.clone()))
-                            .collect()
-                    })
+                    .cloned()
+                    .flatten()
                     .unwrap_or_default();
 
                 tx.authorization_list = unit

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -32,6 +32,10 @@ specification.workspace = true
 bytecode.workspace = true
 auto_impl.workspace = true
 
+# alloy
+alloy-eip2930.workspace = true
+alloy-eip7702 = { workspace = true, features = ["k256"] }
+
 # misc
 derive-where.workspace = true
 cfg-if.workspace = true

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -45,7 +45,10 @@ indicatif = "0.17"
 reqwest = { version = "0.12" }
 rstest = "0.22.0"
 
+alloy-eip7702.workspace = true
 alloy-provider = "0.9.2"
+alloy-signer = "0.9.2"
+alloy-signer-local = "0.9.2"
 
 [features]
 default = ["std", "c-kzg", "secp256k1", "portable", "blst"]

--- a/crates/revm/src/mainnet_exec_inspect.rs
+++ b/crates/revm/src/mainnet_exec_inspect.rs
@@ -109,6 +109,9 @@ where
 mod test {
     use super::*;
     use crate::{MainBuilder, MainContext};
+    use alloy_eip7702::Authorization;
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::PrivateKeySigner;
     use bytecode::{
         opcode::{PUSH1, SSTORE},
         Bytecode,
@@ -116,12 +119,19 @@ mod test {
     use context::Context;
     use context_interface::TransactionType;
     use database::{BenchmarkDB, EEADDRESS, FFADDRESS};
-    use primitives::{address, TxKind, U256};
+    use primitives::{TxKind, U256};
     use specification::hardfork::SpecId;
 
     #[test]
     fn sanity_eip7702_tx() {
-        let auth = address!("0000000000000000000000000000000000000100");
+        let signer = PrivateKeySigner::random();
+        let auth = Authorization {
+            chain_id: U256::ZERO,
+            nonce: 0,
+            address: FFADDRESS,
+        };
+        let signature = signer.sign_hash_sync(&auth.signature_hash()).unwrap();
+        let auth = auth.into_signed(signature);
 
         let bytecode = Bytecode::new_legacy([PUSH1, 0x01, PUSH1, 0x01, SSTORE].into());
 
@@ -131,16 +141,16 @@ mod test {
             .modify_tx_chained(|tx| {
                 tx.tx_type = TransactionType::Eip7702.into();
                 tx.gas_limit = 100_000;
-                tx.authorization_list = vec![(Some(auth), U256::from(0), 0, FFADDRESS)];
+                tx.authorization_list = vec![auth];
                 tx.caller = EEADDRESS;
-                tx.kind = TxKind::Call(auth);
+                tx.kind = TxKind::Call(signer.address());
             });
 
         let mut evm = ctx.build_mainnet();
 
         let ok = evm.transact_previous().unwrap();
 
-        let auth_acc = ok.state.get(&auth).unwrap();
+        let auth_acc = ok.state.get(&signer.address()).unwrap();
         assert_eq!(auth_acc.info.code, Some(Bytecode::new_eip7702(FFADDRESS)));
         assert_eq!(auth_acc.info.nonce, 1);
         assert_eq!(

--- a/crates/statetest-types/Cargo.toml
+++ b/crates/statetest-types/Cargo.toml
@@ -26,3 +26,7 @@ all = "warn"
 revm = { workspace = true, features = ["std", "serde"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
+
+# alloy
+alloy-eip2930 = { workspace = true, features = ["serde"] }
+alloy-eip7702 = { workspace = true, features = ["serde"] }

--- a/crates/statetest-types/src/test_authorization.rs
+++ b/crates/statetest-types/src/test_authorization.rs
@@ -1,44 +1,17 @@
-use revm::{
-    context_interface::transaction::AuthorizationItem,
-    primitives::{Address, U256},
-    specification::eip2::SECP256K1N_HALF,
-};
+use alloy_eip7702::SignedAuthorization;
 use serde::{Deserialize, Serialize};
 
 /// Struct for test authorization
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub struct TestAuthorization {
-    /// The chain ID of the authorization.
-    pub chain_id: U256,
-    /// The address of the authorization.
-    pub address: Address,
-    /// The nonce for the authorization.
-    pub nonce: U256,
-    v: U256,
-    r: U256,
-    s: U256,
-    signer: Option<Address>,
+    #[serde(flatten)]
+    inner: SignedAuthorization,
 }
 
-impl From<TestAuthorization> for AuthorizationItem {
-    fn from(auth: TestAuthorization) -> AuthorizationItem {
-        let mut signer = auth.signer;
-
-        if auth.s > SECP256K1N_HALF {
-            signer = None
-        }
-
-        if auth.v > U256::from(1) {
-            signer = None
-        }
-
-        (
-            signer,
-            auth.chain_id,
-            auth.nonce.try_into().unwrap_or(u64::MAX),
-            auth.address,
-        )
+impl From<TestAuthorization> for SignedAuthorization {
+    fn from(auth: TestAuthorization) -> Self {
+        auth.inner
     }
 }
 

--- a/crates/statetest-types/src/transaction.rs
+++ b/crates/statetest-types/src/transaction.rs
@@ -1,10 +1,10 @@
+use crate::{deserializer::deserialize_maybe_empty, TestAuthorization};
+use alloy_eip2930::AccessList;
 use revm::{
     context_interface::transaction::TransactionType,
     primitives::{Address, Bytes, B256, U256},
 };
 use serde::{Deserialize, Serialize};
-
-use crate::{deserializer::deserialize_maybe_empty, TestAuthorization};
 
 /// Transaction parts.
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -25,7 +25,7 @@ pub struct TransactionParts {
     pub max_priority_fee_per_gas: Option<U256>,
 
     #[serde(default)]
-    pub access_lists: Vec<Option<Vec<AccessListItem>>>,
+    pub access_lists: Vec<Option<AccessList>>,
     pub authorization_list: Option<Vec<TestAuthorization>>,
     #[serde(default)]
     pub blob_versioned_hashes: Vec<B256>,
@@ -80,13 +80,6 @@ pub struct TxPartIndices {
     pub data: usize,
     pub gas: usize,
     pub value: usize,
-}
-
-#[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct AccessListItem {
-    pub address: Address,
-    pub storage_keys: Vec<B256>,
 }
 
 #[cfg(test)]

--- a/examples/block_traces/src/main.rs
+++ b/examples/block_traces/src/main.rs
@@ -126,11 +126,7 @@ async fn main() -> anyhow::Result<()> {
             etx.chain_id = Some(chain_id);
             etx.nonce = tx.nonce();
             if let Some(access_list) = tx.access_list() {
-                etx.access_list = access_list
-                    .0
-                    .iter()
-                    .map(|item| (item.address, item.storage_keys.clone()))
-                    .collect();
+                etx.access_list = access_list.clone()
             } else {
                 etx.access_list = Default::default();
             }


### PR DESCRIPTION
Changes `access_list` and `authorization_list` fields of `TxEnv` to use types from alloy-eips.

I didn't touch the traits so they are still operating on tuples without locking to concrete eips types, allowing for future abstraction.