### PR TITLE
chore: fix minor typo in the comment of `TransactionType` enum

### DIFF
--- a/crates/context/interface/src/transaction/transaction_type.rs
+++ b/crates/context/interface/src/transaction/transaction_type.rs
@@ -13,7 +13,7 @@ pub enum TransactionType {
     Eip4844,
     /// EIP-7702 Set EOA account code transaction type
     Eip7702,
-    /// Custom type means that transaction trait was extend and have custom types
+    /// Custom type means that the transaction trait was extended and has custom types
     Custom,
 }
 


### PR DESCRIPTION
I’ve fixed a typos in the comment for the `TransactionType` enum. The original phrase "was extend" has been corrected to "was extended", and "have" has been changed to "has" to match the singular subject ("transaction trait").

Thanks