### PR TITLE
feat: remove spec id verification for `apply_eip7702_auth_list`

### DIFF
--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -183,11 +183,7 @@ pub fn apply_eip7702_auth_list<
 >(
     context: &mut CTX,
 ) -> Result<u64, ERROR> {
-    let spec = context.cfg().spec().into();
     let tx = context.tx();
-    if !spec.is_enabled_in(SpecId::PRAGUE) {
-        return Ok(0);
-    }
     // Return if there is no auth list.
     if tx.tx_type() != TransactionType::Eip7702 {
         return Ok(0);


### PR DESCRIPTION
Removes the spec id validation in `apply_eip7702_auth_list`.