### PR TITLE
chore: fixed `EIP` to `RIP`

### DIFF
--- a/crates/optimism/src/precompiles.rs
+++ b/crates/optimism/src/precompiles.rs
@@ -51,7 +51,7 @@ pub fn fjord() -> &'static Precompiles {
     static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
     INSTANCE.get_or_init(|| {
         let mut precompiles = Precompiles::cancun().clone();
-        // EIP-7212: secp256r1 P256verify
+        // RIP-7212: secp256r1 P256verify
         precompiles.extend([secp256r1::P256VERIFY]);
         Box::new(precompiles)
     })

--- a/crates/precompile/src/secp256r1.rs
+++ b/crates/precompile/src/secp256r1.rs
@@ -1,4 +1,4 @@
-//! # EIP-7212 secp256r1 Precompile
+//! # RIP-7212 secp256r1 Precompile
 //!
 //! This module implements the [RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md) precompile for
 //! secp256r1 curve support.


### PR DESCRIPTION
I corrected `EIP` to `RIP` references in precompile documentation.