### PR TITLE
bump: changelog tag v70, revm v23.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,24 @@
 Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
 
 # v70 tag
-date: 15.04.2025
+date: 07.05.2025
+
+Maintanance release.
+* `revm-primitives`: 18.0.0 -> 19.0.0 (⚠️ API breaking changes)
+* `revm-bytecode`: 3.0.0 -> 4.0.0 (⚠️ API breaking changes)
+* `revm-state`: 3.0.0 -> 3.0.1 (✓ API compatible changes)
+* `revm-database-interface`: 3.0.0 -> 3.0.1 (✓ API compatible changes)
+* `revm-context-interface`: 3.0.0 -> 4.0.0 (⚠️ API breaking changes)
+* `revm-context`: 3.0.1 -> 4.0.0 (⚠️ API breaking changes)
+* `revm-database`: 3.0.0 -> 3.1.0 (✓ API compatible changes)
+* `revm-interpreter`: 18.0.0 -> 19.0.0 (⚠️ API breaking changes)
+* `revm-precompile`: 19.0.0 -> 20.0.0 (⚠️ API breaking changes)
+* `revm-handler`: 3.0.1 -> 4.0.0 (⚠️ API breaking changes)
+* `revm-inspector`: 3.0.1 -> 4.0.0 (⚠️ API breaking changes)
+* `revm`: 22.0.1 -> 23.0.0 (✓ API compatible changes)
+* `revm-statetest-types`: 3.0.1 -> 4.0.0 (⚠️ API breaking changes)
+* `revme`: 4.0.2 -> 4.1.0 (✓ API compatible changes)
+* `op-revm`: 3.0.2 -> 3.1.0 (✓ API compatible changes)
 
 # v69 tag
 date: 14.04.2025

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "22.0.2"
+version = "23.0.0"
 dependencies = [
  "revm-bytecode",
  "revm-context",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ default-members = ["crates/revm"]
 
 [workspace.dependencies]
 # revm
-revm = { path = "crates/revm", version = "22.0.2", default-features = false }
+revm = { path = "crates/revm", version = "23.0.0", default-features = false }
 primitives = { path = "crates/primitives", package = "revm-primitives", version = "19.0.0", default-features = false }
 bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "4.0.0", default-features = false }
 database = { path = "crates/database", package = "revm-database", version = "3.1.0", default-features = false }

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -10,13 +10,13 @@
 * `SharedMemory` is not longer Rc<RefCell<>> and internally uses Rc<RefCell<Vec<u8>>> buffer.
     * No action if you dont use it inside Interpreter.
 * In `JournalExt` fn `last_journal()` is renamed to `journal()`
+* EOF is disabled from Osaka and not accessible.
 
 # v68 tag (revm v21.0.0) -> v70 tag ( revm v22.0.2)
 
 No breaking changes
 
 # v67 tag (revm v21.0.0) -> v68 tag ( revm v22.0.0)
-
 
 * No code breaking changes
 * alloy-primitives bumped to v1.0.0 and we had a major bump because of it.

--- a/crates/revm/CHANGELOG.md
+++ b/crates/revm/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [22.0.2](https://github.com/bluealloy/revm/compare/revm-v22.0.1...revm-v22.0.2) - 2025-05-07
+## [23.0.0](https://github.com/bluealloy/revm/compare/revm-v22.0.1...revm-v23.0.0) - 2025-05-07
 
 ### Other
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm"
 description = "Revm - Rust Ethereum Virtual Machine"
-version = "22.0.2"
+version = "23.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
Bumped revm to major version as dependent crates have their major number bumped