### PR TITLE
test(op-deposit-tx): Fix sys deposit tx gas test

### DIFF
--- a/crates/optimism/src/handler.rs
+++ b/crates/optimism/src/handler.rs
@@ -566,7 +566,7 @@ mod tests {
     }
 
     #[test]
-    fn test_consume_gas_sys_deposit_tx() {
+    fn test_consume_gas_deposit_tx() {
         let ctx = Context::op()
             .modify_tx_chained(|tx| {
                 tx.base.tx_type = DEPOSIT_TRANSACTION_TYPE;
@@ -577,6 +577,22 @@ mod tests {
         let gas = call_last_frame_return(ctx, InstructionResult::Stop, Gas::new(90));
         assert_eq!(gas.remaining(), 0);
         assert_eq!(gas.spent(), 100);
+        assert_eq!(gas.refunded(), 0);
+    }
+
+    #[test]
+    fn test_consume_gas_sys_deposit_tx() {
+        let ctx = Context::op()
+            .modify_tx_chained(|tx| {
+                tx.base.tx_type = DEPOSIT_TRANSACTION_TYPE;
+                tx.base.gas_limit = 100;
+                tx.deposit.source_hash = B256::ZERO;
+                tx.deposit.is_system_transaction = true;
+            })
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::BEDROCK);
+        let gas = call_last_frame_return(ctx, InstructionResult::Stop, Gas::new(90));
+        assert_eq!(gas.remaining(), 100);
+        assert_eq!(gas.spent(), 0);
         assert_eq!(gas.refunded(), 0);
     }
 


### PR DESCRIPTION
Ref https://github.com/bluealloy/revm/issues/2189

- Fixes name of bedrock non-sys deposit tx gas cost 
- Adds test for bedrock sys deposit tx gas cost 