### PR TITLE
docs: make crates.io version badge clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/bluealloy/revm/actions/workflows/ci.yml/badge.svg)][gh-ci]
 [![License](https://img.shields.io/badge/License-MIT-orange.svg)][mit-license]
-![revm](https://img.shields.io/crates/v/revm.svg)
+[![crates.io](https://img.shields.io/crates/v/revm.svg)](https://crates.io/crates/revm)
 [![Chat][tg-badge]][tg-url]
 
 Revm is a highly efficient and stable implementation of the Ethereum Virtual Machine (EVM) written in Rust.


### PR DESCRIPTION
**Description**
Wrap the `img.shields.io/crates/v/revm.svg` badge in a Markdown link to the crates.io page so that clicking the badge takes users directly to [https://crates.io/crates/revm](https://crates.io/crates/revm). This improves discoverability and provides an easy shortcut to the published crate.
