### PR TITLE
fix: use correct HashMap import

### DIFF
--- a/crates/database/src/in_memory_db.rs
+++ b/crates/database/src/in_memory_db.rs
@@ -1,10 +1,6 @@
 use core::convert::Infallible;
 use database_interface::{Database, DatabaseCommit, DatabaseRef, EmptyDB};
-use primitives::{
-    address,
-    hash_map::{Entry, HashMap},
-    Address, Log, B256, KECCAK_EMPTY, U256,
-};
+use primitives::{address, hash_map::Entry, Address, HashMap, Log, B256, KECCAK_EMPTY, U256};
 use state::{Account, AccountInfo, Bytecode};
 use std::vec::Vec;
 

--- a/crates/database/src/in_memory_db.rs
+++ b/crates/database/src/in_memory_db.rs
@@ -28,7 +28,7 @@ pub struct Cache {
 
 impl Default for Cache {
     fn default() -> Self {
-        let mut contracts = HashMap::new();
+        let mut contracts = HashMap::default();
         contracts.insert(KECCAK_EMPTY, Bytecode::default());
         contracts.insert(B256::ZERO, Bytecode::default());
 

--- a/crates/optimism/src/handler.rs
+++ b/crates/optimism/src/handler.rs
@@ -23,7 +23,7 @@ use revm::{
         Frame, FrameResult, Handler, MainnetHandler,
     },
     interpreter::{interpreter::EthInterpreter, FrameInput, Gas},
-    primitives::{hash_map::HashMap, U256},
+    primitives::{HashMap, U256},
     specification::hardfork::SpecId,
     state::{Account, EvmState},
     Database,


### PR DESCRIPTION
we should always use `primitives::HashMap` vs `primitives::hash_map::HashMap` as `hash_map::HashMap` might have different default hasher generic

this was changed in https://github.com/bluealloy/revm/pull/2131