### PR TITLE
chore: make OPCODE_INFO a static

### DIFF
--- a/crates/bytecode/src/opcode.rs
+++ b/crates/bytecode/src/opcode.rs
@@ -206,7 +206,7 @@ impl OpCode {
 /// Information about opcode, such as name, and stack inputs and outputs
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OpCodeInfo {
-    /// Invariant: `(name_ptr, name_len)` is a [`&'static str`][str]
+    /// Invariant: `(name_ptr, name_len)` is a [`&'static str`][str].
     ///
     /// It is a shorted variant of [`str`] as
     /// the name length is always less than 256 characters.
@@ -228,6 +228,10 @@ pub struct OpCodeInfo {
     /// If the opcode stops execution. aka STOP, RETURN, ..
     terminating: bool,
 }
+
+// SAFETY: The `NonNull` is just a `&'static str`.
+unsafe impl Send for OpCodeInfo {}
+unsafe impl Sync for OpCodeInfo {}
 
 impl fmt::Debug for OpCodeInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -355,7 +359,7 @@ macro_rules! opcodes {
         )*}
 
         /// Maps each opcode to its info.
-        pub const OPCODE_INFO: [Option<OpCodeInfo>; 256] = {
+        pub static OPCODE_INFO: [Option<OpCodeInfo>; 256] = {
             let mut map = [None; 256];
             let mut prev: u8 = 0;
             $(

--- a/crates/precompile/src/bls12_381/g1_msm.rs
+++ b/crates/precompile/src/bls12_381/g1_msm.rs
@@ -76,7 +76,7 @@ pub fn g1_msm(input: &Bytes, gas_limit: u64) -> PrecompileResult {
     if g1_points.is_empty() {
         return Ok(PrecompileOutput::new(
             required_gas,
-            ENCODED_POINT_AT_INFINITY.into(),
+            Bytes::from_static(&ENCODED_POINT_AT_INFINITY),
         ));
     }
 


### PR DESCRIPTION
`const`s get duplicated at all callsites so it's possible that multiple callers (in multiple crates) end up duplicating the array.