### PR TITLE
chore: remove redundant_clone

### DIFF
--- a/crates/interpreter/src/instructions/contract.rs
+++ b/crates/interpreter/src/instructions/contract.rs
@@ -168,7 +168,7 @@ pub fn extcall_input(interpreter: &mut Interpreter<impl InterpreterTypes>) -> Op
     Some(Bytes::copy_from_slice(
         interpreter
             .memory
-            .slice(return_memory_offset.clone())
+            .slice(return_memory_offset)
             .as_ref(),
     ))
 }


### PR DESCRIPTION
```
warning: redundant clone
   --> crates/interpreter/src/instructions/contract.rs:171:40
    |
171 |             .slice(return_memory_offset.clone())
    |                                        ^^^^^^^^ help: remove this
    |
note: this value is dropped without further use
   --> crates/interpreter/src/instructions/contract.rs:171:20
```