### PR TITLE
feat: InspectEvm fn renames, inspector docs, book cleanup

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run tests
         run: |
           cp README.md book/src/README.md
-          sed -i -e 's|../../README.md|README.md|g' book/src/SUMMARY.md
+          sed -i -e 's|../../README.md|./README.md|g' book/src/SUMMARY.md
           mdbook test
 
   lint:
@@ -81,7 +81,10 @@ jobs:
           echo `pwd`/mdbook-template >> $GITHUB_PATH
 
       - name: Build book
-        run: mdbook build book
+        run: |
+          cp README.md book/src/README.md
+          sed -i -e 's|../../README.md|./README.md|g' book/src/SUMMARY.md
+          mdbook build book
 
       - name: Build docs
         run: RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo doc --all --no-deps

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -426,7 +426,7 @@ pub fn execute_test_suite(
                         );
 
                     let timer = Instant::now();
-                    let res = evm.inspect_commit_previous();
+                    let res = evm.inspect_replay_commit();
                     *elapsed.lock().unwrap() += timer.elapsed();
 
                     let spec = cfg.spec();
@@ -498,7 +498,7 @@ pub fn execute_test_suite(
                         TracerEip3155::buffered(stderr()).without_summary(),
                     );
 
-                let _ = evm.inspect_commit_previous();
+                let _ = evm.inspect_replay_commit();
 
                 println!("\nExecution result: {exec_result:#?}");
                 println!("\nExpected exception: {:?}", test.expect_exception);

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -2,8 +2,8 @@
 
 - [Introduction](./../../README.md)
 - [Awesome Revm](./awesome.md)
-- [Dev section](./dev.md)
 - [Architecture](./architecture.md)
+- [Dev section](./dev.md)
 - [Revme](./revme.md)
 - [Release procedure](./release_procedure.md)
 - [Contact](./contact.md)

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -38,7 +38,7 @@ REVM provides four ways to execute transactions through traits (API):
 * `transact(tx)` and `replay()` are function of `ExecuteEvm` trait that allow execution transactions. They return the status of execution with reason, changed state and in of case of failed execution a error.
 * `transact_commit(tx)` and `replay_commit()` are part of `ExecuteCommitEvm` that internally commits the state diff to the database and returns status of execution. Database is requires to support `DatabaseCommit` trait.
 * `inspect()`, `inspect_replay(tx)` and few others are part of `InspectEvm` trait that allow execution with inspection. This is how tracers are called.
