### PR TITLE
chore: make OpEvm ContextSetters impl generic over precompiles

### DIFF
--- a/crates/optimism/src/evm.rs
+++ b/crates/optimism/src/evm.rs
@@ -26,7 +26,7 @@ impl<CTX: Host, INSP>
     }
 }
 
-impl<CTX: ContextSetters, INSP, I> ContextSetters for OpEvm<CTX, INSP, I> {
+impl<CTX: ContextSetters, INSP, I, P> ContextSetters for OpEvm<CTX, INSP, I, P> {
     type Tx = <CTX as ContextSetters>::Tx;
     type Block = <CTX as ContextSetters>::Block;
 


### PR DESCRIPTION
This was previously not generic, meaning we could not have this trait implementation with custom precompiles