### PR TITLE
chore: export eip2930 eip7702 types from one place

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3343,8 +3343,6 @@ dependencies = [
 name = "revm-context"
 version = "1.0.0-alpha.1"
 dependencies = [
- "alloy-eip2930",
- "alloy-eip7702",
  "auto_impl",
  "cfg-if",
  "derive-where",
@@ -3537,8 +3535,6 @@ dependencies = [
 name = "revm-statetest-types"
 version = "1.0.0-alpha.1"
 dependencies = [
- "alloy-eip2930",
- "alloy-eip7702",
  "revm",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,14 +54,14 @@ context = { path = "crates/context", package = "revm-context", version = "1.0.0-
 context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "1.0.0-alpha.1", default-features = false }
 handler = { path = "crates/handler", package = "revm-handler", version = "1.0.0-alpha.1", default-features = false }
 
-# alloy
-alloy-rlp = { version = "0.3", default-features = false }
-alloy-primitives = { version = "0.8", default-features = false }
-alloy-sol-types = { version = "0.8.2", default-features = false }
-
+# alloy 
 alloy-eip2930 = { version = "0.1.0", default-features = false }
 alloy-eip7702 = { version = "0.5.0", default-features = false }
+alloy-primitives = { version = "0.8", default-features = false }
 
+# alloy in examples, revme or feature flagged.
+alloy-rlp = { version = "0.3", default-features = false }
+alloy-sol-types = { version = "0.8.2", default-features = false }
 alloy-consensus = { version = "0.11.1", default-features = false }
 alloy-eips = { version = "0.11.1", default-features = false }
 alloy-provider = { version = "0.11.1", default-features = false }

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -32,10 +32,6 @@ specification.workspace = true
 bytecode.workspace = true
 auto_impl.workspace = true
 
-# alloy
-alloy-eip2930.workspace = true
-alloy-eip7702 = { workspace = true, features = ["k256"] }
-
 # misc
 derive-where.workspace = true
 cfg-if.workspace = true

--- a/crates/context/interface/src/transaction.rs
+++ b/crates/context/interface/src/transaction.rs
@@ -3,6 +3,10 @@ pub mod eip2930;
 pub mod eip7702;
 pub mod transaction_type;
 
+pub use alloy_types::{
+    AccessList, AccessListItem, Authorization, RecoveredAuthority, RecoveredAuthorization,
+    SignedAuthorization,
+};
 pub use eip2930::AccessListTr;
 pub use eip7702::AuthorizationTr;
 use specification::eip4844::GAS_PER_BLOB;

--- a/crates/context/interface/src/transaction/alloy_types.rs
+++ b/crates/context/interface/src/transaction/alloy_types.rs
@@ -1,8 +1,10 @@
 use super::{AccessListTr, AuthorizationTr};
 use primitives::{Address, B256, U256};
 
-use alloy_eip2930::AccessList;
-use alloy_eip7702::{RecoveredAuthorization, SignedAuthorization};
+pub use alloy_eip2930::{AccessList, AccessListItem};
+pub use alloy_eip7702::{
+    Authorization, RecoveredAuthority, RecoveredAuthorization, SignedAuthorization,
+};
 
 impl AccessListTr for AccessList {
     fn access_list(&self) -> impl Iterator<Item = (Address, impl Iterator<Item = B256>)> {

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -20,6 +20,6 @@ pub use cfg::{Cfg, CfgEnv};
 pub use context::*;
 pub use journal_init::JournalInit;
 pub use journaled_state::*;
-pub use tx::{AccessList, SignedAuthorization, TxEnv};
+pub use tx::TxEnv;
 pub mod setters;
 pub use evm::{Evm, EvmData};

--- a/crates/context/src/tx.rs
+++ b/crates/context/src/tx.rs
@@ -1,6 +1,4 @@
-pub use alloy_eip2930::AccessList;
-pub use alloy_eip7702::SignedAuthorization;
-use context_interface::Transaction;
+use context_interface::transaction::{AccessList, SignedAuthorization, Transaction};
 use core::fmt::Debug;
 use primitives::{Address, Bytes, TxKind, B256, U256};
 use std::vec::Vec;

--- a/crates/revm/src/mainnet_builder.rs
+++ b/crates/revm/src/mainnet_builder.rs
@@ -70,7 +70,6 @@ impl MainContext for Context<BlockEnv, TxEnv, CfgEnv, EmptyDB, JournaledState<Em
 #[cfg(test)]
 mod test {
     use crate::{MainBuilder, MainContext};
-    use alloy_eip7702::Authorization;
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
     use bytecode::{
@@ -78,7 +77,7 @@ mod test {
         Bytecode,
     };
     use context::Context;
-    use context_interface::TransactionType;
+    use context_interface::{transaction::Authorization, TransactionType};
     use database::{BenchmarkDB, EEADDRESS, FFADDRESS};
     use handler::ExecuteEvm;
     use primitives::{TxKind, U256};

--- a/crates/statetest-types/Cargo.toml
+++ b/crates/statetest-types/Cargo.toml
@@ -26,7 +26,3 @@ all = "warn"
 revm = { workspace = true, features = ["std", "serde"] }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
-
-# alloy
-alloy-eip2930 = { workspace = true, features = ["serde"] }
-alloy-eip7702 = { workspace = true, features = ["serde"] }

--- a/crates/statetest-types/src/test_authorization.rs
+++ b/crates/statetest-types/src/test_authorization.rs
@@ -1,4 +1,4 @@
-use revm::context::SignedAuthorization;
+use revm::context_interface::transaction::SignedAuthorization;
 use serde::{Deserialize, Serialize};
 
 /// Struct for test authorization

--- a/crates/statetest-types/src/transaction.rs
+++ b/crates/statetest-types/src/transaction.rs
@@ -1,7 +1,6 @@
 use crate::{deserializer::deserialize_maybe_empty, TestAuthorization};
-use alloy_eip2930::AccessList;
 use revm::{
-    context_interface::transaction::TransactionType,
+    context_interface::transaction::{AccessList, TransactionType},
     primitives::{Address, Bytes, B256, U256},
 };
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Reexport of AccessListItem was missing. included libs made public only in one place