### PR TITLE
feat: add builder pattern for TxEnv

### DIFF
--- a/crates/context/src/tx.rs
+++ b/crates/context/src/tx.rs
@@ -383,7 +383,10 @@ impl TxEnvBuilder {
     }
 
     /// Set the authorization list
-    pub fn authorization_list(mut self, authorization_list: Vec<Either<SignedAuthorization, RecoveredAuthorization>>) -> Self {
+    pub fn authorization_list(
+        mut self,
+        authorization_list: Vec<Either<SignedAuthorization, RecoveredAuthorization>>,
+    ) -> Self {
         self.authorization_list = authorization_list;
         if !self.authorization_list.is_empty() {
             self.tx_type = TransactionType::Eip7702 as u8;


### PR DESCRIPTION
resolves #2513

Example usage:
```
let tx_env = TxEnv::builder()
    .caller(some_address)
    .gas_limit(1_000_000)
    .gas_price(50)
    .gas_priority_fee(Some(2)) // Automatically sets type to EIP-1559
    .build();
```
    