### PR TITLE
deps: explicitly bump `auto_impl`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false }
 
 # misc
-auto_impl = "1.2.0"
+auto_impl = "1.3.0"
 bitflags = { version = "2.6.0", default-features = false }
 cfg-if = { version = "1.0", default-features = false }
 derive-where = { version = "1.2.7", default-features = false }


### PR DESCRIPTION
## Description

Explicitly bump `auto_impl` to `1.3.0`. Otherwise depending on `revm-context-interface` results in the following errors:

```
error[E0477]: the type `&'b T` does not fulfill the required lifetime
  --> ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/revm-context-interface-5.0.0/src/transaction.rs:29:1
   |
29 | #[auto_impl(&, Box, Arc, Rc)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
30 | pub trait Transaction {
31 |     type AccessListItem<'a>: AccessListItemTr
   |     ----------------------------------------- definition of `AccessListItem` from trait
   |
note: type must outlive the lifetime `'a` as defined here
  --> ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/revm-context-interface-5.0.0/src/transaction.rs:31:25
   |
31 |     type AccessListItem<'a>: AccessListItemTr
   |                         ^^
   = note: this error originates in the attribute macro `auto_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
help: copy the `where` clause predicates from the trait
   |
31 |     type AccessListItem<'a> where Self: 'a: AccessListItemTr
   |                             ++++++++++++++

error[E0477]: the type `&'b T` does not fulfill the required lifetime
  --> ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/revm-context-interface-5.0.0/src/transaction.rs:29:1
   |
29 | #[auto_impl(&, Box, Arc, Rc)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
34 |     type Authorization<'a>: AuthorizationTr
   |     --------------------------------------- definition of `Authorization` from trait
   |
note: type must outlive the lifetime `'a` as defined here
  --> ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/revm-context-interface-5.0.0/src/transaction.rs:34:24
   |
34 |     type Authorization<'a>: AuthorizationTr
   |                        ^^
   = note: this error originates in the attribute macro `auto_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
help: copy the `where` clause predicates from the trait
   |
34 |     type Authorization<'a> where Self: 'a: AuthorizationTr
   |                            ++++++++++++++

error[E0309]: the parameter type `T` may not live long enough
  --> ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/revm-context-interface-5.0.0/src/transaction.rs:29:1
   |
29 | #[auto_impl(&, Box, Arc, Rc)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `Box<T>` will meet its required lifetime bounds
30 | pub trait Transaction {
31 |     type AccessListItem<'a>: AccessListItemTr
   |                         -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
   |
   = note: this error originates in the attribute macro `auto_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider adding an explicit lifetime bound
   |
31 |     type AccessListItem<'a> where T: 'a: AccessListItemTr
   |                             +++++++++++
```