### PR TITLE
refactor: bubble up PrecompileError

### DIFF
--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -14,6 +14,7 @@ use revm::{
         Cfg,
     },
     database_interface::EmptyDB,
+    precompile::PrecompileError,
     primitives::{
         eip4844::TARGET_BLOB_GAS_PER_BLOCK_CANCUN, hardfork::SpecId, keccak256, Bytes, TxKind, B256,
     },
@@ -138,7 +139,10 @@ fn check_evm_execution(
     test: &Test,
     expected_output: Option<&Bytes>,
     test_name: &str,
-    exec_result: &Result<ExecutionResult<HaltReason>, EVMError<Infallible, InvalidTransaction>>,
+    exec_result: &Result<
+        ExecutionResult<HaltReason>,
+        EVMError<Infallible, PrecompileError, InvalidTransaction>,
+    >,
     db: &mut State<EmptyDB>,
     spec: SpecId,
     print_json_outcome: bool,

--- a/crates/handler/src/evm.rs
+++ b/crates/handler/src/evm.rs
@@ -13,6 +13,7 @@ use interpreter::{
     interpreter::EthInterpreter, Interpreter, InterpreterAction, InterpreterResult,
     InterpreterTypes,
 };
+use precompile::PrecompileError;
 
 /// Main trait that combines the context, instructions and precompiles and allows execution of interpreter.
 #[auto_impl(&mut, Box)]
@@ -127,7 +128,7 @@ where
 {
     type Output = Result<
         ResultAndState<HaltReason>,
-        EVMError<<CTX::Db as Database>::Error, InvalidTransaction>,
+        EVMError<<CTX::Db as Database>::Error, PrecompileError, InvalidTransaction>,
     >;
 
     fn replay(&mut self) -> Self::Output {
@@ -145,7 +146,7 @@ where
 {
     type CommitOutput = Result<
         ExecutionResult<HaltReason>,
-        EVMError<<CTX::Db as Database>::Error, InvalidTransaction>,
+        EVMError<<CTX::Db as Database>::Error, PrecompileError, InvalidTransaction>,
     >;
 
     fn replay_commit(&mut self) -> Self::CommitOutput {

--- a/crates/optimism/src/api/exec.rs
+++ b/crates/optimism/src/api/exec.rs
@@ -11,6 +11,7 @@ use revm::{
     handler::{instructions::EthInstructions, EthFrame, EvmTr, Handler, PrecompileProvider},
     inspector::{InspectCommitEvm, InspectEvm, Inspector, InspectorHandler, JournalExt},
     interpreter::{interpreter::EthInterpreter, InterpreterResult},
+    precompile::PrecompileError,
     DatabaseCommit, ExecuteCommitEvm, ExecuteEvm,
 };
 
@@ -36,7 +37,8 @@ impl<T> OpContextTr for T where
 }
 
 /// Type alias for the error type of the OpEvm.
-type OpError<CTX> = EVMError<<<CTX as ContextTr>::Db as Database>::Error, OpTransactionError>;
+type OpError<CTX> =
+    EVMError<<<CTX as ContextTr>::Db as Database>::Error, PrecompileError, OpTransactionError>;
 
 impl<CTX, INSP, PRECOMPILE> ExecuteEvm
     for OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, PRECOMPILE>

--- a/crates/optimism/src/handler.rs
+++ b/crates/optimism/src/handler.rs
@@ -19,8 +19,7 @@ use revm::{
     },
     inspector::{Inspector, InspectorEvmTr, InspectorFrame, InspectorHandler},
     interpreter::{interpreter::EthInterpreter, FrameInput, Gas},
-    primitives::hardfork::SpecId,
-    primitives::{HashMap, U256},
+    primitives::{hardfork::SpecId, HashMap, U256},
     state::Account,
     Database,
 };
@@ -49,7 +48,7 @@ pub trait IsTxError {
     fn is_tx_error(&self) -> bool;
 }
 
-impl<DB, TX> IsTxError for EVMError<DB, TX> {
+impl<DB, PRECOMPILE, TX> IsTxError for EVMError<DB, PRECOMPILE, TX> {
     fn is_tx_error(&self) -> bool {
         matches!(self, EVMError::Transaction(_))
     }
@@ -479,6 +478,7 @@ mod tests {
         database_interface::EmptyDB,
         handler::EthFrame,
         interpreter::{CallOutcome, InstructionResult, InterpreterResult},
+        precompile::PrecompileError,
         primitives::{bytes, Address, Bytes, B256},
         state::AccountInfo,
     };
@@ -501,7 +501,11 @@ mod tests {
             0..0,
         ));
 
-        let handler = OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<_, _, _>>::new();
+        let handler = OpHandler::<
+            _,
+            EVMError<_, PrecompileError, OpTransactionError>,
+            EthFrame<_, _, _>,
+        >::new();
 
         handler
             .last_frame_result(&mut evm, &mut exec_result)
@@ -609,7 +613,11 @@ mod tests {
 
         let mut evm = ctx.build_op();
 
-        let handler = OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<_, _, _>>::new();
+        let handler = OpHandler::<
+            _,
+            EVMError<_, PrecompileError, OpTransactionError>,
+            EthFrame<_, _, _>,
+        >::new();
         handler.deduct_caller(&mut evm).unwrap();
 
         // Check the account balance is updated.
@@ -647,7 +655,11 @@ mod tests {
 
         let mut evm = ctx.build_op();
 
-        let handler = OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<_, _, _>>::new();
+        let handler = OpHandler::<
+            _,
+            EVMError<_, PrecompileError, OpTransactionError>,
+            EthFrame<_, _, _>,
+        >::new();
         handler.deduct_caller(&mut evm).unwrap();
 
         // Check the account balance is updated.
@@ -682,7 +694,11 @@ mod tests {
             });
 
         let mut evm = ctx.build_op();
-        let handler = OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<_, _, _>>::new();
+        let handler = OpHandler::<
+            _,
+            EVMError<_, PrecompileError, OpTransactionError>,
+            EthFrame<_, _, _>,
+        >::new();
 
         // l1block cost is 1048 fee.
         handler.deduct_caller(&mut evm).unwrap();
@@ -717,7 +733,11 @@ mod tests {
             });
 
         let mut evm = ctx.build_op();
-        let handler = OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<_, _, _>>::new();
+        let handler = OpHandler::<
+            _,
+            EVMError<_, PrecompileError, OpTransactionError>,
+            EthFrame<_, _, _>,
+        >::new();
 
         // operator fee cost is operator_fee_scalar * gas_limit / 1e6 + operator_fee_constant
         // 10_000_000 * 10 / 1_000_000 + 50 = 150
@@ -754,7 +774,11 @@ mod tests {
 
         // l1block cost is 1048 fee.
         let mut evm = ctx.build_op();
-        let handler = OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<_, _, _>>::new();
+        let handler = OpHandler::<
+            _,
+            EVMError<_, PrecompileError, OpTransactionError>,
+            EthFrame<_, _, _>,
+        >::new();
 
         // l1block cost is 1048 fee.
         assert_eq!(
@@ -780,7 +804,11 @@ mod tests {
             .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::REGOLITH);
 
         let mut evm = ctx.build_op();
-        let handler = OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<_, _, _>>::new();
+        let handler = OpHandler::<
+            _,
+            EVMError<_, PrecompileError, OpTransactionError>,
+            EthFrame<_, _, _>,
+        >::new();
 
         assert_eq!(
             handler.validate_env(&mut evm),
@@ -806,7 +834,11 @@ mod tests {
             .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::REGOLITH);
 
         let mut evm = ctx.build_op();
-        let handler = OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<_, _, _>>::new();
+        let handler = OpHandler::<
+            _,
+            EVMError<_, PrecompileError, OpTransactionError>,
+            EthFrame<_, _, _>,
+        >::new();
 
         assert!(handler.validate_env(&mut evm).is_ok());
     }
@@ -822,7 +854,11 @@ mod tests {
             .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::REGOLITH);
 
         let mut evm = ctx.build_op();
-        let handler = OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<_, _, _>>::new();
+        let handler = OpHandler::<
+            _,
+            EVMError<_, PrecompileError, OpTransactionError>,
+            EthFrame<_, _, _>,
+        >::new();
 
         // Nonce and balance checks should be skipped for deposit transactions.
         assert!(handler.validate_env(&mut evm).is_ok());

--- a/crates/optimism/src/transaction/error.rs
+++ b/crates/optimism/src/transaction/error.rs
@@ -1,7 +1,10 @@
 use core::fmt::Display;
-use revm::context_interface::{
-    result::{EVMError, InvalidTransaction},
-    transaction::TransactionError,
+use revm::{
+    context_interface::{
+        result::{EVMError, InvalidTransaction},
+        transaction::TransactionError,
+    },
+    precompile::PrecompileError,
 };
 
 /// Optimism transaction validation error.
@@ -71,7 +74,7 @@ impl From<InvalidTransaction> for OpTransactionError {
     }
 }
 
-impl<DBError> From<OpTransactionError> for EVMError<DBError, OpTransactionError> {
+impl<DBError> From<OpTransactionError> for EVMError<DBError, PrecompileError, OpTransactionError> {
     fn from(value: OpTransactionError) -> Self {
         Self::Transaction(value)
     }

--- a/crates/precompile/src/interface.rs
+++ b/crates/precompile/src/interface.rs
@@ -1,7 +1,7 @@
 use context_interface::result::EVMError;
 use core::fmt;
 use primitives::Bytes;
-use std::string::{String, ToString};
+use std::string::String;
 
 /// A precompile operation result type
 ///
@@ -66,9 +66,9 @@ impl PrecompileError {
     }
 }
 
-impl<DB, TXERROR> From<PrecompileError> for EVMError<DB, TXERROR> {
+impl<DB, TXERROR> From<PrecompileError> for EVMError<DB, PrecompileError, TXERROR> {
     fn from(value: PrecompileError) -> Self {
-        Self::Precompile(value.to_string())
+        Self::Precompile(value)
     }
 }
 

--- a/examples/cheatcode_inspector/src/main.rs
+++ b/examples/cheatcode_inspector/src/main.rs
@@ -453,7 +453,7 @@ fn commit_transaction<InspectorT, BlockTr TxT, CfgT>(
     backend: &mut Backend,
     env: Env<BlockTr TxT, CfgT>,
     inspector: InspectorT,
-) -> Result<(), EVMError<Infallible, InvalidTransaction>>
+) -> Result<(), EVMError<Infallible, PrecompileError, InvalidTransaction>>
 where
     InspectorT: Inspector<
             Context<BlockTr TxT, CfgT, InMemoryDB, Backend>,

--- a/examples/erc20_gas/src/exec.rs
+++ b/examples/erc20_gas/src/exec.rs
@@ -11,11 +11,18 @@ use revm::{
         PrecompileProvider,
     },
     interpreter::{interpreter::EthInterpreter, InterpreterResult},
+    precompile::PrecompileError,
 };
+
+pub type EVMErrorForContext<CTX, PRECOMPILE, TransactionError> =
+    EVMError<ContextTrDbError<CTX>, PRECOMPILE, TransactionError>;
 
 pub fn transact_erc20evm<EVM>(
     evm: &mut EVM,
-) -> Result<ResultAndState<HaltReason>, EVMError<ContextTrDbError<EVM::Context>, InvalidTransaction>>
+) -> Result<
+    ResultAndState<HaltReason>,
+    EVMErrorForContext<EVM::Context, PrecompileError, InvalidTransaction>,
+>
 where
     EVM: EvmTr<
         Context: ContextTr<Journal: JournalTr<FinalOutput = JournalOutput>>,
@@ -31,7 +38,10 @@ where
 
 pub fn transact_erc20evm_commit<EVM>(
     evm: &mut EVM,
-) -> Result<ExecutionResult<HaltReason>, EVMError<ContextTrDbError<EVM::Context>, InvalidTransaction>>
+) -> Result<
+    ExecutionResult<HaltReason>,
+    EVMErrorForContext<EVM::Context, PrecompileError, InvalidTransaction>,
+>
 where
     EVM: EvmTr<
         Context: ContextTr<Journal: JournalTr<FinalOutput = JournalOutput>, Db: DatabaseCommit>,


### PR DESCRIPTION
Precompile errors are represented as a `String`, but there doesn't seem to be anything limiting us from bubbling up the `PrecompileError` type. This gives us better static typing for precompile errors.