### PR TITLE
fix(eof): extdelegate bytecode check after eip7702 load

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -6,7 +6,7 @@ set -e
 # Version for the execution spec tests
 VERSION="v4.2.0"
 # Version for the EOF spec tests, it is currently upgrading to eof devnet-1 so we will use devnet-0 suite.
-EOF_VERSION="v4.1.0"
+EOF_VERSION="eip7692@v2.3.0"
 
 # Directories
 FIXTURES_DIR="test-fixtures"


### PR DESCRIPTION
We should load delegate before checking EOF EXTDELEGATECALL target.