### PR TITLE
fix(op): mark caller account as touched

### DIFF
--- a/crates/op-revm/src/handler.rs
+++ b/crates/op-revm/src/handler.rs
@@ -188,6 +188,8 @@ where
                 .saturating_sub(op_gas_balance_spending);
         }
 
+        // Touch account so we know it is changed.
+        caller_account.mark_touch();
         Ok(())
     }
 


### PR DESCRIPTION
Currently, `op-revm` does not invoke `mark_touch` on the `validate_against_state_and_deduct_caller`. 
Adding this call will bring the behavior in line with [bluealloy/revm v71 (see handler/src/pre_execution.rs line 174).](https://github.com/bluealloy/revm/blob/v71/crates/handler/src/pre_execution.rs#L174)