### PR TITLE
feat: TryDatabaseCommit

### DIFF
--- a/crates/database/interface/src/lib.rs
+++ b/crates/database/interface/src/lib.rs
@@ -44,11 +44,15 @@ pub trait DatabaseCommit {
 }
 
 /// EVM database commit interface that can fail.
+///
+/// This is intended for use with types that may fail to commit changes, e.g.
+/// because they are directly interacting with the filesystem, or must arrange
+/// access to a shared resource.
 pub trait TryDatabaseCommit {
-    /// Error type to be thrown when state accumulation fails.
+    /// Error type for when [`TryDatabaseCommit::try_commit`] fails.
     type Error: core::error::Error;
 
-    /// Commit changes to the database.
+    /// Attempt to commit changes to the database.
     fn try_commit(&mut self, changes: HashMap<Address, Account>) -> Result<(), Self::Error>;
 }
 

--- a/crates/database/interface/src/try_commit.rs
+++ b/crates/database/interface/src/try_commit.rs
@@ -1,0 +1,58 @@
+use crate::DatabaseCommit;
+use core::{convert::Infallible, error::Error, fmt};
+use primitives::{Address, HashMap};
+use state::Account;
+use std::sync::Arc;
+
+/// EVM database commit interface that can fail.
+///
+/// This is intended for use with types that may fail to commit changes, e.g.
+/// because they are directly interacting with the filesystem, or must arrange
+/// access to a shared resource.
+pub trait TryDatabaseCommit {
+    /// Error type for when [`TryDatabaseCommit::try_commit`] fails.
+    type Error: Error;
+
+    /// Attempt to commit changes to the database.
+    fn try_commit(&mut self, changes: HashMap<Address, Account>) -> Result<(), Self::Error>;
+}
+
+impl<Db> TryDatabaseCommit for Db
+where
+    Db: DatabaseCommit,
+{
+    type Error = Infallible;
+
+    #[inline]
+    fn try_commit(&mut self, changes: HashMap<Address, Account>) -> Result<(), Self::Error> {
+        self.commit(changes);
+        Ok(())
+    }
+}
+
+/// Error type for implementation of [`TryDatabaseCommit`] on
+/// [`alloc::sync::Arc`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ArcUpgradeError;
+
+impl fmt::Display for ArcUpgradeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Arc reference is not unique, cannot mutate")
+    }
+}
+
+impl Error for ArcUpgradeError {}
+
+impl<Db> TryDatabaseCommit for Arc<Db>
+where
+    Db: DatabaseCommit + Send + Sync,
+{
+    type Error = ArcUpgradeError;
+
+    #[inline]
+    fn try_commit(&mut self, changes: HashMap<Address, Account>) -> Result<(), Self::Error> {
+        Arc::get_mut(self)
+            .map(|db| db.commit(changes))
+            .ok_or(ArcUpgradeError)
+    }
+}

--- a/crates/database/interface/src/try_commit.rs
+++ b/crates/database/interface/src/try_commit.rs
@@ -56,3 +56,29 @@ where
             .ok_or(ArcUpgradeError)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::DatabaseCommit;
+    use std::sync::Arc;
+
+    struct MockDb;
+
+    impl DatabaseCommit for MockDb {
+        fn commit(&mut self, _changes: HashMap<Address, Account>) {}
+    }
+
+    #[test]
+    fn arc_try_commit() {
+        let mut db = Arc::new(MockDb);
+        let db_2 = Arc::clone(&db);
+
+        assert_eq!(
+            db.try_commit(Default::default()).unwrap_err(),
+            ArcUpgradeError
+        );
+        drop(db_2);
+        db.try_commit(Default::default()).unwrap();
+    }
+}

--- a/crates/database/interface/src/try_commit.rs
+++ b/crates/database/interface/src/try_commit.rs
@@ -31,7 +31,7 @@ where
 }
 
 /// Error type for implementation of [`TryDatabaseCommit`] on
-/// [`alloc::sync::Arc`].
+/// [`Arc`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ArcUpgradeError;
 


### PR DESCRIPTION
Adds a fallible version of `DatabaseCommit`. Idea came up while working [on this PR](https://github.com/init4tech/trevm/pull/85)

Basically, this would allow (e.g.) `Arc<ConcurrentState<Db>>` to be used concurrently for read-access across any number of EVMs (sharing memory cache resources), and then allow `Commit` access to the `BundleState` if and only if you have discarded all-but-one `Arc`. This would enable easier parallel simulation in rounds much easier