### PR TITLE
test(op-precompiles): Check subset of l1 precompiles in op

### DIFF
--- a/crates/optimism/src/evm.rs
+++ b/crates/optimism/src/evm.rs
@@ -110,7 +110,7 @@ mod tests {
         context::result::{ExecutionResult, OutOfGasError},
         context_interface::result::HaltReason,
         database::{BenchmarkDB, BENCH_CALLER, BENCH_CALLER_BALANCE, BENCH_TARGET},
-        precompile::bn128,
+        precompile::{bls12_381_const, bn128, u64_to_address},
         primitives::{hex::FromHex, Address, Bytes, TxKind, U256},
         state::Bytecode,
         Context, ExecuteEvm,

--- a/crates/optimism/src/precompiles.rs
+++ b/crates/optimism/src/precompiles.rs
@@ -196,4 +196,26 @@ mod tests {
         let res = bn128_pair::run_pair(&input, 260_000);
         assert!(matches!(res, Err(PrecompileError::Bn128PairLength)));
     }
+
+    #[test]
+    fn test_cancun_precompiles_in_fjord() {
+        // additional to cancun, fjord has p256verify
+        assert_eq!(fjord().difference(Precompiles::cancun()).len(), 1)
+    }
+
+    #[test]
+    fn test_cancun_precompiles_in_granite() {
+        // granite has p256verify (fjord)
+        // granite has modification of cancun's bn128 pair
+        assert_eq!(granite().difference(Precompiles::cancun()).len(), 2)
+    }
+
+    #[test]
+    fn test_prague_precompiles_in_isthmus() {
+        let new_prague_precompiles = Precompiles::prague().difference(Precompiles::cancun());
+
+        let intersection = isthmus().intersection(&new_prague_precompiles);
+
+        assert!(new_prague_precompiles.difference(&intersection).is_empty())
+    }
 }


### PR DESCRIPTION
Ref https://github.com/bluealloy/revm/issues/2189

Checks that subset of l1 precompiles are part of op precompiles wrt hardfork