### PR TITLE
chore(test): preserve order of fields in json fixtures

### DIFF
--- a/crates/op-revm/Cargo.toml
+++ b/crates/op-revm/Cargo.toml
@@ -36,7 +36,7 @@ serde = { workspace = true, features = ["derive", "rc"], optional = true }
 rstest.workspace = true
 alloy-sol-types.workspace = true
 sha2.workspace = true
-serde_json = { workspace = true, features = ["alloc"] }
+serde_json = { workspace = true, features = ["alloc", "preserve_order"] }
 alloy-primitives.workspace = true
 serde = { workspace = true, features = ["derive"] }
 

--- a/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_g1_add_input_wrong_size.json
+++ b/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_g1_add_input_wrong_size.json
@@ -8,7 +8,31 @@
     }
   },
   "state": {
-    "0x420000000000000000000000000000000000001a": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 1,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
+    },
+    "0x420000000000000000000000000000000000001b": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
@@ -32,10 +56,10 @@
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
     },
-    "0x0000000000000000000000000000000000000000": {
+    "0x420000000000000000000000000000000000001a": {
       "info": {
         "balance": "0x0",
-        "nonce": 1,
+        "nonce": 0,
         "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "code": {
           "LegacyAnalyzed": {
@@ -103,30 +127,6 @@
       },
       "storage": {},
       "status": "LoadedAsNotExisting"
-    },
-    "0x420000000000000000000000000000000000001b": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 0,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
     }
   }
 }

--- a/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_g1_add_out_of_gas.json
+++ b/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_g1_add_out_of_gas.json
@@ -10,6 +10,30 @@
     }
   },
   "state": {
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 0,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
+    },
     "0x0000000000000000000000000000000000000000": {
       "info": {
         "balance": "0x0",
@@ -34,7 +58,7 @@
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
     },
-    "0x4200000000000000000000000000000000000019": {
+    "0x000000000000000000000000000000000000000b": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
@@ -56,9 +80,9 @@
         }
       },
       "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
+      "status": "LoadedAsNotExisting"
     },
-    "0x420000000000000000000000000000000000001a": {
+    "0x4200000000000000000000000000000000000019": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
@@ -105,30 +129,6 @@
       },
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
-    },
-    "0x000000000000000000000000000000000000000b": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 0,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "LoadedAsNotExisting"
     }
   }
 }

--- a/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_g1_msm_input_wrong_size.json
+++ b/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_g1_msm_input_wrong_size.json
@@ -8,6 +8,54 @@
     }
   },
   "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 1,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 0,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
+    },
     "0x4200000000000000000000000000000000000019": {
       "info": {
         "balance": "0x0",
@@ -32,7 +80,7 @@
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
     },
-    "0x420000000000000000000000000000000000001a": {
+    "0x420000000000000000000000000000000000001b": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
@@ -79,54 +127,6 @@
       },
       "storage": {},
       "status": "LoadedAsNotExisting"
-    },
-    "0x0000000000000000000000000000000000000000": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 1,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
-    },
-    "0x420000000000000000000000000000000000001b": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 0,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
     }
   }
 }

