### PR TITLE
refactor!: remove `TxEnv::tx_type` field

### DIFF
--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -301,7 +301,13 @@ pub fn execute_test_suite(
             .max_priority_fee_per_gas
             .map(|b| u128::try_from(b).expect("max priority fee less than u128::MAX"));
         // EIP-4844
-        tx.blob_hashes = unit.transaction.blob_versioned_hashes.clone();
+        if unit.transaction.blob_versioned_hashes.len() > 0 {
+            tx.blob_hashes = Some(unit.transaction.blob_versioned_hashes.clone());
+        } else if unit.transaction.tx_type == Some(3)
+            || unit.transaction.max_fee_per_blob_gas.is_some()
+        {
+            tx.blob_hashes = Some(vec![]);
+        }
         tx.max_fee_per_blob_gas = unit
             .transaction
             .max_fee_per_blob_gas

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -302,17 +302,16 @@ pub fn execute_test_suite(
             .map(|b| u128::try_from(b).expect("max priority fee less than u128::MAX"));
         // EIP-4844
         if unit.transaction.blob_versioned_hashes.len() > 0 {
-            tx.blob_hashes = Some(unit.transaction.blob_versioned_hashes.clone());
+            tx.blob_hashes = unit.transaction.blob_versioned_hashes.clone();
         } else if unit.transaction.tx_type == Some(3)
             || unit.transaction.max_fee_per_blob_gas.is_some()
         {
-            tx.blob_hashes = Some(vec![]);
+            tx.blob_hashes = vec![];
         }
         tx.max_fee_per_blob_gas = unit
             .transaction
             .max_fee_per_blob_gas
-            .map(|b| u128::try_from(b).expect("max fee less than u128::MAX"))
-            .unwrap_or(u128::MAX);
+            .map(|b| u128::try_from(b).expect("max fee less than u128::MAX"));
 
         // Post and execution
         for (spec_name, tests) in unit.post {

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -355,15 +355,6 @@ pub fn execute_test_suite(
             }
 
             for (index, test) in tests.into_iter().enumerate() {
-                let Some(tx_type) = unit.transaction.tx_type(test.indexes.data) else {
-                    if test.expect_exception.is_some() {
-                        continue;
-                    } else {
-                        panic!("Invalid transaction type without expected exception");
-                    }
-                };
-                tx.tx_type = tx_type as u8;
-
                 tx.gas_limit = unit.transaction.gas_limit[test.indexes.gas].saturating_to();
                 tx.data = unit
                     .transaction

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -301,13 +301,7 @@ pub fn execute_test_suite(
             .max_priority_fee_per_gas
             .map(|b| u128::try_from(b).expect("max priority fee less than u128::MAX"));
         // EIP-4844
-        if unit.transaction.blob_versioned_hashes.len() > 0 {
-            tx.blob_hashes = unit.transaction.blob_versioned_hashes.clone();
-        } else if unit.transaction.tx_type == Some(3)
-            || unit.transaction.max_fee_per_blob_gas.is_some()
-        {
-            tx.blob_hashes = vec![];
-        }
+        tx.blob_hashes = unit.transaction.blob_versioned_hashes.clone();
         tx.max_fee_per_blob_gas = unit
             .transaction
             .max_fee_per_blob_gas

--- a/crates/context/interface/src/transaction.rs
+++ b/crates/context/interface/src/transaction.rs
@@ -88,17 +88,17 @@ pub trait Transaction {
     /// Returns vector of fixed size hash(32 bytes)
     ///
     /// Note : EIP-4844 transaction field.
-    fn blob_versioned_hashes(&self) -> Option<&[B256]>;
+    fn blob_versioned_hashes(&self) -> &[B256];
 
     /// Max fee per data gas
     ///
     /// Note : EIP-4844 transaction field.
-    fn max_fee_per_blob_gas(&self) -> u128;
+    fn max_fee_per_blob_gas(&self) -> Option<u128>;
 
     /// Total gas for all blobs. Max number of blocks is already checked
     /// so we dont need to check for overflow.
     fn total_blob_gas(&self) -> u64 {
-        GAS_PER_BLOB * self.blob_versioned_hashes().map(|b| b.len()).unwrap_or(0) as u64
+        GAS_PER_BLOB * self.blob_versioned_hashes().len() as u64
     }
 
     /// Calculates the maximum [EIP-4844] `data_fee` of the transaction.
@@ -109,7 +109,10 @@ pub trait Transaction {
     /// See EIP-4844:
     /// <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4844.md#execution-layer-validation>
     fn calc_max_data_fee(&self) -> U256 {
-        U256::from((self.total_blob_gas() as u128).saturating_mul(self.max_fee_per_blob_gas()))
+        U256::from(
+            (self.total_blob_gas() as u128)
+                .saturating_mul(self.max_fee_per_blob_gas().unwrap_or_default()),
+        )
     }
 
     /// Returns length of the authorization list.

--- a/crates/context/interface/src/transaction.rs
+++ b/crates/context/interface/src/transaction.rs
@@ -88,7 +88,7 @@ pub trait Transaction {
     /// Returns vector of fixed size hash(32 bytes)
     ///
     /// Note : EIP-4844 transaction field.
-    fn blob_versioned_hashes(&self) -> &[B256];
+    fn blob_versioned_hashes(&self) -> Option<&[B256]>;
 
     /// Max fee per data gas
     ///
@@ -98,7 +98,7 @@ pub trait Transaction {
     /// Total gas for all blobs. Max number of blocks is already checked
     /// so we dont need to check for overflow.
     fn total_blob_gas(&self) -> u64 {
-        GAS_PER_BLOB * self.blob_versioned_hashes().len() as u64
+        GAS_PER_BLOB * self.blob_versioned_hashes().map(|b| b.len()).unwrap_or(0) as u64
     }
 
     /// Calculates the maximum [EIP-4844] `data_fee` of the transaction.

--- a/crates/context/src/tx.rs
+++ b/crates/context/src/tx.rs
@@ -20,8 +20,6 @@ use std::{vec, vec::Vec};
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TxEnv {
-    /// Transaction type
-    pub tx_type: u8,
     /// Caller aka Author aka transaction signer
     pub caller: Address,
     /// The gas limit of the transaction.
@@ -124,19 +122,20 @@ impl TxEnv {
 
     /// Derives tx type from transaction fields and sets it to `tx_type`.
     /// Returns error in case some fields were not set correctly.
-    pub fn derive_tx_type(&mut self) -> Result<(), DeriveTxTypeError> {
+    pub fn derive_tx_type(&self) -> Result<TransactionType, DeriveTxTypeError> {
+        let mut tx_type = TransactionType::Legacy;
+
         if !self.access_list.0.is_empty() {
-            self.tx_type = TransactionType::Eip2930 as u8;
+            tx_type = TransactionType::Eip2930;
         }
 
         if self.gas_priority_fee.is_some() {
-            self.tx_type = TransactionType::Eip1559 as u8;
+            tx_type = TransactionType::Eip1559;
         }
 
         if !self.blob_hashes.is_empty() || self.max_fee_per_blob_gas > 0 {
             if let TxKind::Call(_) = self.kind {
-                self.tx_type = TransactionType::Eip4844 as u8;
-                return Ok(());
+                return Ok(TransactionType::Eip4844);
             } else {
                 return Err(DeriveTxTypeError::MissingTargetForEip4844);
             }
@@ -144,8 +143,7 @@ impl TxEnv {
 
         if !self.authorization_list.is_empty() {
             if let TxKind::Call(_) = self.kind {
-                self.tx_type = TransactionType::Eip7702 as u8;
-                return Ok(());
+                return Ok(TransactionType::Eip7702);
             } else {
                 return Err(DeriveTxTypeError::MissingTargetForEip7702);
             }
@@ -161,7 +159,7 @@ impl TxEnv {
         //     }
         // }
 
-        Ok(())
+        Ok(tx_type)
     }
 
     /// Insert a list of signed authorizations into the authorization list.
@@ -178,10 +176,6 @@ impl TxEnv {
 impl Transaction for TxEnv {
     type AccessListItem<'a> = &'a AccessListItem;
     type Authorization<'a> = &'a Either<SignedAuthorization, RecoveredAuthorization>;
-
-    fn tx_type(&self) -> u8 {
-        self.tx_type
-    }
 
     fn kind(&self) -> TxKind {
         self.kind
@@ -447,7 +441,6 @@ impl TxEnvBuilder {
         }
 
         let mut tx = TxEnv {
-            tx_type: self.tx_type.unwrap_or(0),
             caller: self.caller,
             gas_limit: self.gas_limit,
             gas_price: self.gas_price,
@@ -538,8 +531,7 @@ impl TxEnvBuilder {
             }
         }
 
-        let mut tx = TxEnv {
-            tx_type: self.tx_type.unwrap_or(0),
+        let tx = TxEnv {
             caller: self.caller,
             gas_limit: self.gas_limit,
             gas_price: self.gas_price,
@@ -595,13 +587,8 @@ impl TxEnv {
 mod tests {
     use super::*;
 
-    fn effective_gas_setup(
-        tx_type: TransactionType,
-        gas_price: u128,
-        gas_priority_fee: Option<u128>,
-    ) -> u128 {
+    fn effective_gas_setup(gas_price: u128, gas_priority_fee: Option<u128>) -> u128 {
         let tx = TxEnv {
-            tx_type: tx_type as u8,
             gas_price,
             gas_priority_fee,
             ..Default::default()
@@ -612,70 +599,9 @@ mod tests {
 
     #[test]
     fn test_effective_gas_price() {
-        assert_eq!(90, effective_gas_setup(TransactionType::Legacy, 90, None));
-        assert_eq!(
-            90,
-            effective_gas_setup(TransactionType::Legacy, 90, Some(0))
-        );
-        assert_eq!(
-            90,
-            effective_gas_setup(TransactionType::Legacy, 90, Some(10))
-        );
-        assert_eq!(
-            120,
-            effective_gas_setup(TransactionType::Legacy, 120, Some(10))
-        );
-        assert_eq!(90, effective_gas_setup(TransactionType::Eip2930, 90, None));
-        assert_eq!(
-            90,
-            effective_gas_setup(TransactionType::Eip2930, 90, Some(0))
-        );
-        assert_eq!(
-            90,
-            effective_gas_setup(TransactionType::Eip2930, 90, Some(10))
-        );
-        assert_eq!(
-            120,
-            effective_gas_setup(TransactionType::Eip2930, 120, Some(10))
-        );
-        assert_eq!(90, effective_gas_setup(TransactionType::Eip1559, 90, None));
-        assert_eq!(
-            90,
-            effective_gas_setup(TransactionType::Eip1559, 90, Some(0))
-        );
-        assert_eq!(
-            90,
-            effective_gas_setup(TransactionType::Eip1559, 90, Some(10))
-        );
-        assert_eq!(
-            110,
-            effective_gas_setup(TransactionType::Eip1559, 120, Some(10))
-        );
-        assert_eq!(90, effective_gas_setup(TransactionType::Eip4844, 90, None));
-        assert_eq!(
-            90,
-            effective_gas_setup(TransactionType::Eip4844, 90, Some(0))
-        );
-        assert_eq!(
-            90,
-            effective_gas_setup(TransactionType::Eip4844, 90, Some(10))
-        );
-        assert_eq!(
-            110,
-            effective_gas_setup(TransactionType::Eip4844, 120, Some(10))
-        );
-        assert_eq!(90, effective_gas_setup(TransactionType::Eip7702, 90, None));
-        assert_eq!(
-            90,
-            effective_gas_setup(TransactionType::Eip7702, 90, Some(0))
-        );
-        assert_eq!(
-            90,
-            effective_gas_setup(TransactionType::Eip7702, 90, Some(10))
-        );
-        assert_eq!(
-            110,
-            effective_gas_setup(TransactionType::Eip7702, 120, Some(10))
-        );
+        assert_eq!(90, effective_gas_setup(90, None));
+        assert_eq!(90, effective_gas_setup(90, Some(0)));
+        assert_eq!(90, effective_gas_setup(90, Some(10)));
+        assert_eq!(110, effective_gas_setup(120, Some(10)));
     }
 }

--- a/crates/context/src/tx.rs
+++ b/crates/context/src/tx.rs
@@ -133,7 +133,6 @@ impl TxEnv {
             tx_type = TransactionType::Eip1559;
         }
 
-
         if self.max_fee_per_blob_gas.is_some() {
             if let TxKind::Call(_) = self.kind {
                 return Ok(TransactionType::Eip4844);

--- a/crates/handler/src/mainnet_builder.rs
+++ b/crates/handler/src/mainnet_builder.rs
@@ -73,7 +73,7 @@ mod test {
         Bytecode,
     };
     use context::{Context, TxEnv};
-    use context_interface::{transaction::Authorization, TransactionType};
+    use context_interface::transaction::Authorization;
     use database::{BenchmarkDB, EEADDRESS, FFADDRESS};
     use primitives::{hardfork::SpecId, TxKind, U256};
     use primitives::{StorageKey, StorageValue};
@@ -99,7 +99,6 @@ mod test {
 
         let state = evm
             .transact_finalize(TxEnv {
-                tx_type: TransactionType::Eip7702.into(),
                 gas_limit: 100_000,
                 authorization_list: vec![Either::Left(auth)],
                 caller: EEADDRESS,

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -121,7 +121,9 @@ pub fn validate_tx_env<CTX: ContextTr, Error>(
         }
     }
 
-    if tx.access_list().is_some_and(|l| !l.is_empty()) && !spec_id.is_enabled_in(SpecId::BERLIN) {
+    if tx.access_list().is_some_and(|mut l| l.next().is_some())
+        && !spec_id.is_enabled_in(SpecId::BERLIN)
+    {
         return Err(InvalidTransaction::Eip2930NotSupported);
     }
 

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -147,6 +147,10 @@ pub fn validate_tx_env<CTX: ContextTr, Error>(
             return Err(InvalidTransaction::Eip4844NotSupported);
         }
 
+        if tx.kind().is_create() {
+            return Err(InvalidTransaction::BlobCreateTransaction);
+        }
+
         if blobs.is_empty() {
             return Err(InvalidTransaction::EmptyBlobs);
         }

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -121,7 +121,7 @@ pub fn validate_tx_env<CTX: ContextTr, Error>(
         }
     }
 
-    if tx.access_list().is_some() && !spec_id.is_enabled_in(SpecId::BERLIN) {
+    if tx.access_list().is_some_and(|l| !l.is_empty()) && !spec_id.is_enabled_in(SpecId::BERLIN) {
         return Err(InvalidTransaction::Eip2930NotSupported);
     }
 

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -142,7 +142,7 @@ pub fn validate_tx_env<CTX: ContextTr, Error>(
         base_fee,
     )?;
 
-    if let Some(blobs) = tx.blob_versioned_hashes() {
+    if let Some(blob_fee) = tx.max_fee_per_blob_gas() {
         if !spec_id.is_enabled_in(SpecId::CANCUN) {
             return Err(InvalidTransaction::Eip4844NotSupported);
         }
@@ -151,13 +151,13 @@ pub fn validate_tx_env<CTX: ContextTr, Error>(
             return Err(InvalidTransaction::BlobCreateTransaction);
         }
 
-        if blobs.is_empty() {
+        if tx.blob_versioned_hashes().is_empty() {
             return Err(InvalidTransaction::EmptyBlobs);
         }
 
         validate_eip4844_tx(
-            blobs,
-            tx.max_fee_per_blob_gas(),
+            tx.blob_versioned_hashes(),
+            blob_fee,
             context.block().blob_gasprice().unwrap_or_default(),
             context.cfg().blob_max_count(),
         )?;

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -142,13 +142,17 @@ pub fn validate_tx_env<CTX: ContextTr, Error>(
         base_fee,
     )?;
 
-    if !tx.blob_versioned_hashes().is_empty() {
+    if let Some(blobs) = tx.blob_versioned_hashes() {
         if !spec_id.is_enabled_in(SpecId::CANCUN) {
             return Err(InvalidTransaction::Eip4844NotSupported);
         }
 
+        if blobs.is_empty() {
+            return Err(InvalidTransaction::EmptyBlobs);
+        }
+
         validate_eip4844_tx(
-            tx.blob_versioned_hashes(),
+            blobs,
             tx.max_fee_per_blob_gas(),
             context.block().blob_gasprice().unwrap_or_default(),
             context.cfg().blob_max_count(),

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -1,6 +1,6 @@
 use context_interface::{
     result::{InvalidHeader, InvalidTransaction},
-    transaction::{Transaction, TransactionType},
+    transaction::Transaction,
     Block, Cfg, ContextTr,
 };
 use core::cmp;
@@ -87,7 +87,6 @@ pub fn validate_tx_env<CTX: ContextTr, Error>(
     spec_id: SpecId,
 ) -> Result<(), InvalidTransaction> {
     // Check if the transaction's chain id is correct
-    let tx_type = context.tx().tx_type();
     let tx = context.tx();
 
     let base_fee = if context.cfg().is_base_fee_check_disabled() {
@@ -96,8 +95,6 @@ pub fn validate_tx_env<CTX: ContextTr, Error>(
         Some(context.block().basefee() as u128)
     };
 
-    let tx_type = TransactionType::from(tx_type);
-
     // Check chain_id if config is enabled.
     // EIP-155: Simple replay attack protection
     if context.cfg().tx_chain_id_check() {
@@ -105,9 +102,6 @@ pub fn validate_tx_env<CTX: ContextTr, Error>(
             if chain_id != context.cfg().chain_id() {
                 return Err(InvalidTransaction::InvalidChainId);
             }
-        } else if !tx_type.is_legacy() && !tx_type.is_custom() {
-            // Legacy transaction are the only one that can omit chain_id.
-            return Err(InvalidTransaction::MissingChainId);
         }
     }
 
@@ -120,105 +114,44 @@ pub fn validate_tx_env<CTX: ContextTr, Error>(
         });
     }
 
-    match tx_type {
-        TransactionType::Legacy => {
-            // Gas price must be at least the basefee.
-            if let Some(base_fee) = base_fee {
-                if tx.gas_price() < base_fee {
-                    return Err(InvalidTransaction::GasPriceLessThanBasefee);
-                }
-            }
+    // Gas price must be at least the basefee.
+    if let Some(base_fee) = base_fee {
+        if tx.max_fee_per_gas() < base_fee {
+            return Err(InvalidTransaction::GasPriceLessThanBasefee);
         }
-        TransactionType::Eip2930 => {
-            // Enabled in BERLIN hardfork
-            if !spec_id.is_enabled_in(SpecId::BERLIN) {
-                return Err(InvalidTransaction::Eip2930NotSupported);
-            }
+    }
 
-            // Gas price must be at least the basefee.
-            if let Some(base_fee) = base_fee {
-                if tx.gas_price() < base_fee {
-                    return Err(InvalidTransaction::GasPriceLessThanBasefee);
-                }
-            }
+    if tx.access_list().is_some() && !spec_id.is_enabled_in(SpecId::BERLIN) {
+        return Err(InvalidTransaction::Eip2930NotSupported);
+    }
+
+    if tx.max_priority_fee_per_gas().is_some() && !spec_id.is_enabled_in(SpecId::LONDON) {
+        return Err(InvalidTransaction::Eip1559NotSupported);
+    }
+
+    if tx.authorization_list_len() > 0 && !spec_id.is_enabled_in(SpecId::PRAGUE) {
+        return Err(InvalidTransaction::Eip7702NotSupported);
+    }
+
+    validate_priority_fee_tx(
+        tx.max_fee_per_gas(),
+        tx.max_priority_fee_per_gas()
+            .unwrap_or(tx.max_fee_per_gas()),
+        base_fee,
+    )?;
+
+    if !tx.blob_versioned_hashes().is_empty() {
+        if !spec_id.is_enabled_in(SpecId::CANCUN) {
+            return Err(InvalidTransaction::Eip4844NotSupported);
         }
-        TransactionType::Eip1559 => {
-            if !spec_id.is_enabled_in(SpecId::LONDON) {
-                return Err(InvalidTransaction::Eip1559NotSupported);
-            }
 
-            validate_priority_fee_tx(
-                tx.max_fee_per_gas(),
-                tx.max_priority_fee_per_gas().unwrap_or_default(),
-                base_fee,
-            )?;
-        }
-        TransactionType::Eip4844 => {
-            if !spec_id.is_enabled_in(SpecId::CANCUN) {
-                return Err(InvalidTransaction::Eip4844NotSupported);
-            }
-
-            validate_priority_fee_tx(
-                tx.max_fee_per_gas(),
-                tx.max_priority_fee_per_gas().unwrap_or_default(),
-                base_fee,
-            )?;
-
-            validate_eip4844_tx(
-                tx.blob_versioned_hashes(),
-                tx.max_fee_per_blob_gas(),
-                context.block().blob_gasprice().unwrap_or_default(),
-                context.cfg().blob_max_count(),
-            )?;
-        }
-        TransactionType::Eip7702 => {
-            // Check if EIP-7702 transaction is enabled.
-            if !spec_id.is_enabled_in(SpecId::PRAGUE) {
-                return Err(InvalidTransaction::Eip7702NotSupported);
-            }
-
-            validate_priority_fee_tx(
-                tx.max_fee_per_gas(),
-                tx.max_priority_fee_per_gas().unwrap_or_default(),
-                base_fee,
-            )?;
-
-            let auth_list_len = tx.authorization_list_len();
-            // The transaction is considered invalid if the length of authorization_list is zero.
-            if auth_list_len == 0 {
-                return Err(InvalidTransaction::EmptyAuthorizationList);
-            }
-        }
-        /* // TODO(EOF) EOF removed from spec.
-        TransactionType::Eip7873 => {
-            // Check if EIP-7873 transaction is enabled.
-            if !spec_id.is_enabled_in(SpecId::OSAKA) {
-            return Err(InvalidTransaction::Eip7873NotSupported);
-            }
-            // validate chain id
-            if Some(context.cfg().chain_id()) != tx.chain_id() {
-                return Err(InvalidTransaction::InvalidChainId);
-            }
-
-            // validate initcodes.
-            validate_eip7873_initcodes(tx.initcodes())?;
-
-            // InitcodeTransaction is invalid if the to is nil.
-            if tx.kind().is_create() {
-                return Err(InvalidTransaction::Eip7873MissingTarget);
-            }
-
-            validate_priority_fee_tx(
-                tx.max_fee_per_gas(),
-                tx.max_priority_fee_per_gas().unwrap_or_default(),
-                base_fee,
-            )?;
-        }
-        */
-        TransactionType::Custom => {
-            // Custom transaction type check is not done here.
-        }
-    };
+        validate_eip4844_tx(
+            tx.blob_versioned_hashes(),
+            tx.max_fee_per_blob_gas(),
+            context.block().blob_gasprice().unwrap_or_default(),
+            context.cfg().blob_max_count(),
+        )?;
+    }
 
     // Check if gas_limit is more than block_gas_limit
     if !context.cfg().is_block_gas_limit_disabled() && tx.gas_limit() > context.block().gas_limit()

--- a/crates/interpreter/src/gas/calc.rs
+++ b/crates/interpreter/src/gas/calc.rs
@@ -1,7 +1,7 @@
 use super::constants::*;
 use crate::{num_words, tri, SStoreResult, SelfDestructResult, StateLoad};
 use context_interface::{
-    journaled_state::AccountLoad, transaction::AccessListItemTr as _, Transaction, TransactionType,
+    journaled_state::AccountLoad, transaction::AccessListItemTr as _, Transaction,
 };
 use primitives::{eip7702, hardfork::SpecId, U256};
 
@@ -437,22 +437,18 @@ pub fn calculate_initial_tx_gas(
 /// - Intrinsic gas
 /// - Number of tokens in calldata
 pub fn calculate_initial_tx_gas_for_tx(tx: impl Transaction, spec: SpecId) -> InitialAndFloorGas {
-    let mut accounts = 0;
-    let mut storages = 0;
     // legacy is only tx type that does not have access list.
-    if tx.tx_type() != TransactionType::Legacy {
-        (accounts, storages) = tx
-            .access_list()
-            .map(|al| {
-                al.fold((0, 0), |(mut num_accounts, mut num_storage_slots), item| {
-                    num_accounts += 1;
-                    num_storage_slots += item.storage_slots().count();
+    let (accounts, storages) = tx
+        .access_list()
+        .map(|al| {
+            al.fold((0, 0), |(mut num_accounts, mut num_storage_slots), item| {
+                num_accounts += 1;
+                num_storage_slots += item.storage_slots().count();
 
-                    (num_accounts, num_storage_slots)
-                })
+                (num_accounts, num_storage_slots)
             })
-            .unwrap_or_default();
-    }
+        })
+        .unwrap_or_default();
 
     // Access initcodes only if tx is Eip7873.
     // TODO(EOF) Tx type is removed

--- a/crates/interpreter/src/host.rs
+++ b/crates/interpreter/src/host.rs
@@ -143,7 +143,7 @@ impl<CTX: ContextTr> Host for CTX {
     fn blob_hash(&self, number: usize) -> Option<U256> {
         self.tx()
             .blob_versioned_hashes()
-            .get(number)
+            .and_then(|b| b.get(number))
             .map(|t| U256::from_be_bytes(t.0))
     }
 

--- a/crates/interpreter/src/host.rs
+++ b/crates/interpreter/src/host.rs
@@ -143,7 +143,7 @@ impl<CTX: ContextTr> Host for CTX {
     fn blob_hash(&self, number: usize) -> Option<U256> {
         self.tx()
             .blob_versioned_hashes()
-            .and_then(|b| b.get(number))
+            .get(number)
             .map(|t| U256::from_be_bytes(t.0))
     }
 

--- a/crates/interpreter/src/host.rs
+++ b/crates/interpreter/src/host.rs
@@ -1,7 +1,7 @@
 use context_interface::{
     context::{ContextTr, SStoreResult, SelfDestructResult, StateLoad},
     journaled_state::AccountLoad,
-    Block, Cfg, Database, JournalTr, LocalContextTr, Transaction, TransactionType,
+    Block, Cfg, Database, JournalTr, LocalContextTr, Transaction,
 };
 use primitives::{Address, Bytes, Log, StorageKey, StorageValue, B256, U256};
 
@@ -141,11 +141,8 @@ impl<CTX: ContextTr> Host for CTX {
     }
 
     fn blob_hash(&self, number: usize) -> Option<U256> {
-        let tx = &self.tx();
-        if tx.tx_type() != TransactionType::Eip4844 {
-            return None;
-        }
-        tx.blob_versioned_hashes()
+        self.tx()
+            .blob_versioned_hashes()
             .get(number)
             .map(|t| U256::from_be_bytes(t.0))
     }

--- a/crates/op-revm/src/transaction/abstraction.rs
+++ b/crates/op-revm/src/transaction/abstraction.rs
@@ -125,7 +125,7 @@ impl<T: Transaction> Transaction for OpTransaction<T> {
         self.base.gas_price()
     }
 
-    fn blob_versioned_hashes(&self) -> &[B256] {
+    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
         self.base.blob_versioned_hashes()
     }
 

--- a/crates/op-revm/src/transaction/abstraction.rs
+++ b/crates/op-revm/src/transaction/abstraction.rs
@@ -24,7 +24,7 @@ pub trait OpTxTr: Transaction {
     /// Whether the transaction is a system transaction
     fn is_system_transaction(&self) -> bool;
 
-    /// Returns `true` if transaction is of type [`DEPOSIT_TRANSACTION_TYPE`].
+    /// Returns `true` if transaction is a deposit transaction.
     fn is_deposit(&self) -> bool;
 }
 

--- a/crates/op-revm/src/transaction/abstraction.rs
+++ b/crates/op-revm/src/transaction/abstraction.rs
@@ -125,11 +125,11 @@ impl<T: Transaction> Transaction for OpTransaction<T> {
         self.base.gas_price()
     }
 
-    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+    fn blob_versioned_hashes(&self) -> &[B256] {
         self.base.blob_versioned_hashes()
     }
 
-    fn max_fee_per_blob_gas(&self) -> u128 {
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
         self.base.max_fee_per_blob_gas()
     }
 

--- a/crates/op-revm/tests/integration.rs
+++ b/crates/op-revm/tests/integration.rs
@@ -3,9 +3,8 @@ mod common;
 
 use common::compare_or_save_testdata;
 use op_revm::{
-    precompiles::bn128_pair::GRANITE_MAX_INPUT_SIZE,
-    transaction::deposit::DEPOSIT_TRANSACTION_TYPE, DefaultOp, L1BlockInfo, OpBuilder,
-    OpHaltReason, OpSpecId, OpTransaction,
+    precompiles::bn128_pair::GRANITE_MAX_INPUT_SIZE, transaction::deposit::DepositTransactionParts,
+    DefaultOp, L1BlockInfo, OpBuilder, OpHaltReason, OpSpecId, OpTransaction,
 };
 use revm::{
     bytecode::opcode,
@@ -31,8 +30,10 @@ fn test_deposit_tx() {
     let ctx = Context::op()
         .modify_tx_chained(|tx| {
             tx.enveloped_tx = None;
-            tx.deposit.mint = Some(100);
-            tx.base.tx_type = DEPOSIT_TRANSACTION_TYPE;
+            tx.deposit = Some(DepositTransactionParts {
+                mint: Some(100),
+                ..Default::default()
+            });
         })
         .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::HOLOCENE);
 
@@ -56,8 +57,10 @@ fn test_halted_deposit_tx() {
     let ctx = Context::op()
         .modify_tx_chained(|tx| {
             tx.enveloped_tx = None;
-            tx.deposit.mint = Some(100);
-            tx.base.tx_type = DEPOSIT_TRANSACTION_TYPE;
+            tx.deposit = Some(DepositTransactionParts {
+                mint: Some(100),
+                ..Default::default()
+            });
             tx.base.caller = BENCH_CALLER;
             tx.base.kind = TxKind::Call(BENCH_TARGET);
         })


### PR DESCRIPTION
This field is very easy to forget about, and have caused weird bugs multiple times already. It can also always be easily inferred from the specified `TxEnv` values.

This PR removes the `tx_env` and adjusts logic to be invoked based on present fields instead