### PR TITLE
bump tokio version to fix sec issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4645,9 +4645,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ derive-where = { version = "1.2.7", default-features = false }
 enumn = "0.1"
 once_cell = { version = "1.19", default-features = false }
 rand = "0.8"
-tokio = "1.40"
+tokio = "1.44"
 
 # dev-dependencies
 anyhow = "1.0.89"


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2025-0023
https://github.com/tokio-rs/tokio/pull/7232