### PR TITLE
test(op): Add test for verifying default `OpSpecId` update

### DIFF
--- a/crates/op-revm/src/spec.rs
+++ b/crates/op-revm/src/spec.rs
@@ -194,4 +194,9 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn default_op_spec_id() {
+        assert_eq!(OpSpecId::default(), OpSpecId::ISTHMUS);
+    }
 }


### PR DESCRIPTION
Ref https://github.com/bluealloy/revm/issues/2189

Checks that default OP spec ID is updated after OP mainnet isthmus hardfork to next hardfork

Increase test coverage of _crates/op-revm/src/spec.rs_ from 30.51% to 32.79%