### PR TITLE
chore(revme): remove deprecated #[clap] attribute

### DIFF
--- a/bins/revme/src/cmd/statetest.rs
+++ b/bins/revme/src/cmd/statetest.rs
@@ -16,25 +16,25 @@ pub struct Cmd {
     /// If multiple paths are specified they will be run in sequence.
     ///
     /// Folders will be searched recursively for files with the extension `.json`.
-    #[clap(required = true, num_args = 1..)]
+    #[arg(required = true, num_args = 1..)]
     paths: Vec<PathBuf>,
     /// Run tests in a single thread
-    #[clap(short = 's', long)]
+    #[arg(short = 's', long)]
     single_thread: bool,
     /// Output results in JSON format
     ///
     /// It will stop second run of evm on failure.
-    #[clap(long)]
+    #[arg(long)]
     json: bool,
     /// Output outcome in JSON format
     ///
     /// If `--json` is true, this is implied.
     ///
     /// It will stop second run of EVM on failure.
-    #[clap(short = 'o', long)]
+    #[arg(short = 'o', long)]
     json_outcome: bool,
     /// Keep going after a test failure
-    #[clap(long, alias = "no-fail-fast")]
+    #[arg(long, alias = "no-fail-fast")]
     keep_going: bool,
 }
 


### PR DESCRIPTION
ref: https://github.com/bluealloy/revm/pull/1754 replaced `structopt` with `clap`
updates deprecated #[clap(...)] attributes to their modern equivalents in clap 4.x.

logs:
```
warning: use of deprecated function `<cmd::statetest::Cmd as clap::Args>::augment_args::old_attribute`: Attribute `#[clap(...)]` has been deprecated in favor of `#[arg(...)]`
  --> bins/revme/src/cmd/statetest.rs:19:7
   |
19 |     #[clap(required = true, num_args = 1..)]
   |       ^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: use of deprecated function `<cmd::statetest::Cmd as clap::Args>::augment_args::old_attribute`: Attribute `#[clap(...)]` has been deprecated in favor of `#[arg(...)]`
  --> bins/revme/src/cmd/statetest.rs:22:7
   |
22 |     #[clap(short = 's', long)]
   |       ^^^^

warning: use of deprecated function `<cmd::statetest::Cmd as clap::Args>::augment_args::old_attribute`: Attribute `#[clap(...)]` has been deprecated in favor of `#[arg(...)]`
  --> bins/revme/src/cmd/statetest.rs:27:7
   |
27 |     #[clap(long)]
   |       ^^^^

warning: use of deprecated function `<cmd::statetest::Cmd as clap::Args>::augment_args::old_attribute`: Attribute `#[clap(...)]` has been deprecated in favor of `#[arg(...)]`
  --> bins/revme/src/cmd/statetest.rs:34:7
   |
34 |     #[clap(short = 'o', long)]
   |       ^^^^

warning: use of deprecated function `<cmd::statetest::Cmd as clap::Args>::augment_args::old_attribute`: Attribute `#[clap(...)]` has been deprecated in favor of `#[arg(...)]`
  --> bins/revme/src/cmd/statetest.rs:37:7
   |
37 |     #[clap(long, alias = "no-fail-fast")]
   |       ^^^^

warning: `revme` (lib) generated 5 warnings
```

