### PR TITLE
feat(precompile): rug/gmp-based modexp

### DIFF
--- a/.github/workflows/ethereum-tests.yml
+++ b/.github/workflows/ethereum-tests.yml
@@ -40,8 +40,6 @@ jobs:
         run: cargo install cross
 
       - name: Run tests
-        env:
-          ABI: ${{ 32 if matrix.target == 'i686-unknown-linux-gnu' }}
         run: |
           cross run --target ${{matrix.target}} --profile ${{ matrix.profile }} -p revme -- statetest \
           legacytests/Cancun/GeneralStateTests/ \

--- a/.github/workflows/ethereum-tests.yml
+++ b/.github/workflows/ethereum-tests.yml
@@ -41,7 +41,9 @@ jobs:
 
       - name: Run tests
         run: |
-          cross run --target ${{matrix.target}} --profile ${{ matrix.profile }} -p revme -- statetest \
+          cross run --target ${{matrix.target}} --profile ${{ matrix.profile }} \
+          ${{ matrix.target != 'i686-unknown-linux-gnu' && '--features gmp' || '' }} \
+          -p revme -- statetest \
           legacytests/Cancun/GeneralStateTests/ \
           legacytests/Constantinople/GeneralStateTests/
           ./scripts/run-tests.sh clean cross ${{ matrix.profile }} ${{ matrix.target }}

--- a/.github/workflows/ethereum-tests.yml
+++ b/.github/workflows/ethereum-tests.yml
@@ -40,6 +40,8 @@ jobs:
         run: cargo install cross
 
       - name: Run tests
+        env:
+          ABI: ${{ 32 if matrix.target == 'i686-unknown-linux-gnu' }}
         run: |
           cross run --target ${{matrix.target}} --profile ${{ matrix.profile }} -p revme -- statetest \
           legacytests/Cancun/GeneralStateTests/ \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,16 +962,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aurora-engine-modexp"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518bc5745a6264b5fd7b09dffb9667e400ee9e2bbe18555fac75e1fe9afa0df9"
-dependencies = [
- "hex",
- "num",
-]
-
-[[package]]
 name = "auto_impl"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,6 +977,12 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "az"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "backtrace"
@@ -2127,6 +2123,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "gmp-mpfr-sys"
+version = "1.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66d61197a68f6323b9afa616cf83d55d69191e1bf364d4eb7d35ae18defe776"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2829,20 +2835,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint 0.4.6",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2864,15 +2856,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2884,28 +2867,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint 0.4.6",
- "num-integer",
  "num-traits",
 ]
 