--- a/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_g1_msm_out_of_gas.json
+++ b/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_g1_msm_out_of_gas.json
@@ -10,54 +10,6 @@
     }
   },
   "state": {
-    "0x000000000000000000000000000000000000000c": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 0,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "LoadedAsNotExisting"
-    },
-    "0x420000000000000000000000000000000000001a": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 0,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
-    },
     "0x4200000000000000000000000000000000000019": {
       "info": {
         "balance": "0x0",
@@ -110,6 +62,54 @@
       "info": {
         "balance": "0x0",
         "nonce": 1,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
+    },
+    "0x000000000000000000000000000000000000000c": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 0,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "LoadedAsNotExisting"
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 0,
         "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "code": {
           "LegacyAnalyzed": {

--- a/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_g1_msm_wrong_input_layout.json
+++ b/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_g1_msm_wrong_input_layout.json
@@ -8,7 +8,7 @@
     }
   },
   "state": {
-    "0x420000000000000000000000000000000000001b": {
+    "0x4200000000000000000000000000000000000019": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
@@ -80,10 +80,10 @@
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
     },
-    "0x0000000000000000000000000000000000000000": {
+    "0x420000000000000000000000000000000000001b": {
       "info": {
         "balance": "0x0",
-        "nonce": 1,
+        "nonce": 0,
         "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "code": {
           "LegacyAnalyzed": {
@@ -104,10 +104,10 @@
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
     },
-    "0x4200000000000000000000000000000000000019": {
+    "0x0000000000000000000000000000000000000000": {
       "info": {
         "balance": "0x0",
-        "nonce": 0,
+        "nonce": 1,
         "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "code": {
           "LegacyAnalyzed": {

--- a/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_g2_add_input_wrong_size.json
+++ b/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_g2_add_input_wrong_size.json
@@ -8,7 +8,31 @@
     }
   },
   "state": {
-    "0x420000000000000000000000000000000000001a": {
+    "0x000000000000000000000000000000000000000d": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 0,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "LoadedAsNotExisting"
+    },
+    "0x4200000000000000000000000000000000000019": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
@@ -56,7 +80,7 @@
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
     },
-    "0x4200000000000000000000000000000000000019": {
+    "0x420000000000000000000000000000000000001a": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
@@ -103,30 +127,6 @@
       },
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
-    },
-    "0x000000000000000000000000000000000000000d": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 0,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "LoadedAsNotExisting"
     }
   }
 }

--- a/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_g2_add_out_of_gas.json
+++ b/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_g2_add_out_of_gas.json
@@ -10,58 +10,10 @@
     }
   },
   "state": {
-    "0x420000000000000000000000000000000000001a": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 0,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
-    },
     "0x0000000000000000000000000000000000000000": {
       "info": {
         "balance": "0x0",
         "nonce": 1,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
-    },
-    "0x4200000000000000000000000000000000000019": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 0,
         "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "code": {
           "LegacyAnalyzed": {
@@ -106,7 +58,55 @@
       "storage": {},
       "status": "LoadedAsNotExisting"
     },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 0,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
+    },
     "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 0,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
+    },
+    "0x420000000000000000000000000000000000001a": {
       "info": {
         "balance": "0x0",
         "nonce": 0,

--- a/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_g2_msm_input_wrong_size.json
+++ b/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_g2_msm_input_wrong_size.json
@@ -8,31 +8,7 @@
     }
   },
   "state": {
-    "0x4200000000000000000000000000000000000019": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 0,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
-    },
-    "0x420000000000000000000000000000000000001a": {
+    "0x420000000000000000000000000000000000001b": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
@@ -80,7 +56,7 @@
       "storage": {},
       "status": "LoadedAsNotExisting"
     },
