### PR TITLE
perf: cache and use JumpTable::default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3714,6 +3714,7 @@ name = "revm-bytecode"
 version = "3.0.0"
 dependencies = [
  "bitvec",
+ "once_cell",
  "paste",
  "phf",
  "revm-primitives",

--- a/crates/bytecode/Cargo.toml
+++ b/crates/bytecode/Cargo.toml
@@ -22,6 +22,7 @@ primitives.workspace = true
 
 # Jumpmap
 bitvec = { workspace = true, features = ["alloc"] }
+once_cell.workspace = true
 
 # Optional
 serde = { workspace = true, features = ["derive", "rc"], optional = true }

--- a/crates/bytecode/Cargo.toml
+++ b/crates/bytecode/Cargo.toml
@@ -22,7 +22,7 @@ primitives.workspace = true
 
 # Jumpmap
 bitvec = { workspace = true, features = ["alloc"] }
-once_cell.workspace = true
+once_cell = { workspace = true, features = ["alloc"] }
 
 # Optional
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
@@ -33,7 +33,7 @@ phf = { workspace = true, features = ["macros"], optional = true }
 
 [features]
 default = ["std", "parse"]
-std = ["serde?/std", "primitives/std", "bitvec/std", "phf?/std"]
+std = ["serde?/std", "primitives/std", "bitvec/std", "once_cell/std", "phf?/std"]
 hashbrown = ["primitives/hashbrown"]
 serde = ["dep:serde", "primitives/serde", "bitvec/serde", "phf?/serde"]
 serde-json = ["serde"]

--- a/crates/bytecode/src/legacy/analysis.rs
+++ b/crates/bytecode/src/legacy/analysis.rs
@@ -18,12 +18,11 @@ use std::{sync::Arc, vec, vec::Vec};
 /// Undefined behavior if the bytecode does not end with a valid STOP opcode. Please check
 /// [`crate::LegacyAnalyzedBytecode::new`] for details on how the bytecode is validated.
 pub fn analyze_legacy(bytecode: Bytes) -> (JumpTable, Bytes) {
-    let mut jumps: BitVec<u8> = bitvec![u8, Lsb0; 0; bytecode.len()];
-
     if bytecode.is_empty() {
-        return (JumpTable(Arc::new(jumps)), Bytes::from(vec![opcode::STOP]));
+        return (JumpTable::default(), Bytes::from_static(&[opcode::STOP]));
     }
 
+    let mut jumps: BitVec<u8> = bitvec![u8, Lsb0; 0; bytecode.len()];
     let range = bytecode.as_ptr_range();
     let start = range.start;
     let mut iterator = start;

--- a/crates/bytecode/src/legacy/analyzed.rs
+++ b/crates/bytecode/src/legacy/analyzed.rs
@@ -1,8 +1,6 @@
 use super::JumpTable;
 use crate::opcode;
-use bitvec::{bitvec, order::Lsb0};
 use primitives::Bytes;
-use std::sync::Arc;
 
 /// Legacy analyzed bytecode represents the original bytecode format used in Ethereum.
 ///
@@ -45,7 +43,7 @@ impl Default for LegacyAnalyzedBytecode {
         Self {
             bytecode: Bytes::from_static(&[0]),
             original_len: 0,
-            jump_table: JumpTable(Arc::new(bitvec![u8, Lsb0; 0])),
+            jump_table: JumpTable::default(),
         }
     }
 }
@@ -115,9 +113,10 @@ impl LegacyAnalyzedBytecode {
 
 #[cfg(test)]
 mod tests {
-    use crate::{opcode, LegacyRawBytecode};
-
     use super::*;
+    use crate::{opcode, LegacyRawBytecode};
+    use bitvec::{bitvec, order::Lsb0};
+    use std::sync::Arc;
 
     #[test]
     fn test_bytecode_new() {

--- a/crates/bytecode/src/legacy/jump_map.rs
+++ b/crates/bytecode/src/legacy/jump_map.rs
@@ -1,9 +1,10 @@
 use bitvec::vec::BitVec;
+use once_cell::race::OnceBox;
 use primitives::hex;
 use std::{fmt::Debug, sync::Arc};
 
 /// A table of valid `jump` destinations. Cheap to clone and memory efficient, one bit per opcode.
-#[derive(Clone, Default, PartialEq, Eq, Hash, Ord, PartialOrd)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct JumpTable(pub Arc<BitVec<u8>>);
 
@@ -12,6 +13,14 @@ impl Debug for JumpTable {
         f.debug_struct("JumpTable")
             .field("map", &hex::encode(self.0.as_raw_slice()))
             .finish()
+    }
+}
+
+impl Default for JumpTable {
+    #[inline]
+    fn default() -> Self {
+        static DEFAULT: OnceBox<JumpTable> = OnceBox::new();
+        DEFAULT.get_or_init(|| Self(Arc::default()).into()).clone()
     }
 }
 

--- a/crates/state/src/account_info.rs
+++ b/crates/state/src/account_info.rs
@@ -8,16 +8,18 @@ use primitives::{B256, KECCAK_EMPTY, U256};
 #[derive(Clone, Debug, Eq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AccountInfo {
-    /// Account balance
+    /// Account balance.
     pub balance: U256,
-    /// Account nonce
+    /// Account nonce.
     pub nonce: u64,
-    /// code hash
+    /// Hash of the raw bytes in `code`, or [`KECCAK_EMPTY`].
     pub code_hash: B256,
-    /// [`Bytecode`] data associated with this account
+    /// [`Bytecode`] data associated with this account.
     ///
-    /// If [None], `code_hash` will be used to fetch it if code needs to be loaded from
-    /// inside `revm`.
+    /// If [`None`], `code_hash` will be used to fetch it from the database, if code needs to be
+    /// loaded from inside `revm`.
+    ///
+    /// By default, this is `Some(Bytecode::default())`.
     pub code: Option<Bytecode>,
 }
 


### PR DESCRIPTION
The `Bytecode::default` jump table doesn't need to contain any data. Even if it had to, we can still cache it with a singleton as it's an Arc, and then just clone the singleton every time we need a new default jump table.

Closes https://github.com/bluealloy/revm/issues/2436.
