### PR TITLE
feat: rename inspect_previous to inspect_replay

### DIFF
--- a/bins/revme/src/cmd/evmrunner.rs
+++ b/bins/revme/src/cmd/evmrunner.rs
@@ -104,7 +104,7 @@ impl Cmd {
         }
 
         let out = if self.trace {
-            evm.inspect_previous().map_err(|_| Errors::EVMError)?
+            evm.inspect_replay().map_err(|_| Errors::EVMError)?
         } else {
             let out = evm.replay().map_err(|_| Errors::EVMError)?;
             println!("Result: {:#?}", out.result);

--- a/crates/inspector/src/gas.rs
+++ b/crates/inspector/src/gas.rs
@@ -141,7 +141,7 @@ mod tests {
         let mut evm = ctx.build_mainnet_with_inspector(StackInspector::default());
 
         // Run evm.
-        evm.inspect_previous().unwrap();
+        evm.inspect_replay().unwrap();
 
         let inspector = &evm.data.inspector;
 

--- a/crates/inspector/src/inspect.rs
+++ b/crates/inspector/src/inspect.rs
@@ -6,16 +6,16 @@ pub trait InspectEvm: ExecuteEvm {
 
     fn set_inspector(&mut self, inspector: Self::Inspector);
 
-    fn inspect_previous(&mut self) -> Self::Output;
+    fn inspect_replay(&mut self) -> Self::Output;
 
-    fn inspect_previous_with_inspector(&mut self, inspector: Self::Inspector) -> Self::Output {
+    fn inspect_replay_with_inspector(&mut self, inspector: Self::Inspector) -> Self::Output {
         self.set_inspector(inspector);
-        self.inspect_previous()
+        self.inspect_replay()
     }
 
-    fn inspect_previous_with_tx(&mut self, tx: <Self as ContextSetters>::Tx) -> Self::Output {
+    fn inspect_replay_with_tx(&mut self, tx: <Self as ContextSetters>::Tx) -> Self::Output {
         self.set_tx(tx);
-        self.inspect_previous()
+        self.inspect_replay()
     }
 
     fn inspect(
@@ -24,7 +24,7 @@ pub trait InspectEvm: ExecuteEvm {
         inspector: Self::Inspector,
     ) -> Self::Output {
         self.set_tx(tx);
-        self.inspect_previous_with_inspector(inspector)
+        self.inspect_replay_with_inspector(inspector)
     }
 }
 

--- a/crates/inspector/src/mainnet_inspect.rs
+++ b/crates/inspector/src/mainnet_inspect.rs
@@ -37,7 +37,7 @@ where
         self.data.inspector = inspector;
     }
 
-    fn inspect_previous(&mut self) -> Self::Output {
+    fn inspect_replay(&mut self) -> Self::Output {
         let mut t = MainnetHandler::<_, _, EthFrame<_, _, _>> {
             _phantom: core::marker::PhantomData,
         };
@@ -55,7 +55,7 @@ where
     PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
     fn inspect_commit_previous(&mut self) -> Self::CommitOutput {
-        self.inspect_previous().map(|r| {
+        self.inspect_replay().map(|r| {
             self.ctx().db().commit(r.state);
             r.result
         })

--- a/crates/optimism/src/api/default_ctx.rs
+++ b/crates/optimism/src/api/default_ctx.rs
@@ -41,6 +41,6 @@ mod test {
         // execute
         let _ = evm.replay();
         // inspect
-        let _ = evm.inspect_previous();
+        let _ = evm.inspect_replay();
     }
 }

--- a/crates/optimism/src/api/exec.rs
+++ b/crates/optimism/src/api/exec.rs
@@ -81,7 +81,7 @@ where
         self.0.data.inspector = inspector;
     }
 
-    fn inspect_previous(&mut self) -> Self::Output {
+    fn inspect_replay(&mut self) -> Self::Output {
         let mut h = OpHandler::<_, _, EthFrame<_, _, _>>::new();
         h.inspect_run(self)
     }
@@ -95,7 +95,7 @@ where
     PRECOMPILE: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
     fn inspect_commit_previous(&mut self) -> Self::CommitOutput {
-        self.inspect_previous().map(|r| {
+        self.inspect_replay().map(|r| {
             self.ctx().db().commit(r.state);
             r.result
         })

--- a/examples/block_traces/src/main.rs
+++ b/examples/block_traces/src/main.rs
@@ -147,7 +147,7 @@ async fn main() -> anyhow::Result<()> {
         let writer = FlushWriter::new(Arc::clone(&inner));
 
         // Inspect and commit the transaction to the EVM
-        let res = evm.inspect_previous_with_inspector(TracerEip3155::new(Box::new(writer)));
+        let res = evm.inspect_replay_with_inspector(TracerEip3155::new(Box::new(writer)));
 
         if let Err(error) = res {
             println!("Got error: {:?}", error);

--- a/examples/cheatcode_inspector/src/main.rs
+++ b/examples/cheatcode_inspector/src/main.rs
@@ -484,7 +484,7 @@ where
     //     InspectorT,
     //     Context<BlockTr TxT, CfgT, InMemoryDB, Backend>,
     // >::new(context, inspector);
-    let result = evm.inspect_previous(inspector)?;
+    let result = evm.inspect_replay(inspector)?;
     //let result = inspect_main(&mut inspector_context)?;
 
     // Persist the changes to the original backend.
@@ -525,7 +525,7 @@ fn main() -> anyhow::Result<()> {
     }
     .build_mainnet();
 
-    evm.inspect_previous(&mut inspector)?;
+    evm.inspect_replay(&mut inspector)?;
 
     // Sanity check
     assert_eq!(inspector.call_count, 2);


### PR DESCRIPTION
missed replay rename. found in https://github.com/bluealloy/revm/pulls