### PR TITLE
test(op-precompiles): Add test for calling g1 add

### DIFF
--- a/crates/optimism/src/evm.rs
+++ b/crates/optimism/src/evm.rs
@@ -287,7 +287,7 @@ mod tests {
 
         let output = evm.replay().unwrap();
 
-        // assert out of gas for g1 add
+        // assert out of gas
         assert!(matches!(
             output.result,
             ExecutionResult::Halt {
@@ -303,7 +303,6 @@ mod tests {
             .modify_tx_chained(|tx| {
                 tx.base.kind = TxKind::Call(u64_to_address(bls12_381_const::G1_ADD_ADDRESS));
                 tx.base.gas_limit = 21_000 + bls12_381_const::G1_ADD_BASE_GAS_FEE;
-                tx.base.data = Bytes::from([1; bls12_381_const::G1_ADD_INPUT_LENGTH - 2].to_vec());
             })
             .modify_chain_chained(|l1_block| {
                 l1_block.operator_fee_constant = Some(U256::ZERO);

--- a/crates/optimism/src/evm.rs
+++ b/crates/optimism/src/evm.rs
@@ -263,7 +263,8 @@ mod tests {
     }
 
     #[test]
-    fn test_halted_tx_call_bls12_381_g1_add() {
+    #[cfg(feature = "blst")]
+    fn test_halted_tx_call_bls12_381_g1_add_out_of_gas() {
         let ctx = Context::op()
             .modify_tx_chained(|tx| {
                 tx.base.kind = TxKind::Call(u64_to_address(bls12_381_const::G1_ADD_ADDRESS));
@@ -290,6 +291,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "blst")]
     fn test_halted_tx_call_bls12_381_g1_add_input_too_small() {
         let ctx = Context::op()
             .modify_tx_chained(|tx| {

--- a/crates/optimism/src/evm.rs
+++ b/crates/optimism/src/evm.rs
@@ -110,7 +110,7 @@ mod tests {
         context::result::{ExecutionResult, OutOfGasError},
         context_interface::result::HaltReason,
         database::{BenchmarkDB, BENCH_CALLER, BENCH_CALLER_BALANCE, BENCH_TARGET},
-        precompile::bn128,
+        precompile::{bls12_381_const, bn128, u64_to_address},
         primitives::{hex::FromHex, Address, Bytes, TxKind, U256},
         state::Bytecode,
         Context, ExecuteEvm,
@@ -261,6 +261,61 @@ mod tests {
         let output = evm.replay().unwrap();
 
         // assert bails early because input size too big
+        assert!(matches!(
+            output.result,
+            ExecutionResult::Halt {
+                reason: OpHaltReason::Base(HaltReason::PrecompileError),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_halted_tx_call_bls12_381_g1_add() {
+        let ctx = Context::op()
+            .modify_tx_chained(|tx| {
+                tx.base.kind = TxKind::Call(u64_to_address(bls12_381_const::G1_ADD_ADDRESS));
+                tx.base.gas_limit = 21_000 + bls12_381_const::G1_ADD_BASE_GAS_FEE - 1;
+            })
+            .modify_chain_chained(|l1_block| {
+                l1_block.operator_fee_constant = Some(U256::ZERO);
+                l1_block.operator_fee_scalar = Some(U256::ZERO)
+            })
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ISTHMUS);
+
+        let mut evm = ctx.build_op();
+
+        let output = evm.replay().unwrap();
+
+        // assert out of gas for g1 add
+        assert!(matches!(
+            output.result,
+            ExecutionResult::Halt {
+                reason: OpHaltReason::Base(HaltReason::OutOfGas(OutOfGasError::Precompile)),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_halted_tx_call_bls12_381_g1_add_input_too_small() {
+        let ctx = Context::op()
+            .modify_tx_chained(|tx| {
+                tx.base.kind = TxKind::Call(u64_to_address(bls12_381_const::G1_ADD_ADDRESS));
+                tx.base.gas_limit = 21_000 + bls12_381_const::G1_ADD_BASE_GAS_FEE;
+                tx.base.data = Bytes::from([1; bls12_381_const::G1_ADD_INPUT_LENGTH - 2].to_vec());
+            })
+            .modify_chain_chained(|l1_block| {
+                l1_block.operator_fee_constant = Some(U256::ZERO);
+                l1_block.operator_fee_scalar = Some(U256::ZERO)
+            })
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ISTHMUS);
+
+        let mut evm = ctx.build_op();
+
+        let output = evm.replay().unwrap();
+
+        // assert fails post gas check, because input is wrong size
         assert!(matches!(
             output.result,
             ExecutionResult::Halt {


### PR DESCRIPTION
Ref https://github.com/bluealloy/revm/issues/2189

Adds test for checking that op tx calls correct precompile at address reserved for g1 add