### PR TITLE
chore: op remove circular dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2977,7 +2977,6 @@ dependencies = [
  "alloy-sol-types",
  "auto_impl",
  "once_cell",
- "op-revm",
  "revm",
  "rstest",
  "serde",

--- a/crates/op-revm/Cargo.toml
+++ b/crates/op-revm/Cargo.toml
@@ -39,8 +39,6 @@ sha2.workspace = true
 serde_json = { workspace = true, features = ["alloc"] }
 alloy-primitives.workspace = true
 serde = { workspace = true, features = ["derive"] }
-revm = { workspace = true, features = ["secp256r1", "serde"] }
-op-revm = { workspace = true, features = ["serde"] }
 
 [features]
 default = ["std", "c-kzg", "secp256k1", "portable", "blst"]
@@ -52,15 +50,9 @@ std = [
 	"sha2/std",
 	"serde_json/std",
 	"alloy-primitives/std",
-	"op-revm/std"
 ]
 hashbrown = ["revm/hashbrown"]
-serde = [
-	"dep:serde",
-	"revm/serde",
-	"alloy-primitives/serde",
-	"op-revm/serde"
-]
+serde = ["dep:serde", "revm/serde", "alloy-primitives/serde"]
 portable = ["revm/portable"]
 
 dev = [

--- a/crates/op-revm/tests/common.rs
+++ b/crates/op-revm/tests/common.rs
@@ -7,11 +7,17 @@ use revm::{
     primitives::Bytes,
     state::EvmState,
 };
-use serde::{de::DeserializeOwned, Serialize};
-use std::{fs, path::PathBuf};
 
 // Constant for testdata directory path
 pub(crate) const TESTS_TESTDATA: &str = "tests/testdata";
+
+#[cfg(not(feature = "serde"))]
+pub(crate) fn compare_or_save_testdata<HaltReasonTy>(
+    _filename: &str,
+    _output: &ResultAndState<HaltReasonTy>,
+) {
+    // serde needs to be enabled to use this function
+}
 
 /// Compares or saves the execution output to a testdata file.
 ///
@@ -34,12 +40,14 @@ pub(crate) const TESTS_TESTDATA: &str = "tests/testdata";
 /// ```bash
 /// cargo test --features serde
 /// ```
+#[cfg(feature = "serde")]
 pub(crate) fn compare_or_save_testdata<HaltReasonTy>(
     filename: &str,
     output: &ResultAndState<HaltReasonTy>,
 ) where
-    HaltReasonTy: Serialize + DeserializeOwned + PartialEq,
+    HaltReasonTy: serde::Serialize + serde::de::DeserializeOwned + PartialEq,
 {
+    use std::{fs, path::PathBuf};
     let tests_dir = PathBuf::from(TESTS_TESTDATA);
     let testdata_file = tests_dir.join(filename);
 


### PR DESCRIPTION
Remove local revm/op-revm from `dev-dependencies` so it is unblocked for publishing