### PR TITLE
bump: tag v67 revm v21.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
 
+# v67 tag
+date: 28.03.2025
+
+op-revm isthum fix.
+
+* `revm-primitives`: 16.0.0 -> 17.0.0 (⚠ API breaking changes)
+* `revm-bytecode`: 1.0.0 -> 2.0.0 (⚠ API breaking changes)
+* `revm-database-interface`: 1.0.0 -> 2.0.0 (✓ API compatible changes)
+* `revm-context-interface`: 1.0.0 -> 2.0.0 (✓ API compatible changes)
+* `revm-context`: 1.0.0 -> 2.0.0 (⚠ API breaking changes)
+* `revm-database`: 1.0.0 -> 2.0.0 (✓ API compatible changes)
+* `revm-interpreter`: 16.0.0 -> 17.0.0 (✓ API compatible changes)
+* `revm-precompile`: 17.0.0 -> 18.0.0 (⚠ API breaking changes)
+* `revm-handler`: 1.0.0 -> 2.0.0 (⚠ API breaking changes)
+* `revm-inspector`: 1.0.0 -> 2.0.0 (✓ API compatible changes)
+* `revm`: 20.0.0 -> 21.0.0 (✓ API compatible changes)
+* `revme`: 3.0.0 -> 4.0.0 (⚠ API breaking changes)
+* `op-revm`: 1.0.0 -> 2.0.0 (⚠ API breaking changes)
+* `revm-state`: 1.0.0 -> 2.0.0
+* `revm-statetest-types`: 1.0.0 -> 2.0.0
+
 # v66 tag
 date: 24.03.205
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3683,7 +3683,7 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3726,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "alloy-eips",
  "alloy-provider",
@@ -3760,7 +3760,7 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "alloy-sol-types",
  "anyhow",
@@ -3796,7 +3796,7 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "auto_impl",
  "revm-context",
@@ -3812,7 +3812,7 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "16.0.1"
+version = "17.0.0"
 dependencies = [
  "bincode",
  "revm-bytecode",
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "bitflags",
  "revm-bytecode",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "revm-statetest-types"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "revm",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,18 +39,18 @@ default-members = ["crates/revm"]
 
 [workspace.dependencies]
 # revm
-revm = { path = "crates/revm", version = "20.1.0", default-features = false }
+revm = { path = "crates/revm", version = "21.0.0", default-features = false }
 primitives = { path = "crates/primitives", package = "revm-primitives", version = "17.0.0", default-features = false }
 bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "2.0.0", default-features = false }
-database = { path = "crates/database", package = "revm-database", version = "1.0.1", default-features = false }
-database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "1.0.1", default-features = false }
-state = { path = "crates/state", package = "revm-state", version = "1.0.1", default-features = false }
-interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "16.0.1", default-features = false }
-inspector = { path = "crates/inspector", package = "revm-inspector", version = "1.1.0", default-features = false }
+database = { path = "crates/database", package = "revm-database", version = "2.0.0", default-features = false }
+database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "2.0.0", default-features = false }
+state = { path = "crates/state", package = "revm-state", version = "2.0.0", default-features = false }
+interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "17.0.0", default-features = false }
+inspector = { path = "crates/inspector", package = "revm-inspector", version = "2.0.0", default-features = false }
 precompile = { path = "crates/precompile", package = "revm-precompile", version = "18.0.0", default-features = false }
-statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "1.0.1", default-features = false }
+statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "2.0.0", default-features = false }
 context = { path = "crates/context", package = "revm-context", version = "2.0.0", default-features = false }
-context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "1.1.0", default-features = false }
+context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "2.0.0", default-features = false }
 handler = { path = "crates/handler", package = "revm-handler", version = "2.0.0", default-features = false }
 
 # alloy 

