### PR TITLE
feat: Add tx/block to EvmExecution trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3453,7 +3453,6 @@ dependencies = [
 name = "revm-context"
 version = "1.0.0-alpha.3"
 dependencies = [
- "auto_impl",
  "cfg-if",
  "derive-where",
  "revm-bytecode",

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -32,7 +32,6 @@ bytecode.workspace = true
 # misc
 derive-where.workspace = true
 cfg-if.workspace = true
-auto_impl.workspace = true
 
 # Optional
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
@@ -49,7 +48,7 @@ std = [
 	"database/std",
 	"database-interface/std",
 	"primitives/std",
-	"state/std"
+	"state/std",
 ]
 serde = [
 	"dep:serde",
@@ -58,14 +57,14 @@ serde = [
 	"context-interface/serde",
 	"bytecode/serde",
 	"database/serde",
-	"database-interface/serde"
+	"database-interface/serde",
 ]
 dev = [
-    "memory_limit",
-    "optional_balance_check",
-    "optional_block_gas_limit",
-    "optional_eip3607",
-    "optional_no_base_fee",
+	"memory_limit",
+	"optional_balance_check",
+	"optional_block_gas_limit",
+	"optional_eip3607",
+	"optional_no_base_fee",
 ]
 memory_limit = []
 optional_balance_check = []

--- a/crates/context/interface/src/context.rs
+++ b/crates/context/interface/src/context.rs
@@ -84,3 +84,8 @@ pub struct SelfDestructResult {
     pub target_exists: bool,
     pub previously_destroyed: bool,
 }
+
+pub trait ContextSetters: ContextTr {
+    fn set_tx(&mut self, tx: Self::Tx);
+    fn set_block(&mut self, block: Self::Block);
+}

--- a/crates/context/interface/src/lib.rs
+++ b/crates/context/interface/src/lib.rs
@@ -14,7 +14,7 @@ pub mod transaction;
 
 pub use block::Block;
 pub use cfg::{Cfg, CreateScheme, TransactTo};
-pub use context::ContextTr;
+pub use context::{ContextSetters, ContextTr};
 pub use database_interface::{DBErrorMarker, Database};
 pub use journaled_state::JournalTr;
 pub use transaction::{Transaction, TransactionType};

--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -1,4 +1,5 @@
 use crate::{block::BlockEnv, cfg::CfgEnv, journaled_state::Journal, tx::TxEnv};
+use context_interface::ContextSetters;
 use context_interface::{Block, Cfg, ContextTr, JournalTr, Transaction};
 use database_interface::DatabaseRef;
 use database_interface::WrapDatabaseRef;
@@ -87,6 +88,24 @@ impl<
     }
 
     // Keep Default Implementation for Instructions Host Interface
+}
+
+impl<
+        BLOCK: Block,
+        TX: Transaction,
+        DB: Database,
+        CFG: Cfg,
+        JOURNAL: JournalTr<Database = DB>,
+        CHAIN,
+    > ContextSetters for Context<BLOCK, TX, CFG, DB, JOURNAL, CHAIN>
+{
+    fn set_tx(&mut self, tx: Self::Tx) {
+        self.tx = tx;
+    }
+
+    fn set_block(&mut self, block: Self::Block) {
+        self.block = block;
+    }
 }
 
 impl<

--- a/crates/context/src/evm.rs
+++ b/crates/context/src/evm.rs
@@ -1,4 +1,3 @@
-use crate::setters::ContextSetters;
 use core::fmt::Debug;
 use core::ops::{Deref, DerefMut};
 
@@ -25,7 +24,7 @@ impl<CTX> Evm<CTX, (), (), ()> {
     }
 }
 
