### PR TITLE
feat(bytecode): improve legacy bytecode padding

### DIFF
--- a/crates/bytecode/src/legacy/analysis.rs
+++ b/crates/bytecode/src/legacy/analysis.rs
@@ -1,23 +1,37 @@
 use super::JumpTable;
 use crate::opcode;
 use bitvec::{bitvec, order::Lsb0, vec::BitVec};
-use std::sync::Arc;
+use primitives::Bytes;
+use std::{sync::Arc, vec, vec::Vec};
 
 /// Analyze the bytecode to find the jumpdests. Used to create a jump table
 /// that is needed for [`crate::LegacyAnalyzedBytecode`].
 /// This function contains a hot loop and should be optimized as much as possible.
 ///
+/// # Safety
+///
+/// The function uses unsafe pointer arithmetic, but maintains the following invariants:
+/// - The iterator never advances beyond the end of the bytecode
+/// - All pointer offsets are within bounds of the bytecode
+/// - The jump table is never accessed beyond its allocated size
+///
 /// Undefined behavior if the bytecode does not end with a valid STOP opcode. Please check
 /// [`crate::LegacyAnalyzedBytecode::new`] for details on how the bytecode is validated.
-pub fn analyze_legacy(bytetecode: &[u8]) -> JumpTable {
-    let mut jumps: BitVec<u8> = bitvec![u8, Lsb0; 0; bytetecode.len()];
+pub fn analyze_legacy(mut bytecode: Vec<u8>) -> (JumpTable, Bytes) {
+    let mut jumps: BitVec<u8> = bitvec![u8, Lsb0; 0; bytecode.len()];
 
-    let range = bytetecode.as_ptr_range();
+    if bytecode.is_empty() {
+        return (JumpTable(Arc::new(jumps)), Bytes::from(vec![opcode::STOP]));
+    }
+
+    let range = bytecode.as_ptr_range();
     let start = range.start;
     let mut iterator = start;
     let end = range.end;
+    let mut opcode = unsafe { *iterator };
+
     while iterator < end {
-        let opcode = unsafe { *iterator };
+        opcode = unsafe { *iterator };
         if opcode::JUMPDEST == opcode {
             // SAFETY: Jumps are max length of the code
             unsafe { jumps.set_unchecked(iterator.offset_from(start) as usize, true) }
@@ -34,5 +48,135 @@ pub fn analyze_legacy(bytetecode: &[u8]) -> JumpTable {
         }
     }
 
-    JumpTable(Arc::new(jumps))
+    // Calculate padding needed to ensure bytecode ends with STOP
+    // If we're at the end and last opcode is not STOP, we need 1 more byte
+    let padding_size = (iterator as usize) - (end as usize) + (opcode != opcode::STOP) as usize;
+    if padding_size > 0 {
+        bytecode.resize(bytecode.len() + padding_size, 0);
+    }
+
+    (JumpTable(Arc::new(jumps)), Bytes::from(bytecode))
+}
+
+mod tests {
+    #[allow(unused_imports)]
+    use crate::{legacy::analyze_legacy, opcode};
+
+    #[test]
+    fn test_bytecode_ends_with_stop_no_padding_needed() {
+        let bytecode = vec![
+            opcode::PUSH1,
+            0x01,
+            opcode::PUSH1,
+            0x02,
+            opcode::ADD,
+            opcode::STOP,
+        ];
+        let (_, padded_bytecode) = analyze_legacy(bytecode.clone());
+        assert_eq!(padded_bytecode.len(), bytecode.len());
+    }
+
+    #[test]
+    fn test_bytecode_ends_without_stop_requires_padding() {
+        let bytecode = vec![opcode::PUSH1, 0x01, opcode::PUSH1, 0x02, opcode::ADD];
+        let (_, padded_bytecode) = analyze_legacy(bytecode.clone());
+        assert_eq!(padded_bytecode.len(), bytecode.len() + 1);
+    }
+
+    #[test]
+    fn test_bytecode_ends_with_push16_requires_17_bytes_padding() {
+        let bytecode = vec![opcode::PUSH1, 0x01, opcode::PUSH16];
+        let (_, padded_bytecode) = analyze_legacy(bytecode.clone());
+        assert_eq!(padded_bytecode.len(), bytecode.len() + 17);
+    }
+
+    #[test]
+    fn test_bytecode_ends_with_push2_requires_2_bytes_padding() {
+        let bytecode = vec![opcode::PUSH1, 0x01, opcode::PUSH2, 0x02];
+        let (_, padded_bytecode) = analyze_legacy(bytecode.clone());
+        assert_eq!(padded_bytecode.len(), bytecode.len() + 2);
+    }
+
+    #[test]
+    fn test_empty_bytecode_requires_stop() {
+        let bytecode = vec![];
+        let (_, padded_bytecode) = analyze_legacy(bytecode.clone());
+        assert_eq!(padded_bytecode.len(), 1); // Just STOP
+    }
+
+    #[test]
+    fn test_bytecode_with_jumpdest_at_start() {
+        let bytecode = vec![opcode::JUMPDEST, opcode::PUSH1, 0x01, opcode::STOP];
+        let (jump_table, _) = analyze_legacy(bytecode.clone());
+        assert!(jump_table.0[0]); // First byte should be a valid jumpdest
+    }
+
+    #[test]
+    fn test_bytecode_with_jumpdest_after_push() {
+        let bytecode = vec![opcode::PUSH1, 0x01, opcode::JUMPDEST, opcode::STOP];
+        let (jump_table, _) = analyze_legacy(bytecode.clone());
+        assert!(jump_table.0[2]); // JUMPDEST should be at position 2
+    }
+
+    #[test]
+    fn test_bytecode_with_multiple_jumpdests() {
+        let bytecode = vec![
+            opcode::JUMPDEST,
+            opcode::PUSH1,
+            0x01,
+            opcode::JUMPDEST,
+            opcode::STOP,
+        ];
+        let (jump_table, _) = analyze_legacy(bytecode.clone());
+        assert!(jump_table.0[0]); // First JUMPDEST
+        assert!(jump_table.0[3]); // Second JUMPDEST
+    }
+
+    #[test]
+    fn test_bytecode_with_max_push32() {
+        let bytecode = vec![opcode::PUSH32];
+        let (_, padded_bytecode) = analyze_legacy(bytecode.clone());
+        assert_eq!(padded_bytecode.len(), bytecode.len() + 33); // PUSH32 + 32 bytes + STOP
+    }
+
+    #[test]
+    fn test_bytecode_with_invalid_opcode() {
+        let bytecode = vec![0xFF, opcode::STOP]; // 0xFF is an invalid opcode
+        let (jump_table, _) = analyze_legacy(bytecode.clone());
+        assert!(!jump_table.0[0]); // Invalid opcode should not be a jumpdest
+    }
+
+    #[test]
+    fn test_bytecode_with_sequential_pushes() {
+        let bytecode = vec![
+            opcode::PUSH1,
+            0x01,
+            opcode::PUSH2,
+            0x02,
+            0x03,
+            opcode::PUSH4,
+            0x04,
+            0x05,
+            0x06,
+            0x07,
+            opcode::STOP,
+        ];
+        let (jump_table, padded_bytecode) = analyze_legacy(bytecode.clone());
+        assert_eq!(padded_bytecode.len(), bytecode.len());
+        assert!(!jump_table.0[0]); // PUSH1
+        assert!(!jump_table.0[2]); // PUSH2
+        assert!(!jump_table.0[5]); // PUSH4
+    }
+
+    #[test]
+    fn test_bytecode_with_jumpdest_in_push_data() {
+        let bytecode = vec![
+            opcode::PUSH2,
+            opcode::JUMPDEST, // This should not be treated as a JUMPDEST
+            0x02,
+            opcode::STOP,
+        ];
+        let (jump_table, _) = analyze_legacy(bytecode.clone());
+        assert!(!jump_table.0[1]); // JUMPDEST in push data should not be valid
+    }
 }

--- a/crates/bytecode/src/legacy/raw.rs
+++ b/crates/bytecode/src/legacy/raw.rs
@@ -1,7 +1,6 @@
 use super::{analyze_legacy, LegacyAnalyzedBytecode};
 use core::ops::Deref;
 use primitives::Bytes;
-use std::vec::Vec;
 
 /// Used only as intermediate representation for legacy bytecode.
 /// Please check [`LegacyAnalyzedBytecode`] for the main structure that is used in Revm.
@@ -14,12 +13,10 @@ impl LegacyRawBytecode {
     ///
     /// It extends the bytecode with 33 zero bytes and analyzes it to find the jumpdests.
     pub fn into_analyzed(self) -> LegacyAnalyzedBytecode {
-        let len = self.0.len();
-        let mut padded_bytecode = Vec::with_capacity(len + 33);
-        padded_bytecode.extend_from_slice(&self.0);
-        padded_bytecode.resize(len + 33, 0);
-        let jump_table = analyze_legacy(&padded_bytecode);
-        LegacyAnalyzedBytecode::new(padded_bytecode.into(), len, jump_table)
+        let bytecode = self.0;
+        let len = bytecode.len();
+        let (jump_table, padded_bytecode) = analyze_legacy(bytecode.to_vec());
+        LegacyAnalyzedBytecode::new(padded_bytecode, len, jump_table)
     }
 }
 

--- a/crates/bytecode/src/legacy/raw.rs
+++ b/crates/bytecode/src/legacy/raw.rs
@@ -15,7 +15,7 @@ impl LegacyRawBytecode {
     pub fn into_analyzed(self) -> LegacyAnalyzedBytecode {
         let bytecode = self.0;
         let len = bytecode.len();
-        let (jump_table, padded_bytecode) = analyze_legacy(bytecode.to_vec());
+        let (jump_table, padded_bytecode) = analyze_legacy(bytecode);
         LegacyAnalyzedBytecode::new(padded_bytecode, len, jump_table)
     }
 }


### PR DESCRIPTION
# Improve Legacy Bytecode Analysis

## Description
Refactors bytecode analysis to handle padding internally and improve safety. Adds comprehensive test coverage for various bytecode scenarios.

## Changes
- `analyze_legacy` now handles padding internally and returns both jump table and padded bytecode
- Added early return for empty bytecode
- Improved safety documentation for unsafe pointer operations
- Added extensive test suite covering edge cases and padding scenarios

## Testing
Added tests for:
- Empty bytecode
- JUMPDEST positions
- PUSH operations
- Invalid opcodes
- Padding scenarios

Closes #2414