### PR TITLE
Replace InterpreterAction with InterpreterTypes::Output

### DIFF
--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -24,7 +24,6 @@ use bytecode::Bytecode;
 use loop_control::LoopControl as LoopControlImpl;
 use primitives::{hardfork::SpecId, Address, Bytes, U256};
 use return_data::ReturnDataImpl;
-use std::convert::From;
 
 /// Main interpreter structure that contains all components defines in [`InterpreterTypes`].s
 #[derive(Debug, Clone)]

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -116,9 +116,9 @@ impl<EXT> InterpreterTypes for EthInterpreter<EXT> {
     type Output = InterpreterAction;
 }
 
-impl<IW: InterpreterTypes> Interpreter<IW> 
+impl<IW: InterpreterTypes> Interpreter<IW>
 where
-    IW::Output: From<InterpreterAction>
+    IW::Output: From<InterpreterAction>,
 {
     /// Executes the instruction at the current instruction pointer.
     ///

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -144,9 +144,7 @@ impl<IW: InterpreterTypes> Interpreter<IW> {
         self.control
             .set_next_action(InterpreterAction::None, InstructionResult::Continue);
     }
-}
 
-impl<IW: InterpreterTypes<Output = InterpreterAction>> Interpreter<IW> {
     /// Takes the next action from the control and returns it.
     #[inline]
     pub fn take_next_action(&mut self) -> InterpreterAction {
@@ -222,6 +220,28 @@ impl InterpreterResult {
     #[inline]
     pub const fn is_error(&self) -> bool {
         self.result.is_error()
+    }
+}
+
+// Special implementation for types where Output can be created from InterpreterAction
+impl<IW: InterpreterTypes> Interpreter<IW>
+where
+    IW::Output: From<InterpreterAction>,
+{
+    /// Takes the next action from the control and returns it as the specific Output type.
+    #[inline]
+    pub fn take_next_action_as_output(&mut self) -> IW::Output {
+        From::from(self.take_next_action())
+    }
+
+    /// Executes the interpreter until it returns or stops, returning the specific Output type.
+    #[inline]
+    pub fn run_plain_as_output<H: Host + ?Sized>(
+        &mut self,
+        instruction_table: &InstructionTable<IW, H>,
+        host: &mut H,
+    ) -> IW::Output {
+        From::from(self.run_plain(instruction_table, host))
     }
 }
 


### PR DESCRIPTION
The implementation adds a where clause to ensure that IW::Output implements From<InterpreterAction> for proper type conversion, allowing custom output types to be used with the interpreter while maintaining backward compatibility.