### PR TITLE
refactor: use AccessListItem associated type instead of AccessList

### DIFF
--- a/crates/context/interface/src/transaction.rs
+++ b/crates/context/interface/src/transaction.rs
@@ -7,7 +7,7 @@ pub use alloy_types::{
     AccessList, AccessListItem, Authorization, RecoveredAuthority, RecoveredAuthorization,
     SignedAuthorization,
 };
-pub use eip2930::AccessListTr;
+pub use eip2930::AccessListItemTr;
 pub use eip7702::AuthorizationTr;
 pub use transaction_type::TransactionType;
 
@@ -27,7 +27,7 @@ pub trait TransactionError: Debug + core::error::Error {}
 /// deprecated by not returning tx_type.
 #[auto_impl(&, Box, Arc, Rc)]
 pub trait Transaction {
-    type AccessList: AccessListTr;
+    type AccessListItem: AccessListItemTr;
     type Authorization: AuthorizationTr;
 
     /// Returns the transaction type.
@@ -79,7 +79,7 @@ pub trait Transaction {
     /// Access list for the transaction.
     ///
     /// Introduced in EIP-2930.
-    fn access_list(&self) -> Option<&Self::AccessList>;
+    fn access_list(&self) -> Option<impl Iterator<Item = &Self::AccessListItem>>;
 
     /// Returns vector of fixed size hash(32 bytes)
     ///

--- a/crates/context/interface/src/transaction/alloy_types.rs
+++ b/crates/context/interface/src/transaction/alloy_types.rs
@@ -1,4 +1,4 @@
-use super::{AccessListTr, AuthorizationTr};
+use super::{AccessListItemTr, AuthorizationTr};
 use primitives::{Address, B256, U256};
 
 pub use alloy_eip2930::{AccessList, AccessListItem};
@@ -6,18 +6,13 @@ pub use alloy_eip7702::{
     Authorization, RecoveredAuthority, RecoveredAuthorization, SignedAuthorization,
 };
 
-use std::vec::Vec;
-
-impl AccessListTr for Vec<AccessListItem> {
-    fn access_list(&self) -> impl Iterator<Item = (Address, impl Iterator<Item = B256>)> {
-        self.iter()
-            .map(|item| (item.address, item.storage_keys.iter().cloned()))
+impl AccessListItemTr for AccessListItem {
+    fn address(&self) -> &Address {
+        &self.address
     }
-}
 
-impl AccessListTr for AccessList {
-    fn access_list(&self) -> impl Iterator<Item = (Address, impl Iterator<Item = B256>)> {
-        self.0.access_list()
+    fn storage_slots(&self) -> impl Iterator<Item = &B256> {
+        self.storage_keys.iter()
     }
 }
 

--- a/crates/context/interface/src/transaction/eip2930.rs
+++ b/crates/context/interface/src/transaction/eip2930.rs
@@ -9,15 +9,10 @@ use primitives::{Address, B256};
 ///
 /// Number of account and storage slots is used to calculate initial tx gas cost.
 #[auto_impl(&, Box, Arc, Rc)]
-pub trait AccessListTr {
-    /// Iterate over access list.
-    fn access_list(&self) -> impl Iterator<Item = (Address, impl Iterator<Item = B256>)>;
+pub trait AccessListItemTr {
+    /// Returns account address.
+    fn address(&self) -> &Address;
 
-    /// Returns number of account and storage slots.
-    fn access_list_nums(&self) -> (usize, usize) {
-        let storage_num = self.access_list().map(|i| i.1.count()).sum();
-        let account_num = self.access_list().count();
-
-        (account_num, storage_num)
-    }
+    /// Returns storage slot keys.
+    fn storage_slots(&self) -> impl Iterator<Item = &B256>;
 }

--- a/crates/context/src/tx.rs
+++ b/crates/context/src/tx.rs
@@ -1,5 +1,7 @@
 use crate::TransactionType;
-use context_interface::transaction::{AccessList, SignedAuthorization, Transaction};
+use context_interface::transaction::{
+    AccessList, AccessListItem, SignedAuthorization, Transaction,
+};
 use core::fmt::Debug;
 use primitives::{Address, Bytes, TxKind, B256, U256};
 use std::vec::Vec;
@@ -139,7 +141,7 @@ impl TxEnv {
 }
 
 impl Transaction for TxEnv {
-    type AccessList = AccessList;
+    type AccessListItem = AccessListItem;
     type Authorization = SignedAuthorization;
 
     fn tx_type(&self) -> u8 {
@@ -174,8 +176,8 @@ impl Transaction for TxEnv {
         self.chain_id
     }
 
-    fn access_list(&self) -> Option<&Self::AccessList> {
-        Some(&self.access_list)
+    fn access_list(&self) -> Option<impl Iterator<Item = &Self::AccessListItem>> {
+        Some(self.access_list.0.iter())
     }
 
     fn max_fee_per_gas(&self) -> u128 {

--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -3,7 +3,7 @@
 //! They handle initial setup of the EVM, call loop and the final return of the EVM
 
 use bytecode::Bytecode;
-use context_interface::transaction::{AccessListTr, AuthorizationTr};
+use context_interface::transaction::{AccessListItemTr, AuthorizationTr};
 use context_interface::ContextTr;
 use context_interface::{
     journaled_state::JournalTr,
@@ -30,8 +30,12 @@ pub fn load_accounts<CTX: ContextTr, ERROR: From<<CTX::Db as Database>::Error>>(
     // Load access list
     let (tx, journal) = context.tx_journal();
     if let Some(access_list) = tx.access_list() {
-        for (address, storage) in access_list.access_list() {
-            journal.warm_account_and_storage(address, storage.map(|i| U256::from_be_bytes(i.0)))?;
+        for item in access_list {
+            let address = item.address();
+            let storage = item.storage_slots();
+
+            journal
+                .warm_account_and_storage(*address, storage.map(|i| U256::from_be_bytes(i.0)))?;
         }
     }
 

--- a/crates/optimism/src/transaction/abstraction.rs
+++ b/crates/optimism/src/transaction/abstraction.rs
@@ -46,7 +46,7 @@ impl Default for OpTransaction<TxEnv> {
 }
 
 impl<T: Transaction> Transaction for OpTransaction<T> {
-    type AccessList = T::AccessList;
+    type AccessListItem = T::AccessListItem;
     type Authorization = T::Authorization;
 
     fn tx_type(&self) -> u8 {
@@ -81,7 +81,7 @@ impl<T: Transaction> Transaction for OpTransaction<T> {
         self.base.chain_id()
     }
 
-    fn access_list(&self) -> Option<&Self::AccessList> {
+    fn access_list(&self) -> Option<impl Iterator<Item = &Self::AccessListItem>> {
         self.base.access_list()
     }
 


### PR DESCRIPTION
I wanted to use `&[AccessListItem]` inside `Transaction` but it was unable as you couldn't set a slice as the `type AccessList`. This limited the reusability of the API.

This change follows the same pattern as `type Authorization` to ensure maximum reusability. As a result, it should be possible to implement `trait Transaction` for any type of access list.