### PR TITLE
fix: relax jumptable len check

### DIFF
--- a/crates/bytecode/src/legacy/analyzed.rs
+++ b/crates/bytecode/src/legacy/analyzed.rs
@@ -123,11 +123,6 @@ mod tests {
     fn test_bytecode_new() {
         let bytecode = Bytes::from_static(&[opcode::PUSH1, 0x01]);
         let bytecode = LegacyRawBytecode(bytecode).into_analyzed();
-        println!(
-            "bytecode: {:?} jump_table.len(): {:?}",
-            bytecode.bytecode.len(),
-            bytecode.jump_table.0.len()
-        );
         let _ = LegacyAnalyzedBytecode::new(
             bytecode.bytecode,
             bytecode.original_len,

--- a/crates/bytecode/src/legacy/analyzed.rs
+++ b/crates/bytecode/src/legacy/analyzed.rs
@@ -62,7 +62,7 @@ impl LegacyAnalyzedBytecode {
         if original_len > bytecode.len() {
             panic!("original_len is greater than bytecode length");
         }
-        if jump_table.0.len() != bytecode.len() {
+        if original_len > jump_table.0.len()  {
             panic!(
                 "jump table length {} is not equal to bytecode length {}",
                 jump_table.0.len(),
@@ -123,6 +123,11 @@ mod tests {
     fn test_bytecode_new() {
         let bytecode = Bytes::from_static(&[opcode::PUSH1, 0x01]);
         let bytecode = LegacyRawBytecode(bytecode).into_analyzed();
+        println!(
+            "bytecode: {:?} jump_table.len(): {:?}",
+            bytecode.bytecode.len(),
+            bytecode.jump_table.0.len()
+        );
         let _ = LegacyAnalyzedBytecode::new(
             bytecode.bytecode,
             bytecode.original_len,

--- a/crates/bytecode/src/legacy/analyzed.rs
+++ b/crates/bytecode/src/legacy/analyzed.rs
@@ -62,11 +62,11 @@ impl LegacyAnalyzedBytecode {
         if original_len > bytecode.len() {
             panic!("original_len is greater than bytecode length");
         }
-        if original_len > jump_table.0.len()  {
+        if original_len > jump_table.0.len() {
             panic!(
-                "jump table length {} is not equal to bytecode length {}",
+                "jump table length {} is less than original length {}",
                 jump_table.0.len(),
-                bytecode.len()
+                original_len
             );
         }
 
@@ -139,11 +139,11 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "jump table length 34 is not equal to bytecode length 35")]
-    fn test_panic_on_custom_jump_table() {
+    #[should_panic(expected = "jump table length 1 is less than original length 2")]
+    fn test_panic_on_short_jump_table() {
         let bytecode = Bytes::from_static(&[opcode::PUSH1, 0x01]);
         let bytecode = LegacyRawBytecode(bytecode).into_analyzed();
-        let jump_table = JumpTable(Arc::new(bitvec![u8, Lsb0; 0; 34]));
+        let jump_table = JumpTable(Arc::new(bitvec![u8, Lsb0; 0; 1]));
         let _ = LegacyAnalyzedBytecode::new(bytecode.bytecode, bytecode.original_len, jump_table);
     }
 


### PR DESCRIPTION
as jumptable is saved to the next byte, and loaded with new length, checking exact len with bytecode can be problematic. This check was relaxed so that only bytes that are at least the size of the original length will be accepted.