-    "0x420000000000000000000000000000000000001b": {
+    "0x420000000000000000000000000000000000001a": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
@@ -108,6 +84,30 @@
       "info": {
         "balance": "0x0",
         "nonce": 1,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 0,
         "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "code": {
           "LegacyAnalyzed": {

--- a/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_g2_msm_out_of_gas.json
+++ b/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_g2_msm_out_of_gas.json
@@ -10,30 +10,6 @@
     }
   },
   "state": {
-    "0x4200000000000000000000000000000000000019": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 0,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
-    },
     "0x420000000000000000000000000000000000001b": {
       "info": {
         "balance": "0x0",
@@ -58,10 +34,10 @@
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
     },
-    "0x0000000000000000000000000000000000000000": {
+    "0x4200000000000000000000000000000000000019": {
       "info": {
         "balance": "0x0",
-        "nonce": 1,
+        "nonce": 0,
         "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "code": {
           "LegacyAnalyzed": {
@@ -105,6 +81,30 @@
       },
       "storage": {},
       "status": "LoadedAsNotExisting"
+    },
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 1,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
     },
     "0x420000000000000000000000000000000000001a": {
       "info": {

--- a/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_g2_msm_wrong_input_layout.json
+++ b/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_g2_msm_wrong_input_layout.json
@@ -32,30 +32,6 @@
       "storage": {},
       "status": "LoadedAsNotExisting"
     },
-    "0x0000000000000000000000000000000000000000": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 1,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
-    },
     "0x4200000000000000000000000000000000000019": {
       "info": {
         "balance": "0x0",
@@ -80,7 +56,31 @@
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
     },
-    "0x420000000000000000000000000000000000001b": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 1,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
+    },
+    "0x420000000000000000000000000000000000001a": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
@@ -104,7 +104,7 @@
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
     },
-    "0x420000000000000000000000000000000000001a": {
+    "0x420000000000000000000000000000000000001b": {
       "info": {
         "balance": "0x0",
         "nonce": 0,

--- a/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_map_fp2_to_g2_out_of_gas.json
+++ b/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_map_fp2_to_g2_out_of_gas.json
@@ -10,7 +10,7 @@
     }
   },
   "state": {
-    "0x420000000000000000000000000000000000001b": {
+    "0x420000000000000000000000000000000000001a": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
@@ -34,7 +34,31 @@
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
     },
-    "0x420000000000000000000000000000000000001a": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 1,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
+    },
+    "0x4200000000000000000000000000000000000019": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
@@ -82,34 +106,10 @@
       "storage": {},
       "status": "LoadedAsNotExisting"
     },
-    "0x4200000000000000000000000000000000000019": {
+    "0x420000000000000000000000000000000000001b": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
-    },
-    "0x0000000000000000000000000000000000000000": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 1,
         "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "code": {
           "LegacyAnalyzed": {

--- a/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_map_fp_to_g1_input_wrong_size.json
+++ b/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_map_fp_to_g1_input_wrong_size.json
@@ -56,6 +56,30 @@
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
     },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 0,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
+    },
     "0x4200000000000000000000000000000000000019": {
       "info": {
         "balance": "0x0",
@@ -84,30 +108,6 @@
       "info": {
         "balance": "0x0",
         "nonce": 1,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
-    },
-    "0x420000000000000000000000000000000000001b": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 0,
         "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "code": {
           "LegacyAnalyzed": {

--- a/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_map_fp_to_g1_out_of_gas.json
+++ b/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_map_fp_to_g1_out_of_gas.json
@@ -10,6 +10,30 @@
     }
   },
   "state": {
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 0,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
+    },
     "0x0000000000000000000000000000000000000010": {
       "info": {
         "balance": "0x0",
@@ -58,7 +82,7 @@
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
     },
-    "0x420000000000000000000000000000000000001a": {
+    "0x4200000000000000000000000000000000000019": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
@@ -86,30 +110,6 @@
       "info": {
         "balance": "0x0",
         "nonce": 1,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
-    },
-    "0x4200000000000000000000000000000000000019": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 0,
         "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "code": {
           "LegacyAnalyzed": {

--- a/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_pairing_input_wrong_size.json
+++ b/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_pairing_input_wrong_size.json
@@ -32,30 +32,6 @@
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
     },
-    "0x000000000000000000000000000000000000000f": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 0,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "LoadedAsNotExisting"
-    },
     "0x420000000000000000000000000000000000001b": {
       "info": {
         "balance": "0x0",
@@ -103,6 +79,30 @@
       },
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
+    },
+    "0x000000000000000000000000000000000000000f": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 0,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "LoadedAsNotExisting"
     },
     "0x420000000000000000000000000000000000001a": {
       "info": {

--- a/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_pairing_out_of_gas.json
+++ b/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_pairing_out_of_gas.json
@@ -10,7 +10,7 @@
     }
   },
   "state": {
-    "0x4200000000000000000000000000000000000019": {
+    "0x000000000000000000000000000000000000000f": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
@@ -32,33 +32,9 @@
         }
       },
       "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
+      "status": "LoadedAsNotExisting"
     },
     "0x420000000000000000000000000000000000001b": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 0,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
-    },
-    "0x420000000000000000000000000000000000001a": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
@@ -106,7 +82,7 @@
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
     },
-    "0x000000000000000000000000000000000000000f": {
+    "0x4200000000000000000000000000000000000019": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
@@ -128,7 +104,31 @@
         }
       },
       "storage": {},
-      "status": "LoadedAsNotExisting"
+      "status": "Touched | LoadedAsNotExisting"
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 0,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
     }
   }
 }

--- a/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_pairing_wrong_input_layout.json
+++ b/crates/op-revm/tests/testdata/test_halted_tx_call_bls12_381_pairing_wrong_input_layout.json
@@ -8,7 +8,55 @@
     }
   },
   "state": {
-    "0x4200000000000000000000000000000000000019": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 1,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 0,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
+    },
+    "0x420000000000000000000000000000000000001b": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
@@ -56,58 +104,10 @@
       "storage": {},
       "status": "LoadedAsNotExisting"
     },
