### PR TITLE
feat: expand timestamp/block_number to u256

### DIFF
--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -259,9 +259,9 @@ pub fn execute_test_suite(
         cfg.chain_id = 1;
 
         // Block env
-        block.number = unit.env.current_number.try_into().unwrap_or(u64::MAX);
+        block.number = unit.env.current_number;
         block.beneficiary = unit.env.current_coinbase;
-        block.timestamp = unit.env.current_timestamp.try_into().unwrap_or(u64::MAX);
+        block.timestamp = unit.env.current_timestamp;
         block.gas_limit = unit.env.current_gas_limit.try_into().unwrap_or(u64::MAX);
         block.basefee = unit
             .env

--- a/crates/context/interface/src/block.rs
+++ b/crates/context/interface/src/block.rs
@@ -9,7 +9,7 @@ use primitives::{Address, B256, U256};
 #[auto_impl(&, &mut, Box, Arc)]
 pub trait Block {
     /// The number of ancestor blocks of this block (block height).
-    fn number(&self) -> u64;
+    fn number(&self) -> U256;
 
     /// Beneficiary (Coinbase, miner) is a address that have signed the block.
     ///
@@ -17,7 +17,7 @@ pub trait Block {
     fn beneficiary(&self) -> Address;
 
     /// The timestamp of the block in seconds since the UNIX epoch.
-    fn timestamp(&self) -> u64;
+    fn timestamp(&self) -> U256;
 
     /// The gas limit of the block.
     fn gas_limit(&self) -> u64;

--- a/crates/context/src/block.rs
+++ b/crates/context/src/block.rs
@@ -7,14 +7,14 @@ use primitives::{Address, B256, U256};
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BlockEnv {
     /// The number of ancestor blocks of this block (block height)
-    pub number: u64,
+    pub number: U256,
     /// Beneficiary (Coinbase or miner) is a address that have signed the block
     ///
     /// This is the receiver address of all the gas spent in the block.
     pub beneficiary: Address,
 
     /// The timestamp of the block in seconds since the UNIX epoch
-    pub timestamp: u64,
+    pub timestamp: U256,
     /// The gas limit of the block
     pub gas_limit: u64,
     /// The base fee per gas, added in the London upgrade with [EIP-1559]
@@ -55,7 +55,7 @@ impl BlockEnv {
 
 impl Block for BlockEnv {
     #[inline]
-    fn number(&self) -> u64 {
+    fn number(&self) -> U256 {
         self.number
     }
 
@@ -65,7 +65,7 @@ impl Block for BlockEnv {
     }
 
     #[inline]
-    fn timestamp(&self) -> u64 {
+    fn timestamp(&self) -> U256 {
         self.timestamp
     }
 
@@ -98,9 +98,9 @@ impl Block for BlockEnv {
 impl Default for BlockEnv {
     fn default() -> Self {
         Self {
-            number: 0,
+            number: U256::ZERO,
             beneficiary: Address::ZERO,
-            timestamp: 1,
+            timestamp: U256::ONE,
             gas_limit: u64::MAX,
             basefee: 0,
             difficulty: U256::ZERO,

--- a/crates/handler/src/system_call.rs
+++ b/crates/handler/src/system_call.rs
@@ -143,7 +143,7 @@ mod tests {
         let mut my_evm = Context::mainnet()
             .with_db(db)
             // block with number 1 will set storage at slot 0.
-            .modify_block_chained(|b| b.number = 1)
+            .modify_block_chained(|b| b.number = U256::ONE)
             .build_mainnet();
         let output = my_evm
             .transact_system_call_finalize(HISTORY_STORAGE_ADDRESS, block_hash.0.into())

--- a/crates/interpreter/src/host.rs
+++ b/crates/interpreter/src/host.rs
@@ -26,7 +26,7 @@ pub trait Host {
     /// Block prevrandao, calls ContextTr::block().prevrandao()
     fn prevrandao(&self) -> Option<U256>;
     /// Block number, calls ContextTr::block().number()
-    fn block_number(&self) -> u64;
+    fn block_number(&self) -> U256;
     /// Block timestamp, calls ContextTr::block().timestamp()
     fn timestamp(&self) -> U256;
     /// Block beneficiary, calls ContextTr::block().beneficiary()
@@ -113,7 +113,7 @@ impl<CTX: ContextTr> Host for CTX {
         self.block().prevrandao().map(|r| r.into_u256())
     }
 
-    fn block_number(&self) -> u64 {
+    fn block_number(&self) -> U256 {
         self.block().number()
     }
 
@@ -295,8 +295,8 @@ impl Host for DummyHost {
         None
     }
 
-    fn block_number(&self) -> u64 {
-        0
+    fn block_number(&self) -> U256 {
+        U256::ZERO
     }
 
     fn timestamp(&self) -> U256 {

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -141,14 +141,15 @@ pub fn blockhash<WIRE: InterpreterTypes, H: Host + ?Sized>(
     gas!(interpreter, gas::BLOCKHASH);
     popn_top!([], number, interpreter);
 
-    let requested_number = as_u64_saturated!(number);
-
+    let requested_number = *number;
     let block_number = host.block_number();
 
     let Some(diff) = block_number.checked_sub(requested_number) else {
         *number = U256::ZERO;
         return;
     };
+
+    let diff = as_u64_saturated!(diff);
 
     // blockhash should push zero if number is same as current block number.
     if diff == 0 {
@@ -157,7 +158,7 @@ pub fn blockhash<WIRE: InterpreterTypes, H: Host + ?Sized>(
     }
 
     *number = if diff <= BLOCK_HASH_HISTORY {
-        let Some(hash) = host.block_hash(requested_number) else {
+        let Some(hash) = host.block_hash(as_u64_saturated!(requested_number)) else {
             interpreter
                 .control
                 .set_instruction_result(InstructionResult::FatalExternalError);

--- a/crates/op-revm/src/handler.rs
+++ b/crates/op-revm/src/handler.rs
@@ -704,7 +704,7 @@ mod tests {
 
     #[test]
     fn test_reload_l1_block_info_isthmus() {
-        const BLOCK_NUM: u64 = 100;
+        const BLOCK_NUM: U256 = uint!(100_U256);
         const L1_BASE_FEE: U256 = uint!(1_U256);
         const L1_BLOB_BASE_FEE: U256 = uint!(2_U256);
         const L1_BASE_FEE_SCALAR: u64 = 3;
@@ -745,7 +745,7 @@ mod tests {
         let ctx = Context::op()
             .with_db(db)
             .with_chain(L1BlockInfo {
-                l2_block: BLOCK_NUM + 1, // ahead by one block
+                l2_block: BLOCK_NUM + U256::from(1), // ahead by one block
                 ..Default::default()
             })
             .with_block(BlockEnv {

--- a/crates/op-revm/src/l1block.rs
+++ b/crates/op-revm/src/l1block.rs
@@ -29,7 +29,7 @@ use revm::{
 pub struct L1BlockInfo {
     /// The L2 block number. If not same as the one in the context,
     /// L1BlockInfo is not valid and will be reloaded from the database.
-    pub l2_block: u64,
+    pub l2_block: U256,
     /// The base fee of the L1 origin block.
     pub l1_base_fee: U256,
     /// The current L1 fee overhead. None if Ecotone is activated.
@@ -54,7 +54,7 @@ impl L1BlockInfo {
     /// Try to fetch the L1 block info from the database.
     pub fn try_fetch<DB: Database>(
         db: &mut DB,
-        l2_block: u64,
+        l2_block: U256,
         spec_id: OpSpecId,
     ) -> Result<L1BlockInfo, DB::Error> {
         // Ensure the L1 Block account is loaded into the cache after Ecotone. With EIP-4788, it is no longer the case

--- a/examples/block_traces/src/main.rs
+++ b/examples/block_traces/src/main.rs
@@ -10,7 +10,7 @@ use revm::{
     database::{AlloyDB, CacheDB, StateBuilder},
     database_interface::WrapDatabaseAsync,
     inspector::{inspectors::TracerEip3155, InspectEvm},
-    primitives::TxKind,
+    primitives::{TxKind, U256},
     Context, MainBuilder, MainContext,
 };
 use std::fs::create_dir_all;
@@ -78,9 +78,9 @@ async fn main() -> anyhow::Result<()> {
     let ctx = Context::mainnet()
         .with_db(&mut state)
         .modify_block_chained(|b| {
-            b.number = block.header.number;
+            b.number = U256::from(block.header.number);
             b.beneficiary = block.header.beneficiary;
-            b.timestamp = block.header.timestamp;
+            b.timestamp = U256::from(block.header.timestamp);
 
             b.difficulty = block.header.difficulty;
             b.gas_limit = block.header.gas_limit;


### PR DESCRIPTION
block number and timestamp being more that u64 is not possible to happen.

But users who use foundry tests are using the full scope of it so to not break those tests, we are reintroducing bigger u256 fields.

For blockhash opcode we will saturate the block number if the request to `Database::block_hash` excedess the `u64`.