### PR TITLE
fix: correctly propagate features

### DIFF
--- a/.config/zepter.yaml
+++ b/.config/zepter.yaml
@@ -1,0 +1,36 @@
+version:
+  format: 1
+  # Minimum zepter version that is expected to work. This is just for printing a nice error
+  # message when someone tries to use an older version.
+  binary: 0.13.2
+
+# The examples in the following comments assume crate `A` to have a dependency on crate `B`.
+workflows:
+  check:
+    - [
+        "lint",
+        # Check that `A` activates the features of `B`.
+        "propagate-feature",
+        # These are the features to check:
+        "--features=std,serde",
+        # Do not try to add a new section into `[features]` of `A` only because `B` expose that feature. There are edge-cases where this is still needed, but we can add them manually.
+        "--left-side-feature-missing=ignore",
+        # Ignore the case that `A` it outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.
+        "--left-side-outside-workspace=ignore",
+        "--show-path",
+        "--quiet",
+      ]
+  default:
+    # Running `zepter` with no subcommand will check & fix.
+    - [$check.0, "--fix"]
+
+# Will be displayed when any workflow fails:
+help:
+  text: |
+    Revm uses the Zepter CLI to detect abnormalities in Cargo features, e.g. missing propagation.
+
+    It looks like one more checks failed; please check the console output.
+
+    You can try to automatically address them by installing zepter (`cargo install zepter --locked`) and simply running `zepter` in the workspace root.
+  links:
+    - "https://github.com/ggwpez/zepter"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,18 @@ jobs:
         with:
           components: rustfmt
       - run: cargo fmt --all --check
+  
+  # Check crates correctly propagate features
+  feature-propagation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: run zepter
+        run: |
+          cargo install zepter -f --locked
+          zepter --version
+          time zepter run check
 
   typos-check:
     name: TyposCheck

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2862,6 +2862,7 @@ checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
  "phf_shared",
+ "serde",
 ]
 
 [[package]]

--- a/crates/bytecode/Cargo.toml
+++ b/crates/bytecode/Cargo.toml
@@ -37,8 +37,18 @@ phf = { workspace = true, features = ["macros"], optional = true }
 
 [features]
 default = ["std", "parse"]
-std = ["serde?/std", "primitives/std"]
+std = [
+	"serde?/std",
+	"primitives/std",
+	"bitvec/std",
+	"phf?/std"
+]
 hashbrown = ["primitives/hashbrown"]
-serde = ["dep:serde", "primitives/serde", "bitvec/serde"]
+serde = [
+	"dep:serde",
+	"primitives/serde",
+	"bitvec/serde",
+	"phf?/serde"
+]
 serde-json = ["serde"]
 parse = ["phf", "paste"]

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -42,12 +42,23 @@ database.workspace = true
 
 [features]
 default = ["std"]
