### PR TITLE
chore: support functions for eip7918

### DIFF
--- a/crates/context/interface/src/block.rs
+++ b/crates/context/interface/src/block.rs
@@ -3,7 +3,9 @@
 //! [`Block`] trait is used to retrieve block information required for execution.
 pub mod blob;
 
-pub use blob::{calc_blob_gasprice, calc_excess_blob_gas, BlobExcessGasAndPrice};
+pub use blob::{
+    calc_blob_gasprice, calc_excess_blob_gas, calc_excess_blob_gas_osaka, BlobExcessGasAndPrice,
+};
 
 use auto_impl::auto_impl;
 use primitives::{Address, B256, U256};

--- a/crates/context/interface/src/block/blob.rs
+++ b/crates/context/interface/src/block/blob.rs
@@ -65,6 +65,8 @@ pub fn calc_excess_blob_gas(
     parent_excess_blob_gas: u64,
     parent_blob_gas_used: u64,
     parent_target_blob_gas_per_block: u64,
+    base_fee_per_gas: u64,
+    blob_base_cost: u64,
 ) -> u64 {
     (parent_excess_blob_gas + parent_blob_gas_used).saturating_sub(parent_target_blob_gas_per_block)
 }

--- a/crates/context/interface/src/block/blob.rs
+++ b/crates/context/interface/src/block/blob.rs
@@ -7,7 +7,10 @@
 //! excess blob gas.
 //!
 //! [`BlobExcessGasAndPrice`] is used to store the blob gas price and excess blob gas.s
-use primitives::eip4844::MIN_BLOB_GASPRICE;
+use primitives::{
+    eip4844::{GAS_PER_BLOB, MIN_BLOB_GASPRICE},
+    eip7918,
+};
 
 /// Structure holding block blob excess gas and it calculates blob fee
 ///
@@ -27,6 +30,8 @@ pub struct BlobExcessGasAndPrice {
 
 impl BlobExcessGasAndPrice {
     /// Creates a new instance by calculating the blob gas price with [`calc_blob_gasprice`].
+    ///
+    /// `excess_blob_gas` is the excess blob gas of the block, it can be calculated with [`calc_excess_blob_gas`].
     pub fn new(excess_blob_gas: u64, blob_base_fee_update_fraction: u64) -> Self {
         let blob_gasprice = calc_blob_gasprice(excess_blob_gas, blob_base_fee_update_fraction);
         Self {
@@ -39,6 +44,9 @@ impl BlobExcessGasAndPrice {
     /// and the target blob gas per block.
     ///
     /// This fields will be used to calculate `excess_blob_gas` with [`calc_excess_blob_gas`] func.
+    #[deprecated(
+        note = "Use `calc_excess_blob_gas` and `BlobExcessGasAndPrice::new` instead. Only works for forks before Osaka."
+    )]
     pub fn from_parent_and_target(
         parent_excess_blob_gas: u64,
         parent_blob_gas_used: u64,
@@ -57,18 +65,68 @@ impl BlobExcessGasAndPrice {
 }
 
 /// Calculates the `excess_blob_gas` from the parent header's `blob_gas_used` and `excess_blob_gas`.
-///
-/// See also [the EIP-4844 helpers]<https://eips.ethereum.org/EIPS/eip-4844#helpers>
-/// (`calc_excess_blob_gas`).
+/// uses [`calc_excess_blob_gas`] internally.
 #[inline]
 pub fn calc_excess_blob_gas(
     parent_excess_blob_gas: u64,
     parent_blob_gas_used: u64,
     parent_target_blob_gas_per_block: u64,
-    base_fee_per_gas: u64,
-    blob_base_cost: u64,
 ) -> u64 {
-    (parent_excess_blob_gas + parent_blob_gas_used).saturating_sub(parent_target_blob_gas_per_block)
+    calc_excess_blob_gas_osaka(
+        parent_excess_blob_gas,
+        parent_blob_gas_used,
+        parent_target_blob_gas_per_block,
+        false,
+        0,
+        0,
+        0,
+        0,
+        0,
+    )
+}
+
+/// Calculates the `excess_blob_gas` from the parent header's `blob_gas_used` and `excess_blob_gas`.
+///
+/// See also [the EIP-4844 helpers]<https://eips.ethereum.org/EIPS/eip-4844#helpers>
+/// (`calc_excess_blob_gas`).
+///
+/// [EIP-7918: Blob base fee bounded by execution cost](https://eips.ethereum.org/EIPS/eip-7918)
+///
+/// `blob_base_cost` is introduced in EIP-7918 in Osaka fork. All fields after is_osaka input are not needed before Osaka.
+#[allow(clippy::too_many_arguments)]
+#[inline]
+pub fn calc_excess_blob_gas_osaka(
+    parent_excess_blob_gas: u64,
+    parent_blob_gas_used: u64,
+    parent_target_blob_gas_per_block: u64,
+    is_osaka: bool,
+    parent_base_fee_per_gas: u64,
+    parent_blob_base_fee_per_gas: u64,
+    parent_blob_base_fee_update_fraction: u64,
+    max_blob_count: u64,
+    target_blob_count: u64,
+) -> u64 {
+    let excess_and_used = parent_excess_blob_gas.saturating_add(parent_blob_gas_used);
+
+    if is_osaka {
+        if excess_and_used < parent_target_blob_gas_per_block {
+            return 0;
+        }
+
+        if (eip7918::BLOB_BASE_COST.saturating_mul(parent_base_fee_per_gas) as u128)
+            > (GAS_PER_BLOB as u128).saturating_mul(get_base_fee_per_blob_gas(
+                parent_blob_base_fee_per_gas,
+                parent_blob_base_fee_update_fraction,
+            ))
+        {
+            return excess_and_used.saturating_add(
+                parent_blob_gas_used.saturating_mul(max_blob_count - target_blob_count)
+                    / max_blob_count,
+            );
+        }
+    }
+
+    excess_and_used.saturating_sub(parent_target_blob_gas_per_block)
 }
 
 /// Calculates the blob gas price from the header's excess blob gas field.
@@ -82,6 +140,12 @@ pub fn calc_blob_gasprice(excess_blob_gas: u64, blob_base_fee_update_fraction: u
         excess_blob_gas,
         blob_base_fee_update_fraction,
     )
+}
+
+/// Calculates the base fee per blob gas. Calls [`calc_blob_gasprice`] internally.
+/// Name of the function is aligned with EIP-4844 spec.
+pub fn get_base_fee_per_blob_gas(excess_blob_gas: u64, blob_base_fee_update_fraction: u64) -> u128 {
+    calc_blob_gasprice(excess_blob_gas, blob_base_fee_update_fraction)
 }
 
 /// Approximates `factor * e ** (numerator / denominator)` using Taylor expansion.

--- a/crates/primitives/src/eip7918.rs
+++ b/crates/primitives/src/eip7918.rs
@@ -1,0 +1,5 @@
+//! Constants for EIP-7918: Blob base fee bounded by execution cost
+//!
+
+/// Minimum base fee for blobs, if price of the blob is less than this value, this value will be used.
+pub const BLOB_BASE_COST: u64 = 2_u64.pow(14);

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -13,6 +13,7 @@ pub mod eip4844;
 pub mod eip7702;
 pub mod eip7823;
 pub mod eip7825;
+pub mod eip7918;
 pub mod eof;
 pub mod hardfork;
 


### PR DESCRIPTION
Needed for statetest,

excess blob gas `excess_blob_gas` requires a lot of parent block fields and is usually calculated outside of revm. 