-    "0x420000000000000000000000000000000000001b": {
+    "0x4200000000000000000000000000000000000019": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
-    },
-    "0x420000000000000000000000000000000000001a": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 0,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
-    },
-    "0x0000000000000000000000000000000000000000": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 1,
         "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "code": {
           "LegacyAnalyzed": {

--- a/crates/op-revm/tests/testdata/test_halted_tx_call_bn128_pair_fjord.json
+++ b/crates/op-revm/tests/testdata/test_halted_tx_call_bn128_pair_fjord.json
@@ -10,7 +10,7 @@
     }
   },
   "state": {
-    "0x0000000000000000000000000000000000000008": {
+    "0x420000000000000000000000000000000000001b": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
@@ -32,7 +32,7 @@
         }
       },
       "storage": {},
-      "status": "LoadedAsNotExisting"
+      "status": "Touched | LoadedAsNotExisting"
     },
     "0x0000000000000000000000000000000000000000": {
       "info": {
@@ -58,7 +58,7 @@
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
     },
-    "0x420000000000000000000000000000000000001a": {
+    "0x0000000000000000000000000000000000000008": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
@@ -80,9 +80,9 @@
         }
       },
       "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
+      "status": "LoadedAsNotExisting"
     },
-    "0x420000000000000000000000000000000000001b": {
+    "0x420000000000000000000000000000000000001a": {
       "info": {
         "balance": "0x0",
         "nonce": 0,

--- a/crates/op-revm/tests/testdata/test_halted_tx_call_bn128_pair_granite.json
+++ b/crates/op-revm/tests/testdata/test_halted_tx_call_bn128_pair_granite.json
@@ -8,30 +8,6 @@
     }
   },
   "state": {
-    "0x0000000000000000000000000000000000000000": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 1,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
-    },
     "0x0000000000000000000000000000000000000008": {
       "info": {
         "balance": "0x0",
@@ -108,6 +84,30 @@
       "info": {
         "balance": "0x0",
         "nonce": 0,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
+    },
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 1,
         "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "code": {
           "LegacyAnalyzed": {

--- a/crates/op-revm/tests/testdata/test_halted_tx_call_p256verify.json
+++ b/crates/op-revm/tests/testdata/test_halted_tx_call_p256verify.json
@@ -10,54 +10,6 @@
     }
   },
   "state": {
-    "0x4200000000000000000000000000000000000019": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 0,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
-    },
-    "0x420000000000000000000000000000000000001b": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 0,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
-    },
     "0x0000000000000000000000000000000000000100": {
       "info": {
         "balance": "0x0",
@@ -81,6 +33,54 @@
       },
       "storage": {},
       "status": "LoadedAsNotExisting"
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 0,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 0,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
     },
     "0x0000000000000000000000000000000000000000": {
       "info": {
@@ -106,7 +106,7 @@
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
     },
-    "0x420000000000000000000000000000000000001a": {
+    "0x420000000000000000000000000000000000001b": {
       "info": {
         "balance": "0x0",
         "nonce": 0,

--- a/crates/op-revm/tests/testdata/test_log_inspector.json
+++ b/crates/op-revm/tests/testdata/test_log_inspector.json
@@ -41,55 +41,31 @@
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
     },
-    "0x0000000000000000000000000000000000000000": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 0,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
-    },
-    "0x420000000000000000000000000000000000001a": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 0,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
-    },
     "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 0,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
+    },
+    "0x0000000000000000000000000000000000000000": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
@@ -138,6 +114,30 @@
       },
       "storage": {},
       "status": "Touched"
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 0,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
     },
     "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee": {
       "info": {

--- a/crates/op-revm/tests/testdata/test_tx_call_p256verify.json
+++ b/crates/op-revm/tests/testdata/test_tx_call_p256verify.json
@@ -11,30 +11,6 @@
     }
   },
   "state": {
-    "0x4200000000000000000000000000000000000019": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 0,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
-    },
     "0x0000000000000000000000000000000000000000": {
       "info": {
         "balance": "0x0",
@@ -83,7 +59,7 @@
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
     },
-    "0x420000000000000000000000000000000000001b": {
+    "0x4200000000000000000000000000000000000019": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
@@ -108,6 +84,30 @@
       "status": "Touched | LoadedAsNotExisting"
     },
     "0x0000000000000000000000000000000000000100": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 0,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
+    },
+    "0x420000000000000000000000000000000000001b": {
       "info": {
         "balance": "0x0",
         "nonce": 0,


### PR DESCRIPTION
add `preserve_order` and regenerate testdata jsons