### PR TITLE
chore: fix wrong comment & remove useless impl

### DIFF
--- a/crates/interpreter/src/gas.rs
+++ b/crates/interpreter/src/gas.rs
@@ -165,7 +165,7 @@ pub enum MemoryExtensionResult {
     Extended,
     /// Memory size stayed the same.
     Same,
-    /// Not enough gas to extend memory.s
+    /// Not enough gas to extend memory.
     OutOfGas,
 }
 

--- a/crates/interpreter/src/instruction_result.rs
+++ b/crates/interpreter/src/instruction_result.rs
@@ -110,8 +110,6 @@ impl From<TransferError> for InstructionResult {
     }
 }
 
-impl InstructionResult {}
-
 impl From<SuccessReason> for InstructionResult {
     fn from(value: SuccessReason) -> Self {
         match value {
@@ -248,7 +246,7 @@ impl InstructionResult {
     }
 }
 
-/// Internal result that are not ex
+/// Internal results that are not exposed externally
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum InternalResult {
     /// Internal instruction that signals Interpreter should continue running.


### PR DESCRIPTION
When I read the source code of revm, I find some wrong comment. So I fix them.

- fix wrong comment
- remove useless impl