### PR TITLE
tests(op-precompiles): Add missing g2 add tests

### DIFF
--- a/crates/optimism/src/evm.rs
+++ b/crates/optimism/src/evm.rs
@@ -423,6 +423,62 @@ mod tests {
         ));
     }
 
+    #[test]
+    #[cfg(feature = "blst")]
+    fn test_halted_tx_call_bls12_381_g2_add_out_of_gas() {
+        let ctx = Context::op()
+            .modify_tx_chained(|tx| {
+                tx.base.kind = TxKind::Call(u64_to_address(bls12_381_const::G2_ADD_ADDRESS));
+                tx.base.gas_limit = 21_000 + bls12_381_const::G2_ADD_BASE_GAS_FEE - 1;
+            })
+            .modify_chain_chained(|l1_block| {
+                l1_block.operator_fee_constant = Some(U256::ZERO);
+                l1_block.operator_fee_scalar = Some(U256::ZERO)
+            })
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ISTHMUS);
+
+        let mut evm = ctx.build_op();
+
+        let output = evm.replay().unwrap();
+
+        // assert out of gas
+        assert!(matches!(
+            output.result,
+            ExecutionResult::Halt {
+                reason: OpHaltReason::Base(HaltReason::OutOfGas(OutOfGasError::Precompile)),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    #[cfg(feature = "blst")]
+    fn test_halted_tx_call_bls12_381_g2_add_input_wrong_size() {
+        let ctx = Context::op()
+            .modify_tx_chained(|tx| {
+                tx.base.kind = TxKind::Call(u64_to_address(bls12_381_const::G2_ADD_ADDRESS));
+                tx.base.gas_limit = 21_000 + bls12_381_const::G2_ADD_BASE_GAS_FEE;
+            })
+            .modify_chain_chained(|l1_block| {
+                l1_block.operator_fee_constant = Some(U256::ZERO);
+                l1_block.operator_fee_scalar = Some(U256::ZERO)
+            })
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ISTHMUS);
+
+        let mut evm = ctx.build_op();
+
+        let output = evm.replay().unwrap();
+
+        // assert fails post gas check, because input is wrong size
+        assert!(matches!(
+            output.result,
+            ExecutionResult::Halt {
+                reason: OpHaltReason::Base(HaltReason::PrecompileError),
+                ..
+            }
+        ));
+    }
+
     fn g2_msm_test_tx() -> Context<
         BlockEnv,
         OpTransaction<TxEnv>,

--- a/crates/optimism/src/evm.rs
+++ b/crates/optimism/src/evm.rs
@@ -428,7 +428,7 @@ mod tests {
     fn test_halted_tx_call_bls12_381_g2_add_out_of_gas() {
         let ctx = Context::op()
             .modify_tx_chained(|tx| {
-                tx.base.kind = TxKind::Call(u64_to_address(bls12_381_const::G2_ADD_ADDRESS));
+                tx.base.kind = TxKind::Call(bls12_381_const::G2_ADD_ADDRESS);
                 tx.base.gas_limit = 21_000 + bls12_381_const::G2_ADD_BASE_GAS_FEE - 1;
             })
             .modify_chain_chained(|l1_block| {
@@ -456,7 +456,7 @@ mod tests {
     fn test_halted_tx_call_bls12_381_g2_add_input_wrong_size() {
         let ctx = Context::op()
             .modify_tx_chained(|tx| {
-                tx.base.kind = TxKind::Call(u64_to_address(bls12_381_const::G2_ADD_ADDRESS));
+                tx.base.kind = TxKind::Call(bls12_381_const::G2_ADD_ADDRESS);
                 tx.base.gas_limit = 21_000 + bls12_381_const::G2_ADD_BASE_GAS_FEE;
             })
             .modify_chain_chained(|l1_block| {

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -244,7 +244,7 @@ impl Precompiles {
 
         let inner = inner
             .iter()
-            .filter(|(a, _)| other.inner.get(*a).is_none())
+            .filter(|(a, _)| !other.inner.contains_key(*a))
             .map(|(a, p)| (*a, *p))
             .collect::<HashMap<_, _>>();
 
@@ -261,7 +261,7 @@ impl Precompiles {
 
         let inner = inner
             .iter()
-            .filter(|(a, _)| other.inner.get(*a).is_some())
+            .filter(|(a, _)| other.inner.contains_key(*a))
             .map(|(a, p)| (*a, *p))
             .collect::<HashMap<_, _>>();
 


### PR DESCRIPTION
Ref https://github.com/bluealloy/revm/issues/2189

Adds tests from https://github.com/bluealloy/revm/pull/2231/commits/ab3f5eb2dc9d94f6f3b2fa50dc0bb85cdc8b79bc that went missing when fixing merge conflicts