@@ -3852,7 +3813,6 @@ dependencies = [
  "ark-ec",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
- "aurora-engine-modexp",
  "blst",
  "c-kzg",
  "cfg-if",
@@ -3866,6 +3826,7 @@ dependencies = [
  "revm-primitives",
  "ripemd",
  "rstest",
+ "rug",
  "secp256k1",
  "sha2 0.10.8",
  "substrate-bn",
@@ -3986,6 +3947,18 @@ dependencies = [
  "rustc_version 0.4.1",
  "syn 2.0.100",
  "unicode-ident",
+]
+
+[[package]]
+name = "rug"
+version = "1.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4207e8d668e5b8eb574bda8322088ccd0d7782d3d03c7e8d562e82ed82bdcbc3"
+dependencies = [
+ "az",
+ "gmp-mpfr-sys",
+ "libc",
+ "libm",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,6 +962,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aurora-engine-modexp"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518bc5745a6264b5fd7b09dffb9667e400ee9e2bbe18555fac75e1fe9afa0df9"
+dependencies = [
+ "hex",
+ "num",
+]
+
+[[package]]
 name = "auto_impl"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2835,6 +2845,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2856,6 +2880,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2867,6 +2900,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3814,6 +3869,7 @@ dependencies = [
  "ark-ec",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
+ "aurora-engine-modexp",
  "blst",
  "c-kzg",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,9 @@ op-revm = { path = "crates/op-revm", package = "op-revm", version = "6.0.0", def
 # alloy
 alloy-eip2930 = { version = "0.2.1", default-features = false }
 alloy-eip7702 = { version = "0.6.1", default-features = false }
-alloy-primitives = { version = "1.1.2", default-features = false, features = ["sha3-keccak"]}
+alloy-primitives = { version = "1.1.2", default-features = false, features = [
+    "sha3-keccak",
+] }
 
 # alloy in examples, revme or feature flagged.
 alloy-rlp = { version = "0.3.12", default-features = false }
@@ -76,6 +78,7 @@ ark-ec = { version = "0.5", default-features = false }
 ark-ff = { version = "0.5", default-features = false }
 ark-serialize = { version = "0.5", default-features = false }
 aurora-engine-modexp = { version = "1.1", default-features = false }
+rug = { version = "1.27.0", default-features = false }
 blst = "0.3.13"
 bn = { package = "substrate-bn", version = "0.6", default-features = false }
 c-kzg = { version = "2.1.1", default-features = false }
@@ -86,9 +89,6 @@ secp256k1 = { version = "0.30", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 ripemd = { version = "0.1", default-features = false }
 p256 = { version = "0.13.2", default-features = false }
-
-# rug for modexp
-rug = { version = "1.27.0", default-features = false }
 
 # bytecode
 bitvec = { version = "1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
-    # binary 
+    # binary
     "bins/revme",
 
     # libraries
@@ -54,7 +54,7 @@ context-interface = { path = "crates/context/interface", package = "revm-context
 handler = { path = "crates/handler", package = "revm-handler", version = "6.0.0", default-features = false }
 op-revm = { path = "crates/op-revm", package = "op-revm", version = "6.0.0", default-features = false }
 
-# alloy 
+# alloy
 alloy-eip2930 = { version = "0.2.1", default-features = false }
 alloy-eip7702 = { version = "0.6.1", default-features = false }
 alloy-primitives = { version = "1.1.2", default-features = false, features = ["sha3-keccak"]}
@@ -86,6 +86,9 @@ secp256k1 = { version = "0.30", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 ripemd = { version = "0.1", default-features = false }
 p256 = { version = "0.13.2", default-features = false }
+
+# rug for modexp
+rug = { version = "1.27.0", default-features = false }
 
 # bytecode
 bitvec = { version = "1", default-features = false }

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Revm is licensed under MIT Licence.
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in these crates by you, shall be licensed as above, without any additional terms or conditions.
 
-If `gmt` feature flag is used, GPL code gets compiled, if enabled please make sure to follow this license.
+If `gmp` feature flag is used, GPL code gets compiled, if enabled please make sure to follow this license.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Revm is licensed under MIT Licence.
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in these crates by you, shall be licensed as above, without any additional terms or conditions.
 
+If `gmt` feature flag is used, GPL code gets compiled, if enabled please make sure to follow this license.
+
 ### Security
 
 For any security questions or findings, please reach out to me directly via email at dragan0rakita@gmail.com or contact me on Keybase under the username @draganrakita.

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -16,6 +16,7 @@ revm = { workspace = true, features = [
     "blst",
     "serde-json",
     "hashbrown",
+    "gmp",
 ] }
 primitives.workspace = true
 database.workspace = true

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -16,7 +16,6 @@ revm = { workspace = true, features = [
     "blst",
     "serde-json",
     "hashbrown",
-    "gmp",
 ] }
 primitives.workspace = true
 database.workspace = true
@@ -45,6 +44,10 @@ triehash.workspace = true
 walkdir.workspace = true
 k256 = { workspace = true, features = ["ecdsa"] }
 csv = "1.1.6"
+
+[features]
+# Optionally enable gmp because it doesn't work on i686 github actions runners
+gmp = ["revm/gmp"]
 
 [[bench]]
 name = "evm"

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -20,6 +20,9 @@ workspace = true
 # revm
 primitives.workspace = true
 
+# nums
+rug = { workspace = true, features = ["integer"] }
+
 # static precompile sets.
 once_cell = { workspace = true, features = ["alloc"] }
 
@@ -38,9 +41,6 @@ libsecp256k1 = { workspace = true, features = [
 # SHA2-256 and RIPEMD-160
 sha2.workspace = true
 ripemd.workspace = true
-
-# modexp
-aurora-engine-modexp.workspace = true
 
 # Optionally use substrate implementation for eip1962
 bn = { workspace = true, optional = true }
@@ -87,7 +87,6 @@ std = [
 	"c-kzg?/std",
 	"secp256k1?/std",
 	"libsecp256k1?/std",
-	"aurora-engine-modexp/std",
 	"ark-bn254/std",
 	"ark-bls12-381/std",
 	"ark-ec/std",

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -22,7 +22,7 @@ primitives.workspace = true
 
 # modexp precompiles
 aurora-engine-modexp.workspace = true
-# gmp wrapper 
+# gmp wrapper
 rug = { workspace = true, features = ["integer"], optional = true }
 
 # static precompile sets.
@@ -96,6 +96,7 @@ std = [
 	"ark-ff/std",
 	"ark-serialize/std",
 	"p256/std",
+    "rug/std"
 ]
 hashbrown = ["primitives/hashbrown"]
 asm-keccak = ["primitives/asm-keccak"]

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -96,7 +96,7 @@ std = [
 	"ark-ff/std",
 	"ark-serialize/std",
 	"p256/std",
-    "rug/std"
+    "rug?/std"
 ]
 hashbrown = ["primitives/hashbrown"]
 asm-keccak = ["primitives/asm-keccak"]

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -20,8 +20,10 @@ workspace = true
 # revm
 primitives.workspace = true
 
-# nums
-rug = { workspace = true, features = ["integer"] }
+# modexp precompiles
+aurora-engine-modexp.workspace = true
+# gmp wrapper 
+rug = { workspace = true, features = ["integer"], optional = true }
 
 # static precompile sets.
 once_cell = { workspace = true, features = ["alloc"] }
@@ -89,10 +91,11 @@ std = [
 	"libsecp256k1?/std",
 	"ark-bn254/std",
 	"ark-bls12-381/std",
+	"aurora-engine-modexp/std",
 	"ark-ec/std",
 	"ark-ff/std",
 	"ark-serialize/std",
-	"p256/std"
+	"p256/std",
 ]
 hashbrown = ["primitives/hashbrown"]
 asm-keccak = ["primitives/asm-keccak"]
@@ -119,6 +122,10 @@ blst = ["dep:blst"]
 
 # Enables the substrate implementation of eip1962
 bn = ["dep:bn"]
+
+# Use rug (that wraps gmp) for modexp precompile.
+# It is faster library but licences as GPL code, if enabled please make sure to follow the license.
+gmp = ["dep:rug"]
 
 [[bench]]
 name = "bench"

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -49,6 +49,10 @@ cfg_if::cfg_if! {
     }
 }
 
+// silence aurora-engine-modexp if gmp is enabled
+#[cfg(feature = "gmp")]
+use aurora_engine_modexp as _;
+
 use cfg_if::cfg_if;
 use core::hash::Hash;
 use once_cell::race::OnceBox;

--- a/crates/precompile/src/modexp.rs
+++ b/crates/precompile/src/modexp.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use core::cmp::{max, min};
 use primitives::{eip7823, Bytes, U256};
-use rug::Integer;
+use rug::{integer::Order::Msf, Integer};
 use std::vec::Vec;
 
 /// `modexp` precompile with BYZANTIUM gas rules.
@@ -23,9 +23,9 @@ pub const OSAKA: PrecompileWithAddress = PrecompileWithAddress(crate::u64_to_add
 /// GMP-based modular exponentiation implementation
 fn modexp_gmp(base: &[u8], exponent: &[u8], modulus: &[u8]) -> Vec<u8> {
     // Convert byte slices to GMP integers
-    let base_int = Integer::from_digits(base, rug::integer::Order::Msf);
-    let exp_int = Integer::from_digits(exponent, rug::integer::Order::Msf);
-    let mod_int = Integer::from_digits(modulus, rug::integer::Order::Msf);
+    let base_int = Integer::from_digits(base, Msf);
+    let exp_int = Integer::from_digits(exponent, Msf);
+    let mod_int = Integer::from_digits(modulus, Msf);
 
     // Perform modular exponentiation using GMP's pow_mod
     let result = base_int.pow_mod(&exp_int, &mod_int).unwrap_or_default();
@@ -33,7 +33,7 @@ fn modexp_gmp(base: &[u8], exponent: &[u8], modulus: &[u8]) -> Vec<u8> {
     // Convert result back to bytes
     let byte_count = (result.significant_bits() + 7) / 8;
     let mut output = vec![0u8; byte_count as usize];
-    result.write_digits(&mut output, rug::integer::Order::Msf);
+    result.write_digits(&mut output, Msf);
     output
 }
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -106,3 +106,7 @@ bn = ["precompile/bn"]
 # Compile in portable mode, without ISA extensions.
 # Binary can be executed on all systems.
 portable = ["precompile/portable"]
+
+# use gmp for modexp precompile.
+# It is faster library but licences as GPL code, if enabled please make sure to follow the license.
+gmp = ["precompile/gmp"]


### PR DESCRIPTION
Replaces the current modexp implementation with a gmp based implementation

Passes state tests:
```
Running tests in test-fixtures/stable/state_tests...
████████████████████████████████████████████████████████████████████████████████████████ 86/86Finished execution. Total CPU time: 258.077688s
All tests passed!
Running develop statetests...
warning: extern crate `aurora_engine_modexp` is unused in crate `revm_precompile`
  |
  = help: remove the dependency or add `use aurora_engine_modexp as _;` to the crate root
note: the lint level is defined here
 --> crates/precompile/src/lib.rs:4:29
  |
4 | #![cfg_attr(not(test), warn(unused_crate_dependencies))]
  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^

warning: `revm-precompile` (lib) generated 1 warning
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.93s
     Running `target/debug/revme statetest test-fixtures/develop/state_tests`

Running tests in test-fixtures/develop/state_tests...
████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 209/209Finished execution. Total CPU time: 1394.653083s
All tests passed!
Skipping EOF statetests...
Skipping EOF validation tests...
```