### PR TITLE
feat(tx): Add Either RecoveredAuthorization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3743,6 +3743,7 @@ dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
  "auto_impl",
+ "either",
  "revm-database-interface",
  "revm-primitives",
  "revm-state",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ derive-where = { version = "1.2.7", default-features = false }
 once_cell = { version = "1.19", default-features = false }
 rand = "0.8"
 tokio = "1.44"
+either = { version = "1.15.0", default-features = false }
 
 # dev-dependencies
 anyhow = "1.0.89"

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -2,6 +2,7 @@ use super::{
     merkle_trie::{log_rlp_hash, state_merkle_trie_root},
     utils::recover_address,
 };
+use context::either::Either;
 use database::State;
 use indicatif::{ProgressBar, ProgressDrawTarget};
 use inspector::{inspectors::TracerEip3155, InspectCommitEvm};
@@ -396,7 +397,12 @@ pub fn execute_test_suite(
                     .transaction
                     .authorization_list
                     .clone()
-                    .map(|auth_list| auth_list.into_iter().map(Into::into).collect::<Vec<_>>())
+                    .map(|auth_list| {
+                        auth_list
+                            .into_iter()
+                            .map(|i| Either::Left(i.into()))
+                            .collect::<Vec<_>>()
+                    })
                     .unwrap_or_default();
 
                 let to = match unit.transaction.to {

--- a/crates/context/interface/Cargo.toml
+++ b/crates/context/interface/Cargo.toml
@@ -31,11 +31,12 @@ alloy-eip2930.workspace = true
 
 # misc
 auto_impl.workspace = true
+either.workspace = true
 
 # Optional
 serde = { version = "1.0", default-features = false, features = [
-    "derive",
-    "rc",
+	"derive",
+	"rc",
 ], optional = true }
 
 [features]
@@ -46,7 +47,8 @@ std = [
 	"alloy-eip2930/std",
 	"database-interface/std",
 	"primitives/std",
-	"state/std"
+	"state/std",
+	"either/std",
 ]
 serde = [
 	"dep:serde",
@@ -54,6 +56,7 @@ serde = [
 	"state/serde",
 	"alloy-eip7702/serde",
 	"alloy-eip2930/serde",
-	"database-interface/serde"
+	"database-interface/serde",
+	"either/serde",
 ]
 serde-json = ["serde"]

--- a/crates/context/interface/src/lib.rs
+++ b/crates/context/interface/src/lib.rs
@@ -17,6 +17,7 @@ pub use block::Block;
 pub use cfg::{Cfg, CreateScheme, TransactTo};
 pub use context::{ContextSetters, ContextTr};
 pub use database_interface::{DBErrorMarker, Database};
+pub use either;
 pub use journaled_state::JournalTr;
 pub use local::LocalContextTr;
 pub use transaction::{Transaction, TransactionType};

--- a/crates/context/interface/src/transaction.rs
+++ b/crates/context/interface/src/transaction.rs
@@ -27,8 +27,12 @@ pub trait TransactionError: Debug + core::error::Error {}
 /// deprecated by not returning tx_type.
 #[auto_impl(&, Box, Arc, Rc)]
 pub trait Transaction {
-    type AccessListItem: AccessListItemTr;
-    type Authorization: AuthorizationTr;
+    type AccessListItem<'a>: AccessListItemTr
+    where
+        Self: 'a;
+    type Authorization<'a>: AuthorizationTr
+    where
+        Self: 'a;
 
     /// Returns the transaction type.
     ///
@@ -79,7 +83,7 @@ pub trait Transaction {
     /// Access list for the transaction.
     ///
     /// Introduced in EIP-2930.
-    fn access_list(&self) -> Option<impl Iterator<Item = &Self::AccessListItem>>;
+    fn access_list(&self) -> Option<impl Iterator<Item = Self::AccessListItem<'_>>>;
 
     /// Returns vector of fixed size hash(32 bytes)
     ///
@@ -123,7 +127,7 @@ pub trait Transaction {
     /// Set EOA account code for one transaction
     ///
     /// [EIP-Set EOA account code for one transaction](https://eips.ethereum.org/EIPS/eip-7702)
-    fn authorization_list(&self) -> impl Iterator<Item = &Self::Authorization>;
+    fn authorization_list(&self) -> impl Iterator<Item = Self::Authorization<'_>>;
 
     /// List of initcodes found in Initcode transaction. Initcodes can only be accessed
     /// by TXCREATE opcode to create a new EOF contract.

--- a/crates/context/interface/src/transaction/alloy_types.rs
+++ b/crates/context/interface/src/transaction/alloy_types.rs
@@ -1,4 +1,5 @@
 use super::{AccessListItemTr, AuthorizationTr};
+use either::{for_both, Either};
 use primitives::{Address, B256, U256};
 
 pub use alloy_eip2930::{AccessList, AccessListItem};
@@ -49,5 +50,23 @@ impl AuthorizationTr for RecoveredAuthorization {
 
     fn address(&self) -> Address {
         self.address
+    }
+}
+
+impl<L: AuthorizationTr, R: AuthorizationTr> AuthorizationTr for Either<L, R> {
+    fn authority(&self) -> Option<Address> {
+        for_both!(self, s => s.authority())
+    }
+
+    fn chain_id(&self) -> U256 {
+        for_both!(self, s => s.chain_id())
+    }
+
+    fn nonce(&self) -> u64 {
+        for_both!(self, s => s.nonce())
+    }
+
+    fn address(&self) -> Address {
+        for_both!(self, s => s.address())
     }
 }

--- a/crates/handler/src/mainnet_builder.rs
+++ b/crates/handler/src/mainnet_builder.rs
@@ -66,7 +66,7 @@ impl MainContext for Context<BlockEnv, TxEnv, CfgEnv, EmptyDB, Journal<EmptyDB>,
 mod test {
     use crate::ExecuteEvm;
     use crate::{MainBuilder, MainContext};
-    use alloy_signer::SignerSync;
+    use alloy_signer::{Either, SignerSync};
     use alloy_signer_local::PrivateKeySigner;
     use bytecode::{
         opcode::{PUSH1, SSTORE},
@@ -96,7 +96,7 @@ mod test {
             .modify_tx_chained(|tx| {
                 tx.tx_type = TransactionType::Eip7702.into();
                 tx.gas_limit = 100_000;
-                tx.authorization_list = vec![auth];
+                tx.authorization_list = vec![Either::Left(auth)];
                 tx.caller = EEADDRESS;
                 tx.kind = TxKind::Call(signer.address());
             });

--- a/crates/op-revm/src/transaction/abstraction.rs
+++ b/crates/op-revm/src/transaction/abstraction.rs
@@ -67,8 +67,14 @@ impl<TX: Transaction + SystemCallTx> SystemCallTx for OpTransaction<TX> {
 }
 
 impl<T: Transaction> Transaction for OpTransaction<T> {
-    type AccessListItem = T::AccessListItem;
-    type Authorization = T::Authorization;
+    type AccessListItem<'a>
+        = T::AccessListItem<'a>
+    where
+        T: 'a;
+    type Authorization<'a>
+        = T::Authorization<'a>
+    where
+        T: 'a;
 
     fn tx_type(&self) -> u8 {
         self.base.tx_type()
@@ -102,7 +108,7 @@ impl<T: Transaction> Transaction for OpTransaction<T> {
         self.base.chain_id()
     }
 
-    fn access_list(&self) -> Option<impl Iterator<Item = &Self::AccessListItem>> {
+    fn access_list(&self) -> Option<impl Iterator<Item = Self::AccessListItem<'_>>> {
         self.base.access_list()
     }
 
@@ -134,7 +140,7 @@ impl<T: Transaction> Transaction for OpTransaction<T> {
         self.base.authorization_list_len()
     }
 
-    fn authorization_list(&self) -> impl Iterator<Item = &Self::Authorization> {
+    fn authorization_list(&self) -> impl Iterator<Item = Self::Authorization<'_>> {
         self.base.authorization_list()
     }
 


### PR DESCRIPTION
Added lifetime to AccessList and AuthList, this would allow us more flexibility and it should not disrupt current usecases.

AuthList is now `Vec<Either<SignedAuthorizatio,RecoveredAuthorization>>` so we can recover signed upfront before execution starts.