### PR TITLE
chore: Remove bls12-381 no-std fallback method

### DIFF
--- a/crates/precompile/src/bls12_381_utils.rs
+++ b/crates/precompile/src/bls12_381_utils.rs
@@ -1,11 +1,4 @@
-use crate::{
-    bls12_381_const::{
-        G1_ADD_ADDRESS, G1_MSM_ADDRESS, G2_ADD_ADDRESS, G2_MSM_ADDRESS, MAP_FP2_TO_G2_ADDRESS,
-        MAP_FP_TO_G1_ADDRESS, MSM_MULTIPLIER, PAIRING_ADDRESS,
-    },
-    PrecompileError, PrecompileWithAddress,
-};
-use std::vec::Vec;
+use crate::bls12_381_const::MSM_MULTIPLIER;
 
 /// Implements the gas schedule for G1/G2 Multiscalar-multiplication assuming 30
 /// MGas/second, see also: <https://eips.ethereum.org/EIPS/eip-2537#g1g2-multiexponentiation>
@@ -19,44 +12,4 @@ pub fn msm_required_gas(k: usize, discount_table: &[u16], multiplication_cost: u
     let discount = discount_table[index] as u64;
 
     (k as u64 * discount * multiplication_cost) / MSM_MULTIPLIER
-}
-
-pub fn bls12_381_precompiles_not_supported() -> Vec<PrecompileWithAddress> {
-    vec![
-        PrecompileWithAddress(G1_ADD_ADDRESS, |_, _| {
-            Err(PrecompileError::Fatal(
-                "no_std is not supported for BLS12-381 precompiles".into(),
-            ))
-        }),
-        PrecompileWithAddress(G1_MSM_ADDRESS, |_, _| {
-            Err(PrecompileError::Fatal(
-                "no_std is not supported for BLS12-381 precompiles".into(),
-            ))
-        }),
-        PrecompileWithAddress(G2_ADD_ADDRESS, |_, _| {
-            Err(PrecompileError::Fatal(
-                "no_std is not supported for BLS12-381 precompiles".into(),
-            ))
-        }),
-        PrecompileWithAddress(G2_MSM_ADDRESS, |_, _| {
-            Err(PrecompileError::Fatal(
-                "no_std is not supported for BLS12-381 precompiles".into(),
-            ))
-        }),
-        PrecompileWithAddress(PAIRING_ADDRESS, |_, _| {
-            Err(PrecompileError::Fatal(
-                "no_std is not supported for BLS12-381 precompiles".into(),
-            ))
-        }),
-        PrecompileWithAddress(MAP_FP_TO_G1_ADDRESS, |_, _| {
-            Err(PrecompileError::Fatal(
-                "no_std is not supported for BLS12-381 precompiles".into(),
-            ))
-        }),
-        PrecompileWithAddress(MAP_FP2_TO_G2_ADDRESS, |_, _| {
-            Err(PrecompileError::Fatal(
-                "no_std is not supported for BLS12-381 precompiles".into(),
-            ))
-        }),
-    ]
 }


### PR DESCRIPTION
Since we now use arkworks-bls12-381 for no-std, this method is no longer needed