### PR TITLE
feat: system_call switch order of inputs, address than bytes

### DIFF
--- a/crates/handler/src/system_call.rs
+++ b/crates/handler/src/system_call.rs
@@ -45,8 +45,8 @@ pub trait SystemCallEvm: ExecuteEvm {
     /// Block values are taken into account and will determent how system call will be executed.
     fn transact_system_call(
         &mut self,
-        data: Bytes,
         system_contract_address: Address,
+        data: Bytes,
     ) -> Self::Output;
 }
 
@@ -55,8 +55,8 @@ pub trait SystemCallCommitEvm: SystemCallEvm + ExecuteCommitEvm {
     /// Transact the system call and commit to the state.
     fn transact_system_call_commit(
         &mut self,
-        data: Bytes,
         system_contract_address: Address,
+        data: Bytes,
     ) -> Self::CommitOutput;
 }
 
@@ -69,8 +69,8 @@ where
 {
     fn transact_system_call(
         &mut self,
-        data: Bytes,
         system_contract_address: Address,
+        data: Bytes,
     ) -> Self::Output {
         // set tx fields.
         self.set_tx(CTX::Tx::new_system_tx(data, system_contract_address));
@@ -92,10 +92,10 @@ where
 {
     fn transact_system_call_commit(
         &mut self,
-        data: Bytes,
         system_contract_address: Address,
+        data: Bytes,
     ) -> Self::CommitOutput {
-        self.transact_system_call(data, system_contract_address)
+        self.transact_system_call(system_contract_address, data)
             .map(|r| {
                 self.db().commit(r.state);
                 r.result
@@ -136,7 +136,7 @@ mod tests {
             .modify_block_chained(|b| b.number = 1)
             .build_mainnet();
         let res = my_evm
-            .transact_system_call(block_hash.0.into(), HISTORY_STORAGE_ADDRESS)
+            .transact_system_call(HISTORY_STORAGE_ADDRESS, block_hash.0.into())
             .unwrap();
 
         let result = res.result;

--- a/crates/op-revm/src/api/exec.rs
+++ b/crates/op-revm/src/api/exec.rs
@@ -14,6 +14,7 @@ use revm::{
     },
     inspector::{InspectCommitEvm, InspectEvm, Inspector, InspectorHandler, JournalExt},
     interpreter::{interpreter::EthInterpreter, InterpreterResult},
+    primitives::{Address, Bytes},
     DatabaseCommit, ExecuteCommitEvm, ExecuteEvm,
 };
 
@@ -125,8 +126,8 @@ where
 {
     fn transact_system_call(
         &mut self,
-        data: revm::primitives::Bytes,
-        system_contract_address: revm::primitives::Address,
+        system_contract_address: Address,
+        data: Bytes,
     ) -> Self::Output {
         self.set_tx(CTX::Tx::new_system_tx(data, system_contract_address));
         let mut h = OpHandler::<_, _, EthFrame<_, _, _>>::new();


### PR DESCRIPTION
It is more natural for target address to go first