### PR TITLE
add get_account fn to load account once

### DIFF
--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -133,7 +133,7 @@ pub trait Handler {
     fn get_account(&self, evm: &mut Self::Evm) -> Result<Account, Self::Error> {
         let context = evm.ctx();
         let caller = context.tx().caller();
-        let account = context.journal().load_account(caller)?.data.clone();
+        let account = context.journal().load_account_code(caller)?.data.clone();
         Ok(account)
     }
 

--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -12,6 +12,7 @@ use context_interface::{
     Block, Cfg, Database,
 };
 use primitives::{eip7702, hardfork::SpecId, KECCAK_EMPTY, U256};
+use state::Account;
 
 use crate::{EvmTr, PrecompileProvider};
 
@@ -68,6 +69,7 @@ pub fn load_accounts<
 #[inline]
 pub fn deduct_caller<CTX: ContextTr>(
     context: &mut CTX,
+    caller_account: &mut Account
 ) -> Result<(), <CTX::Db as Database>::Error> {
     let basefee = context.block().basefee();
     let blob_price = context.block().blob_gasprice().unwrap_or_default();
@@ -86,10 +88,7 @@ pub fn deduct_caller<CTX: ContextTr>(
     }
 
     let is_call = context.tx().kind().is_call();
-    let caller = context.tx().caller();
 
-    // Load caller's account.
-    let caller_account = context.journal().load_account(caller)?.data;
     // Set new caller account balance.
     caller_account.info.balance = caller_account
         .info

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -1,5 +1,4 @@
 use context_interface::{
-    journaled_state::JournalTr,
     result::{InvalidHeader, InvalidTransaction},
     transaction::{Transaction, TransactionType},
     Block, Cfg, ContextTr, Database,
@@ -29,15 +28,10 @@ pub fn validate_tx_against_state<
     CTX: ContextTr,
     ERROR: From<InvalidTransaction> + From<<CTX::Db as Database>::Error>,
 >(
-    mut context: CTX,
+    context: CTX,
+    account_info: &AccountInfo
 ) -> Result<(), ERROR> {
-    let tx_caller = context.tx().caller();
-
-    // Load acc
-    let account = context.journal().load_account_code(tx_caller)?;
-    let account = account.data.info.clone();
-
-    validate_tx_against_account(&account, context, U256::ZERO)?;
+    validate_tx_against_account(account_info, context, U256::ZERO)?;
     Ok(())
 }
 

--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -54,8 +54,10 @@ where
         &mut self,
         evm: &mut Self::Evm,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        let init_and_floor_gas = self.validate(evm)?;
-        let eip7702_refund = self.pre_execution(evm)? as i64;
+        let mut account = self.get_account(evm)?;
+
+        let init_and_floor_gas = self.validate(evm, &account.info)?;
+        let eip7702_refund = self.pre_execution(evm, &mut account)? as i64;
         let exec_result = self.inspect_execution(evm, &init_and_floor_gas);
         self.post_execution(evm, exec_result?, init_and_floor_gas, eip7702_refund)
     }

--- a/examples/erc20_gas/src/handler.rs
+++ b/examples/erc20_gas/src/handler.rs
@@ -7,7 +7,7 @@ use revm::{
     },
     handler::{EvmTr, EvmTrError, Frame, FrameResult, Handler},
     interpreter::FrameInput,
-    primitives::{hardfork::SpecId, U256},
+    primitives::{hardfork::SpecId, U256}, state::{Account, AccountInfo},
 };
 
 use crate::{erc_address_storage, token_operation, TOKEN, TREASURY};
@@ -41,7 +41,7 @@ where
     type Frame = FRAME;
     type HaltReason = HaltReason;
 
-    fn validate_tx_against_state(&self, evm: &mut Self::Evm) -> Result<(), Self::Error> {
+    fn validate_tx_against_state(&self, evm: &mut Self::Evm, account: &AccountInfo) -> Result<(), Self::Error> {
         let context = evm.ctx();
         let caller = context.tx().caller();
         let caller_nonce = context.journal().load_account(caller)?.data.info.nonce;
@@ -98,7 +98,7 @@ where
         Ok(())
     }
 
-    fn deduct_caller(&self, evm: &mut Self::Evm) -> Result<(), Self::Error> {
+    fn deduct_caller(&self, evm: &mut Self::Evm, caller_account: &mut Account) -> Result<(), Self::Error> {
         let context = evm.ctx();
         // load and touch token account
         let _ = context.journal().load_account(TOKEN)?.data;


### PR DESCRIPTION
Closes #2356 

# Summary
- Created a `get_account` function to get a single `Account` instance.
- Modify `validate` and `pre_execution` functions to pass relevant account parameters for usage instead of loading the account again.
- Update inspector code.