### PR TITLE
fix: `Prague` activation timestamp was `84`, first 7702 bundle landed in `86`

### DIFF
--- a/crates/primitives/src/hardfork.rs
+++ b/crates/primitives/src/hardfork.rs
@@ -69,7 +69,7 @@ pub enum SpecId {
     /// Activated at block 19426587 (Timestamp: 1710338135)
     CANCUN,
     /// Prague hard fork
-    /// Activated at block 22431086 (Timestamp: 1746612311)
+    /// Activated at block 22431084 (Timestamp: 1746612311)
     #[default]
     PRAGUE,
     /// Osaka hard fork


### PR DESCRIPTION
Minor fix / nit following up on: https://github.com/bluealloy/revm/pull/2514

We should use 84 as it corresponds with the activation timestamp: https://eips.ethereum.org/EIPS/eip-7600

That the first 7702 transaction landed in 86 rather than 84 is likely due to it being shared as a private transaction with builders