### PR TITLE
refactor: remove CTX phantomdata from precompile providers

### DIFF
--- a/crates/handler/src/evm.rs
+++ b/crates/handler/src/evm.rs
@@ -123,7 +123,7 @@ impl<CTX, INSP, PRECOMPILES> ExecuteEvm
     for Evm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, PRECOMPILES>
 where
     CTX: ContextSetters + ContextTr<Journal: JournalTr<FinalOutput = JournalOutput>>,
-    PRECOMPILES: PrecompileProvider<Context = CTX, Output = InterpreterResult>,
+    PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
     type Output = Result<
         ResultAndState<HaltReason>,
@@ -141,7 +141,7 @@ impl<CTX, INSP, PRECOMPILES> ExecuteCommitEvm
 where
     CTX: ContextSetters
         + ContextTr<Journal: JournalTr<FinalOutput = JournalOutput>, Db: DatabaseCommit>,
-    PRECOMPILES: PrecompileProvider<Context = CTX, Output = InterpreterResult>,
+    PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
     type CommitOutput = Result<
         ExecutionResult<HaltReason>,

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -74,7 +74,7 @@ pub struct EthFrame<EVM, ERROR, IW: InterpreterTypes> {
 impl<EVM, ERROR> Frame for EthFrame<EVM, ERROR, EthInterpreter>
 where
     EVM: EvmTr<
-        Precompiles: PrecompileProvider<Context = EVM::Context, Output = InterpreterResult>,
+        Precompiles: PrecompileProvider<EVM::Context, Output = InterpreterResult>,
         Instructions: InstructionProvider<
             Context = EVM::Context,
             InterpreterTypes = EthInterpreter,
@@ -146,7 +146,7 @@ impl<EVM, ERROR> EthFrame<EVM, ERROR, EthInterpreter>
 where
     EVM: EvmTr<
         Context: ContextTr,
-        Precompiles: PrecompileProvider<Context = EVM::Context, Output = InterpreterResult>,
+        Precompiles: PrecompileProvider<EVM::Context, Output = InterpreterResult>,
         Instructions: InstructionProvider,
     >,
     ERROR: From<ContextTrDbError<EVM::Context>> + From<PrecompileError>,
@@ -514,7 +514,7 @@ impl<EVM, ERROR> EthFrame<EVM, ERROR, EthInterpreter>
 where
     EVM: EvmTr<
         Context: ContextTr,
-        Precompiles: PrecompileProvider<Context = EVM::Context, Output = InterpreterResult>,
+        Precompiles: PrecompileProvider<EVM::Context, Output = InterpreterResult>,
         Instructions: InstructionProvider<
             Context = EVM::Context,
             InterpreterTypes = EthInterpreter,

--- a/crates/handler/src/mainnet_builder.rs
+++ b/crates/handler/src/mainnet_builder.rs
@@ -6,7 +6,7 @@ use interpreter::interpreter::EthInterpreter;
 use primitives::hardfork::SpecId;
 
 pub type MainnetEvm<CTX, INSP = ()> =
-    Evm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, EthPrecompiles<CTX>>;
+    Evm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, EthPrecompiles>;
 
 pub type MainnetContext<DB> = Context<BlockEnv, TxEnv, CfgEnv, DB, Journal<DB>, ()>;
 

--- a/crates/inspector/src/mainnet_inspect.rs
+++ b/crates/inspector/src/mainnet_inspect.rs
@@ -29,7 +29,7 @@ impl<CTX, INSP, PRECOMPILES> InspectEvm
 where
     CTX: ContextSetters + ContextTr<Journal: JournalTr<FinalOutput = JournalOutput> + JournalExt>,
     INSP: Inspector<CTX, EthInterpreter>,
-    PRECOMPILES: PrecompileProvider<Context = CTX, Output = InterpreterResult>,
+    PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
     type Inspector = INSP;
 
@@ -52,7 +52,7 @@ where
     CTX: ContextSetters
         + ContextTr<Journal: JournalTr<FinalOutput = JournalOutput> + JournalExt, Db: DatabaseCommit>,
     INSP: Inspector<CTX, EthInterpreter>,
-    PRECOMPILES: PrecompileProvider<Context = CTX, Output = InterpreterResult>,
+    PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
     fn inspect_commit_previous(&mut self) -> Self::CommitOutput {
         self.inspect_previous().map(|r| {

--- a/crates/inspector/src/traits.rs
+++ b/crates/inspector/src/traits.rs
@@ -80,7 +80,7 @@ impl<EVM, ERROR> InspectorFrame for EthFrame<EVM, ERROR, EthInterpreter>
 where
     EVM: EvmTr<
             Context: ContextTr,
-            Precompiles: PrecompileProvider<Context = EVM::Context, Output = InterpreterResult>,
+            Precompiles: PrecompileProvider<EVM::Context, Output = InterpreterResult>,
             Instructions: InstructionProvider<
                 Context = EVM::Context,
                 InterpreterTypes = EthInterpreter,

--- a/crates/optimism/src/api/exec.rs
+++ b/crates/optimism/src/api/exec.rs
@@ -42,7 +42,7 @@ impl<CTX, INSP, PRECOMPILE> ExecuteEvm
     for OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, PRECOMPILE>
 where
     CTX: OpContextTr,
-    PRECOMPILE: PrecompileProvider<Context = CTX, Output = InterpreterResult>,
+    PRECOMPILE: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
     type Output = Result<ResultAndState<OpHaltReason>, OpError<CTX>>;
 
@@ -56,7 +56,7 @@ impl<CTX, INSP, PRECOMPILE> ExecuteCommitEvm
     for OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, PRECOMPILE>
 where
     CTX: OpContextTr<Db: DatabaseCommit>,
-    PRECOMPILE: PrecompileProvider<Context = CTX, Output = InterpreterResult>,
+    PRECOMPILE: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
     type CommitOutput = Result<ExecutionResult<OpHaltReason>, OpError<CTX>>;
 
@@ -73,7 +73,7 @@ impl<CTX, INSP, PRECOMPILE> InspectEvm
 where
     CTX: OpContextTr<Journal: JournalExt>,
     INSP: Inspector<CTX, EthInterpreter>,
-    PRECOMPILE: PrecompileProvider<Context = CTX, Output = InterpreterResult>,
+    PRECOMPILE: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
     type Inspector = INSP;
 
@@ -92,7 +92,7 @@ impl<CTX, INSP, PRECOMPILE> InspectCommitEvm
 where
     CTX: OpContextTr<Journal: JournalExt, Db: DatabaseCommit>,
     INSP: Inspector<CTX, EthInterpreter>,
-    PRECOMPILE: PrecompileProvider<Context = CTX, Output = InterpreterResult>,
+    PRECOMPILE: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
     fn inspect_commit_previous(&mut self) -> Self::CommitOutput {
         self.inspect_previous().map(|r| {

--- a/crates/optimism/src/evm.rs
+++ b/crates/optimism/src/evm.rs
@@ -1,4 +1,4 @@
-use crate::precompiles::OpPrecompileProvider;
+use crate::precompiles::OpPrecompiles;
 use revm::{
     context::{setters::ContextSetters, Evm, EvmData},
     context_interface::ContextTr,
@@ -11,18 +11,16 @@ use revm::{
     },
 };
 
-pub struct OpEvm<CTX, INSP, I = EthInstructions<EthInterpreter, CTX>, P = OpPrecompileProvider<CTX>>(
+pub struct OpEvm<CTX, INSP, I = EthInstructions<EthInterpreter, CTX>, P = OpPrecompiles>(
     pub Evm<CTX, INSP, I, P>,
 );
 
-impl<CTX: Host, INSP>
-    OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, OpPrecompileProvider<CTX>>
-{
+impl<CTX: Host, INSP> OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, OpPrecompiles> {
     pub fn new(ctx: CTX, inspector: INSP) -> Self {
         Self(Evm {
             data: EvmData { ctx, inspector },
             instruction: EthInstructions::new_mainnet(),
-            precompiles: OpPrecompileProvider::default(),
+            precompiles: OpPrecompiles::default(),
         })
     }
 }

--- a/examples/erc20_gas/src/exec.rs
+++ b/examples/erc20_gas/src/exec.rs
@@ -19,7 +19,7 @@ pub fn transact_erc20evm<EVM>(
 where
     EVM: EvmTr<
         Context: ContextTr<Journal: JournalTr<FinalOutput = JournalOutput>>,
-        Precompiles: PrecompileProvider<Context = EVM::Context, Output = InterpreterResult>,
+        Precompiles: PrecompileProvider<EVM::Context, Output = InterpreterResult>,
         Instructions: InstructionProvider<
             Context = EVM::Context,
             InterpreterTypes = EthInterpreter,
@@ -35,7 +35,7 @@ pub fn transact_erc20evm_commit<EVM>(
 where
     EVM: EvmTr<
         Context: ContextTr<Journal: JournalTr<FinalOutput = JournalOutput>, Db: DatabaseCommit>,
-        Precompiles: PrecompileProvider<Context = EVM::Context, Output = InterpreterResult>,
+        Precompiles: PrecompileProvider<EVM::Context, Output = InterpreterResult>,
         Instructions: InstructionProvider<
             Context = EVM::Context,
             InterpreterTypes = EthInterpreter,


### PR DESCRIPTION
Right now `EthPrecompiles` and `OpPrecompileProvider` have a CTX generic and PhantomData. This is not neccesarry and is sometimes bad because we can't reuse the same provider object for different databases.

The PR adds `CTX` generic to `PrecompileProvider` trait instead and removes phantomdatas from those types.

Also, `OpPrecompileProvider` is renamed to `OpPrecompiles` to follow eth naming