### PR TITLE
test(op-test-cov): Add test for serializing deposit transaction parts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,6 +2763,7 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 name = "op-revm"
 version = "1.0.0-alpha.5"
 dependencies = [
+ "alloy-primitives",
  "alloy-sol-types",
  "anyhow",
  "auto_impl",
@@ -2771,6 +2772,7 @@ dependencies = [
  "revm",
  "rstest",
  "serde",
+ "serde_json",
  "sha2 0.10.8",
 ]
 

--- a/crates/optimism/Cargo.toml
+++ b/crates/optimism/Cargo.toml
@@ -38,6 +38,8 @@ indicatif.workspace = true
 rstest.workspace = true
 alloy-sol-types.workspace = true
 sha2.workspace = true
+serde_json = { workspace = true, features = ["alloc"] }
+alloy-primitives.workspace = true
 
 [features]
 default = ["std", "c-kzg", "secp256k1", "portable", "blst"]

--- a/crates/optimism/src/transaction/deposit.rs
+++ b/crates/optimism/src/transaction/deposit.rs
@@ -31,3 +31,26 @@ impl DepositTransactionParts {
         }
     }
 }
+
+#[cfg(all(test, feature = "serde"))]
+mod tests {
+    use super::*;
+    use alloy_primitives::b256;
+
+    #[test]
+    fn serialize_json_deposit_tx_parts() {
+        let response = r#"{"source_hash":"0xe927a1448525fb5d32cb50ee1408461a945ba6c39bd5cf5621407d500ecc8de9","mint":52,"is_system_transaction":false}"#;
+
+        let deposit_tx_parts: DepositTransactionParts = serde_json::from_str(response).unwrap();
+        assert_eq!(
+            deposit_tx_parts,
+            DepositTransactionParts {
+                source_hash: b256!(
+                    "0xe927a1448525fb5d32cb50ee1408461a945ba6c39bd5cf5621407d500ecc8de9"
+                ),
+                mint: Some(0x34),
+                is_system_transaction: false,
+            }
+        );
+    }
+}


### PR DESCRIPTION
Improves test coverage for optimism crate