### PR TITLE
chore: use iter_batched for transfer bench

### DIFF
--- a/bins/revme/src/cmd/bench/analysis.rs
+++ b/bins/revme/src/cmd/bench/analysis.rs
@@ -23,8 +23,15 @@ pub fn run(criterion: &mut Criterion) {
     };
     let mut evm = context.build_mainnet();
     criterion.bench_function("analysis", |b| {
-        b.iter(|| {
-            let _ = evm.transact(tx.clone());
-        });
+        b.iter_batched(
+            || {
+                // create a transaction input
+                tx.clone()
+            },
+            |input| {
+                let _ = evm.transact(input);
+            },
+            criterion::BatchSize::SmallInput,
+        );
     });
 }

--- a/bins/revme/src/cmd/bench/burntpix.rs
+++ b/bins/revme/src/cmd/bench/burntpix.rs
@@ -50,9 +50,16 @@ pub fn run(criterion: &mut Criterion) {
     };
 
     criterion.bench_function("burntpix", |b| {
-        b.iter(|| {
-            evm.transact(tx.clone()).unwrap();
-        })
+        b.iter_batched(
+            || {
+                // create a transaction input
+                tx.clone()
+            },
+            |input| {
+                evm.transact(input).unwrap();
+            },
+            criterion::BatchSize::SmallInput,
+        );
     });
 
     //Collects the data and uses it to generate the svg after running the benchmark

--- a/bins/revme/src/cmd/bench/gas_cost_estimator.rs
+++ b/bins/revme/src/cmd/bench/gas_cost_estimator.rs
@@ -34,9 +34,16 @@ pub fn run(criterion: &mut Criterion) {
         };
 
         criterion.bench_function(name, |b| {
-            b.iter(|| {
-                let _ = evm.transact(tx.clone()).unwrap();
-            })
+            b.iter_batched(
+                || {
+                    // create a transaction input
+                    tx.clone()
+                },
+                |input| {
+                    let _ = evm.transact(input).unwrap();
+                },
+                criterion::BatchSize::SmallInput,
+            );
         });
     }
 }

--- a/bins/revme/src/cmd/bench/snailtracer.rs
+++ b/bins/revme/src/cmd/bench/snailtracer.rs
@@ -24,9 +24,16 @@ pub fn run(criterion: &mut Criterion) {
     };
 
     criterion.bench_function("snailtracer", |b| {
-        b.iter(|| {
-            let _ = evm.transact(tx.clone()).unwrap();
-        })
+        b.iter_batched(
+            || {
+                // create a transaction input
+                tx.clone()
+            },
+            |input| {
+                let _ = evm.transact(input).unwrap();
+            },
+            criterion::BatchSize::SmallInput,
+        );
     });
 }
 

--- a/bins/revme/src/cmd/bench/transfer.rs
+++ b/bins/revme/src/cmd/bench/transfer.rs
@@ -27,10 +27,17 @@ pub fn run(criterion: &mut Criterion) {
 
     let mut i = 0;
     criterion.bench_function("transfer", |b| {
-        b.iter(|| {
-            i += 1;
-            let _ = evm.transact(tx.clone()).unwrap();
-        })
+        b.iter_batched(
+            || {
+                // create a transfer input
+                tx.clone()
+            },
+            |input| {
+                i += 1;
+                evm.transact(input).unwrap();
+            },
+            criterion::BatchSize::SmallInput,
+        );
     });
 
     let balance = evm


### PR DESCRIPTION
I noticed the clone ending up in the profiles, instead we can probably use iter_batched here