### PR TITLE
feat: add custom error to context

### DIFF
--- a/crates/context/interface/src/context.rs
+++ b/crates/context/interface/src/context.rs
@@ -2,6 +2,7 @@ pub use crate::journaled_state::StateLoad;
 use crate::{Block, Cfg, Database, JournalTr, Transaction};
 use auto_impl::auto_impl;
 use primitives::U256;
+use std::string::String;
 
 #[auto_impl(&mut, Box)]
 pub trait ContextTr {

--- a/crates/context/interface/src/context.rs
+++ b/crates/context/interface/src/context.rs
@@ -1,7 +1,6 @@
 pub use crate::journaled_state::StateLoad;
 use crate::{Block, Cfg, Database, JournalTr, Transaction};
 use auto_impl::auto_impl;
-use database_interface::DBErrorMarker;
 use primitives::U256;
 
 #[auto_impl(&mut, Box)]
@@ -28,14 +27,14 @@ pub trait ContextTr {
 /// Inner Context error used for Interpreter to set error without returning it frm instruction
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum ContextError<DbError: DBErrorMarker> {
+pub enum ContextError<DbError> {
     /// Database error.
     Db(DbError),
     /// Custom string error.
     Custom(String),
 }
 
-impl<DbError: DBErrorMarker> From<DbError> for ContextError<DbError> {
+impl<DbError> From<DbError> for ContextError<DbError> {
     fn from(value: DbError) -> Self {
         Self::Db(value)
     }

--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -1,4 +1,5 @@
 use crate::{block::BlockEnv, cfg::CfgEnv, journaled_state::Journal, tx::TxEnv};
+use context_interface::context::ContextError;
 use context_interface::{Block, Cfg, ContextTr, JournalTr, Transaction};
 use database_interface::DatabaseRef;
 use database_interface::WrapDatabaseRef;
@@ -27,7 +28,7 @@ pub struct Context<
     /// Inner context.
     pub chain: CHAIN,
     /// Error that happened during execution.
-    pub error: Result<(), <DB as Database>::Error>,
+    pub error: Result<(), ContextError<<DB as Database>::Error>>,
 }
 
 impl<
@@ -78,7 +79,7 @@ impl<
         &mut self.chain
     }
 
-    fn error(&mut self) -> &mut Result<(), <Self::Db as Database>::Error> {
+    fn error(&mut self) -> &mut Result<(), ContextError<<Self::Db as Database>::Error>> {
         &mut self.error
     }
 

--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -28,7 +28,7 @@ pub struct Context<
     /// Inner context.
     pub chain: CHAIN,
     /// Error that happened during execution.
-    pub error: Result<(), ContextError<<DB as Database>::Error>>,
+    pub error: Result<(), ContextError<DB::Error>>,
 }
 
 impl<

--- a/crates/inspector/src/traits.rs
+++ b/crates/inspector/src/traits.rs
@@ -1,5 +1,5 @@
 use crate::{inspect_instructions, Inspector, JournalExt};
-use context::{setters::ContextSetters, ContextTr, Evm};
+use context::{result::FromStringError, setters::ContextSetters, ContextTr, Evm};
 use handler::{
     instructions::InstructionProvider, ContextTrDbError, EthFrame, EvmTr, Frame, FrameInitOrResult,
     PrecompileProvider,
@@ -86,7 +86,7 @@ where
                 InterpreterTypes = EthInterpreter,
             >,
         > + InspectorEvmTr,
-    ERROR: From<ContextTrDbError<EVM::Context>> + From<PrecompileError>,
+    ERROR: From<ContextTrDbError<EVM::Context>> + From<PrecompileError> + FromStringError,
 {
     type IT = EthInterpreter;
 

--- a/crates/interpreter/src/host.rs
+++ b/crates/interpreter/src/host.rs
@@ -161,7 +161,7 @@ impl<CTX: ContextTr> Host for CTX {
             .db()
             .block_hash(requested_number)
             .map_err(|e| {
-                *self.error() = Err(e);
+                *self.error() = Err(e.into());
             })
             .ok()
     }
@@ -172,7 +172,7 @@ impl<CTX: ContextTr> Host for CTX {
         self.journal()
             .load_account_delegated(address)
             .map_err(|e| {
-                *self.error() = Err(e);
+                *self.error() = Err(e.into());
             })
             .ok()
     }
@@ -183,7 +183,7 @@ impl<CTX: ContextTr> Host for CTX {
             .load_account(address)
             .map(|acc| acc.map(|a| a.info.balance))
             .map_err(|e| {
-                *self.error() = Err(e);
+                *self.error() = Err(e.into());
             })
             .ok()
     }
@@ -193,7 +193,7 @@ impl<CTX: ContextTr> Host for CTX {
         self.journal()
             .code(address)
             .map_err(|e| {
-                *self.error() = Err(e);
+                *self.error() = Err(e.into());
             })
             .ok()
     }
@@ -203,7 +203,7 @@ impl<CTX: ContextTr> Host for CTX {
         self.journal()
             .code_hash(address)
             .map_err(|e| {
-                *self.error() = Err(e);
+                *self.error() = Err(e.into());
             })
             .ok()
     }
@@ -213,7 +213,7 @@ impl<CTX: ContextTr> Host for CTX {
         self.journal()
             .sload(address, index)
             .map_err(|e| {
-                *self.error() = Err(e);
+                *self.error() = Err(e.into());
             })
             .ok()
     }
@@ -230,7 +230,7 @@ impl<CTX: ContextTr> Host for CTX {
         self.journal()
             .sstore(address, index, value)
             .map_err(|e| {
-                *self.error() = Err(e);
+                *self.error() = Err(e.into());
             })
             .ok()
     }
@@ -259,7 +259,7 @@ impl<CTX: ContextTr> Host for CTX {
         self.journal()
             .selfdestruct(address, target)
             .map_err(|e| {
-                *self.error() = Err(e);
+                *self.error() = Err(e.into());
             })
             .ok()
     }


### PR DESCRIPTION
Worldcoin uses a custom error inside Inspector to mark the transaction as invalid. To facilitate this use case we added `Custom(String)` error.