### PR TITLE
chore: make clippy happy

### DIFF
--- a/crates/database/src/states/bundle_state.rs
+++ b/crates/database/src/states/bundle_state.rs
@@ -594,7 +594,7 @@ impl BundleState {
         let mut accounts = Vec::with_capacity(state_len);
         let mut storage = Vec::with_capacity(state_len);
 
-        for (address, account) in self.state.iter() {
+        for (address, account) in &self.state {
             // Append account info if it is changed.
             let was_destroyed = account.was_destroyed();
             if is_value_known.is_not_known() || account.is_info_changed() {

--- a/crates/interpreter/src/interpreter/stack.rs
+++ b/crates/interpreter/src/interpreter/stack.rs
@@ -166,7 +166,7 @@ impl Stack {
             return [U256::ZERO; N];
         }
         let mut result = [U256::ZERO; N];
-        for v in result.iter_mut() {
+        for v in &mut result {
             *v = self.data.pop().unwrap_unchecked();
         }
         result


### PR DESCRIPTION
```
warning: it is more concise to loop over references to containers instead of using explicit iteration methods
   --> crates/database/src/states/bundle_state.rs:597:35
    |
597 |         for (address, account) in self.state.iter() {
    |                                   ^^^^^^^^^^^^^^^^^ help: to write this more concisely, try: `&self.state`
```