### PR TITLE
feat: provide more context to precompiles

### DIFF
--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -202,14 +202,25 @@ where
                 return return_result(i.into());
             }
         }
+
+        let interpreter_input = InputsImpl {
+            target_address: inputs.target_address,
+            caller_address: inputs.caller,
+            input: inputs.input.clone(),
+            call_value: inputs.value.get(),
+        };
+        let is_static = inputs.is_static;
+        let gas_limit = inputs.gas_limit;
+
         let is_ext_delegate_call = inputs.scheme.is_ext_delegate_call();
         if !is_ext_delegate_call {
             if let Some(result) = precompiles
                 .run(
                     context,
                     &inputs.bytecode_address,
-                    &inputs.input,
-                    inputs.gas_limit,
+                    &interpreter_input,
+                    is_static,
+                    gas_limit,
                 )
                 .map_err(ERROR::from_string)?
             {
@@ -253,14 +264,6 @@ where
         }
 
         // Create interpreter and executes call and push new CallStackFrame.
-        let interpreter_input = InputsImpl {
-            target_address: inputs.target_address,
-            caller_address: inputs.caller,
-            input: inputs.input.clone(),
-            call_value: inputs.value.get(),
-        };
-        let is_static = inputs.is_static;
-        let gas_limit = inputs.gas_limit;
         Ok(ItemOrResult::Item(Self::new(
             FrameData::Call(CallFrame {
                 return_memory_range: inputs.return_memory_offset.clone(),

--- a/crates/handler/src/precompile_provider.rs
+++ b/crates/handler/src/precompile_provider.rs
@@ -1,7 +1,7 @@
 use auto_impl::auto_impl;
 use context::Cfg;
 use context_interface::ContextTr;
-use interpreter::{Gas, InstructionResult, InterpreterResult};
+use interpreter::{Gas, InputsImpl, InstructionResult, InterpreterResult};
 use precompile::PrecompileError;
 use precompile::{PrecompileSpecId, Precompiles};
 use primitives::{hardfork::SpecId, Address, Bytes};
@@ -19,7 +19,8 @@ pub trait PrecompileProvider<CTX: ContextTr> {
         &mut self,
         context: &mut CTX,
         address: &Address,
-        bytes: &Bytes,
+        inputs: &InputsImpl,
+        is_static: bool,
         gas_limit: u64,
     ) -> Result<Option<Self::Output>, String>;
 
@@ -75,7 +76,8 @@ impl<CTX: ContextTr> PrecompileProvider<CTX> for EthPrecompiles {
         &mut self,
         _context: &mut CTX,
         address: &Address,
-        bytes: &Bytes,
+        inputs: &InputsImpl,
+        _is_static: bool,
         gas_limit: u64,
     ) -> Result<Option<InterpreterResult>, String> {
         let Some(precompile) = self.precompiles.get(address) else {
@@ -88,7 +90,7 @@ impl<CTX: ContextTr> PrecompileProvider<CTX> for EthPrecompiles {
             output: Bytes::new(),
         };
 
-        match (*precompile)(bytes, gas_limit) {
+        match (*precompile)(&inputs.input, gas_limit) {
             Ok(output) => {
                 let underflow = result.gas.record_cost(output.gas_used);
                 assert!(underflow, "Gas underflow is not possible");

--- a/crates/optimism/src/precompiles.rs
+++ b/crates/optimism/src/precompiles.rs
@@ -4,10 +4,10 @@ use revm::{
     context::Cfg,
     context_interface::ContextTr,
     handler::{EthPrecompiles, PrecompileProvider},
-    interpreter::InterpreterResult,
+    interpreter::{InputsImpl, InterpreterResult},
     precompile::{
-        self, bn128, secp256r1, PrecompileError, Precompiles,
-        {PrecompileResult, PrecompileWithAddress},
+        self, bn128, secp256r1, PrecompileError, PrecompileResult, PrecompileWithAddress,
+        Precompiles,
     },
     primitives::{Address, Bytes},
 };
@@ -105,10 +105,12 @@ where
         &mut self,
         context: &mut CTX,
         address: &Address,
-        bytes: &Bytes,
+        inputs: &InputsImpl,
+        is_static: bool,
         gas_limit: u64,
     ) -> Result<Option<Self::Output>, String> {
-        self.inner.run(context, address, bytes, gas_limit)
+        self.inner
+            .run(context, address, inputs, is_static, gas_limit)
     }
 
     #[inline]

--- a/crates/optimism/src/precompiles.rs
+++ b/crates/optimism/src/precompiles.rs
@@ -9,7 +9,7 @@ use revm::{
         self, bn128, secp256r1, PrecompileError, PrecompileResult, PrecompileWithAddress,
         Precompiles,
     },
-    primitives::{Address, Bytes},
+    primitives::Address,
 };
 use std::boxed::Box;
 use std::string::String;


### PR DESCRIPTION
To provide greater support for custom precompiles, it would be useful to pass `InputsImpl` and `is_static` to `PrecompileProvider::run` instead of only a subset of the fields passed as inputs to the Interpreter. There are some use cases for custom chains that inspect the caller or should not be allowed in a static context (state-changing precompiles).
