### PR TITLE
ci: remove concurrency from bench

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,10 +9,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   codspeed:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Codspeed handles runs per commit so we can allow concurrency.