### PR TITLE
feat: support riscv32-unknown-none-elf

### DIFF
--- a/crates/bytecode/src/bytecode.rs
+++ b/crates/bytecode/src/bytecode.rs
@@ -4,6 +4,8 @@
 //! - Legacy bytecode with jump table analysis. Found in [`LegacyAnalyzedBytecode`]
 //! - EOF ( EMV Object Format) bytecode introduced in Osaka that.
 //! - EIP-7702 bytecode, introduces in Prague and contains address to delegated account.
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
 use crate::{
     eip7702::{Eip7702Bytecode, EIP7702_MAGIC_BYTES},
@@ -12,6 +14,12 @@ use crate::{
 };
 use core::fmt::Debug;
 use primitives::{keccak256, Address, Bytes, B256, KECCAK_EMPTY};
+
+#[cfg(not(target_has_atomic = "ptr"))]
+use alloc::rc::Rc as Arc;
+#[cfg(all(not(feature = "std"), target_has_atomic = "ptr"))]
+use alloc::sync::Arc;
+#[cfg(all(feature = "std", target_has_atomic = "ptr"))]
 use std::sync::Arc;
 
 /// Main bytecode structure with all variants.
@@ -216,7 +224,16 @@ impl Bytecode {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(feature = "std"))]
+    extern crate alloc;
+
     use super::{Bytecode, Eof};
+
+    #[cfg(not(target_has_atomic = "ptr"))]
+    use alloc::rc::Rc as Arc;
+    #[cfg(all(not(feature = "std"), target_has_atomic = "ptr"))]
+    use alloc::sync::Arc;
+    #[cfg(all(feature = "std", target_has_atomic = "ptr"))]
     use std::sync::Arc;
 
     #[test]

--- a/crates/bytecode/src/legacy/analysis.rs
+++ b/crates/bytecode/src/legacy/analysis.rs
@@ -1,8 +1,19 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use super::JumpTable;
 use crate::opcode;
 use bitvec::{bitvec, order::Lsb0, vec::BitVec};
 use primitives::Bytes;
-use std::{sync::Arc, vec, vec::Vec};
+
+#[cfg(not(target_has_atomic = "ptr"))]
+use alloc::rc::Rc as Arc;
+#[cfg(all(not(feature = "std"), target_has_atomic = "ptr"))]
+use alloc::sync::Arc;
+#[cfg(all(feature = "std", target_has_atomic = "ptr"))]
+use std::sync::Arc;
+
+use std::{vec, vec::Vec};
 
 /// Analyze the bytecode to find the jumpdests. Used to create a jump table
 /// that is needed for [`crate::LegacyAnalyzedBytecode`].

--- a/crates/bytecode/src/legacy/analyzed.rs
+++ b/crates/bytecode/src/legacy/analyzed.rs
@@ -113,9 +113,18 @@ impl LegacyAnalyzedBytecode {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(feature = "std"))]
+    extern crate alloc;
+
     use super::*;
     use crate::{opcode, LegacyRawBytecode};
     use bitvec::{bitvec, order::Lsb0};
+
+    #[cfg(not(target_has_atomic = "ptr"))]
+    use alloc::rc::Rc as Arc;
+    #[cfg(all(not(feature = "std"), target_has_atomic = "ptr"))]
+    use alloc::sync::Arc;
+    #[cfg(all(feature = "std", target_has_atomic = "ptr"))]
     use std::sync::Arc;
 
     #[test]

--- a/crates/bytecode/src/legacy/jump_map.rs
+++ b/crates/bytecode/src/legacy/jump_map.rs
@@ -1,7 +1,17 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use bitvec::vec::BitVec;
 use once_cell::race::OnceBox;
 use primitives::hex;
-use std::{fmt::Debug, sync::Arc};
+use std::fmt::Debug;
+
+#[cfg(not(target_has_atomic = "ptr"))]
+use alloc::rc::Rc as Arc;
+#[cfg(all(not(feature = "std"), target_has_atomic = "ptr"))]
+use alloc::sync::Arc;
+#[cfg(all(feature = "std", target_has_atomic = "ptr"))]
+use std::sync::Arc;
 
 /// A table of valid `jump` destinations. Cheap to clone and memory efficient, one bit per opcode.
 #[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
@@ -16,6 +26,15 @@ impl Debug for JumpTable {
     }
 }
 
