### PR TITLE
refactor: make str to SpecId conversion fallible

### DIFF
--- a/crates/optimism/src/spec.rs
+++ b/crates/optimism/src/spec.rs
@@ -1,5 +1,4 @@
 use core::str::FromStr;
-
 use revm::primitives::hardfork::{name as eth_name, SpecId, UnknownHardfork};
 
 #[repr(u8)]

--- a/crates/optimism/src/spec.rs
+++ b/crates/optimism/src/spec.rs
@@ -1,4 +1,6 @@
-use revm::primitives::hardfork::{name as eth_name, SpecId};
+use core::str::FromStr;
+
+use revm::primitives::hardfork::{name as eth_name, SpecId, UnknownHardfork};
 
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
@@ -41,11 +43,11 @@ impl From<OpSpecId> for SpecId {
     }
 }
 
-impl TryFrom<&str> for OpSpecId {
-    type Error = ();
+impl FromStr for OpSpecId {
+    type Err = UnknownHardfork;
 
-    fn try_from(name: &str) -> Result<Self, Self::Error> {
-        match name {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
             name::BEDROCK => Ok(OpSpecId::BEDROCK),
             name::REGOLITH => Ok(OpSpecId::REGOLITH),
             name::CANYON => Ok(OpSpecId::CANYON),
@@ -56,7 +58,7 @@ impl TryFrom<&str> for OpSpecId {
             name::ISTHMUS => Ok(OpSpecId::ISTHMUS),
             name::INTEROP => Ok(OpSpecId::INTEROP),
             eth_name::OSAKA => Ok(OpSpecId::OSAKA),
-            _ => Err(()),
+            _ => Err(UnknownHardfork),
         }
     }
 }

--- a/crates/primitives/src/hardfork.rs
+++ b/crates/primitives/src/hardfork.rs
@@ -1,5 +1,6 @@
 #![allow(non_camel_case_types)]
 
+use core::str::FromStr;
 pub use std::string::{String, ToString};
 pub use SpecId::*;
 
@@ -73,11 +74,13 @@ pub mod name {
     pub const LATEST: &str = "Latest";
 }
 
-impl TryFrom<&str> for SpecId {
-    type Error = ();
+pub struct UnknownHardfork;
 
-    fn try_from(name: &str) -> Result<Self, Self::Error> {
-        match name {
+impl FromStr for SpecId {
+    type Err = UnknownHardfork;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
             name::FRONTIER => Ok(Self::FRONTIER),
             name::FRONTIER_THAWING => Ok(Self::FRONTIER_THAWING),
             name::HOMESTEAD => Ok(Self::HOMESTEAD),
@@ -99,7 +102,7 @@ impl TryFrom<&str> for SpecId {
             name::PRAGUE => Ok(Self::PRAGUE),
             name::OSAKA => Ok(Self::OSAKA),
             name::LATEST => Ok(Self::LATEST),
-            _ => Err(()),
+            _ => Err(UnknownHardfork),
         }
     }
 }

--- a/crates/primitives/src/hardfork.rs
+++ b/crates/primitives/src/hardfork.rs
@@ -73,31 +73,33 @@ pub mod name {
     pub const LATEST: &str = "Latest";
 }
 
-impl From<&str> for SpecId {
-    fn from(name: &str) -> Self {
+impl TryFrom<&str> for SpecId {
+    type Error = ();
+
+    fn try_from(name: &str) -> Result<Self, Self::Error> {
         match name {
-            name::FRONTIER => Self::FRONTIER,
-            name::FRONTIER_THAWING => Self::FRONTIER_THAWING,
-            name::HOMESTEAD => Self::HOMESTEAD,
-            name::DAO_FORK => Self::DAO_FORK,
-            name::TANGERINE => Self::TANGERINE,
-            name::SPURIOUS_DRAGON => Self::SPURIOUS_DRAGON,
-            name::BYZANTIUM => Self::BYZANTIUM,
-            name::CONSTANTINOPLE => Self::CONSTANTINOPLE,
-            name::PETERSBURG => Self::PETERSBURG,
-            name::ISTANBUL => Self::ISTANBUL,
-            name::MUIR_GLACIER => Self::MUIR_GLACIER,
-            name::BERLIN => Self::BERLIN,
-            name::LONDON => Self::LONDON,
-            name::ARROW_GLACIER => Self::ARROW_GLACIER,
-            name::GRAY_GLACIER => Self::GRAY_GLACIER,
-            name::MERGE => Self::MERGE,
-            name::SHANGHAI => Self::SHANGHAI,
-            name::CANCUN => Self::CANCUN,
-            name::PRAGUE => Self::PRAGUE,
-            name::OSAKA => Self::OSAKA,
-            name::LATEST => Self::LATEST,
-            _ => Self::LATEST,
+            name::FRONTIER => Ok(Self::FRONTIER),
+            name::FRONTIER_THAWING => Ok(Self::FRONTIER_THAWING),
+            name::HOMESTEAD => Ok(Self::HOMESTEAD),
+            name::DAO_FORK => Ok(Self::DAO_FORK),
+            name::TANGERINE => Ok(Self::TANGERINE),
+            name::SPURIOUS_DRAGON => Ok(Self::SPURIOUS_DRAGON),
+            name::BYZANTIUM => Ok(Self::BYZANTIUM),
+            name::CONSTANTINOPLE => Ok(Self::CONSTANTINOPLE),
+            name::PETERSBURG => Ok(Self::PETERSBURG),
+            name::ISTANBUL => Ok(Self::ISTANBUL),
+            name::MUIR_GLACIER => Ok(Self::MUIR_GLACIER),
+            name::BERLIN => Ok(Self::BERLIN),
+            name::LONDON => Ok(Self::LONDON),
+            name::ARROW_GLACIER => Ok(Self::ARROW_GLACIER),
+            name::GRAY_GLACIER => Ok(Self::GRAY_GLACIER),
+            name::MERGE => Ok(Self::MERGE),
+            name::SHANGHAI => Ok(Self::SHANGHAI),
+            name::CANCUN => Ok(Self::CANCUN),
+            name::PRAGUE => Ok(Self::PRAGUE),
+            name::OSAKA => Ok(Self::OSAKA),
+            name::LATEST => Ok(Self::LATEST),
+            _ => Err(()),
         }
     }
 }


### PR DESCRIPTION
This matches the way string to `SpecId` conversion is handled to [`OpSpecId`](https://github.com/bluealloy/revm/blob/main/crates/optimism/src/spec.rs#L44), causing errors when invalid hardfork names are provided.