### PR TITLE
ci(ethtests): Change legacy statetests repo

### DIFF
--- a/.github/workflows/ethereum-tests.yml
+++ b/.github/workflows/ethereum-tests.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Checkout ethereum/tests
         uses: actions/checkout@v4
         with:
-          repository: ethereum/tests
-          path: ethtests
+          repository: ethereum/legacytests
+          path: legacytests
           submodules: recursive
 
       - name: Install toolchain
@@ -42,6 +42,6 @@ jobs:
       - name: Run tests
         run: |
           cross run --target ${{matrix.target}} --profile ${{ matrix.profile }} -p revme -- statetest \
-          ethtests/GeneralStateTests/ \
-          ethtests/LegacyTests/Constantinople/GeneralStateTests/
+          legacytests/Cancun/GeneralStateTests/ \
+          legacytests/Constantinople/GeneralStateTests/
           ./scripts/run-tests.sh clean cross ${{ matrix.profile }} ${{ matrix.target }}

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -106,6 +106,10 @@ fn skip_test(path: &Path) -> bool {
         | "InitCollision.json"
         | "InitCollisionParis.json"
 
+        // Malformed value.
+        | "ValueOverflow.json"
+        | "ValueOverflowParis.json"
+
         // These tests are passing, but they take a lot of time to execute so we are going to skip them.
         | "Call50000_sha256.json"
         | "static_Call50000_sha256.json"


### PR DESCRIPTION
Statetest have been moved from ethereu/tests to ethereum/legacytests repo: 
https://github.com/ethereum/tests/releases/tag/v17.1