### PR TITLE
test(op-tx): Cover `DepositTransactionParts` constructor in test

### DIFF
--- a/crates/optimism/src/transaction/deposit.rs
+++ b/crates/optimism/src/transaction/deposit.rs
@@ -32,13 +32,11 @@ mod tests {
         let deposit_tx_parts: DepositTransactionParts = serde_json::from_str(response).unwrap();
         assert_eq!(
             deposit_tx_parts,
-            DepositTransactionParts {
-                source_hash: b256!(
-                    "0xe927a1448525fb5d32cb50ee1408461a945ba6c39bd5cf5621407d500ecc8de9"
-                ),
-                mint: Some(0x34),
-                is_system_transaction: false,
-            }
+            DepositTransactionParts::new(
+                b256!("0xe927a1448525fb5d32cb50ee1408461a945ba6c39bd5cf5621407d500ecc8de9"),
+                Some(0x34),
+                false,
+            )
         );
     }
 }


### PR DESCRIPTION
Ref https://github.com/bluealloy/revm/issues/2189

Smol change for 100% coverage of _optimism/src/transaction/deposit.rs_ 