### PR TITLE
chore: bump c-kzg to v2.0.0, group cargo imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,32 +68,40 @@ alloy-signer = { version = "0.12.4", default-features = false }
 alloy-signer-local = { version = "0.12.4", default-features = false }
 alloy-transport = { version = "0.12.4", default-features = false }
 
-# misc
+# precompiles
 aurora-engine-modexp = { version = "1.1", default-features = false }
-auto_impl = "1.2.0"
-bitflags = { version = "2.6.0", default-features = false }
-bitvec = { version = "1", default-features = false }
 blst = "0.3.13"
 bn = { package = "substrate-bn", version = "0.6", default-features = false }
-c-kzg = { version = "1.0.0", default-features = false }
-cfg-if = { version = "1.0", default-features = false }
-clap = "4"
-criterion = { package = "codspeed-criterion-compat", version = "2.7" }
-derive-where = { version = "1.2.7", default-features = false }
-enumn = "0.1"
+c-kzg = { version = "2.0.0", default-features = false }
 k256 = { version = "0.13.3", default-features = false }
-kzg-rs = { version = "0.2.4", default-features = false }
 libsecp256k1 = { version = "0.7", default-features = false }
-once_cell = { version = "1.19", default-features = false }
+kzg-rs = { version = "0.2.4", default-features = false }
+secp256k1 = { version = "0.30", default-features = false }
+sha2 = { version = "0.10", default-features = false }
+ripemd = { version = "0.1", default-features = false }
 p256 = { version = "0.13.2", default-features = false }
+
+# bytecode
+bitvec = { version = "1", default-features = false }
 paste = "1.0"
 phf = { version = "0.11", default-features = false }
-rand = "0.8"
-ripemd = { version = "0.1", default-features = false }
-secp256k1 = { version = "0.30", default-features = false }
+
+# revme
+clap = { version = "4", features = ["derive"] }
+criterion = { package = "codspeed-criterion-compat", version = "2.7" }
+
+# serde
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false }
-sha2 = { version = "0.10", default-features = false }
+
+# misc
+auto_impl = "1.2.0"
+bitflags = { version = "2.6.0", default-features = false }
+cfg-if = { version = "1.0", default-features = false }
+derive-where = { version = "1.2.7", default-features = false }
+enumn = "0.1"
+once_cell = { version = "1.19", default-features = false }
+rand = "0.8"
 tokio = "1.40"
 
 # dev-dependencies

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -39,7 +39,7 @@ microbench.workspace = true
 plain_hasher.workspace = true
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
-clap = { workspace = true, features = ["derive"] }
+clap.workspace = true
 thiserror.workspace = true
 triehash.workspace = true
 walkdir.workspace = true


### PR DESCRIPTION
Shuffled some imports and bumped c-kzg to v2.0.0

For c-kzg v2.1.0 some cleanup needs to be done: https://github.com/ethereum/c-kzg-4844/pull/551

closes #2278 