### PR TITLE
fix: JumpMap from_slice requires len

### DIFF
--- a/crates/bytecode/src/legacy/analyzed.rs
+++ b/crates/bytecode/src/legacy/analyzed.rs
@@ -56,7 +56,7 @@ impl LegacyAnalyzedBytecode {
     /// # Panics
     ///
     /// * If `original_len` is greater than `bytecode.len()`
-    /// * If jump table length is not equal to `bytecode.len() / 32`.
+    /// * If jump table length is less than `original_len`.
     /// * If last bytecode byte is not `0x00` or if bytecode is empty.
     pub fn new(bytecode: Bytes, original_len: usize, jump_table: JumpTable) -> Self {
         if original_len > bytecode.len() {

--- a/crates/bytecode/src/legacy/jump_map.rs
+++ b/crates/bytecode/src/legacy/jump_map.rs
@@ -24,21 +24,21 @@ impl JumpTable {
 
     /// Constructs a jump map from raw bytes and length.
     ///
-    /// Lenght represents number of bits inside slice.
+    /// Bit length represents number of used bits inside slice.
     ///
     /// # Panics
     ///
-    /// Panics if number of bits in slice is less than length.
+    /// Panics if number of bits in slice is less than bit_len.
     #[inline]
-    pub fn from_slice(slice: &[u8], len: usize) -> Self {
+    pub fn from_slice(slice: &[u8], bit_len: usize) -> Self {
         assert!(
-            slice.len() * 8 >= len,
-            "slice bit length {} is less than len {}",
+            slice.len() * 8 >= bit_len,
+            "slice bit length {} is less than bit_len {}",
             slice.len() * 8,
-            len
+            bit_len
         );
         let mut bitvec = BitVec::from_slice(slice);
-        unsafe { bitvec.set_len(len) };
+        unsafe { bitvec.set_len(bit_len) };
         Self(Arc::new(bitvec))
     }
 
@@ -46,5 +46,24 @@ impl JumpTable {
     #[inline]
     pub fn is_valid(&self, pc: usize) -> bool {
         pc < self.0.len() && unsafe { *self.0.get_unchecked(pc) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "slice bit length 8 is less than bit_len 10")]
+    fn test_jump_table_from_slice_panic() {
+        let slice = &[0x00];
+        let _ = JumpTable::from_slice(slice, 10);
+    }
+
+    #[test]
+    fn test_jump_table_from_slice() {
+        let slice = &[0x00];
+        let jumptable = JumpTable::from_slice(slice, 3);
+        assert_eq!(jumptable.0.len(), 3);
     }
 }

--- a/crates/bytecode/src/legacy/jump_map.rs
+++ b/crates/bytecode/src/legacy/jump_map.rs
@@ -22,10 +22,24 @@ impl JumpTable {
         self.0.as_raw_slice()
     }
 
-    /// Constructs a jump map from raw bytes.
+    /// Constructs a jump map from raw bytes and length.
+    ///
+    /// Lenght represents number of bits inside slice.
+    ///
+    /// # Panics
+    ///
+    /// Panics if number of bits in slice is less than length.
     #[inline]
-    pub fn from_slice(slice: &[u8]) -> Self {
-        Self(Arc::new(BitVec::from_slice(slice)))
+    pub fn from_slice(slice: &[u8], len: usize) -> Self {
+        assert!(
+            slice.len() * 8 >= len,
+            "slice bit length {} is less than len {}",
+            slice.len() * 8,
+            len
+        );
+        let mut bitvec = BitVec::from_slice(slice);
+        unsafe { bitvec.set_len(len) };
+        Self(Arc::new(bitvec))
     }
 
     /// Checks if `pc` is a valid jump destination.


### PR DESCRIPTION
This fixes inconsistency with jumpmap always rounding len of bits to the last byte.