### PR TITLE
fix: correct grammar in EofAuxDataTooSmall comment

### DIFF
--- a/crates/interpreter/src/instruction_result.rs
+++ b/crates/interpreter/src/instruction_result.rs
@@ -94,7 +94,7 @@ pub enum InstructionResult {
     SubRoutineStackOverflow,
     /// Aux data overflow, new aux data is larger than `u16` max size.
     EofAuxDataOverflow,
-    /// Aux data is smaller then already present data size.
+    /// Aux data is smaller than already present data size.
     EofAuxDataTooSmall,
     /// `EXT*CALL` target address needs to be padded with 0s.
     InvalidEXTCALLTarget,


### PR DESCRIPTION
Changed "then" to "than" in the comment for EofAuxDataTooSmall enum variant to fix grammatical error.