### PR TITLE
fix: skip account list for legacy

### DIFF
--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -47,7 +47,7 @@ pub fn load_accounts<
 
     // Load access list
     let (tx, journal) = context.tx_journal();
-    // Legacy transaction does not have access list.
+    // legacy is only tx type that does not have access list.
     if tx.tx_type() != TransactionType::Legacy {
         if let Some(access_list) = tx.access_list() {
             for item in access_list {

--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -47,17 +47,20 @@ pub fn load_accounts<
 
     // Load access list
     let (tx, journal) = context.tx_journal();
-    if let Some(access_list) = tx.access_list() {
-        for item in access_list {
-            let address = item.address();
-            let mut storage = item.storage_slots().peekable();
-            if storage.peek().is_none() {
-                journal.warm_account(*address);
-            } else {
-                journal.warm_account_and_storage(
-                    *address,
-                    storage.map(|i| U256::from_be_bytes(i.0)),
-                )?;
+    // Legacy transaction does not have access list.
+    if tx.tx_type() != TransactionType::Legacy {
+        if let Some(access_list) = tx.access_list() {
+            for item in access_list {
+                let address = item.address();
+                let mut storage = item.storage_slots().peekable();
+                if storage.peek().is_none() {
+                    journal.warm_account(*address);
+                } else {
+                    journal.warm_account_and_storage(
+                        *address,
+                        storage.map(|i| U256::from_be_bytes(i.0)),
+                    )?;
+                }
             }
         }
     }

--- a/crates/interpreter/src/gas/calc.rs
+++ b/crates/interpreter/src/gas/calc.rs
@@ -432,7 +432,7 @@ pub fn calculate_initial_tx_gas(
 pub fn calculate_initial_tx_gas_for_tx(tx: impl Transaction, spec: SpecId) -> InitialAndFloorGas {
     let mut accounts = 0;
     let mut storages = 0;
-    // legact is only tx type that does not have access list.
+    // legacy is only tx type that does not have access list.
     if tx.tx_type() != TransactionType::Legacy {
         (accounts, storages) = tx
             .access_list()

--- a/crates/interpreter/src/gas/calc.rs
+++ b/crates/interpreter/src/gas/calc.rs
@@ -1,7 +1,7 @@
 use super::constants::*;
 use crate::{num_words, tri, SStoreResult, SelfDestructResult, StateLoad};
 use context_interface::{
-    journaled_state::AccountLoad, transaction::AccessListItemTr as _, Transaction,
+    journaled_state::AccountLoad, transaction::AccessListItemTr as _, Transaction, TransactionType,
 };
 use primitives::{eip7702, hardfork::SpecId, U256};
 
@@ -430,17 +430,22 @@ pub fn calculate_initial_tx_gas(
 /// - Intrinsic gas
 /// - Number of tokens in calldata
 pub fn calculate_initial_tx_gas_for_tx(tx: impl Transaction, spec: SpecId) -> InitialAndFloorGas {
-    let (accounts, storages) = tx
-        .access_list()
-        .map(|al| {
-            al.fold((0, 0), |(mut num_accounts, mut num_storage_slots), item| {
-                num_accounts += 1;
-                num_storage_slots += item.storage_slots().count();
+    let mut accounts = 0;
+    let mut storages = 0;
+    // legact is only tx type that does not have access list.
+    if tx.tx_type() != TransactionType::Legacy {
+        (accounts, storages) = tx
+            .access_list()
+            .map(|al| {
+                al.fold((0, 0), |(mut num_accounts, mut num_storage_slots), item| {
+                    num_accounts += 1;
+                    num_storage_slots += item.storage_slots().count();
 
-                (num_accounts, num_storage_slots)
+                    (num_accounts, num_storage_slots)
+                })
             })
-        })
-        .unwrap_or_default();
+            .unwrap_or_default();
+    }
 
     calculate_initial_tx_gas(
         spec,


### PR DESCRIPTION
Skip touching access list if we have legacy transaction type.

Tx type needs to dictate what fields we are using, otherwise it is a footgun