### PR TITLE
chore: remove wrong `&mut`/`TODO`, and avoid useless `get_mut`

### DIFF
--- a/crates/optimism/src/handler.rs
+++ b/crates/optimism/src/handler.rs
@@ -369,7 +369,6 @@ where
             // Send the operator fee of the transaction to the coinbase.
             let mut operator_fee_vault_account =
                 evm.ctx().journal().load_account(OPERATOR_FEE_RECIPIENT)?;
-
             operator_fee_vault_account.mark_touch();
             operator_fee_vault_account.data.info.balance += operator_fee_cost;
         }


### PR DESCRIPTION
-  remove wrong `&mut`/`TODO`
- avoid useless `get_mut`
- delete empty file