--- a/crates/context/interface/CHANGELOG.md
+++ b/crates/context/interface/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.0](https://github.com/bluealloy/revm/compare/revm-context-interface-v1.0.0...revm-context-interface-v1.1.0) - 2025-03-28
+## [2.0.0](https://github.com/bluealloy/revm/compare/revm-context-interface-v1.0.0...revm-context-interface-v2.0.0) - 2025-03-28
 
 ### Added
 

--- a/crates/context/interface/Cargo.toml
+++ b/crates/context/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-context-interface"
 description = "Revm context interface crates"
-version = "1.1.0"
+version = "2.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/database/CHANGELOG.md
+++ b/crates/database/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.1](https://github.com/bluealloy/revm/compare/revm-database-v1.0.0...revm-database-v1.0.1) - 2025-03-28
+## [2.0.0](https://github.com/bluealloy/revm/compare/revm-database-v1.0.0...revm-database-v2.0.0) - 2025-03-28
 
 ### Other
 

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-database"
 description = "Revm Database implementations"
-version = "1.0.1"
+version = "2.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/database/interface/CHANGELOG.md
+++ b/crates/database/interface/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.1](https://github.com/bluealloy/revm/compare/revm-database-interface-v1.0.0...revm-database-interface-v1.0.1) - 2025-03-28
+## [2.0.0](https://github.com/bluealloy/revm/compare/revm-database-interface-v1.0.0...revm-database-interface-v2.0.0) - 2025-03-28
 
 ### Other
 

--- a/crates/database/interface/Cargo.toml
+++ b/crates/database/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-database-interface"
 description = "Revm Database interface"
-version = "1.0.1"
+version = "2.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/inspector/CHANGELOG.md
+++ b/crates/inspector/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.0](https://github.com/bluealloy/revm/compare/revm-inspector-v1.0.0...revm-inspector-v1.1.0) - 2025-03-28
+## [2.0.0](https://github.com/bluealloy/revm/compare/revm-inspector-v1.0.0...revm-inspector-v2.0.0) - 2025-03-28
 
 ### Added
 

--- a/crates/inspector/Cargo.toml
+++ b/crates/inspector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-inspector"
 description = "Revm inspector interface"
-version = "1.1.0"
+version = "2.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [16.0.1](https://github.com/bluealloy/revm/compare/revm-interpreter-v16.0.0...revm-interpreter-v16.0.1) - 2025-03-28
+## [17.0.0](https://github.com/bluealloy/revm/compare/revm-interpreter-v16.0.0...revm-interpreter-v17.0.0) - 2025-03-28
 
 ### Other
 

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-interpreter"
 description = "Revm Interpreter that executes bytecode."
-version = "16.0.1"
+version = "17.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/revm/CHANGELOG.md
+++ b/crates/revm/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [20.1.0](https://github.com/bluealloy/revm/compare/revm-v20.0.0...revm-v20.1.0) - 2025-03-28
+## [21.0.0](https://github.com/bluealloy/revm/compare/revm-v20.0.0...revm-v21.0.0) - 2025-03-28
 
 ### Added
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm"
 description = "Revm - Rust Ethereum Virtual Machine"
-version = "20.1.0"
+version = "21.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/state/CHANGELOG.md
+++ b/crates/state/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.1](https://github.com/bluealloy/revm/compare/revm-state-v1.0.0...revm-state-v1.0.1) - 2025-03-28
+## [2.0.0](https://github.com/bluealloy/revm/compare/revm-state-v1.0.0...revm-state-v2.0.0) - 2025-03-28
 
 ### Other
 

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-state"
 description = "Revm state types"
-version = "1.0.1"
+version = "2.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/statetest-types/CHANGELOG.md
+++ b/crates/statetest-types/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.1](https://github.com/bluealloy/revm/compare/revm-statetest-types-v1.0.0...revm-statetest-types-v1.0.1) - 2025-03-28
+## [2.0.0](https://github.com/bluealloy/revm/compare/revm-statetest-types-v1.0.0...revm-statetest-types-v2.0.0) - 2025-03-28
 
 ### Other
 

--- a/crates/statetest-types/Cargo.toml
+++ b/crates/statetest-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-statetest-types"
 description = "Statetest types for revme"
-version = "1.0.1"
+version = "2.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
Bump all versions to major number, this is needed so dependency does not break minor bump