### PR TITLE
[chore]: make ReturnDataImpl and LoopControlImpl public

### DIFF
--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -10,6 +10,7 @@ mod subroutine_stack;
 // re-exports
 pub use ext_bytecode::ExtBytecode;
 pub use input::InputsImpl;
+pub use loop_control::LoopControl as LoopControlImpl;
 pub use return_data::ReturnDataImpl;
 pub use runtime_flags::RuntimeFlags;
 pub use shared_memory::{num_words, SharedMemory};
@@ -22,7 +23,6 @@ use crate::{
     InterpreterAction,
 };
 use bytecode::Bytecode;
-use loop_control::LoopControl as LoopControlImpl;
 use primitives::{hardfork::SpecId, Address, Bytes, U256};
 
 /// Main interpreter structure that contains all components defines in [`InterpreterTypes`].s

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -10,6 +10,7 @@ mod subroutine_stack;
 // re-exports
 pub use ext_bytecode::ExtBytecode;
 pub use input::InputsImpl;
+pub use return_data::ReturnDataImpl;
 pub use runtime_flags::RuntimeFlags;
 pub use shared_memory::{num_words, SharedMemory};
 pub use stack::{Stack, STACK_LIMIT};
@@ -23,7 +24,6 @@ use crate::{
 use bytecode::Bytecode;
 use loop_control::LoopControl as LoopControlImpl;
 use primitives::{hardfork::SpecId, Address, Bytes, U256};
-use return_data::ReturnDataImpl;
 
 /// Main interpreter structure that contains all components defines in [`InterpreterTypes`].s
 #[derive(Debug, Clone)]

--- a/crates/interpreter/src/interpreter/return_data.rs
+++ b/crates/interpreter/src/interpreter/return_data.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Default)]
-pub struct ReturnDataImpl(Bytes);
+pub struct ReturnDataImpl(pub Bytes);
 
 impl ReturnData for ReturnDataImpl {
     fn buffer(&self) -> &[u8] {


### PR DESCRIPTION
As per our discussion the REVM telegram group, I am refactoring REVMC to support the latest REVM API (^20). These are desirable to be public so that I do not implement some other types that implement `WIRE::ReturnData` and `WIRE::Control` traits and keep it simple and consistent. Many thanks!

ref: paradigmxyz/revmc#76