### PR TITLE
chore: Remove TODO for NBITS and remove NBITS from blst MSM API

### DIFF
--- a/crates/precompile/src/bls12_381/arkworks.rs
+++ b/crates/precompile/src/bls12_381/arkworks.rs
@@ -285,7 +285,7 @@ pub(super) fn p2_add_affine(p1: &G2Affine, p2: &G2Affine) -> G2Affine {
 ///
 /// Note: This method assumes that `g1_points` does not contain any points at infinity.
 #[inline]
-pub(super) fn p1_msm(g1_points: Vec<G1Affine>, scalars: Vec<Fr>, _nbits: usize) -> G1Affine {
+pub(super) fn p1_msm(g1_points: Vec<G1Affine>, scalars: Vec<Fr>) -> G1Affine {
     assert_eq!(
         g1_points.len(),
         scalars.len(),
@@ -313,7 +313,7 @@ pub(super) fn p1_msm(g1_points: Vec<G1Affine>, scalars: Vec<Fr>, _nbits: usize) 
 ///
 /// Note: This method assumes that `g2_points` does not contain any points at infinity.
 #[inline]
-pub(super) fn p2_msm(g2_points: Vec<G2Affine>, scalars: Vec<Fr>, _nbits: usize) -> G2Affine {
+pub(super) fn p2_msm(g2_points: Vec<G2Affine>, scalars: Vec<Fr>) -> G2Affine {
     assert_eq!(
         g2_points.len(),
         scalars.len(),

--- a/crates/precompile/src/bls12_381/blst.rs
+++ b/crates/precompile/src/bls12_381/blst.rs
@@ -3,7 +3,7 @@
 use crate::{
     bls12_381_const::{
         FP_LENGTH, FP_PAD_BY, MODULUS_REPR, PADDED_FP_LENGTH, PADDED_G1_LENGTH, PADDED_G2_LENGTH,
-        SCALAR_LENGTH,
+        SCALAR_LENGTH, SCALAR_LENGTH_BITS,
     },
     PrecompileError,
 };
@@ -154,11 +154,7 @@ fn p2_scalar_mul(p: &blst_p2_affine, scalar: &blst_scalar) -> blst_p2_affine {
 ///
 /// Note: This method assumes that `g1_points` does not contain any points at infinity.
 #[inline]
-pub(super) fn p1_msm(
-    g1_points: Vec<blst_p1_affine>,
-    scalars: Vec<blst_scalar>,
-    nbits: usize,
-) -> blst_p1_affine {
+pub(super) fn p1_msm(g1_points: Vec<blst_p1_affine>, scalars: Vec<blst_scalar>) -> blst_p1_affine {
     assert_eq!(
         g1_points.len(),
         scalars.len(),
@@ -183,7 +179,7 @@ pub(super) fn p1_msm(
 
     let scalars_bytes: Vec<_> = scalars.into_iter().flat_map(|s| s.b).collect();
     // Perform multi-scalar multiplication
-    let multiexp = g1_points.mult(&scalars_bytes, nbits);
+    let multiexp = g1_points.mult(&scalars_bytes, SCALAR_LENGTH_BITS);
 
     // Convert result back to affine coordinates
     p1_to_affine(&multiexp)
@@ -196,11 +192,7 @@ pub(super) fn p1_msm(
 /// Note: Scalars are expected to be in Big Endian format.
 /// This method assumes that `g2_points` does not contain any points at infinity.
 #[inline]
-pub(super) fn p2_msm(
-    g2_points: Vec<blst_p2_affine>,
-    scalars: Vec<blst_scalar>,
-    nbits: usize,
-) -> blst_p2_affine {
+pub(super) fn p2_msm(g2_points: Vec<blst_p2_affine>, scalars: Vec<blst_scalar>) -> blst_p2_affine {
     assert_eq!(
         g2_points.len(),
         scalars.len(),
@@ -226,7 +218,7 @@ pub(super) fn p2_msm(
     let scalars_bytes: Vec<_> = scalars.into_iter().flat_map(|s| s.b).collect();
 
     // Perform multi-scalar multiplication
-    let multiexp = g2_points.mult(&scalars_bytes, nbits);
+    let multiexp = g2_points.mult(&scalars_bytes, SCALAR_LENGTH_BITS);
 
     // Convert result back to affine coordinates
     p2_to_affine(&multiexp)

--- a/crates/precompile/src/bls12_381/g1_msm.rs
+++ b/crates/precompile/src/bls12_381/g1_msm.rs
@@ -1,7 +1,7 @@
 use super::crypto_backend::{encode_g1_point, p1_msm, read_g1, read_scalar};
 use crate::bls12_381::utils::remove_g1_padding;
 use crate::bls12_381_const::{
-    DISCOUNT_TABLE_G1_MSM, G1_MSM_ADDRESS, G1_MSM_BASE_GAS_FEE, G1_MSM_INPUT_LENGTH, NBITS,
+    DISCOUNT_TABLE_G1_MSM, G1_MSM_ADDRESS, G1_MSM_BASE_GAS_FEE, G1_MSM_INPUT_LENGTH,
     PADDED_G1_LENGTH, SCALAR_LENGTH,
 };
 use crate::bls12_381_utils::msm_required_gas;
@@ -79,7 +79,7 @@ pub(super) fn g1_msm(input: &Bytes, gas_limit: u64) -> PrecompileResult {
         ));
     }
 
-    let multiexp_aff = p1_msm(g1_points, scalars, NBITS);
+    let multiexp_aff = p1_msm(g1_points, scalars);
 
     let out = encode_g1_point(&multiexp_aff);
     Ok(PrecompileOutput::new(required_gas, out.into()))

--- a/crates/precompile/src/bls12_381/g2_msm.rs
+++ b/crates/precompile/src/bls12_381/g2_msm.rs
@@ -1,7 +1,7 @@
 use super::crypto_backend::{encode_g2_point, p2_msm, read_g2, read_scalar};
 use super::utils::remove_g2_padding;
 use crate::bls12_381_const::{
-    DISCOUNT_TABLE_G2_MSM, G2_MSM_ADDRESS, G2_MSM_BASE_GAS_FEE, G2_MSM_INPUT_LENGTH, NBITS,
+    DISCOUNT_TABLE_G2_MSM, G2_MSM_ADDRESS, G2_MSM_BASE_GAS_FEE, G2_MSM_INPUT_LENGTH,
     PADDED_G2_LENGTH, SCALAR_LENGTH,
 };
 use crate::bls12_381_utils::msm_required_gas;
@@ -80,7 +80,7 @@ pub(super) fn g2_msm(input: &Bytes, gas_limit: u64) -> PrecompileResult {
     }
 
     // Perform multi-scalar multiplication using the safe wrapper
-    let multiexp_aff = p2_msm(g2_points, scalars, NBITS);
+    let multiexp_aff = p2_msm(g2_points, scalars);
 
     let out = encode_g2_point(&multiexp_aff);
     Ok(PrecompileOutput::new(required_gas, out.into()))

--- a/crates/precompile/src/bls12_381_const.rs
+++ b/crates/precompile/src/bls12_381_const.rs
@@ -120,11 +120,10 @@ pub const PADDED_FP2_LENGTH: usize = 2 * PADDED_FP_LENGTH;
 /// This is an element in the scalar field of BLS12-381.
 ///
 /// Note: Since it is already 32 byte aligned, there is no padded version of this constant.
-/// TODO: Maybe change all _LENGTH to _LENGTH_BYTES and then NBITS to _LENGTH_BITS
 pub const SCALAR_LENGTH: usize = 32;
-/// NBITS specifies the number of bits needed to represent an Fr element.
+/// SCALAR_LENGTH_BITS specifies the number of bits needed to represent an Fr element.
 /// This is an element in the scalar field of BLS12-381.
-pub const NBITS: usize = 256;
+pub const SCALAR_LENGTH_BITS: usize = SCALAR_LENGTH * 8;
 
 /// G1_ADD_INPUT_LENGTH specifies the number of bytes that the input to G1ADD
 /// must use.


### PR DESCRIPTION
This PR:

- Renames NBITS to SCALAR_LENGTH_BITS
- removes NBITS from the msm api -- its more of an implementation detail of blst and not of the msm api