### PR TITLE
feat: Standalone Host, remove default fn from context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3302,7 +3302,6 @@ dependencies = [
  "revm-context-interface",
  "revm-database",
  "revm-database-interface",
- "revm-interpreter",
  "revm-primitives",
  "revm-specification",
  "revm-state",

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -23,18 +23,17 @@ all = "warn"
 
 [dependencies]
 # revm
-interpreter.workspace = true
 context-interface.workspace = true
 primitives.workspace = true
 database-interface.workspace = true
 state.workspace = true
 specification.workspace = true
 bytecode.workspace = true
-auto_impl.workspace = true
 
 # misc
 derive-where.workspace = true
 cfg-if.workspace = true
+auto_impl.workspace = true
 
 # Optional
 serde = { workspace = true, features = ["derive", "rc"], optional = true }

--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -1,7 +1,6 @@
 pub use context_interface::Cfg;
 
-use interpreter::MAX_CODE_SIZE;
-use specification::hardfork::SpecId;
+use specification::{eip170::MAX_CODE_SIZE, hardfork::SpecId};
 use std::{vec, vec::Vec};
 
 /// EVM configuration

--- a/crates/context/src/journaled_state.rs
+++ b/crates/context/src/journaled_state.rs
@@ -1,9 +1,9 @@
-use bytecode::{Bytecode, EOF_MAGIC_BYTES, EOF_MAGIC_HASH};
+use bytecode::Bytecode;
 use context_interface::journaled_state::{AccountLoad, Journal, JournalCheckpoint, TransferError};
 use database_interface::Database;
 use interpreter::{SStoreResult, SelfDestructResult, StateLoad};
 use primitives::{
-    hash_map::Entry, Address, Bytes, HashMap, HashSet, Log, B256, KECCAK_EMPTY, PRECOMPILE3, U256,
+    hash_map::Entry, Address, HashMap, HashSet, Log, B256, KECCAK_EMPTY, PRECOMPILE3, U256,
 };
 use specification::hardfork::{SpecId, SpecId::*};
 use state::{Account, EvmState, EvmStorageSlot, TransientStorage};
@@ -142,20 +142,6 @@ impl<DB: Database> Journal for JournaledState<DB> {
 
     fn set_spec_id(&mut self, spec_id: SpecId) {
         self.spec = spec_id;
-    }
-
-    fn code(
-        &mut self,
-        address: Address,
-    ) -> Result<StateLoad<primitives::Bytes>, <Self::Database as Database>::Error> {
-        self.code(address)
-    }
-
-    fn code_hash(
-        &mut self,
-        address: Address,
-    ) -> Result<StateLoad<B256>, <Self::Database as Database>::Error> {
-        self.code_hash(address)
     }
 
     fn transfer(
@@ -415,49 +401,6 @@ impl<DB: Database> JournaledState<DB> {
             });
 
         Ok(None)
-    }
-
-    /// Returns account code bytes and if address is cold loaded.
-    ///
-    /// In case of EOF account it will return `EOF_MAGIC` (0xEF00) as code.
-    #[inline]
-    pub fn code(&mut self, address: Address) -> Result<StateLoad<Bytes>, <DB as Database>::Error> {
-        let a = self.load_account_code(address)?;
-        // SAFETY: Safe to unwrap as load_code will insert code if it is empty.
-        let code = a.info.code.as_ref().unwrap();
-
-        let code = if code.is_eof() {
-            EOF_MAGIC_BYTES.clone()
-        } else {
-            code.original_bytes()
-        };
-
-        Ok(StateLoad::new(code, a.is_cold))
-    }
-
-    /// Gets code hash of address.
-    ///
-    /// In case of EOF account it will return `EOF_MAGIC_HASH`
-    /// (the hash of `0xEF00`).
-    #[inline]
-    pub fn code_hash(
-        &mut self,
-        address: Address,
-    ) -> Result<StateLoad<B256>, <DB as Database>::Error> {
-        let acc = self.load_account_code(address)?;
-        if acc.is_empty() {
-            return Ok(StateLoad::new(B256::ZERO, acc.is_cold));
-        }
-        // SAFETY: Safe to unwrap as load_code will insert code if it is empty.
-        let code = acc.info.code.as_ref().unwrap();
-
-        let hash = if code.is_eof() {
-            EOF_MAGIC_HASH
-        } else {
-            acc.info.code_hash
-        };
-
-        Ok(StateLoad::new(hash, acc.is_cold))
     }
 
     /// Creates account or returns false if collision is detected.

--- a/crates/context/src/journaled_state.rs
+++ b/crates/context/src/journaled_state.rs
@@ -1,7 +1,9 @@
 use bytecode::Bytecode;
-use context_interface::journaled_state::{AccountLoad, Journal, JournalCheckpoint, TransferError};
+use context_interface::{
+    context::{SStoreResult, SelfDestructResult, StateLoad},
+    journaled_state::{AccountLoad, Journal, JournalCheckpoint, TransferError},
+};
 use database_interface::Database;
-use interpreter::{SStoreResult, SelfDestructResult, StateLoad};
 use primitives::{
     hash_map::Entry, Address, HashMap, HashSet, Log, B256, KECCAK_EMPTY, PRECOMPILE3, U256,
 };

--- a/crates/interpreter/src/host.rs
+++ b/crates/interpreter/src/host.rs
@@ -1,28 +1,34 @@
 use context_interface::{
     context::{ContextTr, SStoreResult, SelfDestructResult, StateLoad},
     journaled_state::AccountLoad,
-    Block, Cfg, Database, Journal, Transaction,
+    Block, Cfg, Database, Journal, Transaction, TransactionType,
 };
-use primitives::{Address, Bytes, Log, B256, U256};
+use primitives::{Address, Bytes, Log, B256, BLOCK_HASH_HISTORY, U256};
 
-/// Host trait with all methods that can be called by the Interpreter.
+use crate::instructions::utility::IntoU256;
+
+/// Host trait with all methods are needed by the Interpreter.
 ///
 /// This trait is implemented for all types that have `ContextTr` trait.
 pub trait Host {
     /* Block */
     fn basefee(&self) -> U256;
-    fn blob_basefee(&self) -> U256;
+    fn blob_gasprice(&self) -> U256;
     fn gas_limit(&self) -> U256;
     fn difficulty(&self) -> U256;
-    fn block_number(&self) -> U256;
+    fn prevrandao(&self) -> Option<U256>;
+    fn block_number(&self) -> u64;
     fn timestamp(&self) -> U256;
     fn beneficiary(&self) -> Address;
     fn chain_id(&self) -> U256;
 
     /* Transaction */
-    fn gas_price(&self) -> U256;
+    fn effective_gas_price(&self) -> U256;
     fn caller(&self) -> Address;
     fn blob_hash(&self, number: usize) -> Option<U256>;
+
+    /* Config */
+    fn max_initcode_size(&self) -> usize;
 
     /* State */
     fn block_hash(&mut self, number: u64) -> Option<B256>;
@@ -39,20 +45,23 @@ pub trait Host {
         key: U256,
         value: U256,
     ) -> Option<StateLoad<SStoreResult>>;
+    fn balance(&mut self, address: Address) -> Option<StateLoad<U256>>;
     fn sload(&mut self, address: Address, key: U256) -> Option<StateLoad<U256>>;
     fn tstore(&mut self, address: Address, key: U256, value: U256);
     fn tload(&mut self, address: Address, key: U256) -> U256;
-    fn load_account_delegated(&mut self, address: Address) -> Option<AccountLoad>;
-    fn load_account_code(&mut self, address: Address) -> Option<Bytes>;
-    fn load_account_code_hash(&mut self, address: Address) -> Option<B256>;
+    fn load_account_delegated(&mut self, address: Address) -> Option<StateLoad<AccountLoad>>;
+    fn load_account_code(&mut self, address: Address) -> Option<StateLoad<Bytes>>;
+    fn load_account_code_hash(&mut self, address: Address) -> Option<StateLoad<B256>>;
 }
 
 impl<CTX: ContextTr> Host for CTX {
+    /* Block */
+
     fn basefee(&self) -> U256 {
         U256::from(self.block().basefee())
     }
 
-    fn blob_basefee(&self) -> U256 {
+    fn blob_gasprice(&self) -> U256 {
         U256::from(self.block().blob_gasprice().unwrap_or(0))
     }
 
@@ -64,8 +73,12 @@ impl<CTX: ContextTr> Host for CTX {
         self.block().difficulty()
     }
 
-    fn block_number(&self) -> U256 {
-        U256::from(self.block().number())
+    fn prevrandao(&self) -> Option<U256> {
+        self.block().prevrandao().map(|r| r.into_u256())
+    }
+
+    fn block_number(&self) -> u64 {
+        self.block().number()
     }
 
     fn timestamp(&self) -> U256 {
@@ -80,54 +93,154 @@ impl<CTX: ContextTr> Host for CTX {
         U256::from(self.cfg().chain_id())
     }
 
-    fn gas_price(&self) -> U256 {
-        U256::from(self.tx().gas_price())
+    fn effective_gas_price(&self) -> U256 {
+        let basefee = self.block().basefee();
+        U256::from(self.tx().effective_gas_price(basefee as u128))
     }
 
     fn caller(&self) -> Address {
         self.tx().caller()
     }
 
+    /* Transaction */
+
     fn blob_hash(&self, number: usize) -> Option<U256> {
-        self.tx()
-            .blob_versioned_hashes()
+        let tx = &self.tx();
+        if tx.tx_type() != TransactionType::Eip4844 {
+            return None;
+        }
+        tx.blob_versioned_hashes()
             .get(number)
-            .map(|b| U256::from_be_bytes(b.0))
+            .map(|t| U256::from_be_bytes(t.0))
     }
 
-    fn block_hash(&mut self, number: u64) -> Option<B256> {
+    /* Config */
+
+    fn max_initcode_size(&self) -> usize {
+        self.cfg().max_code_size().saturating_mul(2)
+    }
+
+    /* State */
+
+    fn block_hash(&mut self, requested_number: u64) -> Option<B256> {
+        let block_number = self.block().number();
+
+        let Some(diff) = block_number.checked_sub(requested_number) else {
+            return Some(B256::ZERO);
+        };
+
+        // blockhash should push zero if number is same as current block number.
+        if diff == 0 {
+            return Some(B256::ZERO);
+        }
+
+        if diff <= BLOCK_HASH_HISTORY {
+            return self
+                .journal()
+                .db()
+                .block_hash(requested_number)
+                .map_err(|e| {
+                    *self.error() = Err(e);
+                })
+                .ok();
+        }
+
+        Some(B256::ZERO)
+    }
+
+    fn load_account_delegated(&mut self, address: Address) -> Option<StateLoad<AccountLoad>> {
         self.journal()
-            .db()
-            .block_hash(number)
+            .load_account_delegated(address)
             .map_err(|e| {
                 *self.error() = Err(e);
-                ()
             })
             .ok()
     }
 
+    /// Gets balance of `address` and if the account is cold.
+    fn balance(&mut self, address: Address) -> Option<StateLoad<U256>> {
+        self.journal()
+            .load_account(address)
+            .map(|acc| acc.map(|a| a.info.balance))
+            .map_err(|e| {
+                *self.error() = Err(e);
+            })
+            .ok()
+    }
+
+    /// Gets code of `address` and if the account is cold.
+    fn load_account_code(&mut self, address: Address) -> Option<StateLoad<Bytes>> {
+        self.journal()
+            .code(address)
+            .map_err(|e| {
+                *self.error() = Err(e);
+            })
+            .ok()
+    }
+
+    /// Gets code hash of `address` and if the account is cold.
+    fn load_account_code_hash(&mut self, address: Address) -> Option<StateLoad<B256>> {
+        self.journal()
+            .code_hash(address)
+            .map_err(|e| {
+                *self.error() = Err(e);
+            })
+            .ok()
+    }
+
+    /// Gets storage value of `address` at `index` and if the account is cold.
+    fn sload(&mut self, address: Address, index: U256) -> Option<StateLoad<U256>> {
+        self.journal()
+            .sload(address, index)
+            .map_err(|e| {
+                *self.error() = Err(e);
+            })
+            .ok()
+    }
+
+    /// Sets storage value of account address at index.
+    ///
+    /// Returns [`StateLoad`] with [`SStoreResult`] that contains original/new/old storage value.
+    fn sstore(
+        &mut self,
+        address: Address,
+        index: U256,
+        value: U256,
+    ) -> Option<StateLoad<SStoreResult>> {
+        self.journal()
+            .sstore(address, index, value)
+            .map_err(|e| {
+                *self.error() = Err(e);
+            })
+            .ok()
+    }
+
+    /// Gets the transient storage value of `address` at `index`.
+    fn tload(&mut self, address: Address, index: U256) -> U256 {
+        self.journal().tload(address, index)
+    }
+
+    /// Sets the transient storage value of `address` at `index`.
+    fn tstore(&mut self, address: Address, index: U256, value: U256) {
+        self.journal().tstore(address, index, value)
+    }
+
+    /// Emits a log owned by `address` with given `LogData`.
+    fn log(&mut self, log: Log) {
+        self.journal().log(log);
+    }
+
+    /// Marks `address` to be deleted, with funds transferred to `target`.
     fn selfdestruct(
         &mut self,
         address: Address,
         target: Address,
     ) -> Option<StateLoad<SelfDestructResult>> {
-        self.journal().selfdestruct(address, target)
-    }
-
-    fn selfdestruct_result(&mut self) -> Option<StateLoad<SelfDestructResult>> {
-        self.journal().selfdestruct_result()
-    }
-
-    fn log(&mut self, log: Log) {
-        self.journal().log(log)
-    }
-
-    fn sstore(
-        &mut self,
-        address: Address,
-        key: U256,
-        value: U256,
-    ) -> Option<StateLoad<SStoreResult>> {
-        self.journal().sstore(address, key, value)
+        self.journal()
+            .selfdestruct(address, target)
+            .map_err(|e| {
+                *self.error() = Err(e);
+            })
+            .ok()
     }
 }

--- a/crates/interpreter/src/host.rs
+++ b/crates/interpreter/src/host.rs
@@ -1,0 +1,133 @@
+use context_interface::{
+    context::{ContextTr, SStoreResult, SelfDestructResult, StateLoad},
+    journaled_state::AccountLoad,
+    Block, Cfg, Database, Journal, Transaction,
+};
+use primitives::{Address, Bytes, Log, B256, U256};
+
+/// Host trait with all methods that can be called by the Interpreter.
+///
+/// This trait is implemented for all types that have `ContextTr` trait.
+pub trait Host {
+    /* Block */
+    fn basefee(&self) -> U256;
+    fn blob_basefee(&self) -> U256;
+    fn gas_limit(&self) -> U256;
+    fn difficulty(&self) -> U256;
+    fn block_number(&self) -> U256;
+    fn timestamp(&self) -> U256;
+    fn beneficiary(&self) -> Address;
+    fn chain_id(&self) -> U256;
+
+    /* Transaction */
+    fn gas_price(&self) -> U256;
+    fn caller(&self) -> Address;
+    fn blob_hash(&self, number: usize) -> Option<U256>;
+
+    /* State */
+    fn block_hash(&mut self, number: u64) -> Option<B256>;
+    fn selfdestruct(
+        &mut self,
+        address: Address,
+        target: Address,
+    ) -> Option<StateLoad<SelfDestructResult>>;
+
+    fn log(&mut self, log: Log);
+    fn sstore(
+        &mut self,
+        address: Address,
+        key: U256,
+        value: U256,
+    ) -> Option<StateLoad<SStoreResult>>;
+    fn sload(&mut self, address: Address, key: U256) -> Option<StateLoad<U256>>;
+    fn tstore(&mut self, address: Address, key: U256, value: U256);
+    fn tload(&mut self, address: Address, key: U256) -> U256;
+    fn load_account_delegated(&mut self, address: Address) -> Option<AccountLoad>;
+    fn load_account_code(&mut self, address: Address) -> Option<Bytes>;
+    fn load_account_code_hash(&mut self, address: Address) -> Option<B256>;
+}
+
+impl<CTX: ContextTr> Host for CTX {
+    fn basefee(&self) -> U256 {
+        U256::from(self.block().basefee())
+    }
+
+    fn blob_basefee(&self) -> U256 {
+        U256::from(self.block().blob_gasprice().unwrap_or(0))
+    }
+
+    fn gas_limit(&self) -> U256 {
+        U256::from(self.block().gas_limit())
+    }
+
+    fn difficulty(&self) -> U256 {
+        self.block().difficulty()
+    }
+
+    fn block_number(&self) -> U256 {
+        U256::from(self.block().number())
+    }
+
+    fn timestamp(&self) -> U256 {
+        U256::from(self.block().timestamp())
+    }
+
+    fn beneficiary(&self) -> Address {
+        self.block().beneficiary()
+    }
+
+    fn chain_id(&self) -> U256 {
+        U256::from(self.cfg().chain_id())
+    }
+
+    fn gas_price(&self) -> U256 {
+        U256::from(self.tx().gas_price())
+    }
+
+    fn caller(&self) -> Address {
+        self.tx().caller()
+    }
+
+    fn blob_hash(&self, number: usize) -> Option<U256> {
+        self.tx()
+            .blob_versioned_hashes()
+            .get(number)
+            .map(|b| U256::from_be_bytes(b.0))
+    }
+
+    fn block_hash(&mut self, number: u64) -> Option<B256> {
+        self.journal()
+            .db()
+            .block_hash(number)
+            .map_err(|e| {
+                *self.error() = Err(e);
+                ()
+            })
+            .ok()
+    }
+
+    fn selfdestruct(
+        &mut self,
+        address: Address,
+        target: Address,
+    ) -> Option<StateLoad<SelfDestructResult>> {
+        self.journal().selfdestruct(address, target)
+    }
+
+    fn selfdestruct_result(&mut self) -> Option<StateLoad<SelfDestructResult>> {
+        self.journal().selfdestruct_result()
+    }
+
+    fn log(&mut self, log: Log) {
+        self.journal().log(log)
+    }
+
+    fn sstore(
+        &mut self,
+        address: Address,
+        key: U256,
+        value: U256,
+    ) -> Option<StateLoad<SStoreResult>> {
+        self.journal().sstore(address, key, value)
+    }
+}

--- a/crates/interpreter/src/instructions/block_info.rs
+++ b/crates/interpreter/src/instructions/block_info.rs
@@ -1,11 +1,9 @@
 use crate::{
     gas,
-    instructions::utility::IntoU256,
     interpreter::Interpreter,
     interpreter_types::{InterpreterTypes, LoopControl, RuntimeFlag, StackTr},
     Host,
 };
-use context_interface::{Block, Cfg};
 use primitives::U256;
 use specification::hardfork::SpecId::*;
 
@@ -16,7 +14,7 @@ pub fn chainid<WIRE: InterpreterTypes, H: Host + ?Sized>(
 ) {
     check!(interpreter, ISTANBUL);
     gas!(interpreter, gas::BASE);
-    push!(interpreter, U256::from(host.cfg().chain_id()));
+    push!(interpreter, U256::from(host.chain_id()));
 }
 
 pub fn coinbase<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -24,7 +22,7 @@ pub fn coinbase<WIRE: InterpreterTypes, H: Host + ?Sized>(
     host: &mut H,
 ) {
     gas!(interpreter, gas::BASE);
-    push!(interpreter, host.block().beneficiary().into_word().into());
+    push!(interpreter, host.beneficiary().into_word().into());
 }
 
 pub fn timestamp<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -32,7 +30,7 @@ pub fn timestamp<WIRE: InterpreterTypes, H: Host + ?Sized>(
     host: &mut H,
 ) {
     gas!(interpreter, gas::BASE);
-    push!(interpreter, U256::from(host.block().timestamp()));
+    push!(interpreter, U256::from(host.timestamp()));
 }
 
 pub fn block_number<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -40,7 +38,7 @@ pub fn block_number<WIRE: InterpreterTypes, H: Host + ?Sized>(
     host: &mut H,
 ) {
     gas!(interpreter, gas::BASE);
-    push!(interpreter, U256::from(host.block().number()));
+    push!(interpreter, U256::from(host.block_number()));
 }
 
 pub fn difficulty<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -50,12 +48,9 @@ pub fn difficulty<WIRE: InterpreterTypes, H: Host + ?Sized>(
     gas!(interpreter, gas::BASE);
     if interpreter.runtime_flag.spec_id().is_enabled_in(MERGE) {
         // Unwrap is safe as this fields is checked in validation handler.
-        push!(
-            interpreter,
-            (host.block().prevrandao().unwrap()).into_u256()
-        );
+        push!(interpreter, host.prevrandao().unwrap());
     } else {
-        push!(interpreter, host.block().difficulty());
+        push!(interpreter, host.difficulty());
     }
 }
 
@@ -64,7 +59,7 @@ pub fn gaslimit<WIRE: InterpreterTypes, H: Host + ?Sized>(
     host: &mut H,
 ) {
     gas!(interpreter, gas::BASE);
-    push!(interpreter, U256::from(host.block().gas_limit()));
+    push!(interpreter, U256::from(host.gas_limit()));
 }
 
 /// EIP-3198: BASEFEE opcode
@@ -74,7 +69,7 @@ pub fn basefee<WIRE: InterpreterTypes, H: Host + ?Sized>(
 ) {
     check!(interpreter, LONDON);
     gas!(interpreter, gas::BASE);
-    push!(interpreter, U256::from(host.block().basefee()));
+    push!(interpreter, U256::from(host.basefee()));
 }
 
 /// EIP-7516: BLOBBASEFEE opcode
@@ -84,8 +79,5 @@ pub fn blob_basefee<WIRE: InterpreterTypes, H: Host + ?Sized>(
 ) {
     check!(interpreter, CANCUN);
     gas!(interpreter, gas::BASE);
-    push!(
-        interpreter,
-        U256::from(host.block().blob_gasprice().unwrap_or_default())
-    );
+    push!(interpreter, U256::from(host.blob_gasprice()));
 }

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -87,7 +87,7 @@ impl<EXT, MG: MemoryGetter> InterpreterTypes for EthInterpreter<EXT, MG> {
     type Extend = EXT;
 }
 
-impl<IW: InterpreterTypes, H: Host> CustomInstruction for Instruction<IW, H> {
+impl<IW: InterpreterTypes, H: Host + ?Sized> CustomInstruction for Instruction<IW, H> {
     type Wire = IW;
     type Host = H;
 
@@ -107,7 +107,7 @@ impl<IW: InterpreterTypes> Interpreter<IW> {
     ///
     /// Internally it will increment instruction pointer by one.
     #[inline]
-    pub(crate) fn step<H: Host>(
+    pub(crate) fn step<H: Host + ?Sized>(
         &mut self,
         instruction_table: &[Instruction<IW, H>; 256],
         host: &mut H,
@@ -148,7 +148,7 @@ impl<IW: InterpreterTypes> Interpreter<IW> {
     }
 
     /// Executes the interpreter until it returns or stops.
-    pub fn run_plain<H: Host>(
+    pub fn run_plain<H: Host + ?Sized>(
         &mut self,
         instruction_table: &InstructionTable<IW, H>,
         host: &mut H,

--- a/crates/interpreter/src/lib.rs
+++ b/crates/interpreter/src/lib.rs
@@ -43,5 +43,5 @@ pub use interpreter_action::{
     EOFCreateKind, FrameInput, InterpreterAction,
 };
 pub use interpreter_types::InterpreterTypes;
-pub use specification::constants::{MAX_CODE_SIZE, MAX_INITCODE_SIZE};
+pub use specification::{constants::MAX_INITCODE_SIZE, eip170::MAX_CODE_SIZE};
 pub use table::Instruction;

--- a/crates/interpreter/src/lib.rs
+++ b/crates/interpreter/src/lib.rs
@@ -24,6 +24,7 @@ pub mod interpreter;
 pub mod interpreter_action;
 pub mod interpreter_types;
 pub mod table;
+pub mod host;
 
 // Reexport primary types.
 pub use context_interface::{

--- a/crates/interpreter/src/lib.rs
+++ b/crates/interpreter/src/lib.rs
@@ -18,20 +18,21 @@ use serde_json as _;
 use walkdir as _;
 
 pub mod gas;
+pub mod host;
 mod instruction_result;
 pub mod instructions;
 pub mod interpreter;
 pub mod interpreter_action;
 pub mod interpreter_types;
 pub mod table;
-pub mod host;
 
 // Reexport primary types.
 pub use context_interface::{
     context::{SStoreResult, SelfDestructResult, StateLoad},
-    ContextTr as Host, CreateScheme,
+    CreateScheme,
 };
 pub use gas::{Gas, InitialAndFloorGas};
+pub use host::Host;
 pub use instruction_result::*;
 pub use interpreter::{
     num_words, InputsImpl, Interpreter, InterpreterResult, MemoryGetter, SharedMemory, Stack,

--- a/crates/interpreter/src/table.rs
+++ b/crates/interpreter/src/table.rs
@@ -19,7 +19,7 @@ pub type CustomInstructionTable<IT> = [IT; 256];
 
 pub trait CustomInstruction {
     type Wire: InterpreterTypes;
-    type Host;
+    type Host: ?Sized;
 
     fn exec(&self, interpreter: &mut Interpreter<Self::Wire>, host: &mut Self::Host);
 

--- a/crates/specification/src/constants.rs
+++ b/crates/specification/src/constants.rs
@@ -1,15 +1,12 @@
+use super::eip170;
+
 /// EVM interpreter stack limit
 pub const STACK_LIMIT: usize = 1024;
-
-/// EIP-170: Contract code size limit
-///
-/// By default the limit is `0x6000` (~25kb)
-pub const MAX_CODE_SIZE: usize = 0x6000;
 
 /// EIP-3860: Limit and meter initcode
 ///
 /// Limit of maximum initcode size is `2 * MAX_CODE_SIZE`.
-pub const MAX_INITCODE_SIZE: usize = 2 * MAX_CODE_SIZE;
+pub const MAX_INITCODE_SIZE: usize = 2 * eip170::MAX_CODE_SIZE;
 
 /// EVM call stack limit
 pub const CALL_STACK_LIMIT: u64 = 1024;


### PR DESCRIPTION
Standalone host traits fully decouples `ContextTr` from `Interpreter` and allows easier usage of Interpreter as a standalone component. 

Additionally, this PR does a cleanup from previous https://github.com/bluealloy/revm/pull/2112