### PR TITLE
chore(op-test): Clean up precompile tests

### DIFF
--- a/crates/optimism/src/evm.rs
+++ b/crates/optimism/src/evm.rs
@@ -110,8 +110,8 @@ mod tests {
         context::result::{ExecutionResult, OutOfGasError},
         context_interface::result::HaltReason,
         database::{BenchmarkDB, BENCH_CALLER, BENCH_CALLER_BALANCE, BENCH_TARGET},
-        precompile::bn128,
-        primitives::{hex::FromHex, Address, Bytes, TxKind, U256},
+        precompile::{bn128, u64_to_address},
+        primitives::{Address, Bytes, TxKind, U256},
         state::Bytecode,
         Context, ExecuteEvm,
     };
@@ -178,10 +178,7 @@ mod tests {
     fn test_tx_call_p256verify() {
         let ctx = Context::op()
             .modify_tx_chained(|tx| {
-                tx.base.caller = BENCH_CALLER;
-                tx.base.kind = TxKind::Call(
-                    Address::from_hex("0000000000000000000000000000000000000100").unwrap(),
-                );
+                tx.base.kind = TxKind::Call(u64_to_address(256));
                 tx.base.gas_limit = 24_450; // P256VERIFY base is 3450
             })
             .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::FJORD);
@@ -198,10 +195,7 @@ mod tests {
     fn test_halted_tx_call_p256verify() {
         let ctx = Context::op()
             .modify_tx_chained(|tx| {
-                tx.base.caller = BENCH_CALLER;
-                tx.base.kind = TxKind::Call(
-                    Address::from_hex("0000000000000000000000000000000000000100").unwrap(),
-                );
+                tx.base.kind = TxKind::Call(u64_to_address(256));
                 tx.base.gas_limit = 24_449; // 1 gas low
             })
             .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::FJORD);

--- a/crates/optimism/src/evm.rs
+++ b/crates/optimism/src/evm.rs
@@ -218,7 +218,6 @@ mod tests {
     fn test_halted_tx_call_bn128_pair_fjord() {
         let ctx = Context::op()
             .modify_tx_chained(|tx| {
-                tx.base.caller = BENCH_CALLER;
                 tx.base.kind = TxKind::Call(bn128::pair::ADDRESS);
                 tx.base.data = Bytes::from([1; GRANITE_MAX_INPUT_SIZE + 2].to_vec());
                 tx.base.gas_limit = 19_969_000; // gas needed by bn128::pair for input len
@@ -243,7 +242,6 @@ mod tests {
     fn test_halted_tx_call_bn128_pair_granite() {
         let ctx = Context::op()
             .modify_tx_chained(|tx| {
-                tx.base.caller = BENCH_CALLER;
                 tx.base.kind = TxKind::Call(bn128::pair::ADDRESS);
                 tx.base.data = Bytes::from([1; GRANITE_MAX_INPUT_SIZE + 2].to_vec());
                 tx.base.gas_limit = 19_969_000; // gas needed by bn128::pair for input len


### PR DESCRIPTION
Removes redundancy from op precompile tests