### PR TITLE
feat(database): Implement transition counter for cache-aware transition tracking

### DIFF
--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -69,9 +69,9 @@ pub struct State<DB> {
     /// It can be used by the cache state to detect when transitions have been dropped,
     /// allowing more efficient cache management by knowing when certain cached values
     /// are no longer needed or when they need to be refreshed.
-    /// 
+    ///
     /// For example, the cache can store the last seen transition counter value and compare it
-    /// with the current one to determine if any transitions have been merged or dropped since 
+    /// with the current one to determine if any transitions have been merged or dropped since
     /// the last check.
     pub transition_counter: usize,
 }

--- a/crates/database/src/states/state_builder.rs
+++ b/crates/database/src/states/state_builder.rs
@@ -173,6 +173,7 @@ impl<DB: Database> StateBuilder<DB> {
             bundle_state: self.with_bundle_prestate.unwrap_or_default(),
             use_preloaded_bundle,
             block_hashes: self.with_block_hashes,
+            transition_counter: 0,
         }
     }
 }


### PR DESCRIPTION
Added a global transition counter to the State struct to track when transitions are merged or dropped. This allows the cache state to be aware of transition state changes by comparing the current counter value with the last seen value.

The counter is incremented in two places:
1. When transitions are merged via merge_transitions()
2. When the bundle is taken via take_bundle()

Also added a getter method transition_counter() for cache implementations to use when they need to detect transition changes.