### PR TITLE
No std bls12 381 precompiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ auto_impl = "1.2.0"
 bitflags = { version = "2.6.0", default-features = false }
 bitvec = { version = "1", default-features = false }
 blst = "0.3.13"
+bls12_381 = "0.8"
 bn = { package = "substrate-bn", version = "0.6", default-features = false }
 c-kzg = { version = "1.0.0", default-features = false }
 cfg-if = { version = "1.0", default-features = false }

--- a/crates/optimism/Cargo.toml
+++ b/crates/optimism/Cargo.toml
@@ -25,6 +25,7 @@ all = "warn"
 # revm
 revm = { workspace = true, features = ["secp256r1"] }
 auto_impl.workspace = true
+bls12_381 = {version="0.8",optional=true}
 
 # static precompile sets.
 once_cell = { workspace = true, features = ["alloc"] }
@@ -71,3 +72,4 @@ c-kzg = ["revm/c-kzg"]
 # `kzg-rs` is not audited but useful for `no_std` environment, use it with causing and default to `c-kzg` if possible.
 kzg-rs = ["revm/kzg-rs"]
 blst = ["revm/blst"]
+bls12_381 = ["revm/bls12_381"]

--- a/crates/optimism/src/precompiles.rs
+++ b/crates/optimism/src/precompiles.rs
@@ -72,7 +72,7 @@ pub fn isthmus() -> &'static Precompiles {
         let precompiles = granite().clone();
         // Prague bls12 precompiles
         // Don't include BLS12-381 precompiles in no_std builds.
-        #[cfg(feature = "blst")]
+        #[cfg(any(feature = "blst", feature = "bls12_381"))]
         let precompiles = {
             let mut precompiles = precompiles;
             precompiles.extend(precompile::bls12_381::precompiles());

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -25,6 +25,7 @@ all = "warn"
 # revm
 primitives.workspace = true
 context-interface.workspace = true
+bls12_381 = {version="0.8",optional=true}
 
 # static precompile sets.
 once_cell = { workspace = true, features = ["alloc"] }
@@ -119,6 +120,7 @@ libsecp256k1 = ["dep:libsecp256k1"]
 
 # Enables the BLS12-381 precompiles.
 blst = ["dep:blst"]
+bls12_381 = ["dep:bls12_381"]
 
 [[bench]]
 name = "bench"

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -9,7 +9,7 @@
 extern crate alloc as std;
 
 pub mod blake2;
-#[cfg(feature = "blst")]
+#[cfg(any(feature = "blst", feature = "bls12_381"))]
 pub mod bls12_381;
 pub mod bls12_381_const;
 pub mod bls12_381_utils;


### PR DESCRIPTION
hey @rakita , these are not complete changes but this pr is related to [issue](https://github.com/bluealloy/revm/issues/2172) ! 
I am having a conundrum , can you give me slight guidance on where i am going wrong! 

referenced by workspace at `\revm\Cargo.toml`

Caused by:
  failed to parse manifest at `revm\crates\optimism\Cargo.toml`

Caused by:
  optional dependency `bls12_381` is not included in any feature
  Make sure that `dep:bls12_381` is included in one of features in the [features] table.