### PR TITLE
refactor: remove ContextSetters requirement from EVM execution traits

### DIFF
--- a/bins/revme/src/cmd/evmrunner.rs
+++ b/bins/revme/src/cmd/evmrunner.rs
@@ -104,7 +104,7 @@ impl Cmd {
         }
 
         let out = if self.trace {
-            evm.inspect_previous().map_err(|_| Errors::EVMError)?
+            evm.inspect_replay().map_err(|_| Errors::EVMError)?
         } else {
             let out = evm.replay().map_err(|_| Errors::EVMError)?;
             println!("Result: {:#?}", out.result);

--- a/crates/inspector/src/gas.rs
+++ b/crates/inspector/src/gas.rs
@@ -141,7 +141,7 @@ mod tests {
         let mut evm = ctx.build_mainnet_with_inspector(StackInspector::default());
 
         // Run evm.
-        evm.inspect_previous().unwrap();
+        evm.inspect_replay().unwrap();
 
         let inspector = &evm.data.inspector;
 

--- a/crates/inspector/src/inspect.rs
+++ b/crates/inspector/src/inspect.rs
@@ -6,26 +6,29 @@ pub trait InspectEvm: ExecuteEvm {
 
     fn set_inspector(&mut self, inspector: Self::Inspector);
 
-    fn inspect_previous(&mut self) -> Self::Output;
+    fn inspect_replay(&mut self) -> Self::Output;
 
-    fn inspect_previous_with_inspector(&mut self, inspector: Self::Inspector) -> Self::Output {
+    fn inspect_with_inspector(&mut self, inspector: Self::Inspector) -> Self::Output {
         self.set_inspector(inspector);
-        self.inspect_previous()
+        self.inspect_replay()
     }
+}
 
-    fn inspect_previous_with_tx(&mut self, tx: <Self as ContextSetters>::Tx) -> Self::Output {
-        self.set_tx(tx);
-        self.inspect_previous()
-    }
+pub fn inspect_with_tx<EVM: ContextSetters + InspectEvm>(
+    evm: &mut EVM,
+    tx: EVM::Tx,
+) -> EVM::Output {
+    evm.set_tx(tx);
+    evm.inspect_replay()
+}
 
-    fn inspect(
-        &mut self,
-        tx: <Self as ContextSetters>::Tx,
-        inspector: Self::Inspector,
-    ) -> Self::Output {
-        self.set_tx(tx);
-        self.inspect_previous_with_inspector(inspector)
-    }
+pub fn inspect<EVM: ContextSetters + InspectEvm>(
+    evm: &mut EVM,
+    tx: EVM::Tx,
+    inspector: EVM::Inspector,
+) -> EVM::Output {
+    evm.set_tx(tx);
+    evm.inspect_with_inspector(inspector)
 }
 
 pub trait InspectCommitEvm: InspectEvm + ExecuteCommitEvm {
@@ -38,13 +41,13 @@ pub trait InspectCommitEvm: InspectEvm + ExecuteCommitEvm {
         self.set_inspector(inspector);
         self.inspect_commit_previous()
     }
+}
 
-    fn inspect_commit(
-        &mut self,
-        tx: <Self as ContextSetters>::Tx,
-        inspector: Self::Inspector,
-    ) -> Self::CommitOutput {
-        self.set_tx(tx);
-        self.inspect_commit_previous_with_inspector(inspector)
-    }
+pub fn inspect_commit<EVM: ContextSetters + InspectCommitEvm>(
+    evm: &mut EVM,
+    tx: EVM::Tx,
+    inspector: EVM::Inspector,
+) -> EVM::CommitOutput {
+    evm.set_tx(tx);
+    evm.inspect_commit_previous_with_inspector(inspector)
 }

--- a/crates/inspector/src/lib.rs
+++ b/crates/inspector/src/lib.rs
@@ -21,7 +21,7 @@ pub mod inspectors {
     pub use super::gas::GasInspector;
 }
 
-pub use inspect::{InspectCommitEvm, InspectEvm};
+pub use inspect::{inspect, inspect_commit, inspect_with_tx, InspectCommitEvm, InspectEvm};
 pub use inspector::*;
 pub use noop::NoOpInspector;
 pub use traits::*;

--- a/crates/inspector/src/mainnet_inspect.rs
+++ b/crates/inspector/src/mainnet_inspect.rs
@@ -27,7 +27,7 @@ where
 impl<CTX, INSP, PRECOMPILES> InspectEvm
     for Evm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, PRECOMPILES>
 where
-    CTX: ContextSetters + ContextTr<Journal: JournalTr<FinalOutput = JournalOutput> + JournalExt>,
+    CTX: ContextTr<Journal: JournalTr<FinalOutput = JournalOutput> + JournalExt>,
     INSP: Inspector<CTX, EthInterpreter>,
     PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
@@ -37,7 +37,7 @@ where
         self.data.inspector = inspector;
     }
 
-    fn inspect_previous(&mut self) -> Self::Output {
+    fn inspect_replay(&mut self) -> Self::Output {
         let mut t = MainnetHandler::<_, _, EthFrame<_, _, _>> {
             _phantom: core::marker::PhantomData,
         };
@@ -55,7 +55,7 @@ where
     PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
     fn inspect_commit_previous(&mut self) -> Self::CommitOutput {
-        self.inspect_previous().map(|r| {
+        self.inspect_replay().map(|r| {
             self.ctx().db().commit(r.state);
             r.result
         })

--- a/crates/inspector/src/noop.rs
+++ b/crates/inspector/src/noop.rs
@@ -3,6 +3,6 @@ use interpreter::InterpreterTypes;
 
 /// Dummy [Inspector], helpful as standalone replacement.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct NoOpInspector {}
+pub struct NoOpInspector;
 
 impl<CTX, INTR: InterpreterTypes> Inspector<CTX, INTR> for NoOpInspector {}

--- a/crates/inspector/src/traits.rs
+++ b/crates/inspector/src/traits.rs
@@ -1,5 +1,5 @@
 use crate::{inspect_instructions, Inspector, JournalExt};
-use context::{setters::ContextSetters, ContextTr, Evm};
+use context::{ContextTr, Evm};
 use handler::{
     instructions::InstructionProvider, ContextTrDbError, EthFrame, EvmTr, Frame, FrameInitOrResult,
     PrecompileProvider,
@@ -28,7 +28,7 @@ pub trait InspectorEvmTr: EvmTr {
 
 impl<CTX, INSP, I, P> InspectorEvmTr for Evm<CTX, INSP, I, P>
 where
-    CTX: ContextTr<Journal: JournalExt> + ContextSetters,
+    CTX: ContextTr<Journal: JournalExt>,
     I: InstructionProvider<
         Context = CTX,
         InterpreterTypes: InterpreterTypes<Output = InterpreterAction>,

--- a/crates/optimism/src/api/default_ctx.rs
+++ b/crates/optimism/src/api/default_ctx.rs
@@ -41,6 +41,6 @@ mod test {
         // execute
         let _ = evm.replay();
         // inspect
-        let _ = evm.inspect_previous();
+        let _ = evm.inspect_replay();
     }
 }

--- a/crates/optimism/src/api/exec.rs
+++ b/crates/optimism/src/api/exec.rs
@@ -81,7 +81,7 @@ where
         self.0.data.inspector = inspector;
     }
 
-    fn inspect_previous(&mut self) -> Self::Output {
+    fn inspect_replay(&mut self) -> Self::Output {
         let mut h = OpHandler::<_, _, EthFrame<_, _, _>>::new();
         h.inspect_run(self)
     }
@@ -95,7 +95,7 @@ where
     PRECOMPILE: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
     fn inspect_commit_previous(&mut self) -> Self::CommitOutput {
-        self.inspect_previous().map(|r| {
+        self.inspect_replay().map(|r| {
             self.ctx().db().commit(r.state);
             r.result
         })

--- a/examples/block_traces/src/main.rs
+++ b/examples/block_traces/src/main.rs
@@ -147,7 +147,7 @@ async fn main() -> anyhow::Result<()> {
         let writer = FlushWriter::new(Arc::clone(&inner));
 
         // Inspect and commit the transaction to the EVM
-        let res = evm.inspect_previous_with_inspector(TracerEip3155::new(Box::new(writer)));
+        let res = evm.inspect_with_inspector(TracerEip3155::new(Box::new(writer)));
 
         if let Err(error) = res {
             println!("Got error: {:?}", error);


### PR DESCRIPTION
If you want to use the `ExecuteEvm`, `ExecuteCommitEvm`, or `InspectEvm` traits, you currently always need to implement `ContextSetters`. If you're using the `replay*` methods, you never actually need to use any of the setters though.

This PR removes the excessive constraints on the aforementioned traits by implementing the helper methods as helper functions of the module.

Additionally, I renamed the methods on `InspectEvm` to match the renamed methods on `ExecuteEvm` and `ExecuteCommitEvm`.