-* `inspect_commit()`,`inspect_replay_commit(tx)` that are part of `InspectCommitEvm` trait that extends `InspectEvm` to allow commiting state diff after tracing.
+* `inspect_commit()`,`inspect_replay_commit(tx)` that are part of `InspectCommitEvm` trait that extends `InspectEvm` to allow committing state diff after tracing.
 
 For inspection API to be enabled `Evm` needs to be create with inspector.
 

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -1,4 +1,4 @@
-# Architecture
+# Architecture and API
 
 REVM is a flexible implementation of the Ethereum Virtual Machine (EVM). It follows the rules of the Ethereum mainnet and stays up to date with changes through hardforks as defined in the official [Ethereum 
 execution specs](https://github.com/ethereum/execution-specs).
@@ -7,26 +7,45 @@ You can use REVM in two main ways:
 1. Run regular Ethereum transactions using a Execution API
 2. Create your own custom version of the EVM (for Layer 2 solutions or other chains) using EVM framework
 
-The main `revm` library combines all the different crates into one package and reexports them. You can see overview revm crates in [crates folder](https://github.com/bluealloy/revm/tree/main/crates) and overview of examples in [examples folder](https://github.com/bluealloy/revm/tree/main/examples).
+To see usage examples you can check the [examples folder](https://github.com/bluealloy/revm/tree/ main/examples). Other than documentation, examples are main resource to see and learn about Revm.
 
-REVM works in no_std environments which means it can be used in zero-knowledge virtual machines (zkVMs). It also has very few external dependencies, which you can read more about in the [dev section](./dev.md).
+The main `revm` library combines all crates into one package and reexports them, standalone library are useful if there is need to import functionality with smaller scope. You can see overview of revm crates in [crates folder](https://github.com/bluealloy/revm/tree/main/crates).
+
+REVM works in `no_std` environments which means it can be used in zero-knowledge virtual machines (zkVMs) and it is the standard library in that use case. It also has very few external dependencies.
 
 # Execution API
 
-REVM provides four ways to execute transactions through traits (interfaces).
+`Evm` the main structure for executing mainnet ethereum transaction is build with a `Context` and a builder, code for it looks like this:
 
-The State system builds on the `Database` trait and handles:
-- Getting data from external storage
-- Managing the EVM's output
-- Caching changes when running multiple transactions
+```rust,ignore
+let mut evm = Context::mainnet().with_block(block).build_mainnet();
+let out = evm.transact(tx);
+```
 
-You can implement one of three database interfaces depending on what you need:
+`Evm` struct contains:
+* `Context` - Environment and evm state.
+* `Instructions` - EVM opcode implementations
+* `Precompiles` - Built-in contract implementations
+* `Inspector` - Used for tracing.
 
-- `Database`: Uses a mutable reference (`&mut self`). This is useful when you want to update a cache or track statistics while getting data. Enables basic transaction functions like `transact` and `inspect`.
+And `Context` contains data used in execution:
+* Environment data, the data that is known before execution starts are `Transaction`, `Block`, `Cfg`.
+* `Journal` is place where internal state is stored. Internal state is returned after execution ends.
+   * And `Database` is a interface that allows fetching external data that is needed in runtime. That data are account, storage and bytecode. When loaded they are stored in `Journal` 
 
-- `DatabaseRef`: Uses a regular reference (`&self`). Good for when you only need to read data without making changes. Enables reference-based functions like `transact_ref`.
+REVM provides four ways to execute transactions through traits (API):
 
-- `Database + DatabaseCommit`: Adds the ability to save transaction changes directly. Enables commit functions like `transact_commit`.
+* `transact(tx)` and `replay()` are function of `ExecuteEvm` trait that allow execution transactions. They return the status of execution with reason, changed state and in of case of failed execution a error.
+* `transact_commit(tx)` and `replay_commit()` are part of `ExecuteCommitEvm` that internally commits the state diff to the database and returns status of execution. Database is requires to support `DatabaseCommit` trait.
+* `inspect()`, `inspect_replay(tx)` and few others are part of `InspectEvm` trait that allow execution with inspection. This is how tracers are called.
+* `inspect_commit()`,`inspect_replay_commit(tx)` that are part of `InspectCommitEvm` trait that extends `InspectEvm` to allow commiting state diff after tracing.
+
+For inspection API to be enabled `Evm` needs to be create with inspector.
+
+```rust,ignore
+let mut evm = Context::mainnet().with_block(block).build_mainnet().with_inspector(inspector);
+let _ = evm.inspect_with_tx(tx);
+```
 
 # EVM Framework
 
@@ -38,16 +57,12 @@ Each trait needed to build custom EVM has detailed documentation explaining how 
 
 In summary, REVM is built around several key traits that enable customizable EVM functionality. The core traits include:
 
-* **EvmTr**: The core EVM trait that provides access to the main EVM components:
-  - Context - Environment and state access
-  - Instructions - EVM opcode implementations
-  - Precompiles - Built-in contract implementations
-  - Inspector - Used for tracing, only enabled with `InspectorEvmTr` trait.
-* **ContextTr**: Accessed through EvmTr, defines the execution environment including Tx/Block/Journal/Db:
+* **EvmTr**: The core EVM trait that provides access to `Context`, `Instruction`, `Precompiles`:
+* **ContextTr**: Accessed through EvmTr, defines the execution environment including Tx/Block/Journal/Db.
 * **Handler**: Implements the core execution logic, taking an EvmTr implementation. The default implementation follows Ethereum consensus.
 
 And traits that provide support for inspection and tracing:
 
-* **InspectorEvmTr**: Extends EvmTr to enable inspection mode execution with an associated Inspector type
-* **InspectorHandler**: Extends Handler with inspection-enabled execution paths that make Inspector callbacks
+* **InspectorEvmTr**: Extends EvmTr to enable inspection mode execution with an associated `Inspector` type
+* **InspectorHandler**: Extends Handler with inspection-enabled execution paths that make `Inspector` callbacks
 * **Inspector**: User-implementable trait for EVM inspection/tracing

--- a/book/src/awesome.md
+++ b/book/src/awesome.md
@@ -17,6 +17,7 @@ A curated list of excellent Revm-related resources. Feel free to contribute to t
 - [**Reth:**](https://github.com/paradigmxyz/reth) A modular, contributor-friendly, and ultra-fast implementation of the Ethereum protocol.
 - [**Helios**](https://github.com/a16z/helios) is a trustless, efficient, and portable multichain light client written in Rust.
 - [**Trin**](https://github.com/ethereum/trin) is a Rust implementation of a Portal Network client.
+- 
 
 #### EVM Variants
 - [**Optimism**](https://github.com/bluealloy/revm/tree/main/crates/optimism) is a ethereum L2 network.

--- a/book/src/dev.md
+++ b/book/src/dev.md
@@ -10,28 +10,3 @@ cargo build --release
 **_Note:_** This project tends to use the newest rust version, so if you're encountering a build error try running rustup update first.
 
 **_Note:_** `clang` is required for building revm with `c-kzg` or `secp256k1` feature flags as they depend on `C` libraries. If you don't have it installed, you can install it with `apt install clang`.
-
-# External core dependencies
-
-REVM relies on several key external dependencies to provide its core functionality:
-
-* The `alloy-primitives` crate provides essential native types including:
-  - `ruint` U256 big number type
-  - Address, Bytes, and B256 types
-  - `hashbrown` implementations of HashMap/HashSet with custom hashing algorithms
-* For broad compatibility, REVM is `no_std` compliant and uses the `alloc` crate for heap allocation needs.
-* Precompile functionality requires several cryptography and math libraries:
-  - `c-kzg`: Implements Polynomial Commitments API for EIP-4844 (C implementation with Rust bindings)
-  - `modexp`: Handles big integer modular exponentiation
-  - `secp256k1`: Provides ECDSA public key recovery based on secp256k1 curves
-  - `k256`: Serves as a no_std compatible fallback for secp256k1
-* Transaction environment AccessList and AuthorizationList come from:
-  - `alloy-eip7702`
-  - `alloy-eip2930`
-* Optional serialization support through feature-flagged:
-  - `serde`
-  - `serde-json` 
-* Various utility crates enhance development:
-  - `auto_impl`
-  - `derive_more`
-  - Specialized libraries like `nnum` for specific use cases

--- a/book/src/testing.md
+++ b/book/src/testing.md
@@ -1,1 +1,0 @@
-# Testing

--- a/crates/context/src/journaled_state/init.rs
+++ b/crates/context/src/journaled_state/init.rs
@@ -1,7 +1,7 @@
 use super::Journal;
 use database_interface::EmptyDB;
 
-/// A clonable version of JournaledState that uses EmptyDB.
+/// A cloneable version of JournaledState that uses EmptyDB.
 /// Used to clone the journaled state and for initialization of new journaled state.
 pub type JournalInit = Journal<EmptyDB>;
 

--- a/crates/inspector/src/gas.rs
+++ b/crates/inspector/src/gas.rs
@@ -16,14 +16,19 @@ impl Default for GasInspector {
 }
 
 impl GasInspector {
+    /// Returns the remaining gas.
+    #[inline]
     pub fn gas_remaining(&self) -> u64 {
         self.gas_remaining
     }
 
+    /// Returns the last gas cost.
+    #[inline]
     pub fn last_gas_cost(&self) -> u64 {
         self.last_gas_cost
     }
 
+    /// Create a new gas inspector.
     pub fn new() -> Self {
         Self {
             gas_remaining: 0,
@@ -31,16 +36,19 @@ impl GasInspector {
         }
     }
 
+    /// Sets remaining gas to gas limit.
     #[inline]
     pub fn initialize_interp(&mut self, gas: &Gas) {
         self.gas_remaining = gas.limit();
     }
 
+    /// Sets the remaining gas.
     #[inline]
     pub fn step(&mut self, gas: &Gas) {
         self.gas_remaining = gas.remaining();
     }
 
+    /// calculate last gas cost and remaining gas.
     #[inline]
     pub fn step_end(&mut self, gas: &mut Gas) {
         let remaining = gas.remaining();
@@ -48,6 +56,7 @@ impl GasInspector {
         self.gas_remaining = remaining;
     }
 
+    /// Spend all gas if call failed.
     #[inline]
     pub fn call_end(&mut self, outcome: &mut CallOutcome) {
         if outcome.result.result.is_error() {
@@ -56,6 +65,7 @@ impl GasInspector {
         }
     }
 
+    /// Spend all gas if create failed.
     #[inline]
     pub fn create_end(&mut self, outcome: &mut CreateOutcome) {
         if outcome.result.result.is_error() {

--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -27,7 +27,7 @@ use std::{vec, vec::Vec};
 /// * [`Handler::frame_call`] replaced with [`InspectorHandler::inspect_frame_call`]
 /// * [`Handler::run_exec_loop`] replaced with [`InspectorHandler::inspect_run_exec_loop`]
 ///
-/// * [`Handler::last_frame_result`] replaced with [`InspectorHandler::last_frame_result`]
+/// * [`Handler::last_frame_result`] replaced with [`InspectorHandler::inspect_last_frame_result`]
 ///
 pub trait InspectorHandler: Handler
 where
@@ -122,7 +122,7 @@ where
     ///
     /// This method acts as [`Handler::frame_call`] method for inspection.
     ///
-    /// Internaly it will call [`Inspector::step`], [`Inspector::step_end`] for each instruction.
+    /// Internally it will call [`Inspector::step`], [`Inspector::step_end`] for each instruction.
     /// And [`Inspector::log`],[`Inspector::selfdestruct`] for each log and selfdestruct instruction.
     #[inline]
     fn inspect_frame_call(

--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -1,0 +1,325 @@
+use crate::{Inspector, InspectorEvmTr, InspectorFrame, JournalExt};
+use context::{result::ResultAndState, ContextTr, JournalEntry, Transaction};
+use handler::{EvmTr, Frame, FrameInitOrResult, FrameOrResult, FrameResult, Handler, ItemOrResult};
+use interpreter::{
+    instructions::InstructionTable,
+    interpreter_types::{Jumps, LoopControl},
+    FrameInput, Host, InitialAndFloorGas, InstructionResult, Interpreter, InterpreterAction,
+    InterpreterTypes,
+};
+
+use std::{vec, vec::Vec};
+
+/// Trait that extends [`Handler`] with inspection functionality.
+///
+/// Similar how [`Handler::run`] method serves as the entry point,
+/// [`InspectorHandler::inspect_run`] method serves as the entry point for inspection.
+///
+/// Notice that when inspection is run it skips few functions from handler, this can be
+/// a problem if custom EVM is implemented and some of skipped functions have changed logic.
+/// For custom EVM, those changed functions would need to be also changed in [`InspectorHandler`].
+///
+/// List of functions that are skipped in [`InspectorHandler`]:
+/// * [`Handler::run`] replaced with [`InspectorHandler::inspect_run`]
+/// * [`Handler::run_without_catch_error`] replaced with [`InspectorHandler::inspect_run_without_catch_error`]
+/// * [`Handler::execution`] replaced with [`InspectorHandler::inspect_execution`]
+/// * [`Handler::first_frame_init`] replaced with [`InspectorHandler::inspect_first_frame_init`]
+/// * [`Handler::frame_call`] replaced with [`InspectorHandler::inspect_frame_call`]
+/// * [`Handler::run_exec_loop`] replaced with [`InspectorHandler::inspect_run_exec_loop`]
+///
+/// * [`Handler::last_frame_result`] replaced with [`InspectorHandler::last_frame_result`]
+///
+pub trait InspectorHandler: Handler
+where
+    Self::Evm:
+        InspectorEvmTr<Inspector: Inspector<<<Self as Handler>::Evm as EvmTr>::Context, Self::IT>>,
+    Self::Frame: InspectorFrame<IT = Self::IT>,
+{
+    type IT: InterpreterTypes;
+
+    /// Entry point for inspection.
+    ///
+    /// This method is acts as [`Handler::run`] method for inspection.
+    fn inspect_run(
+        &mut self,
+        evm: &mut Self::Evm,
+    ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
+        match self.inspect_run_without_catch_error(evm) {
+            Ok(output) => Ok(output),
+            Err(e) => self.catch_error(evm, e),
+        }
+    }
+
+    /// Run inspection without catching error.
+    ///
+    /// This method is acts as [`Handler::run_without_catch_error`] method for inspection.
+    fn inspect_run_without_catch_error(
+        &mut self,
+        evm: &mut Self::Evm,
+    ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
+        let init_and_floor_gas = self.validate(evm)?;
+        let eip7702_refund = self.pre_execution(evm)? as i64;
+        let exec_result = self.inspect_execution(evm, &init_and_floor_gas);
+        self.post_execution(evm, exec_result?, init_and_floor_gas, eip7702_refund)
+    }
+
+    /// Run execution loop with inspection support
+    ///
+    /// This method acts as [`Handler::execution`] method for inspection.
+    fn inspect_execution(
+        &mut self,
+        evm: &mut Self::Evm,
+        init_and_floor_gas: &InitialAndFloorGas,
+    ) -> Result<FrameResult, Self::Error> {
+        let gas_limit = evm.ctx().tx().gas_limit() - init_and_floor_gas.initial_gas;
+
+        // Create first frame action
+        let first_frame_input = self.first_frame_input(evm, gas_limit)?;
+        let first_frame = self.inspect_first_frame_init(evm, first_frame_input)?;
+
+        let mut frame_result = match first_frame {
+            ItemOrResult::Item(frame) => self.inspect_run_exec_loop(evm, frame)?,
+            ItemOrResult::Result(result) => result,
+        };
+
+        self.last_frame_result(evm, &mut frame_result)?;
+        Ok(frame_result)
+    }
+
+    /* FRAMES */
+
+    /// Initialize first frame.
+    ///
+    /// This method replaces the [`Handler::first_frame_init`] method from [`Handler`].
+    ///
+    /// * It calls [`Inspector::call`]/[`Inspector::create`]/[`Inspector::eofcreate`] methods to allow inspection of
+    ///   the frame and its modification.
+    /// * If new frame is created a [`Inspector::initialize_interp`] method will be called.
+    /// * If creation of new frame returns the result, the [`Inspector`] `_end` methods will be called.
+    fn inspect_first_frame_init(
+        &mut self,
+        evm: &mut Self::Evm,
+        mut frame_input: <Self::Frame as Frame>::FrameInit,
+    ) -> Result<FrameOrResult<Self::Frame>, Self::Error> {
+        let (ctx, inspector) = evm.ctx_inspector();
+        if let Some(output) = frame_start(ctx, inspector, &mut frame_input) {
+            return Ok(ItemOrResult::Result(output));
+        }
+        let mut ret = self.first_frame_init(evm, frame_input.clone());
+
+        // only if new frame is created call initialize_interp hook.
+        if let Ok(ItemOrResult::Item(frame)) = &mut ret {
+            let (context, inspector) = evm.ctx_inspector();
+            inspector.initialize_interp(frame.interpreter(), context);
+        } else if let Ok(ItemOrResult::Result(result)) = &mut ret {
+            let (context, inspector) = evm.ctx_inspector();
+            frame_end(context, inspector, &frame_input, result);
+        }
+        ret
+    }
+
+    /// Run inspection on frame.
+    ///
+    /// This method acts as [`Handler::frame_call`] method for inspection.
+    ///
+    /// Internaly it will call [`Inspector::step`], [`Inspector::step_end`] for each instruction.
+    /// And [`Inspector::log`],[`Inspector::selfdestruct`] for each log and selfdestruct instruction.
+    #[inline]
+    fn inspect_frame_call(
+        &mut self,
+        frame: &mut Self::Frame,
+        evm: &mut Self::Evm,
+    ) -> Result<FrameInitOrResult<Self::Frame>, Self::Error> {
+        frame.run_inspect(evm)
+    }
+
+    /// Run inspection on execution loop.
+    ///
+    /// This method acts as [`Handler::run_exec_loop`] method for inspection.
+    ///
+    /// It will call:
+    /// * [`InspectorHandler::inspect_frame_call`] to inspect Interpreter execution loop.
+    /// * [`Inspector::call`],[`Inspector::create`],[`Inspector::eofcreate`] to inspect call, create and eofcreate.
+    /// * [`Inspector::call_end`],[`Inspector::create_end`],[`Inspector::eofcreate_end`] to inspect call, create and eofcreate end.
+    /// * [`Inspector::initialize_interp`] to inspect initialized interpreter.
+    fn inspect_run_exec_loop(
+        &mut self,
+        evm: &mut Self::Evm,
+        frame: Self::Frame,
+    ) -> Result<FrameResult, Self::Error> {
+        let mut frame_stack: Vec<Self::Frame> = vec![frame];
+        loop {
+            let frame = frame_stack.last_mut().unwrap();
+            let call_or_result = self.inspect_frame_call(frame, evm)?;
+
+            let result = match call_or_result {
+                ItemOrResult::Item(mut init) => {
+                    let (context, inspector) = evm.ctx_inspector();
+                    if let Some(output) = frame_start(context, inspector, &mut init) {
+                        output
+                    } else {
+                        match self.frame_init(frame, evm, init.clone())? {
+                            ItemOrResult::Item(mut new_frame) => {
+                                // only if new frame is created call initialize_interp hook.
+                                let (context, inspector) = evm.ctx_inspector();
+                                inspector.initialize_interp(new_frame.interpreter(), context);
+                                frame_stack.push(new_frame);
+                                continue;
+                            }
+                            // Dont pop the frame as new frame was not created.
+                            ItemOrResult::Result(mut result) => {
+                                let (context, inspector) = evm.ctx_inspector();
+                                frame_end(context, inspector, &init, &mut result);
+                                result
+                            }
+                        }
+                    }
+                }
+                ItemOrResult::Result(mut result) => {
+                    let (context, inspector) = evm.ctx_inspector();
+                    frame_end(context, inspector, frame.frame_input(), &mut result);
+
+                    // Pop frame that returned result
+                    frame_stack.pop();
+                    result
+                }
+            };
+
+            let Some(frame) = frame_stack.last_mut() else {
+                return Ok(result);
+            };
+
+            self.frame_return_result(frame, evm, result)?;
+        }
+    }
+}
+
+pub fn frame_start<CTX, INTR: InterpreterTypes>(
+    context: &mut CTX,
+    inspector: &mut impl Inspector<CTX, INTR>,
+    frame_input: &mut FrameInput,
+) -> Option<FrameResult> {
+    match frame_input {
+        FrameInput::Call(i) => {
+            if let Some(output) = inspector.call(context, i) {
+                return Some(FrameResult::Call(output));
+            }
+        }
+        FrameInput::Create(i) => {
+            if let Some(output) = inspector.create(context, i) {
+                return Some(FrameResult::Create(output));
+            }
+        }
+        FrameInput::EOFCreate(i) => {
+            if let Some(output) = inspector.eofcreate(context, i) {
+                return Some(FrameResult::EOFCreate(output));
+            }
+        }
+    }
+    None
+}
+
+pub fn frame_end<CTX, INTR: InterpreterTypes>(
+    context: &mut CTX,
+    inspector: &mut impl Inspector<CTX, INTR>,
+    frame_input: &FrameInput,
+    frame_output: &mut FrameResult,
+) {
+    match frame_output {
+        FrameResult::Call(outcome) => {
+            let FrameInput::Call(i) = frame_input else {
+                panic!("FrameInput::Call expected");
+            };
+            inspector.call_end(context, i, outcome);
+        }
+        FrameResult::Create(outcome) => {
+            let FrameInput::Create(i) = frame_input else {
+                panic!("FrameInput::Create expected");
+            };
+            inspector.create_end(context, i, outcome);
+        }
+        FrameResult::EOFCreate(outcome) => {
+            let FrameInput::EOFCreate(i) = frame_input else {
+                panic!("FrameInput::EofCreate expected");
+            };
+            inspector.eofcreate_end(context, i, outcome);
+        }
+    }
+}
+
+/// Run Interpreter loop with inspection support.
+///
+/// This function is used to inspect the Interpreter loop.
+/// It will call [`Inspector::step`] and [`Inspector::step_end`] after each instruction.
+/// And [`Inspector::log`],[`Inspector::selfdestruct`] for each log and selfdestruct instruction.
+pub fn inspect_instructions<CTX, IT>(
+    context: &mut CTX,
+    interpreter: &mut Interpreter<IT>,
+    mut inspector: impl Inspector<CTX, IT>,
+    instructions: &InstructionTable<IT, CTX>,
+) -> InterpreterAction
+where
+    CTX: ContextTr<Journal: JournalExt> + Host,
+    IT: InterpreterTypes,
+{
+    interpreter.reset_control();
+
+    let mut log_num = context.journal().logs().len();
+    // Main loop
+    while interpreter.control.instruction_result().is_continue() {
+        // Get current opcode.
+        let opcode = interpreter.bytecode.opcode();
+
+        // Call Inspector step.
+        inspector.step(interpreter, context);
+        if interpreter.control.instruction_result() != InstructionResult::Continue {
+            break;
+        }
+
+        // SAFETY: In analysis we are doing padding of bytecode so that we are sure that last
+        // byte instruction is STOP so we are safe to just increment program_counter bcs on last instruction
+        // it will do noop and just stop execution of this contract
+        interpreter.bytecode.relative_jump(1);
+
+        // Execute instruction.
+        instructions[opcode as usize](interpreter, context);
+
+        // check if new log is added
+        let new_log = context.journal().logs().len();
+        if log_num < new_log {
+            // as there is a change in log number this means new log is added
+            let log = context.journal().logs().last().unwrap().clone();
+            inspector.log(interpreter, context, log);
+            log_num = new_log;
+        }
+
+        // Call step_end.
+        inspector.step_end(interpreter, context);
+    }
+
+    let next_action = interpreter.take_next_action();
+
+    // handle selfdestruct
+    if let InterpreterAction::Return { result } = &next_action {
+        if result.result == InstructionResult::SelfDestruct {
+            match context.journal().last_journal().last() {
+                Some(JournalEntry::AccountDestroyed {
+                    address,
+                    target,
+                    had_balance,
+                    ..
+                }) => {
+                    inspector.selfdestruct(*address, *target, *had_balance);
+                }
+                Some(JournalEntry::BalanceTransfer {
+                    from, to, balance, ..
+                }) => {
+                    inspector.selfdestruct(*from, *to, *balance);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    next_action
+}

--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -26,9 +26,6 @@ use std::{vec, vec::Vec};
 /// * [`Handler::first_frame_init`] replaced with [`InspectorHandler::inspect_first_frame_init`]
 /// * [`Handler::frame_call`] replaced with [`InspectorHandler::inspect_frame_call`]
 /// * [`Handler::run_exec_loop`] replaced with [`InspectorHandler::inspect_run_exec_loop`]
-///
-/// * [`Handler::last_frame_result`] replaced with [`InspectorHandler::inspect_last_frame_result`]
-///
 pub trait InspectorHandler: Handler
 where
     Self::Evm:

--- a/crates/inspector/src/inspect.rs
+++ b/crates/inspector/src/inspect.rs
@@ -1,41 +1,71 @@
 use handler::evm::{ExecuteCommitEvm, ExecuteEvm};
 
+/// InspectEvm is a API that allows inspecting the EVM.
+///
+/// It extends the `ExecuteEvm` trait and enabled setting inspector
+///
 pub trait InspectEvm: ExecuteEvm {
     type Inspector;
 
+    /// Set the inspector for the EVM.
+    ///
+    /// this function is used to change inspector during execution.
+    /// This function can't change Inspector type, changing inspector type can be done in
+    /// `Evm` with `with_inspector` function.
     fn set_inspector(&mut self, inspector: Self::Inspector);
 
+    /// Inspect the EVM with the current inspector and previous transaction.
     fn inspect_replay(&mut self) -> Self::Output;
 
+    /// Inspect the EVM with the given inspector and transaction.
+    fn inspect(&mut self, tx: Self::Tx, inspector: Self::Inspector) -> Self::Output {
+        self.set_tx(tx);
+        self.inspect_replay_with_inspector(inspector)
+    }
+
+    /// Inspect the EVM with the current inspector and previous transaction by replaying it.
     fn inspect_replay_with_inspector(&mut self, inspector: Self::Inspector) -> Self::Output {
         self.set_inspector(inspector);
         self.inspect_replay()
     }
 
-    fn inspect_replay_with_tx(&mut self, tx: Self::Tx) -> Self::Output {
+    /// Inspect the EVM with the given transaction.
+    fn inspect_with_tx(&mut self, tx: Self::Tx) -> Self::Output {
         self.set_tx(tx);
         self.inspect_replay()
     }
-
-    fn inspect(&mut self, tx: Self::Tx, inspector: Self::Inspector) -> Self::Output {
-        self.set_tx(tx);
-        self.inspect_replay_with_inspector(inspector)
-    }
 }
 
+/// InspectCommitEvm is a API that allows inspecting similar to `InspectEvm` but it has
+/// functions that commit the state diff to the database.
+///
+/// Functions return CommitOutput from [`ExecuteCommitEvm`] trait.
 pub trait InspectCommitEvm: InspectEvm + ExecuteCommitEvm {
-    fn inspect_commit_previous(&mut self) -> Self::CommitOutput;
+    /// Inspect the EVM with the current inspector and previous transaction, similar to [`InspectEvm::inspect_replay`]
+    /// and commit the state diff to the database.
+    fn inspect_replay_commit(&mut self) -> Self::CommitOutput;
 
-    fn inspect_commit_previous_with_inspector(
+    /// Inspects commit with the given inspector and previous transaction, similar to [`InspectEvm::inspect_replay_with_inspector`]
+    /// and commit the state diff to the database.
+    fn inspect_replay_commit_with_inspector(
         &mut self,
         inspector: Self::Inspector,
     ) -> Self::CommitOutput {
         self.set_inspector(inspector);
-        self.inspect_commit_previous()
+        self.inspect_replay_commit()
     }
 
+    /// Inspect the EVM with the current inspector and previous transaction by replaying,similar to [`InspectEvm::inspect_replay_with_inspector`]
+    /// and commit the state diff to the database.
+    fn inspect_replay_with_inspector(&mut self, inspector: Self::Inspector) -> Self::CommitOutput {
+        self.set_inspector(inspector);
+        self.inspect_replay_commit()
+    }
+
+    /// Inspect the EVM with the given transaction and inspector similar to [`InspectEvm::inspect`]
+    /// and commit the state diff to the database.
     fn inspect_commit(&mut self, tx: Self::Tx, inspector: Self::Inspector) -> Self::CommitOutput {
         self.set_tx(tx);
-        self.inspect_commit_previous_with_inspector(inspector)
+        self.inspect_replay_commit_with_inspector(inspector)
     }
 }

--- a/crates/inspector/src/inspector.rs
+++ b/crates/inspector/src/inspector.rs
@@ -1,19 +1,18 @@
-use crate::{InspectorEvmTr, InspectorFrame};
 use auto_impl::auto_impl;
-use context::{result::ResultAndState, ContextTr, Database, Journal, JournalEntry, Transaction};
-use handler::{EvmTr, Frame, FrameInitOrResult, FrameOrResult, FrameResult, Handler, ItemOrResult};
+use context::{Database, Journal, JournalEntry};
 use interpreter::{
-    instructions::InstructionTable,
-    interpreter::EthInterpreter,
-    interpreter_types::{Jumps, LoopControl},
-    CallInputs, CallOutcome, CreateInputs, CreateOutcome, EOFCreateInputs, FrameInput, Host,
-    InitialAndFloorGas, InstructionResult, Interpreter, InterpreterAction, InterpreterTypes,
+    interpreter::EthInterpreter, CallInputs, CallOutcome, CreateInputs, CreateOutcome,
+    EOFCreateInputs, Interpreter, InterpreterTypes,
 };
 use primitives::{Address, Log, U256};
 use state::EvmState;
-use std::{vec, vec::Vec};
 
 /// EVM hooks into execution.
+///
+/// This trait is used to enabled tracing of the EVM execution.
+///
+/// Object that is implemented this trait is used in `InspectorHandler` to trace the EVM execution.
+/// And API that allow calling the inspector can be found in [`crate::InspectEvm`] and [`crate::InspectCommitEvm`].
 #[auto_impl(&mut, Box)]
 pub trait Inspector<CTX, INTR: InterpreterTypes = EthInterpreter> {
     /// Called before the interpreter is initialized.
@@ -142,14 +141,20 @@ pub trait Inspector<CTX, INTR: InterpreterTypes = EthInterpreter> {
     }
 }
 
+/// Extends the journal with additional methods that are used by the inspector.
 #[auto_impl(&mut, Box)]
 pub trait JournalExt {
+    /// Get all logs from the journal.
     fn logs(&self) -> &[Log];
 
+    /// Get the journal entries that are created from last checkpoint.
+    /// new checkpoint is created when sub call is made.
     fn last_journal(&self) -> &[JournalEntry];
 
+    /// Return the current Journaled state.
     fn evm_state(&self) -> &EvmState;
 
+    /// Return the mutable current Journaled state.
     fn evm_state_mut(&mut self) -> &mut EvmState;
 }
 
@@ -173,261 +178,4 @@ impl<DB: Database> JournalExt for Journal<DB> {
     fn evm_state_mut(&mut self) -> &mut EvmState {
         &mut self.state
     }
-}
-
-pub trait InspectorHandler: Handler
-where
-    Self::Evm:
-        InspectorEvmTr<Inspector: Inspector<<<Self as Handler>::Evm as EvmTr>::Context, Self::IT>>,
-    Self::Frame: InspectorFrame<IT = Self::IT>,
-{
-    type IT: InterpreterTypes;
-
-    fn inspect_run(
-        &mut self,
-        evm: &mut Self::Evm,
-    ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        match self.inspect_run_without_catch_error(evm) {
-            Ok(output) => Ok(output),
-            Err(e) => self.catch_error(evm, e),
-        }
-    }
-
-    fn inspect_run_without_catch_error(
-        &mut self,
-        evm: &mut Self::Evm,
-    ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        let init_and_floor_gas = self.validate(evm)?;
-        let eip7702_refund = self.pre_execution(evm)? as i64;
-        let exec_result = self.inspect_execution(evm, &init_and_floor_gas);
-        self.post_execution(evm, exec_result?, init_and_floor_gas, eip7702_refund)
-    }
-
-    fn inspect_execution(
-        &mut self,
-        evm: &mut Self::Evm,
-        init_and_floor_gas: &InitialAndFloorGas,
-    ) -> Result<FrameResult, Self::Error> {
-        let gas_limit = evm.ctx().tx().gas_limit() - init_and_floor_gas.initial_gas;
-
-        // Create first frame action
-        let first_frame_input = self.first_frame_input(evm, gas_limit)?;
-        let first_frame = self.inspect_first_frame_init(evm, first_frame_input)?;
-
-        let mut frame_result = match first_frame {
-            ItemOrResult::Item(frame) => self.inspect_run_exec_loop(evm, frame)?,
-            ItemOrResult::Result(result) => result,
-        };
-
-        self.last_frame_result(evm, &mut frame_result)?;
-        Ok(frame_result)
-    }
-
-    /* FRAMES */
-    fn inspect_first_frame_init(
-        &mut self,
-        evm: &mut Self::Evm,
-        mut frame_input: <Self::Frame as Frame>::FrameInit,
-    ) -> Result<FrameOrResult<Self::Frame>, Self::Error> {
-        let (ctx, inspector) = evm.ctx_inspector();
-        if let Some(output) = frame_start(ctx, inspector, &mut frame_input) {
-            return Ok(ItemOrResult::Result(output));
-        }
-        let mut ret = self.first_frame_init(evm, frame_input.clone());
-
-        // only if new frame is created call initialize_interp hook.
-        if let Ok(ItemOrResult::Item(frame)) = &mut ret {
-            let (context, inspector) = evm.ctx_inspector();
-            inspector.initialize_interp(frame.interpreter(), context);
-        } else if let Ok(ItemOrResult::Result(result)) = &mut ret {
-            let (context, inspector) = evm.ctx_inspector();
-            frame_end(context, inspector, &frame_input, result);
-        }
-        ret
-    }
-
-    #[inline]
-    fn inspect_frame_call(
-        &mut self,
-        frame: &mut Self::Frame,
-        evm: &mut Self::Evm,
-    ) -> Result<FrameInitOrResult<Self::Frame>, Self::Error> {
-        frame.run_inspect(evm)
-    }
-
-    fn inspect_run_exec_loop(
-        &mut self,
-        evm: &mut Self::Evm,
-        frame: Self::Frame,
-    ) -> Result<FrameResult, Self::Error> {
-        let mut frame_stack: Vec<Self::Frame> = vec![frame];
-        loop {
-            let frame = frame_stack.last_mut().unwrap();
-            let call_or_result = self.inspect_frame_call(frame, evm)?;
-
-            let result = match call_or_result {
-                ItemOrResult::Item(mut init) => {
-                    let (context, inspector) = evm.ctx_inspector();
-                    if let Some(output) = frame_start(context, inspector, &mut init) {
-                        output
-                    } else {
-                        match self.frame_init(frame, evm, init.clone())? {
-                            ItemOrResult::Item(mut new_frame) => {
-                                // only if new frame is created call initialize_interp hook.
-                                let (context, inspector) = evm.ctx_inspector();
-                                inspector.initialize_interp(new_frame.interpreter(), context);
-                                frame_stack.push(new_frame);
-                                continue;
-                            }
-                            // Dont pop the frame as new frame was not created.
-                            ItemOrResult::Result(mut result) => {
-                                let (context, inspector) = evm.ctx_inspector();
-                                frame_end(context, inspector, &init, &mut result);
-                                result
-                            }
-                        }
-                    }
-                }
-                ItemOrResult::Result(mut result) => {
-                    let (context, inspector) = evm.ctx_inspector();
-                    frame_end(context, inspector, frame.frame_input(), &mut result);
-
-                    // Pop frame that returned result
-                    frame_stack.pop();
-                    result
-                }
-            };
-
-            let Some(frame) = frame_stack.last_mut() else {
-                return Ok(result);
-            };
-
-            self.frame_return_result(frame, evm, result)?;
-        }
-    }
-}
-
-fn frame_start<CTX, INTR: InterpreterTypes>(
-    context: &mut CTX,
-    inspector: &mut impl Inspector<CTX, INTR>,
-    frame_input: &mut FrameInput,
-) -> Option<FrameResult> {
-    match frame_input {
-        FrameInput::Call(i) => {
-            if let Some(output) = inspector.call(context, i) {
-                return Some(FrameResult::Call(output));
-            }
-        }
-        FrameInput::Create(i) => {
-            if let Some(output) = inspector.create(context, i) {
-                return Some(FrameResult::Create(output));
-            }
-        }
-        FrameInput::EOFCreate(i) => {
-            if let Some(output) = inspector.eofcreate(context, i) {
-                return Some(FrameResult::EOFCreate(output));
-            }
-        }
-    }
-    None
-}
-
-fn frame_end<CTX, INTR: InterpreterTypes>(
-    context: &mut CTX,
-    inspector: &mut impl Inspector<CTX, INTR>,
-    frame_input: &FrameInput,
-    frame_output: &mut FrameResult,
-) {
-    match frame_output {
-        FrameResult::Call(outcome) => {
-            let FrameInput::Call(i) = frame_input else {
-                panic!("FrameInput::Call expected");
-            };
-            inspector.call_end(context, i, outcome);
-        }
-        FrameResult::Create(outcome) => {
-            let FrameInput::Create(i) = frame_input else {
-                panic!("FrameInput::Create expected");
-            };
-            inspector.create_end(context, i, outcome);
-        }
-        FrameResult::EOFCreate(outcome) => {
-            let FrameInput::EOFCreate(i) = frame_input else {
-                panic!("FrameInput::EofCreate expected");
-            };
-            inspector.eofcreate_end(context, i, outcome);
-        }
-    }
-}
-
-pub fn inspect_instructions<CTX, IT>(
-    context: &mut CTX,
-    interpreter: &mut Interpreter<IT>,
-    mut inspector: impl Inspector<CTX, IT>,
-    instructions: &InstructionTable<IT, CTX>,
-) -> InterpreterAction
-where
-    CTX: ContextTr<Journal: JournalExt> + Host,
-    IT: InterpreterTypes,
-{
-    interpreter.reset_control();
-
-    let mut log_num = context.journal().logs().len();
-    // Main loop
-    while interpreter.control.instruction_result().is_continue() {
-        // Get current opcode.
-        let opcode = interpreter.bytecode.opcode();
-
-        // Call Inspector step.
-        inspector.step(interpreter, context);
-        if interpreter.control.instruction_result() != InstructionResult::Continue {
-            break;
-        }
-
-        // SAFETY: In analysis we are doing padding of bytecode so that we are sure that last
-        // byte instruction is STOP so we are safe to just increment program_counter bcs on last instruction
-        // it will do noop and just stop execution of this contract
-        interpreter.bytecode.relative_jump(1);
-
-        // Execute instruction.
-        instructions[opcode as usize](interpreter, context);
-
-        // check if new log is added
-        let new_log = context.journal().logs().len();
-        if log_num < new_log {
-            // as there is a change in log number this means new log is added
-            let log = context.journal().logs().last().unwrap().clone();
-            inspector.log(interpreter, context, log);
-            log_num = new_log;
-        }
-
-        // Call step_end.
-        inspector.step_end(interpreter, context);
-    }
-
-    let next_action = interpreter.take_next_action();
-
-    // handle selfdestruct
-    if let InterpreterAction::Return { result } = &next_action {
-        if result.result == InstructionResult::SelfDestruct {
-            match context.journal().last_journal().last() {
-                Some(JournalEntry::AccountDestroyed {
-                    address,
-                    target,
-                    had_balance,
-                    ..
-                }) => {
-                    inspector.selfdestruct(*address, *target, *had_balance);
-                }
-                Some(JournalEntry::BalanceTransfer {
-                    from, to, balance, ..
-                }) => {
-                    inspector.selfdestruct(*from, *to, *balance);
-                }
-                _ => {}
-            }
-        }
-    }
-
-    next_action
 }

--- a/crates/inspector/src/inspector.rs
+++ b/crates/inspector/src/inspector.rs
@@ -17,8 +17,8 @@ use state::EvmState;
 pub trait Inspector<CTX, INTR: InterpreterTypes = EthInterpreter> {
     /// Called before the interpreter is initialized.
     ///
-    /// If `interp.instruction_result` is set to anything other than [InstructionResult::Continue] then the execution of the interpreter
-    /// is skipped.
+    /// If `interp.instruction_result` is set to anything other than [`interpreter::InstructionResult::Continue`]
+    /// then the execution of the interpreter is skipped.
     #[inline]
     fn initialize_interp(&mut self, interp: &mut Interpreter<INTR>, context: &mut CTX) {
         let _ = interp;
@@ -41,8 +41,8 @@ pub trait Inspector<CTX, INTR: InterpreterTypes = EthInterpreter> {
 
     /// Called after `step` when the instruction has been executed.
     ///
-    /// Setting `interp.instruction_result` to anything other than [InstructionResult::Continue] alters the execution
-    /// of the interpreter.
+    /// Setting `interp.instruction_result` to anything other than [`interpreter::InstructionResult::Continue`]
+    /// alters the execution of the interpreter.
     #[inline]
     fn step_end(&mut self, interp: &mut Interpreter<INTR>, context: &mut CTX) {
         let _ = interp;
@@ -59,7 +59,7 @@ pub trait Inspector<CTX, INTR: InterpreterTypes = EthInterpreter> {
 
     /// Called whenever a call to a contract is about to start.
     ///
-    /// InstructionResulting anything other than [InstructionResult::Continue] overrides the result of the call.
+    /// InstructionResulting anything other than [`interpreter::InstructionResult::Continue`] overrides the result of the call.
     #[inline]
     fn call(&mut self, context: &mut CTX, inputs: &mut CallInputs) -> Option<CallOutcome> {
         let _ = context;

--- a/crates/inspector/src/lib.rs
+++ b/crates/inspector/src/lib.rs
@@ -1,4 +1,7 @@
-//! Optimism-specific constants, types, and helpers.
+//! Inspector is a crate that provides a set of traits that allow inspecting the EVM execution.
+//!
+//! It is used to implement tracers that can be used to inspect the EVM execution.
+//! Implementing inspection is optional and it does not effect the core execution.
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -8,6 +11,7 @@ extern crate alloc as std;
 #[cfg(all(feature = "std", feature = "serde-json"))]
 mod eip3155;
 mod gas;
+pub mod handler;
 mod inspect;
 mod inspector;
 mod mainnet_inspect;
@@ -21,6 +25,7 @@ pub mod inspectors {
     pub use super::gas::GasInspector;
 }
 
+pub use handler::{inspect_instructions, InspectorHandler};
 pub use inspect::{InspectCommitEvm, InspectEvm};
 pub use inspector::*;
 pub use noop::NoOpInspector;

--- a/crates/inspector/src/mainnet_inspect.rs
+++ b/crates/inspector/src/mainnet_inspect.rs
@@ -1,16 +1,20 @@
+use crate::{
+    handler::inspect_instructions,
+    inspect::{InspectCommitEvm, InspectEvm},
+    Inspector, InspectorEvmTr, InspectorFrame, InspectorHandler, JournalExt,
+};
 use context::{ContextSetters, ContextTr, Evm, JournalOutput, JournalTr};
 use database_interface::DatabaseCommit;
 use handler::{
     instructions::InstructionProvider, EthFrame, EvmTr, EvmTrError, Frame, FrameResult, Handler,
     MainnetHandler, PrecompileProvider,
 };
-use interpreter::{interpreter::EthInterpreter, FrameInput, InterpreterResult};
-
-use crate::{
-    inspect::{InspectCommitEvm, InspectEvm},
-    Inspector, InspectorEvmTr, InspectorFrame, InspectorHandler, JournalExt,
+use interpreter::{
+    interpreter::EthInterpreter, FrameInput, Interpreter, InterpreterAction, InterpreterResult,
+    InterpreterTypes,
 };
 
+// Implementing InspectorHandler for MainnetHandler.
 impl<EVM, ERROR, FRAME> InspectorHandler for MainnetHandler<EVM, ERROR, FRAME>
 where
     EVM: InspectorEvmTr<
@@ -24,6 +28,7 @@ where
     type IT = EthInterpreter;
 }
 
+// Implementing InspectEvm for Evm
 impl<CTX, INSP, INST, PRECOMPILES> InspectEvm for Evm<CTX, INSP, INST, PRECOMPILES>
 where
     CTX: ContextSetters + ContextTr<Journal: JournalTr<FinalOutput = JournalOutput> + JournalExt>,
@@ -46,6 +51,7 @@ where
     }
 }
 
+// Implementing InspectCommitEvm for Evm
 impl<CTX, INSP, INST, PRECOMPILES> InspectCommitEvm for Evm<CTX, INSP, INST, PRECOMPILES>
 where
     CTX: ContextSetters
@@ -54,10 +60,50 @@ where
     INST: InstructionProvider<Context = CTX, InterpreterTypes = EthInterpreter>,
     PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
-    fn inspect_commit_previous(&mut self) -> Self::CommitOutput {
+    fn inspect_replay_commit(&mut self) -> Self::CommitOutput {
         self.inspect_replay().map(|r| {
             self.ctx().db().commit(r.state);
             r.result
         })
+    }
+}
+
+// Implementing InspectorEvmTr for Evm
+impl<CTX, INSP, I, P> InspectorEvmTr for Evm<CTX, INSP, I, P>
+where
+    CTX: ContextTr<Journal: JournalExt> + ContextSetters,
+    I: InstructionProvider<
+        Context = CTX,
+        InterpreterTypes: InterpreterTypes<Output = InterpreterAction>,
+    >,
+    INSP: Inspector<CTX, I::InterpreterTypes>,
+{
+    type Inspector = INSP;
+
+    fn inspector(&mut self) -> &mut Self::Inspector {
+        &mut self.data.inspector
+    }
+
+    fn ctx_inspector(&mut self) -> (&mut Self::Context, &mut Self::Inspector) {
+        (&mut self.data.ctx, &mut self.data.inspector)
+    }
+
+    fn run_inspect_interpreter(
+        &mut self,
+        interpreter: &mut Interpreter<
+            <Self::Instructions as InstructionProvider>::InterpreterTypes,
+        >,
+    ) -> <<Self::Instructions as InstructionProvider>::InterpreterTypes as InterpreterTypes>::Output
+    {
+        let context = &mut self.data.ctx;
+        let instructions = &mut self.instruction;
+        let inspector = &mut self.data.inspector;
+
+        inspect_instructions(
+            context,
+            interpreter,
+            inspector,
+            instructions.instruction_table(),
+        )
     }
 }

--- a/crates/inspector/src/traits.rs
+++ b/crates/inspector/src/traits.rs
@@ -1,22 +1,32 @@
-use crate::{inspect_instructions, Inspector, JournalExt};
-use context::{result::FromStringError, ContextSetters, ContextTr, Evm};
+use context::{result::FromStringError, ContextTr};
 use handler::{
     instructions::InstructionProvider, ContextTrDbError, EthFrame, EvmTr, Frame, FrameInitOrResult,
     PrecompileProvider,
 };
 use interpreter::{
-    interpreter::EthInterpreter, FrameInput, Interpreter, InterpreterAction, InterpreterResult,
-    InterpreterTypes,
+    interpreter::EthInterpreter, FrameInput, Interpreter, InterpreterResult, InterpreterTypes,
 };
 
-/// Inspector EVM trait.
+/// Inspector EVM trait. Extends the [`EvmTr`] trait with inspector related methods.
+///
+/// It contains execution of interpreter with [`crate::Inspector`] calls [`crate::Inspector::step`] and [`crate::Inspector::step_end`] calls.
+///
+/// It is used inside [`crate::InspectorHandler`] to extend evm with support for inspection.
 pub trait InspectorEvmTr: EvmTr {
     type Inspector;
 
+    /// Returns a mutable reference to the inspector.
     fn inspector(&mut self) -> &mut Self::Inspector;
 
+    /// Returns a tuple of mutable references to the context and the inspector.
+    ///
+    /// Useful when you want to allow inspector to modify the context.
     fn ctx_inspector(&mut self) -> (&mut Self::Context, &mut Self::Inspector);
 
+    /// Runs the inspector on the interpreter.
+    ///
+    /// This function is called by the EVM when it needs to inspect the Interpreter loop.
+    /// It is responsible for calling the inspector's methods and instructions from table.
     fn run_inspect_interpreter(
         &mut self,
         interpreter: &mut Interpreter<
@@ -25,56 +35,25 @@ pub trait InspectorEvmTr: EvmTr {
     ) -> <<Self::Instructions as InstructionProvider>::InterpreterTypes as InterpreterTypes>::Output;
 }
 
-impl<CTX, INSP, I, P> InspectorEvmTr for Evm<CTX, INSP, I, P>
-where
-    CTX: ContextTr<Journal: JournalExt> + ContextSetters,
-    I: InstructionProvider<
-        Context = CTX,
-        InterpreterTypes: InterpreterTypes<Output = InterpreterAction>,
-    >,
-    INSP: Inspector<CTX, I::InterpreterTypes>,
-{
-    type Inspector = INSP;
-
-    fn inspector(&mut self) -> &mut Self::Inspector {
-        &mut self.data.inspector
-    }
-
-    fn ctx_inspector(&mut self) -> (&mut Self::Context, &mut Self::Inspector) {
-        (&mut self.data.ctx, &mut self.data.inspector)
-    }
-
-    fn run_inspect_interpreter(
-        &mut self,
-        interpreter: &mut Interpreter<
-            <Self::Instructions as InstructionProvider>::InterpreterTypes,
-        >,
-    ) -> <<Self::Instructions as InstructionProvider>::InterpreterTypes as InterpreterTypes>::Output
-    {
-        let context = &mut self.data.ctx;
-        let instructions = &mut self.instruction;
-        let inspector = &mut self.data.inspector;
-
-        inspect_instructions(
-            context,
-            interpreter,
-            inspector,
-            instructions.instruction_table(),
-        )
-    }
-}
-
-// TODO move InspectorFrame here
+/// Traits that extends the Frame with additional functionality that is needed for inspection
+///
+/// It is implemented for [`EthFrame`] as default Ethereum frame implementation.
 pub trait InspectorFrame: Frame {
     type IT: InterpreterTypes;
 
+    /// It runs the frame in inspection mode.
+    ///
+    /// This will internally call [`InspectorEvmTr::run_inspect_interpreter`]
     fn run_inspect(&mut self, evm: &mut Self::Evm) -> Result<FrameInitOrResult<Self>, Self::Error>;
 
+    /// Returns a mutable reference to the interpreter.
     fn interpreter(&mut self) -> &mut Interpreter<Self::IT>;
 
+    /// Returns a reference to the frame input. Frame input is needed for call/create/eofcreate [`crate::Inspector`] methods
     fn frame_input(&self) -> &FrameInput;
 }
 
+/// Impl InspectorFrame for EthFrame.
 impl<EVM, ERROR> InspectorFrame for EthFrame<EVM, ERROR, EthInterpreter>
 where
     EVM: EvmTr<

--- a/crates/optimism/src/api/exec.rs
+++ b/crates/optimism/src/api/exec.rs
@@ -106,7 +106,7 @@ where
     INSP: Inspector<CTX, EthInterpreter>,
     PRECOMPILE: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
-    fn inspect_commit_previous(&mut self) -> Self::CommitOutput {
+    fn inspect_replay_commit(&mut self) -> Self::CommitOutput {
         self.inspect_replay().map(|r| {
             self.ctx().db().commit(r.state);
             r.result

--- a/examples/custom_opcodes/src/main.rs
+++ b/examples/custom_opcodes/src/main.rs
@@ -49,7 +49,7 @@ pub fn main() {
         .with_inspector(TracerEip3155::new_stdout().without_summary());
 
     // inspect the transaction.
-    let _ = evm.inspect_replay_with_tx(TxEnv {
+    let _ = evm.inspect_with_tx(TxEnv {
         kind: TxKind::Call(BENCH_TARGET),
         ..Default::default()
     });

--- a/examples/my_evm/src/api.rs
+++ b/examples/my_evm/src/api.rs
@@ -82,7 +82,7 @@ where
     >,
     INSP: Inspector<CTX, EthInterpreter>,
 {
-    fn inspect_commit_previous(&mut self) -> Self::CommitOutput {
+    fn inspect_replay_commit(&mut self) -> Self::CommitOutput {
         self.inspect_replay().map(|r| {
             self.ctx().db().commit(r.state);
             r.result


### PR DESCRIPTION
* _previous api was not renamed until now (aka `inspect_commit_previous` to `inspect_replay_commit`)
* Added docs for Inspector crate
* book cleaned up, some things removed, architecture part improved
* fixed unknown index.html in book.