### PR TITLE
test(op-precompiles): Add tests for bls12-381 map fp to g

### DIFF
--- a/crates/optimism/src/evm.rs
+++ b/crates/optimism/src/evm.rs
@@ -549,8 +549,8 @@ mod tests {
     #[test]
     #[cfg(feature = "blst")]
     fn test_halted_tx_call_bls12_381_pairing_out_of_gas() {
-        let pairing_gas: u64 = bls12_381_const::PAIRING_PAIRING_MULTIPLIER_BASE
-            + bls12_381_const::PAIRING_PAIRING_OFFSET_BASE;
+        let pairing_gas: u64 =
+            bls12_381_const::PAIRING_MULTIPLIER_BASE + bls12_381_const::PAIRING_OFFSET_BASE;
 
         let ctx = Context::op()
             .modify_tx_chained(|tx| {
@@ -583,8 +583,8 @@ mod tests {
     #[test]
     #[cfg(feature = "blst")]
     fn test_tx_call_bls12_381_pairing_wrong_input_layout() {
-        let pairing_gas: u64 = bls12_381_const::PAIRING_PAIRING_MULTIPLIER_BASE
-            + bls12_381_const::PAIRING_PAIRING_OFFSET_BASE;
+        let pairing_gas: u64 =
+            bls12_381_const::PAIRING_MULTIPLIER_BASE + bls12_381_const::PAIRING_OFFSET_BASE;
 
         let ctx = Context::op()
             .modify_tx_chained(|tx| {

--- a/crates/optimism/src/evm.rs
+++ b/crates/optimism/src/evm.rs
@@ -612,4 +612,60 @@ mod tests {
             }
         ));
     }
+
+    #[test]
+    #[cfg(feature = "blst")]
+    fn test_halted_tx_call_bls12_381_map_fp_to_g1_out_of_gas() {
+        let ctx = Context::op()
+            .modify_tx_chained(|tx| {
+                tx.base.kind = TxKind::Call(u64_to_address(bls12_381_const::MAP_FP_TO_G1_ADDRESS));
+                tx.base.gas_limit = 21_000 + bls12_381_const::MAP_FP_TO_G1_BASE_GAS_FEE - 1;
+            })
+            .modify_chain_chained(|l1_block| {
+                l1_block.operator_fee_constant = Some(U256::ZERO);
+                l1_block.operator_fee_scalar = Some(U256::ZERO)
+            })
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ISTHMUS);
+
+        let mut evm = ctx.build_op();
+
+        let output = evm.replay().unwrap();
+
+        // assert out of gas
+        assert!(matches!(
+            output.result,
+            ExecutionResult::Halt {
+                reason: OpHaltReason::Base(HaltReason::OutOfGas(OutOfGasError::Precompile)),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    #[cfg(feature = "blst")]
+    fn test_halted_tx_call_bls12_381_map_fp_to_g1_input_wrong_size() {
+        let ctx = Context::op()
+            .modify_tx_chained(|tx| {
+                tx.base.kind = TxKind::Call(u64_to_address(bls12_381_const::MAP_FP_TO_G1_ADDRESS));
+                tx.base.gas_limit = 21_000 + bls12_381_const::MAP_FP_TO_G1_BASE_GAS_FEE;
+            })
+            .modify_chain_chained(|l1_block| {
+                l1_block.operator_fee_constant = Some(U256::ZERO);
+                l1_block.operator_fee_scalar = Some(U256::ZERO)
+            })
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ISTHMUS);
+
+        let mut evm = ctx.build_op();
+
+        let output = evm.replay().unwrap();
+
+        // assert fails post gas check, because input is wrong size
+        assert!(matches!(
+            output.result,
+            ExecutionResult::Halt {
+                reason: OpHaltReason::Base(HaltReason::PrecompileError),
+                ..
+            }
+        ));
+    }
 }

--- a/crates/optimism/src/evm.rs
+++ b/crates/optimism/src/evm.rs
@@ -668,4 +668,60 @@ mod tests {
             }
         ));
     }
+
+    #[test]
+    #[cfg(feature = "blst")]
+    fn test_halted_tx_call_bls12_381_map_fp2_to_g2_out_of_gas() {
+        let ctx = Context::op()
+            .modify_tx_chained(|tx| {
+                tx.base.kind = TxKind::Call(u64_to_address(bls12_381_const::MAP_FP2_TO_G2_ADDRESS));
+                tx.base.gas_limit = 21_000 + bls12_381_const::MAP_FP2_TO_G2_BASE_GAS_FEE - 1;
+            })
+            .modify_chain_chained(|l1_block| {
+                l1_block.operator_fee_constant = Some(U256::ZERO);
+                l1_block.operator_fee_scalar = Some(U256::ZERO)
+            })
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ISTHMUS);
+
+        let mut evm = ctx.build_op();
+
+        let output = evm.replay().unwrap();
+
+        // assert out of gas
+        assert!(matches!(
+            output.result,
+            ExecutionResult::Halt {
+                reason: OpHaltReason::Base(HaltReason::OutOfGas(OutOfGasError::Precompile)),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    #[cfg(feature = "blst")]
+    fn test_halted_tx_call_bls12_381_map_fp2_to_g2_input_wrong_size() {
+        let ctx = Context::op()
+            .modify_tx_chained(|tx| {
+                tx.base.kind = TxKind::Call(u64_to_address(bls12_381_const::MAP_FP2_TO_G2_ADDRESS));
+                tx.base.gas_limit = 21_000 + bls12_381_const::MAP_FP2_TO_G2_BASE_GAS_FEE;
+            })
+            .modify_chain_chained(|l1_block| {
+                l1_block.operator_fee_constant = Some(U256::ZERO);
+                l1_block.operator_fee_scalar = Some(U256::ZERO)
+            })
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ISTHMUS);
+
+        let mut evm = ctx.build_op();
+
+        let output = evm.replay().unwrap();
+
+        // assert fails post gas check, because input is wrong size
+        assert!(matches!(
+            output.result,
+            ExecutionResult::Halt {
+                reason: OpHaltReason::Base(HaltReason::PrecompileError),
+                ..
+            }
+        ));
+    }
 }


### PR DESCRIPTION
Ref https://github.com/bluealloy/revm/issues/2189

Add tests for map fp to g1 and map fp2 to g2