### PR TITLE
refactor: rename rem to mod_op to match EVM opcode

### DIFF
--- a/crates/interpreter/src/instructions.rs
+++ b/crates/interpreter/src/instructions.rs
@@ -36,7 +36,7 @@ pub const fn instruction_table<WIRE: InterpreterTypes, H: Host + ?Sized>(
     table[SUB as usize] = arithmetic::sub;
     table[DIV as usize] = arithmetic::div;
     table[SDIV as usize] = arithmetic::sdiv;
-    table[MOD as usize] = arithmetic::rem;
+    table[MOD as usize] = arithmetic::mod_op;
     table[SMOD as usize] = arithmetic::smod;
     table[ADDMOD as usize] = arithmetic::addmod;
     table[MULMOD as usize] = arithmetic::mulmod;

--- a/crates/interpreter/src/instructions/arithmetic.rs
+++ b/crates/interpreter/src/instructions/arithmetic.rs
@@ -54,7 +54,7 @@ pub fn sdiv<WIRE: InterpreterTypes, H: Host + ?Sized>(
     *op2 = i256_div(op1, *op2);
 }
 
-pub fn rem<WIRE: InterpreterTypes, H: Host + ?Sized>(
+pub fn mod_op<WIRE: InterpreterTypes, H: Host + ?Sized>(
     interpreter: &mut Interpreter<WIRE>,
     _host: &mut H,
 ) {


### PR DESCRIPTION
Rename arithmetic::rem function to mod_op to better align with the MOD opcode name in EVM.

Changes:
- Rename rem -> mod_op in arithmetic.rs
- Update corresponding reference in instruction table