### PR TITLE
fix: DepositTx Identifier is 126 (`0x7e`) not `0x7f`

### DIFF
--- a/crates/optimism/src/l1block.rs
+++ b/crates/optimism/src/l1block.rs
@@ -150,7 +150,7 @@ impl L1BlockInfo {
     /// Introduced in isthmus. Prior to isthmus, the operator fee is always zero.
     pub fn operator_fee_charge(&self, input: &[u8], gas_limit: U256) -> U256 {
         // If the input is a deposit transaction or empty, the default value is zero.
-        if input.is_empty() || input.first() == Some(&0x7F) {
+        if input.is_empty() || input.first() == Some(&0x7E) {
             return U256::ZERO;
         }
         let operator_fee_scalar = self
@@ -235,7 +235,7 @@ impl L1BlockInfo {
             return tx_l1_cost;
         }
         // If the input is a deposit transaction or empty, the default value is zero.
-        let tx_l1_cost = if input.is_empty() || input.first() == Some(&0x7F) {
+        let tx_l1_cost = if input.is_empty() || input.first() == Some(&0x7E) {
             return U256::ZERO;
         } else if spec_id.is_enabled_in(OpSpecId::FJORD) {
             self.calculate_tx_l1_cost_fjord(input)
@@ -398,8 +398,8 @@ mod tests {
         assert_eq!(gas_cost, U256::ZERO);
         l1_block_info.clear_tx_l1_cost();
 
-        // Deposit transactions with the EIP-2718 type of 0x7F should result in zero
-        let input = bytes!("7FFACADE");
+        // Deposit transactions with the EIP-2718 type of 0x7E should result in zero
+        let input = bytes!("7EFACADE");
         let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::REGOLITH);
         assert_eq!(gas_cost, U256::ZERO);
     }
@@ -429,8 +429,8 @@ mod tests {
         assert_eq!(gas_cost, U256::ZERO);
         l1_block_info.clear_tx_l1_cost();
 
-        // Deposit transactions with the EIP-2718 type of 0x7F should result in zero
-        let input = bytes!("7FFACADE");
+        // Deposit transactions with the EIP-2718 type of 0x7E should result in zero
+        let input = bytes!("7EFACADE");
         let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::ECOTONE);
         assert_eq!(gas_cost, U256::ZERO);
         l1_block_info.clear_tx_l1_cost();
@@ -529,8 +529,8 @@ mod tests {
         assert_eq!(gas_cost, U256::ZERO);
         l1_block_info.clear_tx_l1_cost();
 
-        // Deposit transactions with the EIP-2718 type of 0x7F should result in zero
-        let input = bytes!("7FFACADE");
+        // Deposit transactions with the EIP-2718 type of 0x7E should result in zero
+        let input = bytes!("7EFACADE");
         let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, OpSpecId::FJORD);
         assert_eq!(gas_cost, U256::ZERO);
     }


### PR DESCRIPTION
### Description

Fixes deposit tx identifier to be the correct `0x7e` instead of `0x7f`.