### PR TITLE
chore: add Prague activation timestamp

### DIFF
--- a/crates/primitives/src/hardfork.rs
+++ b/crates/primitives/src/hardfork.rs
@@ -69,7 +69,7 @@ pub enum SpecId {
     /// Activated at block 19426587 (Timestamp: 1710338135)
     CANCUN,
     /// Prague hard fork
-    /// Activated at block TBD
+    /// Activated at block 22431086 (Timestamp: 1746612311)
     #[default]
     PRAGUE,
     /// Osaka hard fork


### PR DESCRIPTION
https://etherscan.io/block/22431086
https://eips.ethereum.org/EIPS/eip-7600

I am reasonably sure this is the correct block given the first 7702 tx occurs in this block: https://etherscan.io/tx/0xb623d3815c31683104e6d43841fde1219ce2e202bef1d28d6ac28f05e838d779

Though `cast find-block 1746612311 --rpc-url <MAINNET_RPC_URL>` yields: `22431084`

1746612311 -> Wed May 07 2025 10:05:11 GMT+0000

would correspond with https://etherscan.io/block/22431084