### PR TITLE
chore: move all dependencies to workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,15 +962,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,97 +1407,6 @@ checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "ethabi"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
-dependencies = [
- "ethereum-types",
- "hex",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "sha3",
- "thiserror 1.0.69",
- "uint",
-]
-
-[[package]]
-name = "ethbloom"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
-dependencies = [
- "crunchy",
- "fixed-hash",
- "impl-codec",
- "impl-rlp",
- "impl-serde",
- "scale-info",
- "tiny-keccak",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
-dependencies = [
- "ethbloom",
- "fixed-hash",
- "impl-codec",
- "impl-rlp",
- "impl-serde",
- "primitive-types",
- "scale-info",
- "uint",
-]
-
-[[package]]
-name = "ethers-contract"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fceafa3578c836eeb874af87abacfb041f92b4da0a78a5edd042564b8ecdaaa"
-dependencies = [
- "const-hex",
- "ethers-core",
- "futures-util",
- "once_cell",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ethers-core"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d80cc6ad30b14a48ab786523af33b37f28a8623fc06afd55324816ef18fb1f"
-dependencies = [
- "arrayvec",
- "bytes",
- "chrono",
- "const-hex",
- "elliptic-curve",
- "ethabi",
- "generic-array",
- "k256",
- "num_enum",
- "open-fastrlp",
- "rand",
- "rlp",
- "serde",
- "serde_json",
- "strum",
- "tempfile",
- "thiserror 1.0.69",
- "tiny-keccak",
- "unicode-xid",
 ]
 
 [[package]]
@@ -2216,24 +2116,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-rlp"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
-dependencies = [
- "rlp",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2352,7 +2234,6 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "sha2 0.10.8",
- "signature",
 ]
 
 [[package]]
@@ -2656,7 +2537,6 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -2705,31 +2585,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "open-fastrlp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "bytes",
- "ethereum-types",
- "open-fastrlp-derive",
-]
-
-[[package]]
-name = "open-fastrlp-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
-dependencies = [
- "bytes",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "openssl"
@@ -3139,9 +2994,6 @@ checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
- "impl-rlp",
- "impl-serde",
- "scale-info",
  "uint",
 ]
 
@@ -3395,7 +3247,6 @@ dependencies = [
  "alloy-signer-local",
  "alloy-sol-types",
  "anyhow",
- "ethers-contract",
  "indicatif",
  "reqwest",
  "revm-bytecode",
@@ -3410,7 +3261,7 @@ dependencies = [
  "revm-primitives",
  "revm-specification",
  "revm-state",
- "rstest 0.22.0",
+ "rstest",
 ]
 
 [[package]]
@@ -3474,7 +3325,7 @@ dependencies = [
  "revm-database-interface",
  "revm-primitives",
  "revm-state",
- "rstest 0.22.0",
+ "rstest",
  "serde",
  "serde_json",
  "tokio",
@@ -3490,7 +3341,7 @@ dependencies = [
  "indicatif",
  "revm-primitives",
  "revm-state",
- "rstest 0.22.0",
+ "rstest",
  "serde",
  "tokio",
 ]
@@ -3559,7 +3410,7 @@ dependencies = [
  "revm-database",
  "revm-inspector",
  "revm-precompile",
- "rstest 0.23.0",
+ "rstest",
  "serde",
 ]
 
@@ -3583,7 +3434,7 @@ dependencies = [
  "revm-primitives",
  "revm-specification",
  "ripemd",
- "rstest 0.22.0",
+ "rstest",
  "secp256k1",
  "serde",
  "serde_derive",
@@ -3635,7 +3486,6 @@ name = "revme"
 version = "3.0.0-alpha.1"
 dependencies = [
  "alloy-rlp",
- "alloy-sol-macro",
  "alloy-sol-types",
  "clap",
  "codspeed-criterion-compat",
@@ -3647,8 +3497,15 @@ dependencies = [
  "plain_hasher",
  "revm",
  "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
  "revm-database",
+ "revm-database-interface",
+ "revm-handler",
  "revm-inspector",
+ "revm-primitives",
+ "revm-specification",
+ "revm-state",
  "revm-statetest-types",
  "serde",
  "serde_json",
@@ -3698,31 +3555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
- "rlp-derive",
  "rustc-hex",
-]
-
-[[package]]
-name = "rlp-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "rstest"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b423f0e62bdd61734b67cd21ff50871dfaeb9cc74f869dcd6af974fbcb19936"
-dependencies = [
- "futures",
- "futures-timer",
- "rstest_macros 0.22.0",
- "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -3733,26 +3566,8 @@ checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
 dependencies = [
  "futures",
  "futures-timer",
- "rstest_macros 0.23.0",
+ "rstest_macros",
  "rustc_version 0.4.1",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e1711e7d14f74b12a58411c542185ef7fb7f2e7f8ee6e2940a883628522b42"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version 0.4.1",
- "syn 2.0.96",
- "unicode-ident",
 ]
 
 [[package]]
@@ -3928,30 +3743,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "scale-info"
-version = "2.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
-dependencies = [
- "cfg-if",
- "derive_more",
- "parity-scale-codec",
- "scale-info-derive",
-]
-
-[[package]]
-name = "scale-info-derive"
-version = "2.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.96",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,15 +55,65 @@ context-interface = { path = "crates/context/interface", package = "revm-context
 handler = { path = "crates/handler", package = "revm-handler", version = "1.0.0-alpha.1", default-features = false }
 
 # alloy
+alloy-rlp = { version = "0.3", default-features = false }
+alloy-primitives = { version = "0.8", default-features = false }
+alloy-sol-types = { version = "0.8.2", default-features = false }
+
 alloy-eip2930 = { version = "0.1.0", default-features = false }
 alloy-eip7702 = { version = "0.5.0", default-features = false }
 
+alloy-consensus = { version = "0.9.2", default-features = false }
+alloy-eips = { version = "0.9.2", default-features = false }
+alloy-provider = { version = "0.9.2", default-features = false }
+alloy-signer = { version = "0.9.2", default-features = false }
+alloy-signer-local = { version = "0.9.2", default-features = false }
+alloy-transport = { version = "0.9.2", default-features = false }
+alloy-transport-http = { version = "0.9.2", default-features = false }
+
 # misc
+aurora-engine-modexp = { version = "1.1", default-features = false }
+auto_impl = "1.2.0"
+bitflags = { version = "2.6.0", default-features = false }
+bitvec = { version = "1", default-features = false }
+blst = "0.3.13"
+bn = { package = "substrate-bn", version = "0.6", default-features = false }
+c-kzg = { version = "1.0.3", default-features = false }
 cfg-if = { version = "1.0", default-features = false }
-auto_impl = { version = "1.2.0" }
-derive-where = { version = "1.2.7", default-features = false }
-derive_more = { version = "1.0.0", default-features = false }
+clap = "4"
 criterion = { package = "codspeed-criterion-compat", version = "2.7" }
+derive_more = { version = "1.0.0", default-features = false }
+derive-where = { version = "1.2.7", default-features = false }
+enumn = "0.1"
+k256 = { version = "0.13.3", default-features = false }
+kzg-rs = { version = "0.2.4", default-features = false }
+libsecp256k1 = { version = "0.7", default-features = false }
+once_cell = { version = "1.19", default-features = false }
+p256 = { version = "0.13.2", default-features = false }
+paste = "1.0"
+phf = { version = "0.11", default-features = false }
+rand = "0.8"
+reqwest = "0.12"
+ripemd = { version = "0.1", default-features = false }
+secp256k1 = { version = "0.29", default-features = false }
+serde = { version = "1.0", default-features = false }
+serde_json = { version = "1.0", default-features = false }
+sha2 = { version = "0.10", default-features = false }
+tokio = "1.40"
+
+# dev-dependencies
+anyhow = "1.0.89"
+bincode = "1.3"
+eyre = "0.6.12"
+hash-db = "0.15"
+hashbrown = "0.14"
+indicatif = "0.17"
+microbench = "0.5"
+plain_hasher = "0.2"
+rstest = "0.23.0"
+serde_derive = "1.0"
+thiserror = "1.0"
+triehash = "0.8"
+walkdir = "2.5"
 
 [workspace.package]
 license = "MIT"

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -10,32 +10,36 @@ repository.workspace = true
 
 [dependencies]
 # revm
-database.workspace = true
 revm = { workspace = true, features = ["std", "hashbrown", "c-kzg", "blst"] }
-statetest-types = { workspace = true }
-inspector = { workspace = true, features = ["std", "serde-json"] }
-# enable parse std and parse feature. 
+primitives.workspace = true
+database.workspace = true
+database-interface.workspace = true
+state.workspace = true
+specification.workspace = true
 bytecode = { workspace = true, features = ["std", "parse"] }
+context.workspace = true
+context-interface.workspace = true
+handler.workspace = true
+inspector = { workspace = true, features = ["std", "serde-json"] }
+statetest-types.workspace = true
 
-hash-db = "0.15"
-hashbrown = "0.14"
-indicatif = "0.17"
-microbench = "0.5"
-plain_hasher = "0.2"
+# alloy
+alloy-rlp = { workspace = true, features = ["arrayvec", "derive"] }
+alloy-sol-types.workspace = true
 
-alloy-rlp = { version = "0.3", default-features = false, features = [
-    "arrayvec",
-    "derive",
-] }
-alloy-sol-macro = "0.8.0"
-alloy-sol-types = "0.8.2"
-serde = { version = "1.0", features = ["derive", "rc"] }
-serde_json = { version = "1.0", features = ["preserve_order"] }
-clap = { version = "4", features = ["derive"] }
-thiserror = "1.0"
-triehash = "0.8"
-walkdir = "2.5"
-k256 = { version = "0.13.3", features = ["ecdsa"] }
+# misc
+hash-db.workspace = true
+hashbrown.workspace = true
+indicatif.workspace = true
+microbench.workspace = true
+plain_hasher.workspace = true
+serde = { workspace = true, features = ["derive", "rc"] }
+serde_json = { workspace = true, features = ["preserve_order"] }
+clap = { workspace = true, features = ["derive"] }
+thiserror.workspace = true
+triehash.workspace = true
+walkdir.workspace = true
+k256 = { workspace = true, features = ["ecdsa"] }
 
 [dev-dependencies]
 criterion.workspace = true

--- a/bins/revme/src/cmd/bench/burntpix.rs
+++ b/bins/revme/src/cmd/bench/burntpix.rs
@@ -6,8 +6,7 @@ use static_data::{
     STORAGE_ONE, STORAGE_TWO, STORAGE_ZERO,
 };
 
-use alloy_sol_macro::sol;
-use alloy_sol_types::SolCall;
+use alloy_sol_types::{sol, SolCall};
 use database::{CacheDB, BENCH_CALLER};
 use revm::{
     context_interface::result::{ExecutionResult, Output},

--- a/crates/bytecode/Cargo.toml
+++ b/crates/bytecode/Cargo.toml
@@ -27,19 +27,14 @@ primitives.workspace = true
 specification.workspace = true
 
 # Jumpmap
-bitvec = { version = "1", default-features = false, features = ["alloc"] }
+bitvec = { workspace = true, features = ["alloc"] }
 
 # Optional
-serde = { version = "1.0", default-features = false, features = [
-    "derive",
-    "rc",
-], optional = true }
+serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
 # parse opcode feature
-paste = { version = "1.0", optional = true }
-phf = { version = "0.11", default-features = false, optional = true, features = [
-    "macros",
-] }
+paste = { workspace = true, optional = true }
+phf = { workspace = true, features = ["macros"], optional = true }
 
 [features]
 default = ["std", "parse"]

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -41,10 +41,7 @@ derive-where.workspace = true
 cfg-if.workspace = true
 
 # Optional
-serde = { version = "1.0", default-features = false, features = [
-    "derive",
-    "rc",
-], optional = true }
+serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
 [dev-dependencies]
 database.workspace = true

--- a/crates/context/interface/Cargo.toml
+++ b/crates/context/interface/Cargo.toml
@@ -30,7 +30,7 @@ specification.workspace = true
 alloy-eip7702 = { workspace = true, features = ["k256"] }
 alloy-eip2930.workspace = true
 
-# mics
+# misc
 auto_impl.workspace = true
 
 # Optional

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -30,27 +30,23 @@ bytecode.workspace = true
 auto_impl = "1.2"
 
 # Optional
-serde = { version = "1.0", default-features = false, features = [
-    "derive",
-    "rc",
-], optional = true }
+serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
 # alloydb
-tokio = { version = "1.40", features = [
+tokio = { workspace = true, features = [
     "rt-multi-thread",
     "macros",
 ], optional = true }
-alloy-provider = { version = "0.9.2", optional = true, default-features = false }
-alloy-eips = { version = "0.9.2", optional = true, default-features = false }
-alloy-transport = { version = "0.9.2", optional = true, default-features = false }
-
+alloy-provider = { workspace = true, optional = true }
+alloy-eips = { workspace = true, optional = true }
+alloy-transport = { workspace = true, optional = true }
 
 [dev-dependencies]
-serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
-anyhow = "1.0.83"
-indicatif = "0.17"
-rstest = "0.22.0"
-alloy-sol-types = "0.8"
+serde_json = { workspace = true, features = ["alloc"] }
+anyhow.workspace = true
+indicatif.workspace = true
+rstest.workspace = true
+alloy-sol-types.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/database/interface/Cargo.toml
+++ b/crates/database/interface/Cargo.toml
@@ -26,24 +26,20 @@ all = "warn"
 state.workspace = true
 primitives.workspace = true
 
-# mics
+# misc
 auto_impl.workspace = true
 
 # Optional
-serde = { version = "1.0", default-features = false, features = [
-    "derive",
-    "rc",
-], optional = true }
+serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
 # asyncdb
-tokio = { version = "1.40", optional = true }
-
+tokio = { workspace = true, optional = true }
 
 [dev-dependencies]
-anyhow = "1.0.83"
-indicatif = "0.17"
-rstest = "0.22.0"
-alloy-sol-types = "0.8"
+anyhow.workspace = true
+indicatif.workspace = true
+rstest.workspace = true
+alloy-sol-types.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/inspector/Cargo.toml
+++ b/crates/inspector/Cargo.toml
@@ -34,13 +34,8 @@ interpreter.workspace = true
 auto_impl.workspace = true
 
 # Optional
-serde = { version = "1.0", default-features = false, features = [
-    "derive",
-    "rc",
-], optional = true }
-serde_json = { version = "1.0", default-features = false, features = [
-    "alloc",
-], optional = true }
+serde = { workspace = true, features = ["derive", "rc"], optional = true }
+serde_json = { workspace = true, features = ["alloc"], optional = true }
 
 [dev-dependencies]
 revm = { workspace = true, features = ["serde"] }

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -29,16 +29,13 @@ specification.workspace = true
 context-interface.workspace = true
 
 # optional
-serde = { version = "1.0", default-features = false, features = [
-    "derive",
-    "rc",
-], optional = true }
+serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
 [dev-dependencies]
 database-interface.workspace = true
-walkdir = "2.5"
-serde_json = "1.0"
-bincode = "1.3"
+walkdir.workspace = true
+serde_json.workspace = true
+bincode.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/optimism/Cargo.toml
+++ b/crates/optimism/Cargo.toml
@@ -29,21 +29,17 @@ inspector.workspace = true
 auto_impl.workspace = true
 
 # static precompile sets.
-once_cell = { version = "1.19", default-features = false, features = ["alloc"] }
+once_cell = { workspace = true, features = ["alloc"] }
 
 # Optional
-serde = { version = "1.0", default-features = false, features = [
-    "derive",
-    "rc",
-], optional = true }
-
+serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
 [dev-dependencies]
 database.workspace = true
-anyhow = "1.0.89"
-indicatif = "0.17"
-rstest = "0.23.0"
-alloy-sol-types = "0.8"
+anyhow.workspace = true
+indicatif.workspace = true
+rstest.workspace = true
+alloy-sol-types.workspace = true
 
 [features]
 default = ["std", "c-kzg", "secp256k1", "portable", "blst"]

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -28,57 +28,55 @@ context-interface.workspace = true
 specification.workspace = true
 
 # static precompile sets.
-once_cell = { version = "1.19", default-features = false, features = ["alloc"] }
+once_cell = { workspace = true, features = ["alloc"] }
 
 # ecRecover
-k256 = { version = "0.13.3", default-features = false, features = ["ecdsa"] }
-secp256k1 = { version = ">=0.28, <=0.29", default-features = false, features = [
+k256 = { workspace = true, features = ["ecdsa"] }
+secp256k1 = { workspace = true, features = [
     "alloc",
     "recovery",
     "rand",
     "global-context",
 ], optional = true }
-libsecp256k1 = { version = "0.7", default-features = false, package = "libsecp256k1", features = [
+libsecp256k1 = { workspace = true, features = [
     "static-context",
 ], optional = true }
 
 # SHA2-256 and RIPEMD-160
-sha2 = { version = "0.10", default-features = false }
-ripemd = { version = "0.1", default-features = false }
+sha2.workspace = true
+ripemd.workspace = true
 
 # modexp
-aurora-engine-modexp = { version = "1.1", default-features = false }
+aurora-engine-modexp.workspace = true
 
 # ecAdd, ecMul, ecPairing
-bn = { package = "substrate-bn", version = "0.6", default-features = false }
+bn.workspace = true
 
 # KZG point evaluation precompile
-c-kzg = { version = "1.0.3", default-features = false, optional = true, features = [
+c-kzg = { workspace = true, optional = true, features = [
     "ethereum_kzg_settings",
 ] }
 
 # Optionally use `kzg-rs` for a pure Rust implementation of KZG point evaluation.
-kzg-rs = { version = "0.2.4", default-features = false, optional = true }
+kzg-rs = { workspace = true, optional = true }
 
 # BLS12-381 precompiles
-blst = { version = "0.3.13", optional = true }
+blst = { workspace = true, optional = true }
 
 # p256verify precompile
-p256 = { version = "0.13.2", optional = true, default-features = false, features = [
-    "ecdsa",
-] }
+p256 = { workspace = true, optional = true, features = ["ecdsa"] }
 
 # utils
-cfg-if = { version = "1.0", default-features = false }
+cfg-if.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
-rand = { version = "0.8", features = ["std"] }
-eyre = "0.6.12"
-rstest = "0.22.0"
-serde = "1.0"
-serde_json = "1.0"
-serde_derive = "1.0"
+rand = { workspace = true, features = ["std"] }
+eyre.workspace = true
+rstest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_derive.workspace = true
 
 [features]
 default = ["std", "c-kzg", "secp256k1", "portable", "blst"]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -22,10 +22,7 @@ rust_2018_idioms = "deny"
 all = "warn"
 
 [dependencies]
-alloy-primitives = { version = "0.8", default-features = false, features = [
-    "rlp",
-    "map",
-] }
+alloy-primitives = { workspace = true, features = ["rlp", "map"] }
 
 [features]
 default = ["std"]

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -38,19 +38,16 @@ handler.workspace = true
 
 [dev-dependencies]
 database.workspace = true
-alloy-sol-types = { version = "0.8.2", default-features = false, features = [
-    "std",
-] }
-ethers-contract = { version = "2.0.14", default-features = false }
-anyhow = "1.0.89"
-indicatif = "0.17"
-reqwest = { version = "0.12" }
-rstest = "0.22.0"
+alloy-sol-types = { workspace = true, features = ["std"] }
+anyhow.workspace = true
+indicatif.workspace = true
+reqwest.workspace = true
+rstest.workspace = true
 
 alloy-eip7702.workspace = true
-alloy-provider = "0.9.2"
-alloy-signer = "0.9.2"
-alloy-signer-local = "0.9.2"
+alloy-provider.workspace = true
+alloy-signer.workspace = true
+alloy-signer-local.workspace = true
 
 [features]
 default = ["std", "c-kzg", "secp256k1", "portable", "blst"]

--- a/crates/specification/Cargo.toml
+++ b/crates/specification/Cargo.toml
@@ -26,14 +26,10 @@ all = "warn"
 primitives.workspace = true
 
 # misc
-enumn = { version = "0.1" }
+enumn.workspace = true
 
 # Optional
-serde = { version = "1.0", default-features = false, features = [
-    "derive",
-    "rc",
-], optional = true }
-
+serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
 [dev-dependencies]
 

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -28,14 +28,10 @@ bytecode.workspace = true
 specification.workspace = true
 
 # misc
-bitflags = { version = "2.6.0", default-features = false }
+bitflags.workspace = true
 
 # Optional
-serde = { version = "1.0", default-features = false, features = [
-    "derive",
-    "rc",
-], optional = true }
-
+serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
 [features]
 default = ["std"]

--- a/crates/statetest-types/Cargo.toml
+++ b/crates/statetest-types/Cargo.toml
@@ -24,8 +24,8 @@ all = "warn"
 [dependencies]
 # revm
 revm = { workspace = true, features = ["std", "serde"] }
-serde = { version = "1.0", features = ["derive", "rc"] }
-serde_json = { version = "1.0", features = ["preserve_order"] }
+serde = { workspace = true, features = ["derive", "rc"] }
+serde_json = { workspace = true, features = ["preserve_order"] }
 
 # alloy
 alloy-eip2930 = { workspace = true, features = ["serde"] }

--- a/examples/block_traces/Cargo.toml
+++ b/examples/block_traces/Cargo.toml
@@ -27,15 +27,15 @@ database = { workspace = true, features = ["std", "alloydb"] }
 inspector = { workspace = true, features = ["std", "serde-json"] }
 
 # tokio
-tokio = { version = "1.40", features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 # alloy
-alloy-eips = "0.9.2"
-alloy-provider = "0.9.2"
-alloy-consensus = "0.9.2"
+alloy-eips.workspace = true
+alloy-provider = { workspace = true, default-features = true }
+alloy-consensus.workspace = true
 
 # progress bar
-indicatif = "0.17"
+indicatif.workspace = true
 
-# mics
-anyhow = "1.0.89"
+# misc
+anyhow.workspace = true

--- a/examples/block_traces/src/main.rs
+++ b/examples/block_traces/src/main.rs
@@ -45,7 +45,7 @@ async fn main() -> anyhow::Result<()> {
     // Set up the HTTP transport which is consumed by the RPC client.
     let rpc_url = "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27".parse()?;
 
-    // Create ethers client and wrap it in Arc<M>
+    // Create a provider
     let client = ProviderBuilder::new().on_http(rpc_url);
 
     // Params

--- a/examples/contract_deployment/Cargo.toml
+++ b/examples/contract_deployment/Cargo.toml
@@ -25,5 +25,5 @@ all = "warn"
 revm = { workspace = true, features = ["std"] }
 database.workspace = true
 
-# mics
+# misc
 anyhow = "1.0.89"

--- a/examples/database_components/Cargo.toml
+++ b/examples/database_components/Cargo.toml
@@ -25,6 +25,6 @@ all = "warn"
 # srevm 
 revm.workspace = true
 
-# mics
+# misc
 auto_impl.workspace = true
 derive_more.workspace = true

--- a/examples/erc20_gas/Cargo.toml
+++ b/examples/erc20_gas/Cargo.toml
@@ -9,7 +9,6 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 
-
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
@@ -27,13 +26,11 @@ revm.workspace = true
 database = { workspace = true, features = ["std", "alloydb"] }
 
 # tokio
-tokio = { version = "1.40", features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 # alloy
-alloy-sol-types = { version = "0.8.2", default-features = false, features = [
-    "std",
-] }
-alloy-transport-http = "0.9.2"
-alloy-provider = "0.9.2"
-reqwest = { version = "0.12" }
-anyhow = "1.0.89"
+alloy-sol-types = { workspace = true, features = ["std"] }
+alloy-transport-http.workspace = true
+alloy-provider = { workspace = true, default-features = true }
+reqwest.workspace = true
+anyhow.workspace = true

--- a/examples/uniswap_get_reserves/Cargo.toml
+++ b/examples/uniswap_get_reserves/Cargo.toml
@@ -27,14 +27,12 @@ revm.workspace = true
 database = { workspace = true, features = ["std", "alloydb"] }
 
 # tokio
-tokio = { version = "1.40", features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 # alloy
-alloy-sol-types = { version = "0.8.2", default-features = false, features = [
-    "std",
-] }
-alloy-eips = "0.9.2"
-alloy-provider = "0.9.2"
+alloy-sol-types = { workspace = true, features = ["std"] }
+alloy-eips.workspace = true
+alloy-provider = { workspace = true, default-features = true }
 
-# mics
-anyhow = "1.0.89"
+# misc
+anyhow.workspace = true

--- a/examples/uniswap_get_reserves/src/main.rs
+++ b/examples/uniswap_get_reserves/src/main.rs
@@ -17,7 +17,7 @@ async fn main() -> anyhow::Result<()> {
     // Set up the HTTP transport which is consumed by the RPC client.
     let rpc_url = "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27".parse()?;
 
-    // Create ethers client and wrap it in Arc<M>
+    // Create a provider
     let client = ProviderBuilder::new().on_http(rpc_url);
     let client = WrapDatabaseAsync::new(AlloyDB::new(client, BlockId::latest())).unwrap();
 

--- a/examples/uniswap_v2_usdc_swap/Cargo.toml
+++ b/examples/uniswap_v2_usdc_swap/Cargo.toml
@@ -26,14 +26,12 @@ revm.workspace = true
 database = { workspace = true, features = ["std", "alloydb"] }
 
 # tokio
-tokio = { version = "1.40", features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 # alloy
-alloy-sol-types = { version = "0.8.2", default-features = false, features = [
-    "std",
-] }
-alloy-eips = "0.9.2"
-alloy-transport-http = "0.9.2"
-alloy-provider = "0.9.2"
-reqwest = { version = "0.12" }
-anyhow = "1.0.89"
+alloy-sol-types = { workspace = true, features = ["std"] }
+alloy-eips.workspace = true
+alloy-transport-http.workspace = true
+alloy-provider = { workspace = true, default-features = true }
+reqwest.workspace = true
+anyhow.workspace = true

--- a/examples/uniswap_v2_usdc_swap/src/main.rs
+++ b/examples/uniswap_v2_usdc_swap/src/main.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
     // Set up the HTTP transport which is consumed by the RPC client.
     let rpc_url = "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27".parse()?;
 
-    // Create ethers client and wrap it in Arc<M>
+    // Create a provider
     let client = ProviderBuilder::new().on_http(rpc_url);
 
     let alloy = WrapDatabaseAsync::new(AlloyDB::new(client, BlockId::latest())).unwrap();


### PR DESCRIPTION
Required to make my life easier when updating dependencies

Cargo.lock diff is from disabling default features on alloy and removing ethers. I've tested examples still work.

Powered by cursor agent and manually checked by me