-impl<CTX: ContextSetters, INSP, I, P> Evm<CTX, INSP, I, P> {
+impl<CTX, INSP, I, P> Evm<CTX, INSP, I, P> {
     /// Consumed self and returns new Evm type with given Inspector.
     pub fn with_inspector<OINSP>(self, inspector: OINSP) -> Evm<CTX, OINSP, I, P> {
         Evm {
@@ -50,19 +49,6 @@ impl<CTX: ContextSetters, INSP, I, P> Evm<CTX, INSP, I, P> {
     /// Consumes self and returns inner Inspector.
     pub fn into_inspector(self) -> INSP {
         self.data.inspector
-    }
-}
-
-impl<CTX: ContextSetters, INSP, I, P> ContextSetters for Evm<CTX, INSP, I, P> {
-    type Tx = <CTX as ContextSetters>::Tx;
-    type Block = <CTX as ContextSetters>::Block;
-
-    fn set_tx(&mut self, tx: Self::Tx) {
-        self.data.ctx.set_tx(tx);
-    }
-
-    fn set_block(&mut self, block: Self::Block) {
-        self.data.ctx.set_block(block);
     }
 }
 

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -17,7 +17,6 @@ pub mod tx;
 pub use block::BlockEnv;
 pub use cfg::{Cfg, CfgEnv};
 pub use context::*;
+pub use evm::{Evm, EvmData};
 pub use journaled_state::*;
 pub use tx::TxEnv;
-pub mod setters;
-pub use evm::{Evm, EvmData};

--- a/crates/inspector/Cargo.toml
+++ b/crates/inspector/Cargo.toml
@@ -54,7 +54,7 @@ std = [
 	"interpreter/std",
 	"precompile/std",
 	"primitives/std",
-	"state/std"
+	"state/std",
 ]
 serde = [
 	"dep:serde",
@@ -64,6 +64,6 @@ serde = [
 	"handler/serde",
 	"interpreter/serde",
 	"primitives/serde",
-	"state/serde"
+	"state/serde",
 ]
 serde-json = ["serde", "dep:serde_json"]

--- a/crates/inspector/src/inspect.rs
+++ b/crates/inspector/src/inspect.rs
@@ -1,4 +1,3 @@
-use context::setters::ContextSetters;
 use handler::evm::{ExecuteCommitEvm, ExecuteEvm};
 
 pub trait InspectEvm: ExecuteEvm {
@@ -13,16 +12,12 @@ pub trait InspectEvm: ExecuteEvm {
         self.inspect_previous()
     }
 
-    fn inspect_previous_with_tx(&mut self, tx: <Self as ContextSetters>::Tx) -> Self::Output {
+    fn inspect_previous_with_tx(&mut self, tx: Self::Tx) -> Self::Output {
         self.set_tx(tx);
         self.inspect_previous()
     }
 
-    fn inspect(
-        &mut self,
-        tx: <Self as ContextSetters>::Tx,
-        inspector: Self::Inspector,
-    ) -> Self::Output {
+    fn inspect(&mut self, tx: Self::Tx, inspector: Self::Inspector) -> Self::Output {
         self.set_tx(tx);
         self.inspect_previous_with_inspector(inspector)
     }
@@ -39,11 +34,7 @@ pub trait InspectCommitEvm: InspectEvm + ExecuteCommitEvm {
         self.inspect_commit_previous()
     }
 
-    fn inspect_commit(
-        &mut self,
-        tx: <Self as ContextSetters>::Tx,
-        inspector: Self::Inspector,
-    ) -> Self::CommitOutput {
+    fn inspect_commit(&mut self, tx: Self::Tx, inspector: Self::Inspector) -> Self::CommitOutput {
         self.set_tx(tx);
         self.inspect_commit_previous_with_inspector(inspector)
     }

--- a/crates/inspector/src/mainnet_inspect.rs
+++ b/crates/inspector/src/mainnet_inspect.rs
@@ -1,4 +1,4 @@
-use context::{setters::ContextSetters, ContextTr, Evm, JournalOutput, JournalTr};
+use context::{ContextSetters, ContextTr, Evm, JournalOutput, JournalTr};
 use database_interface::DatabaseCommit;
 use handler::{
     instructions::EthInstructions, EthFrame, EvmTr, EvmTrError, Frame, FrameResult, Handler,

--- a/crates/inspector/src/traits.rs
+++ b/crates/inspector/src/traits.rs
@@ -1,5 +1,5 @@
 use crate::{inspect_instructions, Inspector, JournalExt};
-use context::{setters::ContextSetters, ContextTr, Evm};
+use context::{ContextSetters, ContextTr, Evm};
 use handler::{
     instructions::InstructionProvider, ContextTrDbError, EthFrame, EvmTr, Frame, FrameInitOrResult,
     PrecompileProvider,

--- a/crates/optimism/src/evm.rs
+++ b/crates/optimism/src/evm.rs
@@ -1,6 +1,6 @@
 use crate::precompiles::OpPrecompiles;
 use revm::{
-    context::{setters::ContextSetters, Evm, EvmData},
+    context::{ContextSetters, Evm, EvmData},
     context_interface::ContextTr,
     handler::{
         instructions::{EthInstructions, InstructionProvider},
@@ -27,9 +27,9 @@ impl<CTX: Host, INSP> OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, OpP
     }
 }
 
-impl<CTX: ContextSetters, INSP, I, P> InspectorEvmTr for OpEvm<CTX, INSP, I, P>
+impl<CTX, INSP, I, P> InspectorEvmTr for OpEvm<CTX, INSP, I, P>
 where
-    CTX: ContextTr<Journal: JournalExt>,
+    CTX: ContextTr<Journal: JournalExt> + ContextSetters,
     I: InstructionProvider<
         Context = CTX,
         InterpreterTypes: InterpreterTypes<Output = InterpreterAction>,
@@ -54,19 +54,6 @@ where
     ) -> <<Self::Instructions as InstructionProvider>::InterpreterTypes as InterpreterTypes>::Output
     {
         self.0.run_inspect_interpreter(interpreter)
-    }
-}
-
-impl<CTX: ContextSetters, INSP, I, P> ContextSetters for OpEvm<CTX, INSP, I, P> {
-    type Tx = <CTX as ContextSetters>::Tx;
-    type Block = <CTX as ContextSetters>::Block;
-
-    fn set_tx(&mut self, tx: Self::Tx) {
-        self.0.data.ctx.set_tx(tx);
-    }
-
-    fn set_block(&mut self, block: Self::Block) {
-        self.0.data.ctx.set_block(block);
     }
 }
 


### PR DESCRIPTION
Integrate ContextSetter with EvmExecution as evm execution needs to know tx and block so we can execute multiple tx on one created evm.

Creating evm for only one tx has performance penalties.