### PR TITLE
fix(op): Handler deposit tx halt, catch_error handle

### DIFF
--- a/crates/database/src/in_memory_db.rs
+++ b/crates/database/src/in_memory_db.rs
@@ -430,26 +430,28 @@ impl BenchmarkDB {
 /// BYTECODE address
 pub const FFADDRESS: Address = address!("ffffffffffffffffffffffffffffffffffffffff");
 pub const BENCH_TARGET: Address = FFADDRESS;
+pub const BENCH_TARGET_BALANCE: U256 = U256::from_limbs([10000000, 0, 0, 0]);
 /// CALLER address
 pub const EEADDRESS: Address = address!("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
 pub const BENCH_CALLER: Address = EEADDRESS;
+pub const BENCH_CALLER_BALANCE: U256 = U256::from_limbs([10000000, 0, 0, 0]);
 
 impl Database for BenchmarkDB {
     type Error = Infallible;
     /// Get basic account information.
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
-        if address == FFADDRESS {
+        if address == BENCH_TARGET {
             return Ok(Some(AccountInfo {
                 nonce: 1,
-                balance: U256::from(10000000),
+                balance: BENCH_TARGET_BALANCE,
                 code: Some(self.0.clone()),
                 code_hash: self.1,
             }));
         }
-        if address == EEADDRESS {
+        if address == BENCH_CALLER {
             return Ok(Some(AccountInfo {
                 nonce: 0,
-                balance: U256::from(10000000),
+                balance: BENCH_CALLER_BALANCE,
                 code: None,
                 code_hash: KECCAK_EMPTY,
             }));

--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -117,14 +117,14 @@ pub trait Handler {
         evm: &mut Self::Evm,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
         // run inner handler and catch all errors to handle cleanup.
-        match self.run_without_cache_error(evm) {
+        match self.run_without_catch_error(evm) {
             Ok(output) => Ok(output),
             Err(e) => self.catch_error(evm, e),
         }
     }
 
     #[inline]
-    fn run_without_cache_error(
+    fn run_without_catch_error(
         &mut self,
         evm: &mut Self::Evm,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {

--- a/crates/inspector/src/inspector.rs
+++ b/crates/inspector/src/inspector.rs
@@ -191,13 +191,13 @@ where
         &mut self,
         evm: &mut Self::Evm,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        match self.inspect_run_without_cache_error(evm) {
+        match self.inspect_run_without_catch_error(evm) {
             Ok(output) => Ok(output),
             Err(e) => self.catch_error(evm, e),
         }
     }
 
-    fn inspect_run_without_cache_error(
+    fn inspect_run_without_catch_error(
         &mut self,
         evm: &mut Self::Evm,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {

--- a/crates/inspector/src/inspector.rs
+++ b/crates/inspector/src/inspector.rs
@@ -191,6 +191,16 @@ where
         &mut self,
         evm: &mut Self::Evm,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
+        match self.inspect_run_without_cache_error(evm) {
+            Ok(output) => Ok(output),
+            Err(e) => self.catch_error(evm, e),
+        }
+    }
+
+    fn inspect_run_without_cache_error(
+        &mut self,
+        evm: &mut Self::Evm,
+    ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
         let init_and_floor_gas = self.validate(evm)?;
         let eip7702_refund = self.pre_execution(evm)? as i64;
         let exec_result = self.inspect_execution(evm, &init_and_floor_gas);

--- a/crates/optimism/src/evm.rs
+++ b/crates/optimism/src/evm.rs
@@ -78,11 +78,15 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{transaction::deposit::DEPOSIT_TRANSACTION_TYPE, DefaultOp, OpBuilder, OpSpecId};
+    use crate::{
+        transaction::deposit::DEPOSIT_TRANSACTION_TYPE, DefaultOp, OpBuilder, OpHaltReason,
+        OpSpecId,
+    };
     use database::{BenchmarkDB, BENCH_CALLER, BENCH_CALLER_BALANCE, BENCH_TARGET};
     use precompile::Address;
     use revm::{
         bytecode::opcode,
+        context::result::ExecutionResult,
         primitives::{TxKind, U256},
         state::Bytecode,
         Context, ExecuteEvm,
@@ -133,6 +137,13 @@ mod tests {
         let output = evm.transact_previous().unwrap();
 
         // balance should be 100 + previous balance
+        assert_eq!(
+            output.result,
+            ExecutionResult::Halt {
+                reason: OpHaltReason::FailedDeposit,
+                gas_used: 30_000_000
+            }
+        );
         assert_eq!(
             output.state.get(&BENCH_CALLER).map(|a| a.info.balance),
             Some(U256::from(100) + BENCH_CALLER_BALANCE)

--- a/crates/optimism/src/evm.rs
+++ b/crates/optimism/src/evm.rs
@@ -75,3 +75,67 @@ where
         (&mut self.0.data.ctx, &mut self.0.precompiles)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{transaction::deposit::DEPOSIT_TRANSACTION_TYPE, DefaultOp, OpBuilder, OpSpecId};
+    use database::{BenchmarkDB, BENCH_CALLER, BENCH_CALLER_BALANCE, BENCH_TARGET};
+    use precompile::Address;
+    use revm::{
+        bytecode::opcode,
+        primitives::{TxKind, U256},
+        state::Bytecode,
+        Context, ExecuteEvm,
+    };
+
+    #[test]
+    fn test_deposit_tx() {
+        let ctx = Context::op()
+            .modify_tx_chained(|tx| {
+                tx.enveloped_tx = None;
+                tx.deposit.mint = Some(100);
+                tx.base.tx_type = DEPOSIT_TRANSACTION_TYPE;
+            })
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::HOLOCENE);
+
+        let mut evm = ctx.build_op();
+
+        let output = evm.transact_previous().unwrap();
+
+        // balance should be 100
+        assert_eq!(
+            output
+                .state
+                .get(&Address::default())
+                .map(|a| a.info.balance),
+            Some(U256::from(100))
+        );
+    }
+
+    #[test]
+    fn test_halted_deposit_tx() {
+        let ctx = Context::op()
+            .modify_tx_chained(|tx| {
+                tx.enveloped_tx = None;
+                tx.deposit.mint = Some(100);
+                tx.base.tx_type = DEPOSIT_TRANSACTION_TYPE;
+                tx.base.caller = BENCH_CALLER;
+                tx.base.kind = TxKind::Call(BENCH_TARGET);
+            })
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::HOLOCENE)
+            .with_db(BenchmarkDB::new_bytecode(Bytecode::new_legacy(
+                [opcode::POP].into(),
+            )));
+
+        // POP would return a halt.
+        let mut evm = ctx.build_op();
+
+        let output = evm.transact_previous().unwrap();
+
+        // balance should be 100 + previous balance
+        assert_eq!(
+            output.state.get(&BENCH_CALLER).map(|a| a.info.balance),
+            Some(U256::from(100) + BENCH_CALLER_BALANCE)
+        );
+    }
+}

--- a/crates/optimism/src/handler.rs
+++ b/crates/optimism/src/handler.rs
@@ -387,6 +387,7 @@ where
                 return Err(ERROR::from(OpTransactionError::HaltedDepositPostRegolith));
             }
         }
+        evm.ctx().chain().clear_tx_l1_cost();
         Ok(result)
     }
 


### PR DESCRIPTION
Fixes optimism case where deposit is experiencing a halt in execution, this case would still need to trigger minting of balance.

Added tests for deposit tx and halted deposit tx.

Additionally removed clear and end handlers and introduced `catch_error` that would clear inconsistent state or in optimism case handle deposit tx error.