### PR TITLE
chore(op-revm): type alias for default OptimismEvm 

### DIFF
--- a/crates/op-revm/src/api.rs
+++ b/crates/op-revm/src/api.rs
@@ -5,5 +5,5 @@ pub mod default_ctx;
 pub mod exec;
 
 pub use builder::OpBuilder;
-pub use default_ctx::DefaultOp;
+pub use default_ctx::OpContext;
 pub use exec::{OpContextTr, OpError};

--- a/crates/op-revm/src/api/builder.rs
+++ b/crates/op-revm/src/api/builder.rs
@@ -1,5 +1,5 @@
 //! Optimism builder trait [`OpBuilder`] used to build [`OpEvm`].
-use crate::{evm::OpEvm, transaction::OpTxTr, L1BlockInfo, OpSpecId};
+use crate::{evm::OpEvm, precompiles::OpPrecompiles, transaction::OpTxTr, L1BlockInfo, OpSpecId};
 use revm::{
     context::Cfg,
     context_interface::{Block, JournalTr},
@@ -9,19 +9,20 @@ use revm::{
     Context, Database,
 };
 
+/// Type alias for the default OpEvm.
+pub type OptimismEvm<CTX, INSP = ()> =
+    OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, OpPrecompiles>;
+
 /// Trait that allows for optimism OpEvm to be built.
 pub trait OpBuilder: Sized {
     /// Type of the context.
     type Context;
 
     /// Build the op.
-    fn build_op(self) -> OpEvm<Self::Context, (), EthInstructions<EthInterpreter, Self::Context>>;
+    fn build_op(self) -> OptimismEvm<Self::Context>;
 
     /// Build the op with an inspector.
-    fn build_op_with_inspector<INSP>(
-        self,
-        inspector: INSP,
-    ) -> OpEvm<Self::Context, INSP, EthInstructions<EthInterpreter, Self::Context>>;
+    fn build_op_with_inspector<INSP>(self, inspector: INSP) -> OptimismEvm<Self::Context, INSP>;
 }
 
 impl<BLOCK, TX, CFG, DB, JOURNAL> OpBuilder for Context<BLOCK, TX, CFG, DB, JOURNAL, L1BlockInfo>
@@ -34,14 +35,11 @@ where
 {
     type Context = Self;
 
-    fn build_op(self) -> OpEvm<Self::Context, (), EthInstructions<EthInterpreter, Self::Context>> {
+    fn build_op(self) -> OptimismEvm<Self::Context> {
         OpEvm::new(self, ())
     }
 
-    fn build_op_with_inspector<INSP>(
-        self,
-        inspector: INSP,
-    ) -> OpEvm<Self::Context, INSP, EthInstructions<EthInterpreter, Self::Context>> {
+    fn build_op_with_inspector<INSP>(self, inspector: INSP) -> OptimismEvm<Self::Context, INSP> {
         OpEvm::new(self, inspector)
     }
 }

--- a/crates/op-revm/src/api/default_ctx.rs
+++ b/crates/op-revm/src/api/default_ctx.rs
@@ -7,16 +7,16 @@ use revm::{
 };
 
 /// Type alias for the default context type of the OpEvm.
-pub type OpContext<DB> =
+pub type OptimismContext<DB> =
     Context<BlockEnv, OpTransaction<TxEnv>, CfgEnv<OpSpecId>, DB, Journal<DB>, L1BlockInfo>;
 
 /// Trait that allows for a default context to be created.
-pub trait DefaultOp {
+pub trait OpContext {
     /// Create a default context.
-    fn op() -> OpContext<EmptyDB>;
+    fn op() -> Self;
 }
 
-impl DefaultOp for OpContext<EmptyDB> {
+impl OpContext for OptimismContext<EmptyDB> {
     fn op() -> Self {
         Context::mainnet()
             .with_tx(OpTransaction::default())

--- a/crates/op-revm/src/api/default_ctx.rs
+++ b/crates/op-revm/src/api/default_ctx.rs
@@ -1,4 +1,4 @@
-//! Contains trait [`DefaultOp`] used to create a default context.
+//! Contains trait [`OpContext`] used to create a default context.
 use crate::{L1BlockInfo, OpSpecId, OpTransaction};
 use revm::{
     context::{BlockEnv, CfgEnv, TxEnv},

--- a/crates/op-revm/src/fast_lz.rs
+++ b/crates/op-revm/src/fast_lz.rs
@@ -111,7 +111,7 @@ fn u24(input: &[u8], idx: u32) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::{builder::OpBuilder, default_ctx::DefaultOp};
+    use crate::api::{builder::OpBuilder, default_ctx::OpContext};
     use alloy_sol_types::sol;
     use alloy_sol_types::SolCall;
     use revm::{

--- a/crates/op-revm/src/handler.rs
+++ b/crates/op-revm/src/handler.rs
@@ -500,12 +500,12 @@ where
 mod tests {
     use super::*;
     use crate::{
-        api::default_ctx::OpContext,
+        api::default_ctx::OptimismContext,
         constants::{
             BASE_FEE_SCALAR_OFFSET, ECOTONE_L1_BLOB_BASE_FEE_SLOT, ECOTONE_L1_FEE_SCALARS_SLOT,
             L1_BASE_FEE_SLOT, L1_BLOCK_CONTRACT, OPERATOR_FEE_SCALARS_SLOT,
         },
-        DefaultOp, OpBuilder,
+        OpBuilder, OpContext,
     };
     use alloy_primitives::uint;
     use revm::{
@@ -523,7 +523,7 @@ mod tests {
 
     /// Creates frame result.
     fn call_last_frame_return(
-        ctx: OpContext<EmptyDB>,
+        ctx: OptimismContext<EmptyDB>,
         instruction_result: InstructionResult,
         gas: Gas,
     ) -> Gas {

--- a/crates/op-revm/src/lib.rs
+++ b/crates/op-revm/src/lib.rs
@@ -18,7 +18,7 @@ pub mod transaction;
 
 pub use api::{
     builder::OpBuilder,
-    default_ctx::{DefaultOp, OpContext},
+    default_ctx::{OpContext, OptimismContext},
 };
 pub use evm::OpEvm;
 pub use l1block::L1BlockInfo;

--- a/crates/op-revm/tests/integration.rs
+++ b/crates/op-revm/tests/integration.rs
@@ -4,7 +4,7 @@ mod common;
 use common::compare_or_save_testdata;
 use op_revm::{
     precompiles::bn128_pair::GRANITE_MAX_INPUT_SIZE,
-    transaction::deposit::DEPOSIT_TRANSACTION_TYPE, DefaultOp, L1BlockInfo, OpBuilder,
+    transaction::deposit::DEPOSIT_TRANSACTION_TYPE, L1BlockInfo, OpBuilder, OpContext,
     OpHaltReason, OpSpecId, OpTransaction,
 };
 use revm::{


### PR DESCRIPTION
Changes:

1. Introduced type alias OptimismEvm for the default OpEvm configuration. 
2. Renamed for consistency with Mainnet Revm conventions and improved clarity. 


If you prefer the original name, let me know, and I'll discard this PR and include only the type alias :)