### PR TITLE
docs: Bytecode crate

### DIFF
--- a/bins/revme/src/cmd/bytecode.rs
+++ b/bins/revme/src/cmd/bytecode.rs
@@ -39,9 +39,9 @@ impl Cmd {
     /// Runs statetest command.
     pub fn run(&self) {
         let container_kind = if self.eof_initcode {
-            Some(CodeType::ReturnContract)
+            Some(CodeType::Initcode)
         } else if self.eof_runtime {
-            Some(CodeType::ReturnOrStop)
+            Some(CodeType::Runtime)
         } else {
             None
         };

--- a/bins/revme/src/cmd/eofvalidation.rs
+++ b/bins/revme/src/cmd/eofvalidation.rs
@@ -77,9 +77,9 @@ pub fn run_test(path: &Path) -> Result<(), Error> {
                 }
                 test_sum += 1;
                 let kind = if test_vector.container_kind.is_some() {
-                    Some(CodeType::ReturnContract)
+                    Some(CodeType::Initcode)
                 } else {
-                    Some(CodeType::ReturnOrStop)
+                    Some(CodeType::Runtime)
                 };
                 // In future this can be generalized to cover multiple forks, Not just Osaka.
                 let Some(test_result) = test_vector.results.get("Osaka") else {

--- a/crates/bytecode/src/bytecode.rs
+++ b/crates/bytecode/src/bytecode.rs
@@ -117,11 +117,7 @@ impl Bytecode {
     /// # Panics
     ///
     /// For possible panics see [`LegacyAnalyzedBytecode::new`].
-    pub fn new_analyzed(
-        bytecode: Bytes,
-        original_len: usize,
-        jump_table: JumpTable,
-    ) -> Self {
+    pub fn new_analyzed(bytecode: Bytes, original_len: usize, jump_table: JumpTable) -> Self {
         Self::LegacyAnalyzed(LegacyAnalyzedBytecode::new(
             bytecode,
             original_len,

--- a/crates/bytecode/src/bytecode.rs
+++ b/crates/bytecode/src/bytecode.rs
@@ -7,7 +7,7 @@ use core::fmt::Debug;
 use primitives::{keccak256, Address, Bytes, B256, KECCAK_EMPTY};
 use std::sync::Arc;
 
-/// State of the [`Bytecode`] analysis
+/// Main bytecode structure with all variants.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Bytecode {
@@ -81,7 +81,7 @@ impl Bytecode {
     ///
     /// # Panics
     ///
-    /// Panics if bytecode is in incorrect format.
+    /// Panics if bytecode is in incorrect format. If you want to handle errors use [`Self::new_raw_checked`].
     #[inline]
     pub fn new_raw(bytecode: Bytes) -> Self {
         Self::new_raw_checked(bytecode).expect("Expect correct EOF bytecode")
@@ -114,11 +114,10 @@ impl Bytecode {
 
     /// Create new checked bytecode.
     ///
-    /// # Safety
+    /// # Panics
     ///
-    /// Bytecode needs to end with `STOP` (`0x00`) opcode as checked bytecode assumes
-    /// that it is safe to iterate over bytecode without checking lengths.
-    pub unsafe fn new_analyzed(
+    /// For possible panics see [`LegacyAnalyzedBytecode::new`].
+    pub fn new_analyzed(
         bytecode: Bytes,
         original_len: usize,
         jump_table: JumpTable,
@@ -156,7 +155,7 @@ impl Bytecode {
         self.bytes_ref().clone()
     }
 
-    /// Returns bytes.
+    /// Returns raw bytes reference.
     #[inline]
     pub fn bytes_ref(&self) -> &Bytes {
         match self {
@@ -166,13 +165,13 @@ impl Bytecode {
         }
     }
 
-    /// Returns bytes slice.
+    /// Returns raw bytes slice.
     #[inline]
     pub fn bytes_slice(&self) -> &[u8] {
         self.bytes_ref()
     }
 
-    /// Returns a reference to the original bytecode.
+    /// Returns the original bytecode.
     #[inline]
     pub fn original_bytes(&self) -> Bytes {
         match self {

--- a/crates/bytecode/src/eof.rs
+++ b/crates/bytecode/src/eof.rs
@@ -1,13 +1,13 @@
 mod body;
+mod code_info;
 mod decode_helpers;
 mod header;
 pub mod printer;
-mod types_section;
 pub mod verification;
 
 pub use body::EofBody;
+pub use code_info::CodeInfo;
 pub use header::EofHeader;
-pub use types_section::TypesSection;
 pub use verification::*;
 
 use core::cmp::min;
@@ -39,7 +39,7 @@ impl Default for Eof {
     fn default() -> Self {
         let body = EofBody {
             // Types section with zero inputs, zero outputs and zero max stack size.
-            types_section: vec![TypesSection::default()],
+            code_info: vec![CodeInfo::default()],
             code_section: vec![1],
             // One code section with a STOP byte.
             code: Bytes::from_static(&[0x00]),
@@ -136,10 +136,10 @@ pub enum EofDecodeError {
     MissingBodyWithoutData,
     /// Body size is more than specified in the header
     DanglingData,
-    /// Invalid types section data
-    InvalidTypesSection,
-    /// Invalid types section size
-    InvalidTypesSectionSize,
+    /// Invalid code info data
+    InvalidCodeInfo,
+    /// Invalid code info size
+    InvalidCodeInfoSize,
     /// Invalid EOF magic number
     InvalidEOFMagicNumber,
     /// Invalid EOF version
@@ -154,8 +154,8 @@ pub enum EofDecodeError {
     InvalidDataKind,
     /// Invalid kind after code
     InvalidKindAfterCode,
-    /// Mismatch of code and types sizes
-    MismatchCodeAndTypesSize,
+    /// Mismatch of code and info sizes
+    MismatchCodeAndInfoSize,
     /// There should be at least one size
     NonSizes,
     /// Missing size
@@ -178,8 +178,8 @@ impl fmt::Display for EofDecodeError {
             Self::MissingInput => "Short input while processing EOF",
             Self::MissingBodyWithoutData => "Short body while processing EOF",
             Self::DanglingData => "Body size is more than specified in the header",
-            Self::InvalidTypesSection => "Invalid types section data",
-            Self::InvalidTypesSectionSize => "Invalid types section size",
+            Self::InvalidCodeInfo => "Invalid types section data",
+            Self::InvalidCodeInfoSize => "Invalid types section size",
             Self::InvalidEOFMagicNumber => "Invalid EOF magic number",
             Self::InvalidEOFVersion => "Invalid EOF version",
             Self::InvalidTypesKind => "Invalid number for types kind",
@@ -187,7 +187,7 @@ impl fmt::Display for EofDecodeError {
             Self::InvalidTerminalByte => "Invalid terminal code",
             Self::InvalidDataKind => "Invalid data kind",
             Self::InvalidKindAfterCode => "Invalid kind after code",
-            Self::MismatchCodeAndTypesSize => "Mismatch of code and types sizes",
+            Self::MismatchCodeAndInfoSize => "Mismatch of code and types sizes",
             Self::NonSizes => "There should be at least one size",
             Self::ShortInputForSizes => "Missing size",
             Self::ZeroSize => "Size cant be zero",

--- a/crates/bytecode/src/eof/code_info.rs
+++ b/crates/bytecode/src/eof/code_info.rs
@@ -10,7 +10,7 @@ const EOF_NON_RETURNING_FUNCTION: u8 = 0x80;
 /// Types section that contains stack information for matching code section
 #[derive(Debug, Clone, Default, Hash, PartialEq, Eq, Copy, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct TypesSection {
+pub struct CodeInfo {
     /// `inputs` - 1 byte - `0x00-0x7F`
     ///
     /// Number of stack elements the code section consumes
@@ -25,8 +25,8 @@ pub struct TypesSection {
     pub max_stack_size: u16,
 }
 
-impl TypesSection {
-    /// Returns new `TypesSection` with the given inputs, outputs, and max_stack_size.
+impl CodeInfo {
+    /// Returns new `CodeInfo` with the given inputs, outputs, and max_stack_size.
     pub fn new(inputs: u8, outputs: u8, max_stack_size: u16) -> Self {
         Self {
             inputs,
@@ -72,10 +72,10 @@ impl TypesSection {
     /// Validates the section.
     pub fn validate(&self) -> Result<(), EofDecodeError> {
         if self.inputs > 0x7f || self.outputs > 0x80 || self.max_stack_size > 0x03FF {
-            return Err(EofDecodeError::InvalidTypesSection);
+            return Err(EofDecodeError::InvalidCodeInfo);
         }
         if self.inputs as u16 > self.max_stack_size {
-            return Err(EofDecodeError::InvalidTypesSection);
+            return Err(EofDecodeError::InvalidCodeInfo);
         }
         Ok(())
     }

--- a/crates/bytecode/src/eof/decode_helpers.rs
+++ b/crates/bytecode/src/eof/decode_helpers.rs
@@ -1,6 +1,9 @@
 use super::EofDecodeError;
 
-/// Consumes a u8 from the input.
+/// Consumes a single byte from the input slice and returns a tuple containing the remaining input slice
+/// and the consumed byte as a u8.
+///
+/// Returns `EofDecodeError::MissingInput` if the input slice is empty.
 #[inline]
 pub(crate) fn consume_u8(input: &[u8]) -> Result<(&[u8], u8), EofDecodeError> {
     if input.is_empty() {
@@ -10,6 +13,8 @@ pub(crate) fn consume_u8(input: &[u8]) -> Result<(&[u8], u8), EofDecodeError> {
 }
 
 /// Consumes a u16 from the input.
+///
+/// Returns `EofDecodeError::MissingInput` if the input slice is less than 2 bytes.
 #[inline]
 pub(crate) fn consume_u16(input: &[u8]) -> Result<(&[u8], u16), EofDecodeError> {
     if input.len() < 2 {

--- a/crates/bytecode/src/eof/verification.rs
+++ b/crates/bytecode/src/eof/verification.rs
@@ -1,5 +1,5 @@
 use crate::{
-    eof::{Eof, EofDecodeError, TypesSection},
+    eof::{CodeInfo, Eof, EofDecodeError},
     opcode::{self, OPCODE_INFO},
     utils::{read_i16, read_u16},
 };
@@ -11,7 +11,7 @@ use std::{borrow::Cow, fmt, vec, vec::Vec};
 
 /// Decodes `raw` into an [`Eof`] container and validates it.
 pub fn validate_raw_eof(raw: Bytes) -> Result<Eof, EofError> {
-    validate_raw_eof_inner(raw, Some(CodeType::ReturnContract))
+    validate_raw_eof_inner(raw, Some(CodeType::Initcode))
 }
 
 /// Decodes `raw` into an [`Eof`] container and validates it.
@@ -32,11 +32,11 @@ pub fn validate_raw_eof_inner(
 ///
 /// Only place where validation happen is in Creating Transaction.
 ///
-/// Because of that we are assuming [CodeType] is [ReturnContract][CodeType::ReturnContract].
+/// Because of that we are assuming [CodeType] is [ReturnContract][CodeType::Initcode].
 ///
-/// Note: If needed we can make a flag that would assume [ReturnContract][CodeType::ReturnContract]..
+/// Note: If needed we can make a flag that would assume [ReturnContract][CodeType::Initcode]..
 pub fn validate_eof(eof: &Eof) -> Result<(), EofError> {
-    validate_eof_inner(eof, Some(CodeType::ReturnContract))
+    validate_eof_inner(eof, Some(CodeType::Initcode))
 }
 
 #[inline]
@@ -78,8 +78,8 @@ pub fn validate_eof_codes(
     eof: &Eof,
     this_code_type: Option<CodeType>,
 ) -> Result<Vec<CodeType>, EofValidationError> {
-    if eof.body.code_section.len() != eof.body.types_section.len() {
-        return Err(EofValidationError::InvalidTypesSection);
+    if eof.body.code_section.len() != eof.body.code_info.len() {
+        return Err(EofValidationError::InvalidCodeInfo);
     }
 
     if eof.body.code_section.is_empty() {
@@ -89,9 +89,9 @@ pub fn validate_eof_codes(
 
     // The first code section must have a type signature
     // (0, 0x80, max_stack_height) (0 inputs non-returning function)
-    let first_types = &eof.body.types_section[0];
+    let first_types = &eof.body.code_info[0];
     if first_types.inputs != 0 || !first_types.is_non_returning() {
-        return Err(EofValidationError::InvalidTypesSection);
+        return Err(EofValidationError::InvalidCodeInfo);
     }
 
     // Tracking access of code and sub containers.
@@ -109,7 +109,7 @@ pub fn validate_eof_codes(
             eof.header.data_size as usize,
             index,
             eof.body.container_section.len(),
-            &eof.body.types_section,
+            &eof.body.code_info,
             &mut tracker,
         )?;
     }
@@ -123,9 +123,7 @@ pub fn validate_eof_codes(
         return Err(EofValidationError::SubContainerNotAccessed);
     }
 
-    if tracker.this_container_code_type == Some(CodeType::ReturnContract)
-        && !eof.body.is_data_filled
-    {
+    if tracker.this_container_code_type == Some(CodeType::Initcode) && !eof.body.is_data_filled {
         return Err(EofValidationError::DataNotFilled);
     }
 
@@ -212,8 +210,6 @@ pub enum EofValidationError {
     RETFBiggestStackNumMoreThenOutputs,
     /// Stack requirement is more than smallest stack items
     StackUnderflow,
-    /// Smallest stack items is more than types output
-    TypesStackUnderflow,
     /// Jump out of bounds
     JumpUnderflow,
     /// Jump to out of bounds
@@ -227,10 +223,10 @@ pub enum EofValidationError {
     /// Code section not accessed
     CodeSectionNotAccessed,
     /// Types section invalid
-    InvalidTypesSection,
+    InvalidCodeInfo,
     /// First types section is invalid
     /// It should have inputs 0 and outputs `0x80`
-    InvalidFirstTypesSection,
+    InvalidFirstCodeInfo,
     /// Max stack element mismatch
     MaxStackMismatch,
     /// No code sections present
@@ -241,7 +237,7 @@ pub enum EofValidationError {
     SubContainerCalledInTwoModes,
     /// Sub container not accessed
     SubContainerNotAccessed,
-    /// Data size needs to be filled for [ReturnContract][CodeType::ReturnContract] type
+    /// Data size needs to be filled for [ReturnContract][CodeType::Initcode] type
     DataNotFilled,
     /// Section is marked as non-returning but has either RETF or
     /// JUMPF to returning section opcodes
@@ -266,9 +262,8 @@ pub struct AccessTracker {
 }
 
 impl AccessTracker {
-    /// Returns a new instance of `CodeSubContainerAccess`.
-    ///
-    /// Mark first code section as accessed and push first it to the stack.
+    /// Creates a new instance with the given container type and section sizes.
+    /// The first code section is marked as accessed and added to the processing stack.
     ///
     /// # Panics
     ///
@@ -292,11 +287,11 @@ impl AccessTracker {
         this
     }
 
-    /// Mark code as accessed.
+    /// Marks a code section as accessed and adds it to the processing stack if not previously accessed.
     ///
-    /// If code was not accessed before, it will be added to the processing stack.
+    /// # Panics
     ///
-    /// Assumes that index is valid.
+    /// Panics if the index is out of bounds.
     pub fn access_code(&mut self, index: usize) {
         let was_accessed = mem::replace(&mut self.codes[index], true);
         if !was_accessed {
@@ -325,22 +320,21 @@ impl AccessTracker {
     }
 }
 
-/// Types of code sections
+/// Types of code sections in EOF container
 ///
-/// It is a error if container to contain
-/// both RETURNCONTRACT and either of RETURN or STOP.
+/// Container cannot mix RETURNCONTRACT with RETURN/STOP opcodes
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CodeType {
-    /// Return contract code
-    ReturnContract,
-    /// Return or Stop opcodes
-    ReturnOrStop,
+    /// Code that initializes and returns a contract.
+    Initcode,
+    /// Runtime code that ends with RETURN or STOP opcodes.
+    Runtime,
 }
 
 impl CodeType {
     /// Returns `true` of the code is initcode.
     pub fn is_initcode(&self) -> bool {
-        matches!(self, CodeType::ReturnContract)
+        matches!(self, CodeType::Initcode)
     }
 }
 
@@ -368,7 +362,6 @@ impl fmt::Display for EofValidationError {
                 "RETF biggest stack num is more than outputs"
             }
             Self::StackUnderflow => "Stack requirement is above smallest stack items",
-            Self::TypesStackUnderflow => "Smallest stack items is more than output type",
             Self::JumpUnderflow => "Jump destination is too low",
             Self::JumpOverflow => "Jump destination is too high",
             Self::BackwardJumpBiggestNumMismatch => {
@@ -381,8 +374,8 @@ impl fmt::Display for EofValidationError {
                 "Last instruction of bytecode is not terminating"
             }
             Self::CodeSectionNotAccessed => "Code section was not accessed",
-            Self::InvalidTypesSection => "Invalid types section",
-            Self::InvalidFirstTypesSection => "Invalid first types section",
+            Self::InvalidCodeInfo => "Invalid types section",
+            Self::InvalidFirstCodeInfo => "Invalid first types section",
             Self::MaxStackMismatch => "Max stack element mismatches",
             Self::NoCodeSections => "No code sections",
             Self::SubContainerCalledInTwoModes => "Sub container called in two modes",
@@ -407,7 +400,7 @@ pub fn validate_eof_code(
     data_size: usize,
     this_types_index: usize,
     num_of_containers: usize,
-    types: &[TypesSection],
+    types: &[CodeInfo],
     tracker: &mut AccessTracker,
 ) -> Result<(), EofValidationError> {
     let this_types = &types[this_types_index];
@@ -621,7 +614,7 @@ pub fn validate_eof_code(
                     // Code section out of bounds.
                     return Err(EofValidationError::EOFCREATEInvalidIndex);
                 }
-                tracker.set_subcontainer_type(index, CodeType::ReturnContract)?;
+                tracker.set_subcontainer_type(index, CodeType::Initcode)?;
             }
             opcode::RETURNCONTRACT => {
                 let index = code[i + 1] as usize;
@@ -632,19 +625,19 @@ pub fn validate_eof_code(
                 }
                 if *tracker
                     .this_container_code_type
-                    .get_or_insert(CodeType::ReturnContract)
-                    != CodeType::ReturnContract
+                    .get_or_insert(CodeType::Initcode)
+                    != CodeType::Initcode
                 {
                     // TODO : Make custom error
                     return Err(EofValidationError::SubContainerCalledInTwoModes);
                 }
-                tracker.set_subcontainer_type(index, CodeType::ReturnOrStop)?;
+                tracker.set_subcontainer_type(index, CodeType::Runtime)?;
             }
             opcode::RETURN | opcode::STOP => {
                 if *tracker
                     .this_container_code_type
-                    .get_or_insert(CodeType::ReturnOrStop)
-                    != CodeType::ReturnOrStop
+                    .get_or_insert(CodeType::Runtime)
+                    != CodeType::Runtime
                 {
                     return Err(EofValidationError::SubContainerCalledInTwoModes);
                 }
@@ -821,7 +814,7 @@ mod test {
     fn size_limit() {
         let eof = validate_raw_eof_inner(
             hex!("ef00010100040200010003040001000080000130500000").into(),
-            Some(CodeType::ReturnOrStop),
+            Some(CodeType::Runtime),
         );
         assert!(eof.is_ok());
     }
@@ -858,7 +851,7 @@ mod test {
         let eof = validate_raw_eof_inner(
             hex!("ef000101000c02000300040001000304000000008000000080000000000000e300020000e50001")
                 .into(),
-            Some(CodeType::ReturnOrStop),
+            Some(CodeType::Runtime),
         );
         assert_eq!(
             eof,
@@ -873,7 +866,7 @@ mod test {
         let eof = validate_raw_eof_inner(
             hex!("ef000101000402000100060300010014040000000080000260006000ee00ef00010100040200010001040000000080000000")
                 .into(),
-            Some(CodeType::ReturnOrStop),
+            Some(CodeType::Runtime),
         );
         assert_eq!(
             eof,

--- a/crates/bytecode/src/legacy.rs
+++ b/crates/bytecode/src/legacy.rs
@@ -1,7 +1,9 @@
+mod analysis;
 mod analyzed;
 mod jump_map;
 mod raw;
 
+pub use analysis::analyze_legacy;
 pub use analyzed::LegacyAnalyzedBytecode;
 pub use jump_map::JumpTable;
-pub use raw::{analyze_legacy, LegacyRawBytecode};
+pub use raw::LegacyRawBytecode;

--- a/crates/bytecode/src/legacy/analysis.rs
+++ b/crates/bytecode/src/legacy/analysis.rs
@@ -1,0 +1,38 @@
+use super::JumpTable;
+use crate::opcode;
+use bitvec::{bitvec, order::Lsb0, vec::BitVec};
+use std::sync::Arc;
+
+/// Analyze the bytecode to find the jumpdests. Used to create a jump table
+/// that is needed for [`crate::LegacyAnalyzedBytecode`].
+/// This function contains a hot loop and should be optimized as much as possible.
+///
+/// Undefined behavior if the bytecode does not end with a valid STOP opcode. Please check
+/// [`crate::LegacyAnalyzedBytecode::new`] for details on how the bytecode is validated.
+pub fn analyze_legacy(bytetecode: &[u8]) -> JumpTable {
+    let mut jumps: BitVec<u8> = bitvec![u8, Lsb0; 0; bytetecode.len()];
+
+    let range = bytetecode.as_ptr_range();
+    let start = range.start;
+    let mut iterator = start;
+    let end = range.end;
+    while iterator < end {
+        let opcode = unsafe { *iterator };
+        if opcode::JUMPDEST == opcode {
+            // SAFETY: Jumps are max length of the code
+            unsafe { jumps.set_unchecked(iterator.offset_from(start) as usize, true) }
+            iterator = unsafe { iterator.offset(1) };
+        } else {
+            let push_offset = opcode.wrapping_sub(opcode::PUSH1);
+            if push_offset < 32 {
+                // SAFETY: Iterator access range is checked in the while loop
+                iterator = unsafe { iterator.offset((push_offset + 2) as isize) };
+            } else {
+                // SAFETY: Iterator access range is checked in the while loop
+                iterator = unsafe { iterator.offset(1) };
+            }
+        }
+    }
+
+    JumpTable(Arc::new(jumps))
+}

--- a/crates/bytecode/src/legacy/analyzed.rs
+++ b/crates/bytecode/src/legacy/analyzed.rs
@@ -139,7 +139,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "jump table length 34 is not equal to bytecode length 2")]
+    #[should_panic(expected = "jump table length 34 is not equal to bytecode length 35")]
     fn test_panic_on_custom_jump_table() {
         let bytecode = Bytes::from_static(&[opcode::PUSH1, 0x01]);
         let bytecode = LegacyRawBytecode(bytecode).into_analyzed();

--- a/crates/bytecode/src/legacy/analyzed.rs
+++ b/crates/bytecode/src/legacy/analyzed.rs
@@ -1,13 +1,37 @@
 use super::JumpTable;
+use crate::opcode;
 use bitvec::{bitvec, order::Lsb0};
 use primitives::Bytes;
 use std::sync::Arc;
 
-// Legacy analyzed
+/// Legacy analyzed bytecode represents the original bytecode format used in Ethereum.
+///
+/// # Jump Table
+///
+/// A jump table maps valid jump destinations in the bytecode.
+///
+/// While other EVM implementations typically analyze bytecode and cache jump tables at runtime,
+/// Revm requires the jump table to be pre-computed and contained alongside the code,
+/// and present with the bytecode when executing.
+///
+/// # Bytecode Padding
+///
+/// All legacy bytecode is padded with 33 zero bytes at the end. This padding ensures the
+/// bytecode always ends with a valid STOP (0x00) opcode. The reason for 33 bytes padding (and not one byte)
+/// is handling the edge cases  where a PUSH32 opcode appears at the end of the original
+/// bytecode without enough remaining bytes for its immediate data. Original bytecode length
+/// is stored in order to be able to copy original bytecode.
+///
+/// # Gas safety
+///
+/// When bytecode is created through CREATE, CREATE2, or contract creation transactions, it undergoes
+/// analysis to generate its jump table. This analysis is O(n) on side of bytecode that is expensive,
+/// but the high gas cost required to store bytecode in the database is high enough to cover the
+/// expense of doing analysis and generate the jump table.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LegacyAnalyzedBytecode {
-    /// Bytecode with 32 zero bytes padding
+    /// Bytecode with 33 zero bytes padding
     bytecode: Bytes,
     /// Original bytes length
     original_len: usize,
@@ -28,7 +52,32 @@ impl Default for LegacyAnalyzedBytecode {
 
 impl LegacyAnalyzedBytecode {
     /// Creates new analyzed bytecode.
+    ///
+    /// # Panics
+    ///
+    /// * If `original_len` is greater than `bytecode.len()`
+    /// * If jump table length is not equal to `bytecode.len() / 32`.
+    /// * If last bytecode byte is not `0x00` or if bytecode is empty.
     pub fn new(bytecode: Bytes, original_len: usize, jump_table: JumpTable) -> Self {
+        if original_len > bytecode.len() {
+            panic!("original_len is greater than bytecode length");
+        }
+        if jump_table.0.len() != bytecode.len() {
+            panic!(
+                "jump table length {} is not equal to bytecode length {}",
+                jump_table.0.len(),
+                bytecode.len()
+            );
+        }
+
+        if bytecode.is_empty() {
+            panic!("bytecode cannot be empty");
+        }
+
+        if bytecode.last() != Some(&opcode::STOP) {
+            panic!("last bytecode byte should be STOP (0x00)");
+        }
+
         Self {
             bytecode,
             original_len,
@@ -61,5 +110,56 @@ impl LegacyAnalyzedBytecode {
     /// Returns [JumpTable] of analyzed bytes.
     pub fn jump_table(&self) -> &JumpTable {
         &self.jump_table
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{opcode, LegacyRawBytecode};
+
+    use super::*;
+
+    #[test]
+    fn test_bytecode_new() {
+        let bytecode = Bytes::from_static(&[opcode::PUSH1, 0x01]);
+        let bytecode = LegacyRawBytecode(bytecode).into_analyzed();
+        let _ = LegacyAnalyzedBytecode::new(
+            bytecode.bytecode,
+            bytecode.original_len,
+            bytecode.jump_table,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "original_len is greater than bytecode length")]
+    fn test_panic_on_large_original_len() {
+        let bytecode = Bytes::from_static(&[opcode::PUSH1, 0x01]);
+        let bytecode = LegacyRawBytecode(bytecode).into_analyzed();
+        let _ = LegacyAnalyzedBytecode::new(bytecode.bytecode, 100, bytecode.jump_table);
+    }
+
+    #[test]
+    #[should_panic(expected = "jump table length 34 is not equal to bytecode length 2")]
+    fn test_panic_on_custom_jump_table() {
+        let bytecode = Bytes::from_static(&[opcode::PUSH1, 0x01]);
+        let bytecode = LegacyRawBytecode(bytecode).into_analyzed();
+        let jump_table = JumpTable(Arc::new(bitvec![u8, Lsb0; 0; 34]));
+        let _ = LegacyAnalyzedBytecode::new(bytecode.bytecode, bytecode.original_len, jump_table);
+    }
+
+    #[test]
+    #[should_panic(expected = "last bytecode byte should be STOP (0x00)")]
+    fn test_panic_on_non_stop_bytecode() {
+        let bytecode = Bytes::from_static(&[opcode::PUSH1, 0x01]);
+        let jump_table = JumpTable(Arc::new(bitvec![u8, Lsb0; 0; 2]));
+        let _ = LegacyAnalyzedBytecode::new(bytecode, 2, jump_table);
+    }
+
+    #[test]
+    #[should_panic(expected = "bytecode cannot be empty")]
+    fn test_panic_on_empty_bytecode() {
+        let bytecode = Bytes::from_static(&[]);
+        let jump_table = JumpTable(Arc::new(bitvec![u8, Lsb0; 0; 0]));
+        let _ = LegacyAnalyzedBytecode::new(bytecode, 0, jump_table);
     }
 }

--- a/crates/bytecode/src/legacy/jump_map.rs
+++ b/crates/bytecode/src/legacy/jump_map.rs
@@ -2,7 +2,7 @@ use bitvec::vec::BitVec;
 use primitives::hex;
 use std::{fmt::Debug, sync::Arc};
 
-/// A map of valid `jump` destinations
+/// A table of valid `jump` destinations. Cheap to clone and memory efficient, one bit per opcode.
 #[derive(Clone, Default, PartialEq, Eq, Hash, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct JumpTable(pub Arc<BitVec<u8>>);

--- a/crates/bytecode/src/legacy/raw.rs
+++ b/crates/bytecode/src/legacy/raw.rs
@@ -1,25 +1,24 @@
-use super::{JumpTable, LegacyAnalyzedBytecode};
-use crate::opcode;
-use bitvec::{bitvec, order::Lsb0, vec::BitVec};
+use super::{analyze_legacy, LegacyAnalyzedBytecode};
 use core::ops::Deref;
 use primitives::Bytes;
-use std::{sync::Arc, vec::Vec};
+use std::vec::Vec;
 
+/// Used only as intermediate representation for legacy bytecode.
+/// Please check [`LegacyAnalyzedBytecode`] for the main structure that is used in Revm.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LegacyRawBytecode(pub Bytes);
 
 impl LegacyRawBytecode {
-    pub fn analysis(&self) -> JumpTable {
-        analyze_legacy(&self.0)
-    }
-
+    /// Converts the raw bytecode into an analyzed bytecode.
+    ///
+    /// It extends the bytecode with 33 zero bytes and analyzes it to find the jumpdests.
     pub fn into_analyzed(self) -> LegacyAnalyzedBytecode {
-        let jump_table = self.analysis();
         let len = self.0.len();
         let mut padded_bytecode = Vec::with_capacity(len + 33);
         padded_bytecode.extend_from_slice(&self.0);
         padded_bytecode.resize(len + 33, 0);
+        let jump_table = analyze_legacy(&padded_bytecode);
         LegacyAnalyzedBytecode::new(padded_bytecode.into(), len, jump_table)
     }
 }
@@ -42,33 +41,4 @@ impl Deref for LegacyRawBytecode {
     fn deref(&self) -> &Self::Target {
         &self.0
     }
-}
-
-/// Analyze the bytecode to find the jumpdests
-pub fn analyze_legacy(bytetecode: &[u8]) -> JumpTable {
-    let mut jumps: BitVec<u8> = bitvec![u8, Lsb0; 0; bytetecode.len()];
-
-    let range = bytetecode.as_ptr_range();
-    let start = range.start;
-    let mut iterator = start;
-    let end = range.end;
-    while iterator < end {
-        let opcode = unsafe { *iterator };
-        if opcode::JUMPDEST == opcode {
-            // SAFETY: Jumps are max length of the code
-            unsafe { jumps.set_unchecked(iterator.offset_from(start) as usize, true) }
-            iterator = unsafe { iterator.offset(1) };
-        } else {
-            let push_offset = opcode.wrapping_sub(opcode::PUSH1);
-            if push_offset < 32 {
-                // SAFETY: Iterator access range is checked in the while loop
-                iterator = unsafe { iterator.offset((push_offset + 2) as isize) };
-            } else {
-                // SAFETY: Iterator access range is checked in the while loop
-                iterator = unsafe { iterator.offset(1) };
-            }
-        }
-    }
-
-    JumpTable(Arc::new(jumps))
 }

--- a/crates/bytecode/src/lib.rs
+++ b/crates/bytecode/src/lib.rs
@@ -1,4 +1,10 @@
-//! Optimism-specific constants, types, and helpers.
+//! Crate that contains bytecode types and opcode constants.
+//!
+//! EOF bytecode contains its verification logic and only valid EOF bytecode can be created.
+//!
+//! Legacy bytecode will always contain a jump table.
+//!
+//! While EIP-7702 bytecode must contains a Address.
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/crates/bytecode/src/opcode.rs
+++ b/crates/bytecode/src/opcode.rs
@@ -132,7 +132,7 @@ impl OpCode {
     }
 
     /// Returns the opcode information for the given opcode.
-    /// Check [OpCodeInfo](OpCodeInfo) for more information.
+    /// Check [OpCodeInfo] for more information.
     #[inline]
     pub const fn info_by_op(opcode: u8) -> Option<OpCodeInfo> {
         if let Some(opcode) = Self::new(opcode) {

--- a/crates/bytecode/src/opcode.rs
+++ b/crates/bytecode/src/opcode.rs
@@ -1,4 +1,4 @@
-//! EVM opcode definitions and utilities.
+//! EVM opcode definitions and utilities. It contains opcode information and utilities to work with opcodes.
 
 #[cfg(feature = "parse")]
 pub mod parse;
@@ -14,6 +14,7 @@ use core::{fmt, ptr::NonNull};
 pub struct OpCode(u8);
 
 impl fmt::Display for OpCode {
+    /// Formats the opcode as a string
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let n = self.get();
         if let Some(val) = OPCODE_INFO[n as usize] {
@@ -26,6 +27,8 @@ impl fmt::Display for OpCode {
 
 impl OpCode {
     /// Instantiates a new opcode from a u8.
+    ///
+    /// Returns None if the opcode is not valid.
     #[inline]
     pub const fn new(opcode: u8) -> Option<Self> {
         match OPCODE_INFO[opcode as usize] {
@@ -129,6 +132,7 @@ impl OpCode {
     }
 
     /// Returns the opcode information for the given opcode.
+    /// Check [OpCodeInfo](OpCodeInfo) for more information.
     #[inline]
     pub const fn info_by_op(opcode: u8) -> Option<OpCodeInfo> {
         if let Some(opcode) = Self::new(opcode) {
@@ -259,7 +263,7 @@ impl OpCodeInfo {
         // SAFETY: `self.name_*` can only be initialized with a valid `&'static str`.
         unsafe {
             // TODO : Use `str::from_raw_parts` when it's stable.
-            let slice = core::slice::from_raw_parts(self.name_ptr.as_ptr(), self.name_len as usize);
+            let slice = std::slice::from_raw_parts(self.name_ptr.as_ptr(), self.name_len as usize);
             core::str::from_utf8_unchecked(slice)
         }
     }
@@ -308,7 +312,7 @@ pub const fn not_eof(mut op: OpCodeInfo) -> OpCodeInfo {
     op
 }
 
-/// Sets the immediate bytes number.
+/// Used for [`OPCODE_INFO`] to set the immediate bytes number in the [`OpCodeInfo`].
 ///
 /// RJUMPV is special case where the bytes len is depending on bytecode value,
 /// for RJUMPV size will be set to one byte while minimum is two.
@@ -318,14 +322,14 @@ pub const fn immediate_size(mut op: OpCodeInfo, n: u8) -> OpCodeInfo {
     op
 }
 
-/// Sets the terminating flag to true.
+/// Use for [`OPCODE_INFO`] to set the terminating flag to true in the [`OpCodeInfo`].
 #[inline]
 pub const fn terminating(mut op: OpCodeInfo) -> OpCodeInfo {
     op.terminating = true;
     op
 }
 
-/// Sets the number of stack inputs and outputs.
+/// Use for [`OPCODE_INFO`] to sets the number of stack inputs and outputs in the [`OpCodeInfo`].
 #[inline]
 pub const fn stack_io(mut op: OpCodeInfo, inputs: u8, outputs: u8) -> OpCodeInfo {
     op.inputs = inputs;
@@ -336,6 +340,9 @@ pub const fn stack_io(mut op: OpCodeInfo, inputs: u8, outputs: u8) -> OpCodeInfo
 /// Alias for the [`JUMPDEST`] opcode
 pub const NOP: u8 = JUMPDEST;
 
+/// Created all opcodes constants and two maps:
+///  * `OPCODE_INFO` maps opcode number to the opcode info
+///  * `NAME_TO_OPCODE` that maps opcode name to the opcode number.
 macro_rules! opcodes {
     ($($val:literal => $name:ident => $($modifier:ident $(( $($modifier_arg:expr),* ))?),*);* $(;)?) => {
         // Constants for each opcode. This also takes care of duplicate names.

--- a/crates/bytecode/src/opcode/parse.rs
+++ b/crates/bytecode/src/opcode/parse.rs
@@ -1,3 +1,8 @@
+//! Parsing opcodes from strings.
+//!
+//! This module provides a function to parse opcodes from strings.
+//! It is a utility function that needs to be enabled with `parse` feature.
+
 use super::OpCode;
 use crate::opcode::NAME_TO_OPCODE;
 use core::fmt;

--- a/crates/context/interface/src/result.rs
+++ b/crates/context/interface/src/result.rs
@@ -507,7 +507,7 @@ pub enum HaltReason {
 
     /// Aux data overflow, new aux data is larger than [u16] max size.
     EofAuxDataOverflow,
-    /// Aud data is smaller then already present data size.
+    /// Aux data is smaller than already present data size.
     EofAuxDataTooSmall,
     /// EOF Subroutine stack overflow
     SubRoutineStackOverflow,

--- a/crates/interpreter/src/instruction_result.rs
+++ b/crates/interpreter/src/instruction_result.rs
@@ -94,7 +94,7 @@ pub enum InstructionResult {
     SubRoutineStackOverflow,
     /// Aux data overflow, new aux data is larger than `u16` max size.
     EofAuxDataOverflow,
-    /// Aux data is smaller then already present data size.
+    /// Aux data is smaller than already present data size.
     EofAuxDataTooSmall,
     /// `EXT*CALL` target address needs to be padded with 0s.
     InvalidEXTCALLTarget,

--- a/crates/interpreter/src/instructions/control.rs
+++ b/crates/interpreter/src/instructions/control.rs
@@ -109,7 +109,7 @@ pub fn callf<WIRE: InterpreterTypes, H: Host + ?Sized>(
     let idx = interpreter.bytecode.read_u16() as usize;
 
     // Get target types
-    let Some(types) = interpreter.bytecode.code_section_info(idx) else {
+    let Some(types) = interpreter.bytecode.code_info(idx) else {
         panic!("Invalid EOF in execution, expecting correct intermediate in callf")
     };
 
@@ -166,7 +166,7 @@ pub fn jumpf<WIRE: InterpreterTypes, H: Host + ?Sized>(
     // Get target types
     let types = interpreter
         .bytecode
-        .code_section_info(idx)
+        .code_info(idx)
         .expect("Invalid code section index");
 
     // Check max stack height for target code section.
@@ -278,7 +278,7 @@ mod test {
     use crate::{table::make_instruction_table, DummyHost, Gas};
     use bytecode::opcode::{CALLF, JUMPF, NOP, RETF, RJUMP, RJUMPI, RJUMPV, STOP};
     use bytecode::{
-        eof::{Eof, TypesSection},
+        eof::{Eof, CodeInfo},
         Bytecode,
     };
     use primitives::bytes;
@@ -382,11 +382,11 @@ mod test {
     }
 
     fn eof_setup(bytes1: Bytes, bytes2: Bytes) -> Interpreter {
-        eof_setup_with_types(bytes1, bytes2, TypesSection::default())
+        eof_setup_with_types(bytes1, bytes2, CodeInfo::default())
     }
 
     /// Two code section and types section is for last code.
-    fn eof_setup_with_types(bytes1: Bytes, bytes2: Bytes, types: TypesSection) -> Interpreter {
+    fn eof_setup_with_types(bytes1: Bytes, bytes2: Bytes, types: CodeInfo) -> Interpreter {
         let mut eof = dummy_eof();
 
         eof.body.code_section.clear();
@@ -395,7 +395,7 @@ mod test {
 
         eof.header.code_sizes.push(bytes1.len() as u16);
         eof.body.code_section.push(bytes1.len());
-        eof.body.types_section.push(TypesSection::new(0, 0, 11));
+        eof.body.types_section.push(CodeInfo::new(0, 0, 11));
 
         eof.header.code_sizes.push(bytes2.len() as u16);
         eof.body.code_section.push(bytes2.len() + bytes1.len());
@@ -472,7 +472,7 @@ mod test {
         let bytes1 = Bytes::from([CALLF, 0x00, 0x01]);
         let bytes2 = Bytes::from([STOP]);
         let mut interp =
-            eof_setup_with_types(bytes1, bytes2.clone(), TypesSection::new(0, 0, 1025));
+            eof_setup_with_types(bytes1, bytes2.clone(), CodeInfo::new(0, 0, 1025));
 
         // CALLF
         interp.step(&table, &mut host);
@@ -510,7 +510,7 @@ mod test {
         let bytes1 = Bytes::from([JUMPF, 0x00, 0x01]);
         let bytes2 = Bytes::from([STOP]);
         let mut interp =
-            eof_setup_with_types(bytes1, bytes2.clone(), TypesSection::new(0, 0, 1025));
+            eof_setup_with_types(bytes1, bytes2.clone(), CodeInfo::new(0, 0, 1025));
 
         // JUMPF
         interp.step(&table, &mut host);

--- a/crates/interpreter/src/interpreter/ext_bytecode.rs
+++ b/crates/interpreter/src/interpreter/ext_bytecode.rs
@@ -1,7 +1,7 @@
 use core::ops::Deref;
 
 use bytecode::{
-    eof::TypesSection,
+    eof::CodeInfo,
     utils::{read_i16, read_u16},
     Bytecode,
 };
@@ -147,10 +147,8 @@ impl Immediates for ExtBytecode {
 }
 
 impl EofCodeInfo for ExtBytecode {
-    fn code_section_info(&self, idx: usize) -> Option<&TypesSection> {
-        self.base
-            .eof()
-            .and_then(|eof| eof.body.types_section.get(idx))
+    fn code_info(&self, idx: usize) -> Option<&CodeInfo> {
+        self.base.eof().and_then(|eof| eof.body.code_info.get(idx))
     }
 
     fn code_section_pc(&self, idx: usize) -> Option<usize> {

--- a/crates/interpreter/src/interpreter_types.rs
+++ b/crates/interpreter/src/interpreter_types.rs
@@ -1,4 +1,4 @@
-use bytecode::eof::TypesSection;
+use bytecode::eof::CodeInfo;
 use specification::hardfork::SpecId;
 
 use crate::{Gas, InstructionResult, InterpreterAction};
@@ -96,7 +96,7 @@ pub trait SubRoutineStack {
     fn pop(&mut self) -> Option<usize>;
 
     // /// Returns code info from EOF body.
-    // fn eof_code_info(&self, idx: usize) -> Option<&TypesSection>;
+    // fn eof_code_info(&self, idx: usize) -> Option<&CodeInfo>;
 }
 
 pub trait StackTr {
@@ -172,7 +172,7 @@ pub trait EofData {
 
 pub trait EofCodeInfo {
     /// Returns code information containing stack information.
-    fn code_section_info(&self, idx: usize) -> Option<&TypesSection>;
+    fn code_info(&self, idx: usize) -> Option<&CodeInfo>;
 
     /// Returns program counter at the start of code section.
     fn code_section_pc(&self, idx: usize) -> Option<usize>;


### PR DESCRIPTION
EOF TypesSection renamed to CodeInfo to be more informative.
CodeType enum now has `Runtime` and `Initcode` values 

Docs for legacy and bytecode crate are updated.