### PR TITLE
chore: add criterion benchmark for evm build

### DIFF
--- a/bins/revme/benches/evm.rs
+++ b/bins/revme/benches/evm.rs
@@ -6,6 +6,7 @@ fn evm(c: &mut Criterion) {
     bench::burntpix::run(c);
     bench::snailtracer::run(c);
     bench::transfer::run(c);
+    bench::evm_build::run(c);
 }
 criterion_group!(benches, evm);
 criterion_main!(benches);

--- a/bins/revme/src/cmd/bench.rs
+++ b/bins/revme/src/cmd/bench.rs
@@ -1,5 +1,6 @@
 pub mod analysis;
 pub mod burntpix;
+pub mod evm_build;
 pub mod snailtracer;
 pub mod transfer;
 
@@ -11,6 +12,7 @@ pub enum BenchName {
     Burntpix,
     Snailtracer,
     Transfer,
+    EvmBuild,
 }
 
 impl BenchName {
@@ -19,6 +21,7 @@ impl BenchName {
         BenchName::Burntpix,
         BenchName::Snailtracer,
         BenchName::Transfer,
+        BenchName::EvmBuild,
     ];
 
     pub fn as_str(self) -> &'static str {
@@ -27,6 +30,7 @@ impl BenchName {
             BenchName::Burntpix => "burntpix",
             BenchName::Snailtracer => "snailtracer",
             BenchName::Transfer => "transfer",
+            BenchName::EvmBuild => "evm_build",
         }
     }
 }
@@ -70,6 +74,9 @@ impl Cmd {
             }
             BenchName::Transfer => {
                 transfer::run(&mut criterion);
+            }
+            BenchName::EvmBuild => {
+                evm_build::run(&mut criterion);
             }
         }
     }

--- a/bins/revme/src/cmd/bench.rs
+++ b/bins/revme/src/cmd/bench.rs
@@ -30,7 +30,7 @@ impl BenchName {
             BenchName::Burntpix => "burntpix",
             BenchName::Snailtracer => "snailtracer",
             BenchName::Transfer => "transfer",
-            BenchName::EvmBuild => "evm_build",
+            BenchName::EvmBuild => "evm-build",
         }
     }
 }

--- a/bins/revme/src/cmd/bench/evm_build.rs
+++ b/bins/revme/src/cmd/bench/evm_build.rs
@@ -1,12 +1,10 @@
 use criterion::Criterion;
-use revm::{Context, ExecuteEvm, MainBuilder, MainContext};
+use revm::{Context, MainBuilder, MainContext};
 
 pub fn run(criterion: &mut Criterion) {
-    let mut evm = Context::mainnet().build_mainnet();
-
-    criterion.bench_function("evm_build", |b| {
+    criterion.bench_function("evm-build", |b| {
         b.iter(|| {
-            let _ = evm.replay().unwrap();
+            let _ = Context::mainnet().build_mainnet();
         });
     });
 }

--- a/bins/revme/src/cmd/bench/evm_build.rs
+++ b/bins/revme/src/cmd/bench/evm_build.rs
@@ -1,0 +1,12 @@
+use criterion::Criterion;
+use revm::{Context, ExecuteEvm, MainBuilder, MainContext};
+
+pub fn run(criterion: &mut Criterion) {
+    let mut evm = Context::mainnet().build_mainnet();
+
+    criterion.bench_function("evm_build", |b| {
+        b.iter(|| {
+            let _ = evm.replay().unwrap();
+        });
+    });
+}


### PR DESCRIPTION
## Changes
- This PR closes https://github.com/bluealloy/revm/issues/2308 by adding a benchmark to measures the how long the EVM build takes to initialization instructions via `evm.replay()` 

## Note:
- the `build_mainnet` step was left out of the benchmark as to focus on time spent to initialize instructions.  Let me know if the intention was to include the `build_mainnet` into the benchmark as well, and I'll happily add it 🤙 
