### PR TITLE
fix(op-revm): Add input size limitations to bls12-381 {G1/G2} MSM + pairing

### DIFF
--- a/crates/optimism/src/precompiles.rs
+++ b/crates/optimism/src/precompiles.rs
@@ -75,6 +75,12 @@ pub fn isthmus() -> &'static Precompiles {
         let mut precompiles = granite().clone();
         // Prague bls12 precompiles
         precompiles.extend(precompile::bls12_381::precompiles());
+        // Isthmus bls12 precompile modifications
+        precompiles.extend([
+            bls12_381::ISTHMUS_G1_MSM,
+            bls12_381::ISTHMUS_G2_MSM,
+            bls12_381::ISTHMUS_PAIRING,
+        ]);
         Box::new(precompiles)
     })
 }
@@ -143,6 +149,55 @@ pub mod bn128_pair {
             bn128::pair::ISTANBUL_PAIR_BASE,
             gas_limit,
         )
+    }
+}
+
+pub mod bls12_381 {
+    use super::*;
+    use revm::{
+        precompile::bls12_381_const::{G1_MSM_ADDRESS, G2_MSM_ADDRESS, PAIRING_ADDRESS},
+        primitives::Bytes,
+    };
+
+    #[cfg(not(feature = "std"))]
+    use crate::std::string::ToString;
+
+    pub const ISTHMUS_G1_MSM_MAX_INPUT_SIZE: usize = 513760;
+    pub const ISTHMUS_G2_MSM_MAX_INPUT_SIZE: usize = 488448;
+    pub const ISTHMUS_PAIRING_MAX_INPUT_SIZE: usize = 235008;
+
+    pub const ISTHMUS_G1_MSM: PrecompileWithAddress =
+        PrecompileWithAddress(G1_MSM_ADDRESS, run_g1_msm);
+    pub const ISTHMUS_G2_MSM: PrecompileWithAddress =
+        PrecompileWithAddress(G2_MSM_ADDRESS, run_g2_msm);
+    pub const ISTHMUS_PAIRING: PrecompileWithAddress =
+        PrecompileWithAddress(PAIRING_ADDRESS, run_pair);
+
+    pub fn run_g1_msm(input: &Bytes, gas_limit: u64) -> PrecompileResult {
+        if input.len() > ISTHMUS_G1_MSM_MAX_INPUT_SIZE {
+            return Err(PrecompileError::Other(
+                "G1MSM input length too long for OP Stack input size limitation".to_string(),
+            ));
+        }
+        precompile::bls12_381::g1_msm::g1_msm(input, gas_limit)
+    }
+
+    pub fn run_g2_msm(input: &Bytes, gas_limit: u64) -> PrecompileResult {
+        if input.len() > ISTHMUS_G2_MSM_MAX_INPUT_SIZE {
+            return Err(PrecompileError::Other(
+                "G2MSM input length too long for OP Stack input size limitation".to_string(),
+            ));
+        }
+        precompile::bls12_381::g2_msm::g2_msm(input, gas_limit)
+    }
+
+    pub fn run_pair(input: &Bytes, gas_limit: u64) -> PrecompileResult {
+        if input.len() > ISTHMUS_PAIRING_MAX_INPUT_SIZE {
+            return Err(PrecompileError::Other(
+                "Pairing input length too long for OP Stack input size limitation".to_string(),
+            ));
+        }
+        precompile::bls12_381::pairing::pairing(input, gas_limit)
     }
 }
 

--- a/crates/precompile/src/bls12_381/g1_msm.rs
+++ b/crates/precompile/src/bls12_381/g1_msm.rs
@@ -20,7 +20,7 @@ pub const PRECOMPILE: PrecompileWithAddress = PrecompileWithAddress(G1_MSM_ADDRE
 /// Output is an encoding of multi-scalar-multiplication operation result - single G1
 /// point (`128` bytes).
 /// See also: <https://eips.ethereum.org/EIPS/eip-2537#abi-for-g1-multiexponentiation>
-pub(super) fn g1_msm(input: &Bytes, gas_limit: u64) -> PrecompileResult {
+pub fn g1_msm(input: &Bytes, gas_limit: u64) -> PrecompileResult {
     let input_len = input.len();
     if input_len == 0 || input_len % G1_MSM_INPUT_LENGTH != 0 {
         return Err(PrecompileError::Other(format!(

--- a/crates/precompile/src/bls12_381/g2_msm.rs
+++ b/crates/precompile/src/bls12_381/g2_msm.rs
@@ -20,7 +20,7 @@ pub const PRECOMPILE: PrecompileWithAddress = PrecompileWithAddress(G2_MSM_ADDRE
 /// Output is an encoding of multi-scalar-multiplication operation result - single G2
 /// point (`256` bytes).
 /// See also: <https://eips.ethereum.org/EIPS/eip-2537#abi-for-g2-multiexponentiation>
-pub(super) fn g2_msm(input: &Bytes, gas_limit: u64) -> PrecompileResult {
+pub fn g2_msm(input: &Bytes, gas_limit: u64) -> PrecompileResult {
     let input_len = input.len();
     if input_len == 0 || input_len % G2_MSM_INPUT_LENGTH != 0 {
         return Err(PrecompileError::Other(format!(

--- a/crates/precompile/src/bls12_381/pairing.rs
+++ b/crates/precompile/src/bls12_381/pairing.rs
@@ -23,7 +23,7 @@ pub const PRECOMPILE: PrecompileWithAddress = PrecompileWithAddress(PAIRING_ADDR
 /// target field and 0x00 otherwise.
 ///
 /// See also: <https://eips.ethereum.org/EIPS/eip-2537#abi-for-pairing>
-pub(super) fn pairing(input: &Bytes, gas_limit: u64) -> PrecompileResult {
+pub fn pairing(input: &Bytes, gas_limit: u64) -> PrecompileResult {
     let input_len = input.len();
     if input_len == 0 || input_len % PAIRING_INPUT_LENGTH != 0 {
         return Err(PrecompileError::Other(format!(


### PR DESCRIPTION
## Overview

Adds input size limitations to the BLS12-381 G1/G2 MSM and pairing precompiles. This was originally started in https://github.com/bluealloy/revm/pull/2039, but looks to have been lost.

[Specification Reference](https://specs.optimism.io/protocol/isthmus/exec-engine.html#bls-precompiles)