### PR TITLE
fix: pre EIP-7702 does not need to load code

### DIFF
--- a/crates/context/src/journaled_state.rs
+++ b/crates/context/src/journaled_state.rs
@@ -643,7 +643,8 @@ impl<DB: Database, ENTRY: JournalEntryTr> Journal<DB, ENTRY> {
         address: Address,
     ) -> Result<StateLoad<AccountLoad>, DB::Error> {
         let spec = self.spec;
-        let account = self.load_code(address)?;
+        let is_eip7702_enabled = spec.is_enabled_in(SpecId::PRAGUE);
+        let account = self.load_account_optional(address, is_eip7702_enabled)?;
         let is_empty = account.state_clear_aware_is_empty(spec);
 
         let mut account_load = StateLoad::new(


### PR DESCRIPTION
Prior to the activation of EIP-7702, the gas calculation for a transaction did not require the target account bytecode if an out of gas error was immediately determined. Thus, transactions failing instantly due to OOG did not necessitate bytecode availability.
Stateless witness provided via `debug_executionWitness `  like Geth won't include such bytecode causing revm reports this as an error.