### PR TITLE
chore: fixed broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ As previously noted, there are several groups of projects that utilize this tech
 * **Major block builders**.
 * **Clients**: [Reth](https://github.com/paradigmxyz/reth), [Helios](https://github.com/a16z/helios), [Trin](https://github.com/ethereum/trin),..
 * **Tooling**: [Foundry](https://github.com/foundry-rs/foundry/), [Hardhat](https://github.com/NomicFoundation/hardhat),..
-* **L2s**: [Optimism](https://github.com/bluealloy/revm/tree/main/crates/optimism), [Coinbase](https://www.base.org/), [Scroll](https://github.com/scroll-tech/revm),..
+* **L2s**: [Optimism](https://github.com/bluealloy/revm/tree/main/crates/op-revm), [Coinbase](https://www.base.org/), [Scroll](https://github.com/scroll-tech/revm),..
 * **zkVM**: [Risc0](https://github.com/risc0/risc0-ethereum), [Succinct](https://github.com/succinctlabs/rsp),..
 
 The full list of projects that use Revm is available in the awesome-revm section of the book.

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -51,7 +51,7 @@ let _ = evm.inspect_with_tx(tx);
 
 To learn how to build your own custom EVM:
 - Check out the [example-my-evm](https://github.com/bluealloy/revm/tree/main/examples/my_evm) guide
-- Look at [op-revm](https://github.com/bluealloy/revm/tree/main/crates/optimism) to see how Optimism uses REVM
+- Look at [op-revm](https://github.com/bluealloy/revm/tree/main/crates/op-revm) to see how Optimism uses REVM
 
 Each trait needed to build custom EVM has detailed documentation explaining how it works and is worth reading.
 

--- a/book/src/awesome.md
+++ b/book/src/awesome.md
@@ -19,7 +19,7 @@ A curated list of excellent Revm-related resources. Feel free to contribute to t
 - [**Trin**](https://github.com/ethereum/trin) is a Rust implementation of a Portal Network client.
 
 #### EVM Variants
-- [**Optimism**](https://github.com/bluealloy/revm/tree/main/crates/optimism) is a ethereum L2 network.
+- [**Optimism**](https://github.com/bluealloy/revm/tree/main/crates/op-revm) is a ethereum L2 network.
 - [**Base**](https://www.base.org/) is an Ethereum Layer 2 (L2) chain that offers a safe, low-cost, developer-friendly way to build on-chain
 - [**Scroll**](https://github.com/scroll-tech/revm) is its own Layer 2 network built on Ethereum (more specifically, a “zero-knowledge rollup”).
 


### PR DESCRIPTION
Hi! I updated all outdated links that were pointing to `crates/optimism` and replaced them with `crates/op-revm`. This matches the recent directory change introduced in [revm#2415](https://github.com/bluealloy/revm/pull/2415).