### PR TITLE
test: broken example when using database with lifetime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2314,6 +2314,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inspector_with_lifetime"
+version = "0.0.0"
+dependencies = [
+ "alloy-primitives",
+ "anyhow",
+ "revm",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3548,6 +3548,7 @@ name = "revm-inspector"
 version = "1.0.0-alpha.5"
 dependencies = [
  "auto_impl",
+ "derive-where",
  "revm-context",
  "revm-database",
  "revm-database-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
     "examples/database_components",
     "examples/uniswap_get_reserves",
     "examples/uniswap_v2_usdc_swap",
-    "examples/erc20_gas",
+    "examples/erc20_gas", "examples/inspector_with_lifetime",
     #"examples/custom_opcodes",
 ]
 resolver = "2"

--- a/crates/inspector/Cargo.toml
+++ b/crates/inspector/Cargo.toml
@@ -32,6 +32,7 @@ state.workspace = true
 interpreter.workspace = true
 
 auto_impl.workspace = true
+derive-where.workspace = true
 
 # Optional
 serde = { workspace = true, features = ["derive", "rc"], optional = true }

--- a/crates/inspector/src/gas.rs
+++ b/crates/inspector/src/gas.rs
@@ -67,10 +67,13 @@ impl GasInspector {
 
 #[cfg(test)]
 mod tests {
+    use core::marker::PhantomData;
+
     use super::*;
     use crate::{InspectEvm, Inspector};
     use context::Context;
     use database::{BenchmarkDB, BENCH_CALLER, BENCH_TARGET};
+    use derive_where::derive_where;
     use handler::{MainBuilder, MainContext};
     use interpreter::{
         interpreter_types::{Jumps, LoopControl},
@@ -79,14 +82,17 @@ mod tests {
     use primitives::{Bytes, TxKind};
     use state::bytecode::{opcode, Bytecode};
 
-    #[derive(Default, Debug)]
-    struct StackInspector {
+    #[derive_where(Default, Debug)]
+    struct StackInspector<CTX> {
         pc: usize,
         gas_inspector: GasInspector,
         gas_remaining_steps: Vec<(usize, u64)>,
+        phantom: PhantomData<CTX>,
     }
 
-    impl<CTX, INTR: InterpreterTypes> Inspector<CTX, INTR> for StackInspector {
+    impl<CTX, INTR: InterpreterTypes> Inspector<INTR> for StackInspector<CTX> {
+        type Context<'context> = CTX;
+
         fn initialize_interp(&mut self, interp: &mut Interpreter<INTR>, _context: &mut CTX) {
             self.gas_inspector.initialize_interp(interp.control.gas());
         }

--- a/crates/inspector/src/mainnet_inspect.rs
+++ b/crates/inspector/src/mainnet_inspect.rs
@@ -15,7 +15,10 @@ impl<EVM, ERROR, FRAME> InspectorHandler for MainnetHandler<EVM, ERROR, FRAME>
 where
     EVM: InspectorEvmTr<
         Context: ContextTr<Journal: JournalTr<FinalOutput = JournalOutput>>,
-        Inspector: Inspector<<<Self as Handler>::Evm as EvmTr>::Context, EthInterpreter>,
+        Inspector: for<'context> Inspector<
+            EthInterpreter,
+            Context<'context> = <<Self as Handler>::Evm as EvmTr>::Context,
+        >,
     >,
     ERROR: EvmTrError<EVM>,
     FRAME: Frame<Evm = EVM, Error = ERROR, FrameResult = FrameResult, FrameInit = FrameInput>
@@ -28,7 +31,7 @@ impl<CTX, INSP, PRECOMPILES> InspectEvm
     for Evm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, PRECOMPILES>
 where
     CTX: ContextSetters + ContextTr<Journal: JournalTr<FinalOutput = JournalOutput> + JournalExt>,
-    INSP: Inspector<CTX, EthInterpreter>,
+    INSP: for<'context> Inspector<EthInterpreter, Context<'context> = CTX>,
     PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
     type Inspector = INSP;
@@ -51,7 +54,7 @@ impl<CTX, INSP, PRECOMPILES> InspectCommitEvm
 where
     CTX: ContextSetters
         + ContextTr<Journal: JournalTr<FinalOutput = JournalOutput> + JournalExt, Db: DatabaseCommit>,
-    INSP: Inspector<CTX, EthInterpreter>,
+    INSP: for<'context> Inspector<EthInterpreter, Context<'context> = CTX>,
     PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
     fn inspect_commit_previous(&mut self) -> Self::CommitOutput {

--- a/crates/inspector/src/noop.rs
+++ b/crates/inspector/src/noop.rs
@@ -3,6 +3,6 @@ use interpreter::InterpreterTypes;
 
 /// Dummy [Inspector], helpful as standalone replacement.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct NoOpInspector {}
+pub struct NoOpInspector;
 
 impl<CTX, INTR: InterpreterTypes> Inspector<CTX, INTR> for NoOpInspector {}

--- a/crates/inspector/src/noop.rs
+++ b/crates/inspector/src/noop.rs
@@ -1,8 +1,15 @@
+use core::marker::PhantomData;
+
 use crate::inspector::Inspector;
+use derive_where::derive_where;
 use interpreter::InterpreterTypes;
 
 /// Dummy [Inspector], helpful as standalone replacement.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct NoOpInspector;
+#[derive_where(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NoOpInspector<CTX> {
+    phantom: PhantomData<CTX>,
+}
 
-impl<CTX, INTR: InterpreterTypes> Inspector<CTX, INTR> for NoOpInspector {}
+impl<CTX, INTR: InterpreterTypes> Inspector<INTR> for NoOpInspector<CTX> {
+    type Context<'context> = CTX;
+}

--- a/crates/inspector/src/traits.rs
+++ b/crates/inspector/src/traits.rs
@@ -33,7 +33,7 @@ where
         Context = CTX,
         InterpreterTypes: InterpreterTypes<Output = InterpreterAction>,
     >,
-    INSP: Inspector<CTX, I::InterpreterTypes>,
+    INSP: for<'context> Inspector<I::InterpreterTypes, Context<'context> = CTX>,
 {
     type Inspector = INSP;
 

--- a/crates/optimism/src/api/default_ctx.rs
+++ b/crates/optimism/src/api/default_ctx.rs
@@ -37,7 +37,7 @@ mod test {
     fn default_run_op() {
         let ctx = Context::op();
         // convert to optimism context
-        let mut evm = ctx.build_op_with_inspector(NoOpInspector {});
+        let mut evm = ctx.build_op_with_inspector(NoOpInspector::default());
         // execute
         let _ = evm.replay();
         // inspect

--- a/crates/optimism/src/api/exec.rs
+++ b/crates/optimism/src/api/exec.rs
@@ -84,7 +84,7 @@ impl<CTX, INSP, PRECOMPILE> InspectEvm
     for OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, PRECOMPILE>
 where
     CTX: OpContextTr<Journal: JournalExt> + ContextSetters,
-    INSP: Inspector<CTX, EthInterpreter>,
+    INSP: for<'context> Inspector<EthInterpreter, Context<'context> = CTX>,
     PRECOMPILE: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
     type Inspector = INSP;
@@ -103,7 +103,7 @@ impl<CTX, INSP, PRECOMPILE> InspectCommitEvm
     for OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, PRECOMPILE>
 where
     CTX: OpContextTr<Journal: JournalExt, Db: DatabaseCommit> + ContextSetters,
-    INSP: Inspector<CTX, EthInterpreter>,
+    INSP: for<'context> Inspector<EthInterpreter, Context<'context> = CTX>,
     PRECOMPILE: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
     fn inspect_commit_previous(&mut self) -> Self::CommitOutput {

--- a/crates/optimism/src/evm.rs
+++ b/crates/optimism/src/evm.rs
@@ -34,7 +34,7 @@ where
         Context = CTX,
         InterpreterTypes: InterpreterTypes<Output = InterpreterAction>,
     >,
-    INSP: Inspector<CTX, I::InterpreterTypes>,
+    INSP: for<'context> Inspector<I::InterpreterTypes, Context<'context> = CTX>,
 {
     type Inspector = INSP;
 

--- a/crates/optimism/src/handler.rs
+++ b/crates/optimism/src/handler.rs
@@ -452,7 +452,10 @@ impl<EVM, ERROR, FRAME> InspectorHandler for OpHandler<EVM, ERROR, FRAME>
 where
     EVM: InspectorEvmTr<
         Context: OpContextTr,
-        Inspector: Inspector<<<Self as Handler>::Evm as EvmTr>::Context, EthInterpreter>,
+        Inspector: for<'context> Inspector<
+            EthInterpreter,
+            Context<'context> = <<Self as Handler>::Evm as EvmTr>::Context,
+        >,
     >,
     ERROR: EvmTrError<EVM> + From<OpTransactionError> + FromStringError + IsTxError,
     // TODO `FrameResult` should be a generic trait.

--- a/examples/inspector_with_lifetime/Cargo.toml
+++ b/examples/inspector_with_lifetime/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "inspector_with_lifetime"
+version = "0.0.0"
+publish = false
+authors.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[lints.rust]
+unreachable_pub = "warn"
+unused_must_use = "deny"
+rust_2018_idioms = "deny"
+
+[lints.rustdoc]
+all = "warn"
+
+[dependencies]
+# revms
+revm = { workspace = true, features = ["std"] }
+
+# alloy
+alloy-primitives = { workspace = true, features = ["rand"] }
+
+# misc
+anyhow = "1.0.89"
+

--- a/examples/inspector_with_lifetime/src/main.rs
+++ b/examples/inspector_with_lifetime/src/main.rs
@@ -23,15 +23,14 @@ pub trait DBSuperTrait: Database<Error = Infallible> + DatabaseCommit {}
 
 impl<T: Database<Error = Infallible> + DatabaseCommit> DBSuperTrait for T {}
 
-fn mine_block<'db, 'inspector, InspectorT>(
+fn mine_block<InspectorT>(
     cfg: &CfgEnv,
-    db: &'db mut dyn DBSuperTrait,
+    db: &mut dyn DBSuperTrait,
     transactions: Vec<TxEnv>,
-    inspector: &'inspector mut InspectorT,
+    inspector: &mut InspectorT,
 ) -> Result<Vec<ExecutionResult>, EVMError<Infallible>>
 where
-    'db: 'inspector,
-    InspectorT: Inspector<ContextRef<'inspector>>,
+    InspectorT: for<'context> Inspector<Context<'context> = ContextRef<'context>>,
 {
     let block = BlockEnv {
         prevrandao: Some(B256::random()),
@@ -40,7 +39,7 @@ where
 
     let mut results = Vec::new();
     for tx in transactions {
-        let result = run_transaction(&block, cfg, &mut *db, tx, &mut *inspector)?;
+        let result = run_transaction(&block, cfg, db, tx, inspector)?;
 
         results.push(result);
     }
@@ -48,27 +47,26 @@ where
     Ok(results)
 }
 
-fn run_transaction<'db, 'inspector, InspectorT>(
+fn run_transaction<InspectorT>(
     block: &BlockEnv,
     cfg: &CfgEnv,
-    db: &'db mut dyn DBSuperTrait,
+    db: &mut dyn DBSuperTrait,
     tx: TxEnv,
-    inspector: &'inspector mut InspectorT,
+    inspector: &mut InspectorT,
 ) -> Result<ExecutionResult, EVMError<Infallible>>
 where
-    'db: 'inspector,
-    InspectorT: Inspector<ContextRef<'inspector>>,
+    InspectorT: for<'context> Inspector<Context<'context> = ContextRef<'context>>,
 {
     let context = revm::Context {
         block: block.clone(),
         tx,
         cfg: cfg.clone(),
-        journaled_state: Journal::<_, JournalEntry>::new(cfg.spec, &mut *db),
+        journaled_state: Journal::<_, JournalEntry>::new(cfg.spec, db),
         chain: (),
         error: Ok(()),
     };
 
-    let mut evm = context.build_mainnet_with_inspector(&mut *inspector);
+    let mut evm = context.build_mainnet_with_inspector(inspector);
     evm.replay_commit()
 }
 
@@ -77,7 +75,7 @@ fn main() -> anyhow::Result<()> {
     let mut db = State::builder().build();
     let transactions = vec![];
 
-    let mut inspector = NoOpInspector;
+    let mut inspector = NoOpInspector::default();
     let results = mine_block(&cfg, &mut db, transactions, &mut inspector)?;
     println!("results: {results:?}");
 

--- a/examples/inspector_with_lifetime/src/main.rs
+++ b/examples/inspector_with_lifetime/src/main.rs
@@ -1,0 +1,85 @@
+use std::convert::Infallible;
+
+use revm::{
+    context::{
+        result::{EVMError, ExecutionResult},
+        BlockEnv, CfgEnv, TxEnv,
+    },
+    database::State,
+    inspector::NoOpInspector,
+    primitives::B256,
+    Database, DatabaseCommit, ExecuteCommitEvm, Inspector, Journal, JournalEntry, MainBuilder as _,
+};
+
+pub type ContextRef<'db> = revm::Context<
+    BlockEnv,
+    TxEnv,
+    CfgEnv,
+    &'db mut dyn Database<Error = Infallible>,
+    Journal<&'db mut dyn Database<Error = Infallible>>,
+>;
+
+pub trait DBSuperTrait: Database<Error = Infallible> + DatabaseCommit {}
+
+impl<T: Database<Error = Infallible> + DatabaseCommit> DBSuperTrait for T {}
+
+fn mine_block<'db, 'inspector, InspectorT>(
+    cfg: &CfgEnv,
+    db: &'db mut dyn DBSuperTrait,
+    transactions: Vec<TxEnv>,
+    inspector: &'inspector mut InspectorT,
+) -> Result<Vec<ExecutionResult>, EVMError<Infallible>>
+where
+    'db: 'inspector,
+    InspectorT: Inspector<ContextRef<'inspector>>,
+{
+    let block = BlockEnv {
+        prevrandao: Some(B256::random()),
+        ..BlockEnv::default()
+    };
+
+    let mut results = Vec::new();
+    for tx in transactions {
+        let result = run_transaction(&block, cfg, &mut *db, tx, &mut *inspector)?;
+
+        results.push(result);
+    }
+
+    Ok(results)
+}
+
+fn run_transaction<'db, 'inspector, InspectorT>(
+    block: &BlockEnv,
+    cfg: &CfgEnv,
+    db: &'db mut dyn DBSuperTrait,
+    tx: TxEnv,
+    inspector: &'inspector mut InspectorT,
+) -> Result<ExecutionResult, EVMError<Infallible>>
+where
+    'db: 'inspector,
+    InspectorT: Inspector<ContextRef<'inspector>>,
+{
+    let context = revm::Context {
+        block: block.clone(),
+        tx,
+        cfg: cfg.clone(),
+        journaled_state: Journal::<_, JournalEntry>::new(cfg.spec, &mut *db),
+        chain: (),
+        error: Ok(()),
+    };
+
+    let mut evm = context.build_mainnet_with_inspector(&mut *inspector);
+    evm.replay_commit()
+}
+
+fn main() -> anyhow::Result<()> {
+    let cfg = CfgEnv::default();
+    let mut db = State::builder().build();
+    let transactions = vec![];
+
+    let mut inspector = NoOpInspector;
+    let results = mine_block(&cfg, &mut db, transactions, &mut inspector)?;
+    println!("results: {results:?}");
+
+    Ok(())
+}


### PR DESCRIPTION
This example serves to illustrate a limitation when using the current API with (mutable) references.

The first commit shows the resulting compiler error - when using the current API.

The second commit tries to resolve this by introducing the `Context` as an associated type on `trait Inspector` such that we can introduce a `'context` lifetime for the context. This lifetime represents the duration during which the `Context` will be available to the inspector.

This results in the following compiler error:

```rs
error[E0308]: mismatched types
  --> examples/inspector_with_lifetime/src/main.rs:79:19
   |
79 |     let results = mine_block(&cfg, &mut db, transactions, &mut inspector)?;
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
   |
   = note: expected struct `revm::Context<_, _, _, &mut dyn revm::Database<Error = Infallible>, Journal<&mut dyn revm::Database<Error = Infallible>>, _>`
              found struct `revm::Context<_, _, _, &'context mut (dyn revm::Database<Error = Infallible> + 'context), Journal<&'context mut (dyn revm::Database<Error = Infallible> + 'context)>, _>`
note: the lifetime requirement is introduced here
  --> examples/inspector_with_lifetime/src/main.rs:33:41
   |
33 |     InspectorT: for<'context> Inspector<Context<'context> = ContextRef<'context>>,
   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

I've tried a lot of things to circumvent this but have been unable to. This might be a language limitation rather than an API limitation. See [this article](https://kazlauskas.me/entries/due-to-borrowck-limitations).

I still wanted to bring this to your attention, in case you had any ideas on how to solve it.