+#[cfg(not(target_has_atomic = "ptr"))]
+impl Default for JumpTable {
+    #[inline]
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+#[cfg(any(target_has_atomic = "ptr", feature = "std"))]
 impl Default for JumpTable {
     #[inline]
     fn default() -> Self {

--- a/crates/context/interface/src/block.rs
+++ b/crates/context/interface/src/block.rs
@@ -6,7 +6,8 @@ use auto_impl::auto_impl;
 use primitives::{Address, B256, U256};
 
 /// Trait for retrieving block information required for execution.
-#[auto_impl(&, &mut, Box, Arc)]
+#[cfg_attr(target_has_atomic = "ptr", auto_impl(&, &mut, Box, Arc))]
+#[cfg_attr(not(target_has_atomic = "ptr"), auto_impl(&, &mut, Box))]
 pub trait Block {
     /// The number of ancestor blocks of this block (block height).
     fn number(&self) -> u64;

--- a/crates/context/interface/src/cfg.rs
+++ b/crates/context/interface/src/cfg.rs
@@ -3,7 +3,8 @@ use core::fmt::Debug;
 use core::hash::Hash;
 use primitives::{hardfork::SpecId, Address, TxKind, U256};
 
-#[auto_impl(&, &mut, Box, Arc)]
+#[cfg_attr(target_has_atomic = "ptr", auto_impl(&, &mut, Box, Arc))]
+#[cfg_attr(not(target_has_atomic = "ptr"), auto_impl(&, &mut, Box))]
 pub trait Cfg {
     type Spec: Into<SpecId> + Clone;
 

--- a/crates/context/interface/src/transaction.rs
+++ b/crates/context/interface/src/transaction.rs
@@ -26,7 +26,8 @@ pub trait TransactionError: Debug + core::error::Error {}
 ///
 /// It can be extended to support new transaction types and only transaction types can be
 /// deprecated by not returning tx_type.
-#[auto_impl(&, Box, Arc, Rc)]
+#[cfg_attr(target_has_atomic = "ptr", auto_impl(&, Box, Arc, Rc))]
+#[cfg_attr(not(target_has_atomic = "ptr"), auto_impl(&, Box, Rc))]
 pub trait Transaction {
     type AccessListItem<'a>: AccessListItemTr
     where
@@ -214,7 +215,8 @@ pub trait Transaction {
     }
 }
 
-#[auto_impl(&, &mut, Box, Arc)]
+#[cfg_attr(target_has_atomic = "ptr", auto_impl(&, &mut, Box, Arc))]
+#[cfg_attr(not(target_has_atomic = "ptr"), auto_impl(&, &mut, Box))]
 pub trait TransactionGetter {
     type Transaction: Transaction;
 

--- a/crates/context/interface/src/transaction/eip2930.rs
+++ b/crates/context/interface/src/transaction/eip2930.rs
@@ -8,7 +8,8 @@ use primitives::{Address, B256};
 /// are warm loaded before transaction execution.
 ///
 /// Number of account and storage slots is used to calculate initial tx gas cost.
-#[auto_impl(&, Box, Arc, Rc)]
+#[cfg_attr(target_has_atomic = "ptr", auto_impl(&, Box, Arc, Rc))]
+#[cfg_attr(not(target_has_atomic = "ptr"), auto_impl(&, Box, Rc))]
 pub trait AccessListItemTr {
     /// Returns account address.
     fn address(&self) -> &Address;

--- a/crates/context/interface/src/transaction/eip7702.rs
+++ b/crates/context/interface/src/transaction/eip7702.rs
@@ -2,7 +2,8 @@ use auto_impl::auto_impl;
 use primitives::{Address, U256};
 
 /// Authorization trait.
-#[auto_impl(&, Box, Arc, Rc)]
+#[cfg_attr(target_has_atomic = "ptr", auto_impl(&, Box, Arc, Rc))]
+#[cfg_attr(not(target_has_atomic = "ptr"), auto_impl(&, Box, Rc))]
 pub trait AuthorizationTr {
     /// Authority address.
     ///

--- a/crates/database/interface/src/lib.rs
+++ b/crates/database/interface/src/lib.rs
@@ -64,7 +64,8 @@ pub trait DatabaseCommit {
 ///
 /// Use [`WrapDatabaseRef`] to provide [`Database`] implementation for a type
 /// that only implements this trait.
-#[auto_impl(&, &mut, Box, Rc, Arc)]
+#[cfg_attr(target_has_atomic = "ptr", auto_impl(&, &mut, Box, Rc, Arc))]
+#[cfg_attr(not(target_has_atomic = "ptr"), auto_impl(&, &mut, Box, Rc))]
 pub trait DatabaseRef {
     /// The database error type.
     type Error: DBErrorMarker + Error;

--- a/crates/database/interface/src/try_commit.rs
+++ b/crates/database/interface/src/try_commit.rs
@@ -1,7 +1,16 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use crate::DatabaseCommit;
 use core::{convert::Infallible, error::Error, fmt};
 use primitives::{Address, HashMap};
 use state::Account;
+
+#[cfg(not(target_has_atomic = "ptr"))]
+use alloc::rc::Rc as Arc;
+#[cfg(all(not(feature = "std"), target_has_atomic = "ptr"))]
+use alloc::sync::Arc;
+#[cfg(all(feature = "std", target_has_atomic = "ptr"))]
 use std::sync::Arc;
 
 /// EVM database commit interface that can fail.
@@ -59,8 +68,17 @@ where
 
 #[cfg(test)]
 mod test {
+    #[cfg(not(feature = "std"))]
+    extern crate alloc;
+
     use super::*;
     use crate::DatabaseCommit;
+
+    #[cfg(not(target_has_atomic = "ptr"))]
+    use alloc::rc::Rc as Arc;
+    #[cfg(all(not(feature = "std"), target_has_atomic = "ptr"))]
+    use alloc::sync::Arc;
+    #[cfg(all(feature = "std", target_has_atomic = "ptr"))]
     use std::sync::Arc;
 
     struct MockDb;

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use super::frame_data::*;
 use crate::{
     instructions::InstructionProvider, precompile_provider::PrecompileProvider, EvmTr,
@@ -29,7 +32,14 @@ use primitives::{
 use primitives::{keccak256, Address, Bytes, B256, U256};
 use state::Bytecode;
 use std::borrow::ToOwned;
-use std::{boxed::Box, sync::Arc};
+use std::boxed::Box;
+
+#[cfg(not(target_has_atomic = "ptr"))]
+use alloc::rc::Rc as Arc;
+#[cfg(all(not(feature = "std"), target_has_atomic = "ptr"))]
+use alloc::sync::Arc;
+#[cfg(all(feature = "std", target_has_atomic = "ptr"))]
+use std::sync::Arc;
 
 /// Call frame trait
 pub trait Frame: Sized {

--- a/crates/handler/src/instructions.rs
+++ b/crates/handler/src/instructions.rs
@@ -6,7 +6,8 @@ use interpreter::{
 use std::boxed::Box;
 
 /// Stores instructions for EVM.
-#[auto_impl(&, Arc, Rc)]
+#[cfg_attr(target_has_atomic = "ptr", auto_impl(&, Arc, Rc))]
+#[cfg_attr(not(target_has_atomic = "ptr"), auto_impl(&, Rc))]
 pub trait InstructionProvider {
     /// Context type.
     type Context;

--- a/crates/interpreter/src/instructions/control.rs
+++ b/crates/interpreter/src/instructions/control.rs
@@ -270,6 +270,9 @@ pub fn unknown<WIRE: InterpreterTypes, H: Host + ?Sized>(
 
 #[cfg(test)]
 mod test {
+    #[cfg(not(feature = "std"))]
+    extern crate alloc;
+
     use super::*;
     use crate::interpreter::SubRoutineReturnFrame;
     use crate::{host::DummyHost, instruction_table, interpreter::EthInterpreter};
@@ -279,6 +282,12 @@ mod test {
         Bytecode,
     };
     use primitives::bytes;
+
+    #[cfg(not(target_has_atomic = "ptr"))]
+    use alloc::rc::Rc as Arc;
+    #[cfg(all(not(feature = "std"), target_has_atomic = "ptr"))]
+    use alloc::sync::Arc;
+    #[cfg(all(feature = "std", target_has_atomic = "ptr"))]
     use std::sync::Arc;
 
     #[test]

--- a/crates/interpreter/src/instructions/data.rs
+++ b/crates/interpreter/src/instructions/data.rs
@@ -84,8 +84,17 @@ pub fn data_copy<WIRE: InterpreterTypes, H: Host + ?Sized>(
 
 #[cfg(test)]
 mod test {
+    #[cfg(not(feature = "std"))]
+    extern crate alloc;
+
     use bytecode::{Bytecode, Eof};
     use primitives::{b256, bytes, Bytes};
+
+    #[cfg(not(target_has_atomic = "ptr"))]
+    use alloc::rc::Rc as Arc;
+    #[cfg(all(not(feature = "std"), target_has_atomic = "ptr"))]
+    use alloc::sync::Arc;
+    #[cfg(all(feature = "std", target_has_atomic = "ptr"))]
     use std::sync::Arc;
 
     use super::*;


### PR DESCRIPTION
This PR enhances the codebase's compatibility with no_std and platforms lacking atomic support by:

- Conditionally importing and using Arc or Rc based on the presence of atomics and the std feature.
- Updating trait definitions to use #[cfg_attr] for auto_impl, ensuring correct trait implementations for both atomic and non-atomic targets.
- Adding extern crate alloc where necessary for no_std environments.
- Applying these changes across multiple crates, including bytecode, context/interface, database/interface, handler, and interpreter.

These changes improve portability and make the codebase more robust for embedded and constrained environments. No functional logic is changed; only trait bounds and imports are updated for broader platform support.