### PR TITLE
chore: remove wrong `&mut` and duplicated spec

### DIFF
--- a/crates/context/src/journaled_state.rs
+++ b/crates/context/src/journaled_state.rs
@@ -387,7 +387,7 @@ impl<DB: Database, ENTRY: JournalEntryTr> Journal<DB, ENTRY> {
         self.load_account(*to)?;
 
         // sub balance from
-        let from_account = &mut self.state.get_mut(from).unwrap();
+        let from_account = self.state.get_mut(from).unwrap();
         Self::touch_account(self.journal.last_mut().unwrap(), from, from_account);
         let from_balance = &mut from_account.info.balance;
 

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -316,10 +316,12 @@ where
         let caller_balance = context
             .journal()
             .load_account(inputs.caller)?
-            .map(|a| a.info.balance);
+            .data
+            .info
+            .balance;
 
         // Check if caller has enough balance to send to the created contract.
-        if caller_balance.data < inputs.value {
+        if caller_balance < inputs.value {
             return return_error(InstructionResult::OutOfFunds);
         }
 

--- a/crates/optimism/src/handler.rs
+++ b/crates/optimism/src/handler.rs
@@ -150,7 +150,6 @@ where
                 .enveloped_tx()
                 .expect("all not deposit tx have enveloped tx")
                 .clone();
-            let spec = ctx.cfg().spec();
             tx_l1_cost = ctx.chain().calculate_tx_l1_cost(&enveloped_tx, spec);
         }
 
@@ -178,7 +177,6 @@ where
             }
 
             let mut caller_account = ctx.journal().load_account(caller)?;
-
             caller_account.info.balance = caller_account
                 .info
                 .balance


### PR DESCRIPTION
- `&mut` and spec is useless