### PR TITLE
chore: Add `g1_mul`, `g1_add` and `read_scalar` methods into substrate wrapper for bn128

### DIFF
--- a/crates/precompile/src/bn128.rs
+++ b/crates/precompile/src/bn128.rs
@@ -140,7 +140,7 @@ pub fn run_mul(input: &[u8], gas_cost: u64, gas_limit: u64) -> PrecompileResult 
 
     let p = read_g1_point(&input[..G1_LEN])?;
 
-    let scalar = read_scalar(&input[G1_LEN..G1_LEN + SCALAR_LEN])?;
+    let scalar = read_scalar(&input[G1_LEN..G1_LEN + SCALAR_LEN]);
     let result = g1_point_mul(p, scalar);
 
     let output = encode_g1_point(result);

--- a/crates/precompile/src/bn128.rs
+++ b/crates/precompile/src/bn128.rs
@@ -4,7 +4,10 @@ use crate::{
 };
 use std::vec::Vec;
 
-use substrate::{encode_g1_point, pairing_check, read_g1_point, read_g2_point};
+use substrate::{
+    encode_g1_point, g1_point_add, g1_point_mul, pairing_check, read_g1_point, read_g2_point,
+    read_scalar,
+};
 mod substrate;
 
 pub mod add {
@@ -121,7 +124,7 @@ pub fn run_add(input: &[u8], gas_cost: u64, gas_limit: u64) -> PrecompileResult 
 
     let p1 = read_g1_point(&input[..G1_LEN])?;
     let p2 = read_g1_point(&input[G1_LEN..])?;
-    let result = p1 + p2;
+    let result = g1_point_add(p1, p2);
 
     let output = encode_g1_point(result);
 
@@ -137,10 +140,8 @@ pub fn run_mul(input: &[u8], gas_cost: u64, gas_limit: u64) -> PrecompileResult 
 
     let p = read_g1_point(&input[..G1_LEN])?;
 
-    // `Fr::from_slice` can only fail when the length is not 32.
-    let fr = bn::Fr::from_slice(&input[G1_LEN..G1_LEN + SCALAR_LEN]).unwrap();
-
-    let result = p * fr;
+    let scalar = read_scalar(&input[G1_LEN..G1_LEN + SCALAR_LEN])?;
+    let result = g1_point_mul(p, scalar);
 
     let output = encode_g1_point(result);
 

--- a/crates/precompile/src/bn128/substrate.rs
+++ b/crates/precompile/src/bn128/substrate.rs
@@ -1,4 +1,4 @@
-use super::{FQ2_LEN, FQ_LEN, G1_LEN};
+use super::{FQ2_LEN, FQ_LEN, G1_LEN, SCALAR_LEN};
 use crate::PrecompileError;
 use bn::{AffineG1, AffineG2, Fq, Fq2, Group, Gt, G1, G2};
 
@@ -133,9 +133,15 @@ pub(super) fn read_g2_point(input: &[u8]) -> Result<G2, PrecompileError> {
 ///
 /// Note: The scalar does not need to be canonical.
 #[inline]
-pub(super) fn read_scalar(input: &[u8]) -> Result<bn::Fr, PrecompileError> {
-    // `Fr::from_slice` can only fail when the length is not 32.
-    bn::Fr::from_slice(input).map_err(|_| PrecompileError::Bn128FieldPointNotAMember)
+pub(super) fn read_scalar(input: &[u8]) -> bn::Fr {
+    assert_eq!(
+        input.len(),
+        SCALAR_LEN,
+        "unexpected scalar length. got {}, expected {SCALAR_LEN}",
+        input.len()
+    );
+    // `Fr::from_slice` can only fail when the length is not `SCALAR_LEN`.
+    bn::Fr::from_slice(input).unwrap()
 }
 
 /// Performs point addition on two G1 points.

--- a/crates/precompile/src/bn128/substrate.rs
+++ b/crates/precompile/src/bn128/substrate.rs
@@ -129,6 +129,27 @@ pub(super) fn read_g2_point(input: &[u8]) -> Result<G2, PrecompileError> {
     new_g2_point(ba, bb)
 }
 
+/// Reads a scalar from the input slice
+///
+/// Note: The scalar does not need to be canonical.
+#[inline]
+pub(super) fn read_scalar(input: &[u8]) -> Result<bn::Fr, PrecompileError> {
+    // `Fr::from_slice` can only fail when the length is not 32.
+    bn::Fr::from_slice(input).map_err(|_| PrecompileError::Bn128FieldPointNotAMember)
+}
+
+/// Performs point addition on two G1 points.
+#[inline]
+pub(super) fn g1_point_add(p1: G1, p2: G1) -> G1 {
+    p1 + p2
+}
+
+/// Performs a G1 scalar multiplication.
+#[inline]
+pub(super) fn g1_point_mul(p: G1, fr: bn::Fr) -> G1 {
+    p * fr
+}
+
 /// pairing_check performs a pairing check on a list of G1 and G2 point pairs and
 /// returns true if the result is equal to the identity element.
 ///

--- a/crates/precompile/src/bn128/substrate.rs
+++ b/crates/precompile/src/bn128/substrate.rs
@@ -132,6 +132,10 @@ pub(super) fn read_g2_point(input: &[u8]) -> Result<G2, PrecompileError> {
 /// Reads a scalar from the input slice
 ///
 /// Note: The scalar does not need to be canonical.
+///
+/// # Panics
+///
+/// If `input.len()` is not equal to [`SCALAR_LEN`].
 #[inline]
 pub(super) fn read_scalar(input: &[u8]) -> bn::Fr {
     assert_eq!(


### PR DESCRIPTION
This adds point_mul, point_add and read_scalar. They are implicitly in the public API of the bn254 curve.