### PR TITLE
fix: use HashMap::default in LocalContext

### DIFF
--- a/crates/context/src/local.rs
+++ b/crates/context/src/local.rs
@@ -19,7 +19,7 @@ pub struct LocalContext {
 impl Default for LocalContext {
     fn default() -> Self {
         Self {
-            initcode_mapping: HashMap::new(),
+            initcode_mapping: HashMap::default(),
             shared_memory_buffer: Rc::new(RefCell::new(Vec::with_capacity(1024 * 4))),
         }
     }


### PR DESCRIPTION
otherwise i get this error from reth:
```
error[E0308]: mismatched types
   --> /home/fgimenez/.cargo/git/checkouts/revm-0a89e51b0ec51a84/f7693cc/crates/context/src/local.rs:22:31
    |
22  |             initcode_mapping: HashMap::new(),
    |                               ^^^^^^^^^^^^^^ expected `HashMap<FixedBytes<32>, Initcode, RandomState>`, found `HashMap<_, _>`
    |
    = note: `std::hash::RandomState` and `RandomState` have similar names, but are actually distinct types
note: `std::hash::RandomState` is defined in crate `std`
   --> /home/fgimenez/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/hash/random.rs:36:1
    |
36  | pub struct RandomState {
    | ^^^^^^^^^^^^^^^^^^^^^^
note: `RandomState` is defined in crate `foldhash`
   --> /home/fgimenez/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/foldhash-0.1.5/src/fast.rs:153:1
    |
153 | pub struct RandomState {
    | ^^^^^^^^^^^^^^^^^^^^^^

    Checking op-alloy-network v0.15.1
For more information about this error, try `rustc --explain E0308`.
error: could not compile `revm-context` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```