### PR TITLE
Docs: replace dead memory-opcodes link with current reference

### DIFF
--- a/crates/bytecode/src/opcode.rs
+++ b/crates/bytecode/src/opcode.rs
@@ -174,7 +174,7 @@ impl OpCode {
 
     /// Returns true if the opcode modifies memory.
     ///
-    /// <https://bluealloy.github.io/revm/crates/interpreter/memory.html#opcodes>
+    /// <https://reth.rs/docs/reth/revm/revm/interpreter/instructions/memory/index.html#function>
     ///
     /// <https://github.com/crytic/evm-opcodes>
     #[inline]


### PR DESCRIPTION
### Description  
Fixes a broken link in `opcodes.rs` doc-comment and expands the section header.
