### PR TITLE
chore: fixed dead link kzg_point_evaluation.rs

### DIFF
--- a/crates/precompile/src/kzg_point_evaluation.rs
+++ b/crates/precompile/src/kzg_point_evaluation.rs
@@ -119,7 +119,7 @@ mod tests {
 
     #[test]
     fn basic_test() {
-        // Test data from: https://github.com/ethereum/c-kzg-4844/blob/main/tests/verify_kzg_proof/kzg-mainnet/verify_kzg_proof_case_correct_proof_31ebd010e6098750/data.yaml
+        // Test data from: https://github.com/ethereum/c-kzg-4844/blob/main/tests/verify_kzg_proof/kzg-mainnet/verify_kzg_proof_case_correct_proof_4_4/data.yaml
 
         let commitment = hex!("8f59a8d2a1a625a17f3fea0fe5eb8c896db3764f3185481bc22f91b4aaffcca25f26936857bc3a7c2539ea8ec3a952b7").to_vec();
         let mut versioned_hash = Sha256::digest(&commitment).to_vec();


### PR DESCRIPTION
Hi! I fixed a dead link in the comment block of the `kzg_point_evaluation.rs` test module. The original URL was outdated and has been replaced with the correct link referencing updated test data.


ref: https://github.com/ethereum/c-kzg-4844/pull/572/files#diff-3b040e087b66564bb54ec02ea442619dd00ce6d050aaaf4a0c51c28850712c3d
