### PR TITLE
feat: allow reuse of API for calculating initial tx gas for tx

### DIFF
--- a/crates/context/interface/src/result.rs
+++ b/crates/context/interface/src/result.rs
@@ -301,12 +301,18 @@ pub enum InvalidTransaction {
     /// Initial gas for a Call contains:
     /// - initial stipend gas
     /// - gas for access list and input data
-    CallGasCostMoreThanGasLimit,
+    CallGasCostMoreThanGasLimit {
+        initial_gas: u64,
+        gas_limit: u64,
+    },
     /// Gas floor calculated from EIP-7623 Increase calldata cost
     /// is more than the gas limit.
     ///
     /// Tx data is too large to be executed.
-    GasFloorMoreThanGasLimit,
+    GasFloorMoreThanGasLimit {
+        gas_floor: u64,
+        gas_limit: u64,
+    },
     /// EIP-3607 Reject transactions from senders with deployed code
     RejectCallerWithCode,
     /// Transaction account does not have enough amount of ether to cover transferred value and gas_limit*gas_price.
@@ -385,11 +391,23 @@ impl fmt::Display for InvalidTransaction {
             Self::CallerGasLimitMoreThanBlock => {
                 write!(f, "caller gas limit exceeds the block gas limit")
             }
-            Self::CallGasCostMoreThanGasLimit => {
-                write!(f, "call gas cost exceeds the gas limit")
+            Self::CallGasCostMoreThanGasLimit {
+                initial_gas,
+                gas_limit,
+            } => {
+                write!(
+                    f,
+                    "call gas cost ({initial_gas}) exceeds the gas limit ({gas_limit})"
+                )
             }
-            Self::GasFloorMoreThanGasLimit => {
-                write!(f, "gas floor exceeds the gas limit")
+            Self::GasFloorMoreThanGasLimit {
+                gas_floor,
+                gas_limit,
+            } => {
+                write!(
+                    f,
+                    "gas floor ({gas_floor}) exceeds the gas limit ({gas_limit})"
+                )
             }
             Self::RejectCallerWithCode => {
                 write!(f, "reject transactions from senders with deployed code")

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -317,13 +317,19 @@ pub fn validate_initial_tx_gas(
 
     // Additional check to see if limit is big enough to cover initial gas.
     if gas.initial_gas > tx.gas_limit() {
-        return Err(InvalidTransaction::CallGasCostMoreThanGasLimit);
+        return Err(InvalidTransaction::CallGasCostMoreThanGasLimit {
+            gas_limit: tx.gas_limit(),
+            initial_gas: gas.initial_gas,
+        });
     }
 
     // EIP-7623: Increase calldata cost
     // floor gas should be less than gas limit.
     if spec.is_enabled_in(SpecId::PRAGUE) && gas.floor_gas > tx.gas_limit() {
-        return Err(InvalidTransaction::GasFloorMoreThanGasLimit);
+        return Err(InvalidTransaction::GasFloorMoreThanGasLimit {
+            gas_floor: gas.floor_gas,
+            gas_limit: tx.gas_limit(),
+        });
     };
 
     Ok(gas)


### PR DESCRIPTION
This PR:
- adds rich error information for `InvalidTransaction::CallGasCostMoreThanGasLimit` and `InvalidTransaction::GasFloorMoreThanGasLimit`, such that we can inform the user - in the error message - about which values they should use to make their transaction valid.
- Splits off the `calculate_initial_tx_gas_for_tx` function so it can be reused

If approved, this PR should be applied after #2214, as it depends on the change made there.