### PR TITLE
feat: add the GAS2ETH opcode

### DIFF
--- a/crates/bytecode/src/opcode.rs
+++ b/crates/bytecode/src/opcode.rs
@@ -665,7 +665,7 @@ opcodes! {
     0xF9 => EXTDELEGATECALL => stack_io(3, 1);
     0xFA => STATICCALL      => stack_io(6, 1), not_eof;
     0xFB => EXTSTATICCALL   => stack_io(3, 1);
-    // 0xFC
+    0xFC => GAS2ETH      => stack_io(2, 1);
     0xFD => REVERT       => stack_io(2, 0), terminating;
     0xFE => INVALID      => stack_io(0, 0), terminating;
     0xFF => SELFDESTRUCT => stack_io(1, 0), not_eof, terminating;
@@ -768,8 +768,8 @@ mod tests {
                 eof_opcode_num += 1;
             }
         }
-        assert_eq!(opcode_num, 169);
-        assert_eq!(eof_opcode_num, 153);
+        assert_eq!(opcode_num, 170);
+        assert_eq!(eof_opcode_num, 154);
     }
 
     #[test]

--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -80,6 +80,13 @@ pub trait JournalTr {
     /// Touches the account.
     fn touch_account(&mut self, address: Address);
 
+    /// Increases the balance of an account.
+    fn mint(
+        &mut self,
+        account: Address,
+        amount: U256,
+    ) -> Result<(bool, bool), <Self::Database as Database>::Error>;
+
     /// Transfers the balance from one account to another.
     fn transfer(
         &mut self,

--- a/crates/context/src/journal.rs
+++ b/crates/context/src/journal.rs
@@ -187,6 +187,11 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
     }
 
     #[inline]
+    fn mint(&mut self, account: Address, amount: U256) -> Result<(bool, bool), DB::Error> {
+        self.inner.mint(&mut self.database, account, amount)
+    }
+
+    #[inline]
     fn transfer(
         &mut self,
         from: Address,

--- a/crates/interpreter/src/instructions.rs
+++ b/crates/interpreter/src/instructions.rs
@@ -210,6 +210,7 @@ pub const fn instruction_table<WIRE: InterpreterTypes, H: Host + ?Sized>(
     table[EXTDELEGATECALL as usize] = contract::extdelegatecall;
     table[STATICCALL as usize] = contract::static_call;
     table[EXTSTATICCALL as usize] = contract::extstaticcall;
+    table[GAS2ETH as usize] = contract::gas2eth;
     table[REVERT as usize] = control::revert;
     table[INVALID as usize] = control::invalid;
     table[SELFDESTRUCT as usize] = host::selfdestruct;

--- a/examples/cheatcode_inspector/src/main.rs
+++ b/examples/cheatcode_inspector/src/main.rs
@@ -140,6 +140,10 @@ impl JournalTr for Backend {
         self.journaled_state.touch_account(address);
     }
 
+    fn mint(&mut self, account: Address, amount: U256) -> Result<(bool, bool), Infallible> {
+        self.journaled_state.mint(account, amount)
+    }
+
     fn transfer(
         &mut self,
         from: Address,


### PR DESCRIPTION
POC implementation for EIP-7791: GAS2ETH opcode. Not meant to be merged, just looking for feedback.

Implemented it by adding a `mint` function to the journaled state, which just increases the balance of an account by some amount.

I left a few TODOs as questions, so that someone more familiar with `revm` may chime in. Namely:
- Would it be safe to wrap when multiplying `gas_amount` with `gas_price`? (intuitively yes, since I think 2 ^ 128 should be plenty to fit both quantities).
- Should we not call `host.mint` in a static call context?
- Which spec should we hide the opcode behind?

I wrote a test that used an inspector to properly meter gas, but the account's balance was not getting updated, so it would be nice to get some pointers on that.