### PR TITLE
fix: remove wrong Clone Trait in WrapDatabaseRef

### DIFF
--- a/crates/database/interface/src/lib.rs
+++ b/crates/database/interface/src/lib.rs
@@ -82,7 +82,7 @@ pub trait DatabaseRef {
 }
 
 /// Wraps a [`DatabaseRef`] to provide a [`Database`] implementation.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WrapDatabaseRef<T: DatabaseRef>(pub T);
 
 impl<F: DatabaseRef> From<F> for WrapDatabaseRef<F> {

--- a/crates/inspector/src/eip3155.rs
+++ b/crates/inspector/src/eip3155.rs
@@ -266,11 +266,8 @@ where
             mem_size: self.mem_size as u64,
 
             op_name: OpCode::new(self.opcode).map(|i| i.as_str()),
-            error: if !interp.control.instruction_result().is_ok() {
-                Some(format!("{:?}", interp.control.instruction_result()))
-            } else {
-                None
-            },
+            error: (!interp.control.instruction_result().is_ok())
+                .then(|| format!("{:?}", interp.control.instruction_result())),
             memory: self.memory.take(),
             storage: None,
             return_stack: None,


### PR DESCRIPTION
 Removed the `Copy` traits from the `WrapDatabaseRef` struct's derive attributes.

`WrapDatabaseRef` shouldn't own `Copy` traits.