### PR TITLE
feat: add constructor with hardfork

### DIFF
--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -76,28 +76,23 @@ impl CfgEnv {
 }
 
 impl<SPEC> CfgEnv<SPEC> {
-    pub fn with_chain_id(mut self, chain_id: u64) -> Self {
-        self.chain_id = chain_id;
-        self
-    }
-
-    pub fn with_spec<OSPEC: Into<SpecId>>(self, spec: OSPEC) -> CfgEnv<OSPEC> {
-        CfgEnv {
-            chain_id: self.chain_id,
-            limit_contract_code_size: self.limit_contract_code_size,
+    pub fn with_spec(spec: SPEC) -> Self {
+        Self {
+            chain_id: 1,
+            limit_contract_code_size: None,
             spec,
-            disable_nonce_check: self.disable_nonce_check,
-            blob_target_and_max_count: self.blob_target_and_max_count,
+            disable_nonce_check: false,
+            blob_target_and_max_count: vec![(SpecId::CANCUN, 3, 6), (SpecId::PRAGUE, 6, 9)],
             #[cfg(feature = "memory_limit")]
-            memory_limit: self.memory_limit,
+            memory_limit: (1 << 32) - 1,
             #[cfg(feature = "optional_balance_check")]
-            disable_balance_check: self.disable_balance_check,
+            disable_balance_check: false,
             #[cfg(feature = "optional_block_gas_limit")]
-            disable_block_gas_limit: self.disable_block_gas_limit,
+            disable_block_gas_limit: false,
             #[cfg(feature = "optional_eip3607")]
-            disable_eip3607: self.disable_eip3607,
+            disable_eip3607: false,
             #[cfg(feature = "optional_no_base_fee")]
-            disable_base_fee: self.disable_base_fee,
+            disable_base_fee: false,
         }
     }
 
@@ -184,23 +179,7 @@ impl<SPEC: Into<SpecId> + Copy> Cfg for CfgEnv<SPEC> {
 
 impl<SPEC: Default> Default for CfgEnv<SPEC> {
     fn default() -> Self {
-        Self {
-            chain_id: 1,
-            limit_contract_code_size: None,
-            spec: Default::default(),
-            disable_nonce_check: false,
-            blob_target_and_max_count: vec![(SpecId::CANCUN, 3, 6), (SpecId::PRAGUE, 6, 9)],
-            #[cfg(feature = "memory_limit")]
-            memory_limit: (1 << 32) - 1,
-            #[cfg(feature = "optional_balance_check")]
-            disable_balance_check: false,
-            #[cfg(feature = "optional_block_gas_limit")]
-            disable_block_gas_limit: false,
-            #[cfg(feature = "optional_eip3607")]
-            disable_eip3607: false,
-            #[cfg(feature = "optional_no_base_fee")]
-            disable_base_fee: false,
-        }
+        Self::with_spec(SPEC::default())
     }
 }
 

--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -76,7 +76,7 @@ impl CfgEnv {
 }
 
 impl<SPEC> CfgEnv<SPEC> {
-    pub fn with_spec(spec: SPEC) -> Self {
+    pub fn new_with_spec(spec: SPEC) -> Self {
         Self {
             chain_id: 1,
             limit_contract_code_size: None,
@@ -93,6 +93,31 @@ impl<SPEC> CfgEnv<SPEC> {
             disable_eip3607: false,
             #[cfg(feature = "optional_no_base_fee")]
             disable_base_fee: false,
+        }
+    }
+
+    pub fn with_chain_id(mut self, chain_id: u64) -> Self {
+        self.chain_id = chain_id;
+        self
+    }
+
+    pub fn with_spec<OSPEC: Into<SpecId>>(self, spec: OSPEC) -> CfgEnv<OSPEC> {
+        CfgEnv {
+            chain_id: self.chain_id,
+            limit_contract_code_size: self.limit_contract_code_size,
+            spec,
+            disable_nonce_check: self.disable_nonce_check,
+            blob_target_and_max_count: self.blob_target_and_max_count,
+            #[cfg(feature = "memory_limit")]
+            memory_limit: self.memory_limit,
+            #[cfg(feature = "optional_balance_check")]
+            disable_balance_check: self.disable_balance_check,
+            #[cfg(feature = "optional_block_gas_limit")]
+            disable_block_gas_limit: self.disable_block_gas_limit,
+            #[cfg(feature = "optional_eip3607")]
+            disable_eip3607: self.disable_eip3607,
+            #[cfg(feature = "optional_no_base_fee")]
+            disable_base_fee: self.disable_base_fee,
         }
     }
 
@@ -179,7 +204,7 @@ impl<SPEC: Into<SpecId> + Copy> Cfg for CfgEnv<SPEC> {
 
 impl<SPEC: Default> Default for CfgEnv<SPEC> {
     fn default() -> Self {
-        Self::with_spec(SPEC::default())
+        Self::new_with_spec(SPEC::default())
     }
 }
 

--- a/crates/optimism/src/api/default_ctx.rs
+++ b/crates/optimism/src/api/default_ctx.rs
@@ -29,7 +29,7 @@ impl DefaultOp
     fn op() -> Self {
         Context::mainnet()
             .with_tx(OpTransaction::default())
-            .with_cfg(CfgEnv::new().with_spec(OpSpecId::BEDROCK))
+            .with_cfg(CfgEnv::with_spec(OpSpecId::BEDROCK))
             .with_chain(L1BlockInfo::default())
     }
 }

--- a/crates/optimism/src/api/default_ctx.rs
+++ b/crates/optimism/src/api/default_ctx.rs
@@ -29,7 +29,7 @@ impl DefaultOp
     fn op() -> Self {
         Context::mainnet()
             .with_tx(OpTransaction::default())
-            .with_cfg(CfgEnv::with_spec(OpSpecId::BEDROCK))
+            .with_cfg(CfgEnv::new_with_spec(OpSpecId::BEDROCK))
             .with_chain(L1BlockInfo::default())
     }
 }


### PR DESCRIPTION
Introduces an API that allows construction of a `CfgEnv` with a `SpecId`. This is useful when using a `SpecId` type that doesn't implement `Default`.

The changes avoid duplication of default parameters by calling `with_spec` from `fn default`.