### PR TITLE
feat: make blob max number optional

### DIFF
--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -313,6 +313,13 @@ pub fn execute_test_suite(
 
             cfg.spec = spec_name.to_spec_id();
 
+            // set default max blobs number to be 9 for prague
+            if cfg.spec.is_enabled_in(SpecId::PRAGUE) {
+                cfg.set_blob_max_count(9);
+            } else {
+                cfg.set_blob_max_count(6);
+            }
+
             // EIP-4844
             if let Some(current_excess_blob_gas) = unit.env.current_excess_blob_gas {
                 block.set_blob_excess_gas_and_price(

--- a/crates/context/interface/src/cfg.rs
+++ b/crates/context/interface/src/cfg.rs
@@ -13,9 +13,10 @@ pub trait Cfg {
     fn spec(&self) -> Self::Spec;
 
     /// Returns the blob target and max count for the given spec id.
+    /// If it is None, check for max count will be skipped.
     ///
     /// EIP-7840: Add blob schedule to execution client configuration files
-    fn blob_max_count(&self, spec_id: SpecId) -> u64;
+    fn blob_max_count(&self) -> Option<u64>;
 
     fn max_code_size(&self) -> usize;
 

--- a/crates/context/interface/src/transaction.rs
+++ b/crates/context/interface/src/transaction.rs
@@ -110,9 +110,7 @@ pub trait Transaction {
     /// See EIP-4844:
     /// <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4844.md#execution-layer-validation>
     fn calc_max_data_fee(&self) -> U256 {
-        let blob_gas = U256::from(self.total_blob_gas());
-        let max_blob_fee = U256::from(self.max_fee_per_blob_gas());
-        max_blob_fee.saturating_mul(blob_gas)
+        U256::from((self.total_blob_gas() as u128).saturating_mul(self.max_fee_per_blob_gas()))
     }
 
     /// Returns length of the authorization list.
@@ -171,9 +169,9 @@ pub trait Transaction {
     /// Return U256 or error if all values overflow U256 number.
     fn max_balance_spending(&self) -> Result<U256, InvalidTransaction> {
         // gas_limit * max_fee + value + additional_gas_cost
-        let mut max_balance_spending = U256::from(self.gas_limit())
-            .checked_mul(U256::from(self.max_fee_per_gas()))
-            .and_then(|gas_cost| gas_cost.checked_add(self.value()))
+        let mut max_balance_spending = (self.gas_limit() as u128)
+            .checked_mul(self.max_fee_per_gas())
+            .and_then(|gas_cost| U256::from(gas_cost).checked_add(self.value()))
             .ok_or(InvalidTransaction::OverflowPaymentInTransaction)?;
 
         // add blob fee

--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -24,11 +24,10 @@ pub struct CfgEnv<SPEC = SpecId> {
     pub limit_contract_code_size: Option<usize>,
     /// Skips the nonce validation against the account's nonce
     pub disable_nonce_check: bool,
-    /// Blob target count. EIP-7840 Add blob schedule to EL config files.
+    /// Blob max count. EIP-7840 Add blob schedule to EL config files.
     ///
-    /// If this config is not set, the default value will be used.
-    /// For cancun those are 3 and 6 and for prague those are 6 and 9.
-    pub blob_target_and_max_count: Option<(u64, u64)>,
+    /// If this config is not set, the check for max blobs will be skipped.
+    pub blob_max_count: Option<u64>,
     /// A hard memory limit in bytes beyond which
     /// [OutOfGasError::Memory][context_interface::result::OutOfGasError::Memory] cannot be resized.
     ///
@@ -83,7 +82,7 @@ impl<SPEC> CfgEnv<SPEC> {
             limit_contract_code_size: None,
             spec,
             disable_nonce_check: false,
-            blob_target_and_max_count: None, //vec![(SpecId::CANCUN, 3, 6), (SpecId::PRAGUE, 6, 9)],
+            blob_max_count: None, //vec![(SpecId::CANCUN, 3, 6), (SpecId::PRAGUE, 6, 9)],
             #[cfg(feature = "memory_limit")]
             memory_limit: (1 << 32) - 1,
             #[cfg(feature = "optional_balance_check")]
@@ -110,7 +109,7 @@ impl<SPEC> CfgEnv<SPEC> {
             limit_contract_code_size: self.limit_contract_code_size,
             spec,
             disable_nonce_check: self.disable_nonce_check,
-            blob_target_and_max_count: self.blob_target_and_max_count,
+            blob_max_count: self.blob_max_count,
             #[cfg(feature = "memory_limit")]
             memory_limit: self.memory_limit,
             #[cfg(feature = "optional_balance_check")]
@@ -124,20 +123,20 @@ impl<SPEC> CfgEnv<SPEC> {
         }
     }
 
-    /// Sets the blob target and max count over hardforks.
-    pub fn with_blob_max_and_target_count(mut self, blob_taget: u64, blob_max_count: u64) -> Self {
-        self.set_blob_max_and_target_count(blob_taget, blob_max_count);
+    /// Sets the blob target
+    pub fn with_blob_max_count(mut self, blob_max_count: u64) -> Self {
+        self.set_blob_max_count(blob_max_count);
         self
     }
 
-    /// Sets the blob target and max count over hardforks.
-    pub fn set_blob_max_and_target_count(&mut self, blob_target: u64, blob_max_count: u64) {
-        self.blob_target_and_max_count = Some((blob_target, blob_max_count));
+    /// Sets the blob target
+    pub fn set_blob_max_count(&mut self, blob_max_count: u64) {
+        self.blob_max_count = Some(blob_max_count);
     }
 
     /// Clears the blob target and max count over hardforks.
-    pub fn clear_blob_max_and_target_count(&mut self) {
-        self.blob_target_and_max_count = None;
+    pub fn clear_blob_max_count(&mut self) {
+        self.blob_max_count = None;
     }
 }
 
@@ -154,7 +153,7 @@ impl<SPEC: Into<SpecId> + Copy> Cfg for CfgEnv<SPEC> {
 
     #[inline]
     fn blob_max_count(&self) -> Option<u64> {
-        self.blob_target_and_max_count.map(|(_, max)| max)
+        self.blob_max_count
     }
 
     fn max_code_size(&self) -> usize {

--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -2,7 +2,6 @@
 pub use context_interface::Cfg;
 
 use primitives::{eip170::MAX_CODE_SIZE, hardfork::SpecId};
-use std::{vec, vec::Vec};
 
 /// EVM configuration
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -27,8 +26,9 @@ pub struct CfgEnv<SPEC = SpecId> {
     pub disable_nonce_check: bool,
     /// Blob target count. EIP-7840 Add blob schedule to EL config files.
     ///
-    /// Note : Items must be sorted by `SpecId`.
-    pub blob_target_and_max_count: Vec<(SpecId, u64, u64)>,
+    /// If this config is not set, the default value will be used.
+    /// For cancun those are 3 and 6 and for prague those are 6 and 9.
+    pub blob_target_and_max_count: Option<(u64, u64)>,
     /// A hard memory limit in bytes beyond which
     /// [OutOfGasError::Memory][context_interface::result::OutOfGasError::Memory] cannot be resized.
     ///
@@ -83,7 +83,7 @@ impl<SPEC> CfgEnv<SPEC> {
             limit_contract_code_size: None,
             spec,
             disable_nonce_check: false,
-            blob_target_and_max_count: vec![(SpecId::CANCUN, 3, 6), (SpecId::PRAGUE, 6, 9)],
+            blob_target_and_max_count: None, //vec![(SpecId::CANCUN, 3, 6), (SpecId::PRAGUE, 6, 9)],
             #[cfg(feature = "memory_limit")]
             memory_limit: (1 << 32) - 1,
             #[cfg(feature = "optional_balance_check")]
@@ -125,15 +125,19 @@ impl<SPEC> CfgEnv<SPEC> {
     }
 
     /// Sets the blob target and max count over hardforks.
-    pub fn with_blob_max_and_target_count(mut self, blob_params: Vec<(SpecId, u64, u64)>) -> Self {
-        self.set_blob_max_and_target_count(blob_params);
+    pub fn with_blob_max_and_target_count(mut self, blob_taget: u64, blob_max_count: u64) -> Self {
+        self.set_blob_max_and_target_count(blob_taget, blob_max_count);
         self
     }
 
     /// Sets the blob target and max count over hardforks.
-    pub fn set_blob_max_and_target_count(&mut self, mut blob_params: Vec<(SpecId, u64, u64)>) {
-        blob_params.sort_by_key(|(id, _, _)| *id);
-        self.blob_target_and_max_count = blob_params;
+    pub fn set_blob_max_and_target_count(&mut self, blob_target: u64, blob_max_count: u64) {
+        self.blob_target_and_max_count = Some((blob_target, blob_max_count));
+    }
+
+    /// Clears the blob target and max count over hardforks.
+    pub fn clear_blob_max_and_target_count(&mut self) {
+        self.blob_target_and_max_count = None;
     }
 }
 
@@ -149,17 +153,8 @@ impl<SPEC: Into<SpecId> + Copy> Cfg for CfgEnv<SPEC> {
     }
 
     #[inline]
-    fn blob_max_count(&self, spec_id: SpecId) -> u64 {
-        self.blob_target_and_max_count
-            .iter()
-            .rev()
-            .find_map(|(id, _, max)| {
-                if spec_id as u8 >= *id as u8 {
-                    return Some(*max);
-                }
-                None
-            })
-            .unwrap_or(6)
+    fn blob_max_count(&self) -> Option<u64> {
+        self.blob_target_and_max_count.map(|(_, max)| max)
     }
 
     fn max_code_size(&self) -> usize {
@@ -225,9 +220,6 @@ mod test {
     #[test]
     fn blob_max_and_target_count() {
         let cfg: CfgEnv = Default::default();
-        assert_eq!(cfg.blob_max_count(SpecId::BERLIN), (6));
-        assert_eq!(cfg.blob_max_count(SpecId::CANCUN), (6));
-        assert_eq!(cfg.blob_max_count(SpecId::PRAGUE), (9));
-        assert_eq!(cfg.blob_max_count(SpecId::OSAKA), (9));
+        assert_eq!(cfg.blob_max_count(), None);
     }
 }


### PR DESCRIPTION
Closing https://github.com/bluealloy/revm/issues/2477

Have made this parameter optional as it only checks for the transaction blob len is not more than limi. It does not affect the gas calculations. 