### PR TITLE
feat(InspectEvm): add inspect_finalize method for tx+inspector with state

### DIFF
--- a/crates/inspector/src/inspect.rs
+++ b/crates/inspector/src/inspect.rs
@@ -28,6 +28,7 @@ pub trait InspectEvm: ExecuteEvm {
         Ok(ResultAndState::new(output, state))
     }
 
+    /// Inspect the EVM with the given inspector and transaction, and finalize the state.
     fn inspect_finalize(
         &mut self,
         tx: Self::Tx,

--- a/crates/inspector/src/inspect.rs
+++ b/crates/inspector/src/inspect.rs
@@ -28,6 +28,16 @@ pub trait InspectEvm: ExecuteEvm {
         Ok(ResultAndState::new(output, state))
     }
 
+    fn inspect_finalize(
+        &mut self,
+        tx: Self::Tx,
+        inspector: Self::Inspector,
+    ) -> Result<ResultAndState<Self::ExecutionResult, Self::State>, Self::Error> {
+        let output = self.inspect(tx, inspector)?;
+        let state = self.finalize();
+        Ok(ResultAndState::new(output, state))
+    }
+
     /// Inspect the EVM with the given inspector and transaction.
     fn inspect(
         &mut self,


### PR DESCRIPTION
[ticket](https://github.com/bluealloy/revm/issues/2591#issuecomment-2949600915)

Add inspect_finalize, same pattern as inspect_tx_finalize but this time the function take the tx + inspector and return ResultAndState which contains Self::ExecutionResult (result of the tx) and Self::State (the state).