### PR TITLE
Return Fatal error on bls precompiles if in no_std #2208

### DIFF
--- a/crates/precompile/src/bls12_381.rs
+++ b/crates/precompile/src/bls12_381.rs
@@ -19,7 +19,7 @@ pub fn precompiles() -> impl Iterator<Item = PrecompileWithAddress> {
             vec![
                 PrecompileWithAddress(
                     u64_to_address(0x0A),
-                    |_,_| Err(PrecompileError::Fatal("no_std is not supported for BLS12-381 precompiles".into()))
+                    |_,_| Err(PrecompileError::Fatal("no_std is not supported for BLS12-381".into()))
                 )
             ].into_iter()
         } else {

--- a/crates/precompile/src/bls12_381.rs
+++ b/crates/precompile/src/bls12_381.rs
@@ -1,4 +1,5 @@
 use crate::PrecompileWithAddress;
+use cfg_if::cfg_if;
 
 mod g1;
 pub mod g1_add;
@@ -13,14 +14,24 @@ mod utils;
 
 /// Returns the BLS12-381 precompiles with their addresses.
 pub fn precompiles() -> impl Iterator<Item = PrecompileWithAddress> {
-    [
-        g1_add::PRECOMPILE,
-        g1_msm::PRECOMPILE,
-        g2_add::PRECOMPILE,
-        g2_msm::PRECOMPILE,
-        pairing::PRECOMPILE,
-        map_fp_to_g1::PRECOMPILE,
-        map_fp2_to_g2::PRECOMPILE,
-    ]
-    .into_iter()
+    cfg_if! {
+        if #[cfg(not(feature = "std"))] {  // If no_std is enabled
+            vec![
+                PrecompileWithAddress(
+                    u64_to_address(0x0A),
+                    |_,_| Err(PrecompileError::Fatal("no_std is not supported for BLS12-381 precompiles".into()))
+                )
+            ].into_iter()
+        } else {
+            vec![
+                g1_add::PRECOMPILE,
+                g1_msm::PRECOMPILE,
+                g2_add::PRECOMPILE,
+                g2_msm::PRECOMPILE,
+                pairing::PRECOMPILE,
+                map_fp_to_g1::PRECOMPILE,
+                map_fp2_to_g2::PRECOMPILE,
+            ].into_iter()
+        }
+    }
 }


### PR DESCRIPTION
As of now , i have added if condition globally to all precompile together, as i working on [issue](https://github.com/bluealloy/revm/issues/2172) but if you feel the need of more personal error like "c-kzg feature is not enabled" , I'll push it within this pr itself