### PR TITLE
refactor: add immutable gas API to LoopControl

### DIFF
--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -655,14 +655,20 @@ where
 
                 // Return unspend gas.
                 if ins_result.is_ok_or_revert() {
-                    interpreter.control.gas().erase_cost(out_gas.remaining());
+                    interpreter
+                        .control
+                        .gas_mut()
+                        .erase_cost(out_gas.remaining());
                     self.memory
                         .borrow_mut()
                         .set(mem_start, &interpreter.return_data.buffer()[..target_len]);
                 }
 
                 if ins_result.is_ok() {
-                    interpreter.control.gas().record_refund(out_gas.refunded());
+                    interpreter
+                        .control
+                        .gas_mut()
+                        .record_refund(out_gas.refunded());
                 }
             }
             FrameResult::Create(outcome) => {
@@ -684,7 +690,7 @@ where
                     "Fatal external error in insert_eofcreate_outcome"
                 );
 
-                let this_gas = interpreter.control.gas();
+                let this_gas = interpreter.control.gas_mut();
                 if instruction_result.is_ok_or_revert() {
                     this_gas.erase_cost(outcome.gas().remaining());
                 }
@@ -716,7 +722,7 @@ where
                     "Fatal external error in insert_eofcreate_outcome"
                 );
 
-                let this_gas = interpreter.control.gas();
+                let this_gas = interpreter.control.gas_mut();
                 if instruction_result.is_ok_or_revert() {
                     this_gas.erase_cost(outcome.gas().remaining());
                 }

--- a/crates/inspector/src/eip3155.rs
+++ b/crates/inspector/src/eip3155.rs
@@ -246,7 +246,7 @@ where
     }
 
     fn step_end(&mut self, interp: &mut Interpreter<INTR>, context: &mut CTX) {
-        self.gas_inspector.step_end(interp.control.gas());
+        self.gas_inspector.step_end(interp.control.gas_mut());
         if self.skip {
             self.skip = false;
             return;

--- a/crates/inspector/src/gas.rs
+++ b/crates/inspector/src/gas.rs
@@ -98,7 +98,7 @@ mod tests {
         }
 
         fn step_end(&mut self, interp: &mut Interpreter<INTR>, _context: &mut CTX) {
-            self.gas_inspector.step_end(interp.control.gas());
+            self.gas_inspector.step_end(interp.control.gas_mut());
             self.gas_remaining_steps
                 .push((self.pc, self.gas_inspector.gas_remaining()));
         }

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -201,10 +201,13 @@ pub fn sstore<WIRE: InterpreterTypes, H: Host + ?Sized>(
         )
     );
 
-    interpreter.control.gas().record_refund(gas::sstore_refund(
-        interpreter.runtime_flag.spec_id(),
-        &state_load.data,
-    ));
+    interpreter
+        .control
+        .gas_mut()
+        .record_refund(gas::sstore_refund(
+            interpreter.runtime_flag.spec_id(),
+            &state_load.data,
+        ));
 }
 
 /// EIP-1153: Transient storage opcodes
@@ -290,7 +293,10 @@ pub fn selfdestruct<WIRE: InterpreterTypes, H: Host + ?Sized>(
 
     // EIP-3529: Reduction in refunds
     if !interpreter.runtime_flag.spec_id().is_enabled_in(LONDON) && !res.previously_destroyed {
-        interpreter.control.gas().record_refund(gas::SELFDESTRUCT)
+        interpreter
+            .control
+            .gas_mut()
+            .record_refund(gas::SELFDESTRUCT)
     }
 
     gas!(

--- a/crates/interpreter/src/instructions/macros.rs
+++ b/crates/interpreter/src/instructions/macros.rs
@@ -71,7 +71,7 @@ macro_rules! gas {
         $crate::gas!($interpreter, $gas, ())
     };
     ($interpreter:expr, $gas:expr, $ret:expr) => {
-        if !$interpreter.control.gas().record_cost($gas) {
+        if !$interpreter.control.gas_mut().record_cost($gas) {
             $interpreter
                 .control
                 .set_instruction_result($crate::InstructionResult::OutOfGas);
@@ -110,7 +110,7 @@ macro_rules! resize_memory {
         let words_num = $crate::interpreter::num_words($offset.saturating_add($len));
         match $interpreter
             .control
-            .gas()
+            .gas_mut()
             .record_memory_expansion(words_num)
         {
             $crate::gas::MemoryExtensionResult::Extended => {

--- a/crates/interpreter/src/interpreter/loop_control.rs
+++ b/crates/interpreter/src/interpreter/loop_control.rs
@@ -40,7 +40,11 @@ impl LoopControlTr for LoopControl {
         self.instruction_result = result;
     }
 
-    fn gas(&mut self) -> &mut Gas {
+    fn gas(&self) -> &Gas {
+        &self.gas
+    }
+
+    fn gas_mut(&mut self) -> &mut Gas {
         &mut self.gas
     }
 

--- a/crates/interpreter/src/interpreter_types.rs
+++ b/crates/interpreter/src/interpreter_types.rs
@@ -186,7 +186,8 @@ pub trait ReturnData {
 pub trait LoopControl {
     fn set_instruction_result(&mut self, result: InstructionResult);
     fn set_next_action(&mut self, action: InterpreterAction, result: InstructionResult);
-    fn gas(&mut self) -> &mut Gas;
+    fn gas(&self) -> &Gas;
+    fn gas_mut(&mut self) -> &mut Gas;
     fn instruction_result(&self) -> InstructionResult;
     fn take_next_action(&mut self) -> InterpreterAction;
 }


### PR DESCRIPTION
This refactor allows borrowing either an immutable or mutable `Gas` for the `trait LoopControlTr`