### PR TITLE
chore: Avoid clone before converting ref BundleAccount to CacheAccount

### DIFF
--- a/crates/database/src/states/cache_account.rs
+++ b/crates/database/src/states/cache_account.rs
@@ -13,6 +13,12 @@ pub struct CacheAccount {
     pub status: AccountStatus,
 }
 
+impl From<BundleAccount> for CacheAccount {
+    fn from(account: BundleAccount) -> Self {
+        CacheAccount::from(&account)
+    }
+}
+
 impl From<&BundleAccount> for CacheAccount {
     fn from(account: &BundleAccount) -> Self {
         let storage = account

--- a/crates/database/src/states/cache_account.rs
+++ b/crates/database/src/states/cache_account.rs
@@ -13,8 +13,8 @@ pub struct CacheAccount {
     pub status: AccountStatus,
 }
 
-impl From<BundleAccount> for CacheAccount {
-    fn from(account: BundleAccount) -> Self {
+impl From<&BundleAccount> for CacheAccount {
+    fn from(account: &BundleAccount) -> Self {
         let storage = account
             .storage
             .iter()

--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -188,9 +188,7 @@ impl<DB: Database> State<DB> {
             hash_map::Entry::Vacant(entry) => {
                 if self.use_preloaded_bundle {
                     // Load account from bundle state
-                    if let Some(account) =
-                        self.bundle_state.account(&address).cloned().map(Into::into)
-                    {
+                    if let Some(account) = self.bundle_state.account(&address).map(Into::into) {
                         return Ok(entry.insert(account));
                     }
                 }


### PR DESCRIPTION
I just learned in #2570, that the clone here could be avoided. Since the conversion is not used somewhere else I adapted it.