### PR TITLE
Add a custom address to the CreateScheme.

### DIFF
--- a/crates/context/interface/src/cfg.rs
+++ b/crates/context/interface/src/cfg.rs
@@ -1,7 +1,7 @@
 use auto_impl::auto_impl;
 use core::fmt::Debug;
 use core::hash::Hash;
-use primitives::{Address, hardfork::SpecId, TxKind, U256};
+use primitives::{hardfork::SpecId, Address, TxKind, U256};
 
 #[auto_impl(&, &mut, Box, Arc)]
 pub trait Cfg {
@@ -56,7 +56,5 @@ pub enum CreateScheme {
         salt: U256,
     },
     /// Custom scheme where we set up the original address
-    Custom {
-        address: Address,
-    }
+    Custom { address: Address },
 }

--- a/crates/context/interface/src/cfg.rs
+++ b/crates/context/interface/src/cfg.rs
@@ -1,7 +1,7 @@
 use auto_impl::auto_impl;
 use core::fmt::Debug;
 use core::hash::Hash;
-use primitives::{hardfork::SpecId, TxKind, U256};
+use primitives::{Address, hardfork::SpecId, TxKind, U256};
 
 #[auto_impl(&, &mut, Box, Arc)]
 pub trait Cfg {
@@ -55,4 +55,8 @@ pub enum CreateScheme {
         /// Salt
         salt: U256,
     },
+    /// Custom scheme where we set up the original address
+    Custom {
+        address: Address,
+    }
 }

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -346,6 +346,7 @@ where
                 init_code_hash = keccak256(&inputs.init_code);
                 inputs.caller.create2(salt.to_be_bytes(), init_code_hash)
             }
+            CreateScheme::Custom { address } => address,
         };
 
         // warm load account.

--- a/crates/interpreter/src/interpreter_action/create_inputs.rs
+++ b/crates/interpreter/src/interpreter_action/create_inputs.rs
@@ -25,7 +25,7 @@ impl CreateInputs {
             CreateScheme::Create2 { salt } => self
                 .caller
                 .create2_from_code(salt.to_be_bytes(), &self.init_code),
-            CreateScheme::Custom { address} => address,
+            CreateScheme::Custom { address } => address,
         }
     }
 }

--- a/crates/interpreter/src/interpreter_action/create_inputs.rs
+++ b/crates/interpreter/src/interpreter_action/create_inputs.rs
@@ -25,6 +25,7 @@ impl CreateInputs {
             CreateScheme::Create2 { salt } => self
                 .caller
                 .create2_from_code(salt.to_be_bytes(), &self.init_code),
+            CreateScheme::Custom { address} => address,
         }
     }
 }


### PR DESCRIPTION
In [Linera](https://github.com/linera-io/linera-protocol), we use REVM to run EVM apps.

In our usage, it would be very nice if we could add a specific Custom address besides the `Create/Create2` classic possibilities. This would simplify the code a lot.

If needed, I can feature gate this possibility.