-std = ["serde?/std"]
+std = [
+	"serde?/std",
+	"bytecode/std",
+	"context-interface/std",
+	"database/std",
+	"database-interface/std",
+	"primitives/std",
+	"state/std"
+]
 serde = [
-    "dep:serde",
-    "primitives/serde",
-    "state/serde",
-    "context-interface/serde",
+	"dep:serde",
+	"primitives/serde",
+	"state/serde",
+	"context-interface/serde",
+	"bytecode/serde",
+	"database/serde",
+	"database-interface/serde"
 ]
 dev = [
     "memory_limit",

--- a/crates/context/interface/Cargo.toml
+++ b/crates/context/interface/Cargo.toml
@@ -40,12 +40,20 @@ serde = { version = "1.0", default-features = false, features = [
 
 [features]
 default = ["std"]
-std = ["serde?/std", "alloy-eip7702/std", "alloy-eip2930/std"]
+std = [
+	"serde?/std",
+	"alloy-eip7702/std",
+	"alloy-eip2930/std",
+	"database-interface/std",
+	"primitives/std",
+	"state/std"
+]
 serde = [
-    "dep:serde",
-    "primitives/serde",
-    "state/serde",
-    "alloy-eip7702/serde",
-    "alloy-eip2930/serde",
+	"dep:serde",
+	"primitives/serde",
+	"state/serde",
+	"alloy-eip7702/serde",
+	"alloy-eip2930/serde",
+	"database-interface/serde"
 ]
 serde-json = ["serde"]

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -50,8 +50,24 @@ alloy-sol-types.workspace = true
 
 [features]
 default = ["std"]
-std = ["serde?/std"]
-serde = ["dep:serde"]
+std = [
+	"serde?/std",
+	"alloy-eips?/std",
+	"alloy-sol-types/std",
+	"bytecode/std",
+	"database-interface/std",
+	"primitives/std",
+	"state/std",
+	"serde_json/std"
+]
+serde = [
+	"dep:serde",
+	"alloy-eips?/serde",
+	"bytecode/serde",
+	"database-interface/serde",
+	"primitives/serde",
+	"state/serde"
+]
 alloydb = [
     "std",
     "database-interface/asyncdb",

--- a/crates/database/interface/Cargo.toml
+++ b/crates/database/interface/Cargo.toml
@@ -43,6 +43,15 @@ alloy-sol-types.workspace = true
 
 [features]
 default = ["std"]
-std = ["serde?/std"]
-serde = ["dep:serde"]
+std = [
+	"serde?/std",
+	"alloy-sol-types/std",
+	"primitives/std",
+	"state/std"
+]
+serde = [
+	"dep:serde",
+	"primitives/serde",
+	"state/serde"
+]
 asyncdb = ["dep:tokio"]

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -48,11 +48,29 @@ alloy-signer-local.workspace = true
 
 [features]
 default = ["std"]
-std = ["serde?/std"]
+std = [
+	"serde?/std",
+	"alloy-eip7702/std",
+	"bytecode/std",
+	"context/std",
+	"context-interface/std",
+	"database/std",
+	"database-interface/std",
+	"interpreter/std",
+	"precompile/std",
+	"primitives/std",
+	"state/std"
+]
 serde = [
-    "dep:serde",
-    "primitives/serde",
-    "state/serde",
-    "context-interface/serde",
+	"dep:serde",
+	"primitives/serde",
+	"state/serde",
+	"context-interface/serde",
+	"alloy-eip7702/serde",
+	"bytecode/serde",
+	"context/serde",
+	"database/serde",
+	"database-interface/serde",
+	"interpreter/serde"
 ]
 serde-json = ["serde"]

--- a/crates/inspector/Cargo.toml
+++ b/crates/inspector/Cargo.toml
@@ -43,6 +43,27 @@ database = { workspace = true, features = ["serde"] }
 [features]
 default = ["std"]
 # Preserve order of json field
-std = ["serde?/std", "serde_json?/std", "serde_json?/preserve_order"]
-serde = ["dep:serde", "database/serde"]
+std = [
+	"serde?/std",
+	"serde_json?/std",
+	"serde_json?/preserve_order",
+	"context/std",
+	"database/std",
+	"database-interface/std",
+	"handler/std",
+	"interpreter/std",
+	"precompile/std",
+	"primitives/std",
+	"state/std"
+]
+serde = [
+	"dep:serde",
+	"database/serde",
+	"context/serde",
+	"database-interface/serde",
+	"handler/serde",
+	"interpreter/serde",
+	"primitives/serde",
+	"state/serde"
+]
 serde-json = ["serde", "dep:serde_json"]

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -37,13 +37,20 @@ bincode.workspace = true
 
 [features]
 default = ["std"]
-std = ["serde?/std", "primitives/std", "context-interface/std"]
+std = [
+	"serde?/std",
+	"primitives/std",
+	"context-interface/std",
+	"bytecode/std",
+	"database-interface/std"
+]
 hashbrown = ["primitives/hashbrown"]
 serde = [
-    "dep:serde",
-    "primitives/serde",
-    "bytecode/serde",
-    "context-interface/serde",
+	"dep:serde",
+	"primitives/serde",
+	"bytecode/serde",
+	"context-interface/serde",
+	"database-interface/serde"
 ]
 arbitrary = ["std", "primitives/arbitrary"]
 # TODO : Should be set from Context or from crate that consumes this PR.

--- a/crates/optimism/Cargo.toml
+++ b/crates/optimism/Cargo.toml
@@ -40,7 +40,12 @@ alloy-sol-types.workspace = true
 
 [features]
 default = ["std", "c-kzg", "secp256k1", "portable", "blst"]
-std = ["serde?/std", "revm/std"]
+std = [
+	"serde?/std",
+	"revm/std",
+	"alloy-sol-types/std",
+	"once_cell/std"
+]
 hashbrown = ["revm/hashbrown"]
 serde = ["dep:serde", "revm/serde"]
 portable = ["revm/portable"]

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -80,14 +80,19 @@ serde_derive.workspace = true
 [features]
 default = ["std", "c-kzg", "secp256k1", "portable", "blst"]
 std = [
-    "primitives/std",
-    "k256/std",
-    "once_cell/std",
-    "ripemd/std",
-    "sha2/std",
-    "c-kzg?/std",
-    "secp256k1?/std",
-    "libsecp256k1?/std",
+	"primitives/std",
+	"k256/std",
+	"once_cell/std",
+	"ripemd/std",
+	"sha2/std",
+	"c-kzg?/std",
+	"secp256k1?/std",
+	"libsecp256k1?/std",
+	"aurora-engine-modexp/std",
+	"p256?/std",
+	"context-interface/std",
+	"serde/std",
+	"serde_json/std"
 ]
 hashbrown = ["primitives/hashbrown"]
 asm-keccak = ["primitives/asm-keccak"]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -34,7 +34,10 @@ serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
 [features]
 default = ["std"]
-std = ["alloy-primitives/std"]
+std = [
+	"alloy-primitives/std",
+	"serde?/std"
+]
 serde = ["dep:serde", "alloy-primitives/serde"]
 
 hashbrown = ["alloy-primitives/map-hashbrown"]

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -39,20 +39,30 @@ handler.workspace = true
 [features]
 default = ["std", "c-kzg", "secp256k1", "portable", "blst"]
 std = [
-    "interpreter/std",
-    "precompile/std",
-    "handler/std",
-    "context/std",
-    "context-interface/std",
+	"interpreter/std",
+	"precompile/std",
+	"handler/std",
+	"context/std",
+	"context-interface/std",
+	"bytecode/std",
+	"database/std",
+	"database-interface/std",
+	"inspector/std",
+	"primitives/std",
+	"state/std"
 ]
 hashbrown = ["interpreter/hashbrown", "precompile/hashbrown"]
 serde = [
-    "interpreter/serde",
-    "database-interface/serde",
-    "primitives/serde",
-    "handler/serde",
-    "context-interface/serde",
-    "inspector/serde",
+	"interpreter/serde",
+	"database-interface/serde",
+	"primitives/serde",
+	"handler/serde",
+	"context-interface/serde",
+	"inspector/serde",
+	"bytecode/serde",
+	"context/serde",
+	"database/serde",
+	"state/serde"
 ]
 arbitrary = ["primitives/arbitrary"]
 asm-keccak = ["primitives/asm-keccak"]

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -34,5 +34,10 @@ serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
 [features]
 default = ["std"]
-std = ["serde?/std", "primitives/std"]
+std = [
+	"serde?/std",
+	"primitives/std",
+	"bitflags/std",
+	"bytecode/std"
+]
 serde = ["dep:serde", "primitives/serde", "bitflags/serde", "bytecode/serde"]


### PR DESCRIPTION
Right now `std` and `serde` are not always correctly propagated. This PR fixes it and adds `zepter` CI job checking features propagation as we do in alloy and reth