### PR TITLE
Fix minor grammar issues in comments for workflows

### DIFF
--- a/.config/zepter.yaml
+++ b/.config/zepter.yaml
@@ -13,9 +13,9 @@ workflows:
         "propagate-feature",
         # These are the features to check:
         "--features=std,serde",
-        # Do not try to add a new section into `[features]` of `A` only because `B` expose that feature. There are edge-cases where this is still needed, but we can add them manually.
+        # Do not try to add a new section into `[features]` of `A` only because `B` exposes that feature. There are edge-cases where this is still needed, but we can add them manually.
         "--left-side-feature-missing=ignore",
-        # Ignore the case that `A` it outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.
+        # Ignore the case that `A` is outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.
         "--left-side-outside-workspace=ignore",
         "--show-path",
         "--quiet",

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -29,8 +29,8 @@ jobs:
           git add Cargo.lock
           git commit -m "Update Cargo.lock" || echo "No changes to commit"
         # This will run the release-plz action
-        # The action dectect API breaking changes detection with cargo-semver-checks.
-        # Semver is auto incremneted based on this
+        # The action detect API breaking changes detection with cargo-semver-checks.
+        # Semver is auto incremented based on this
         # A PR with the semver bump is created with a new release tag and changelog
         # if you configure the cargo registry token, the action will also publish the new version to crates.io
       - name: Run release-plz


### PR DESCRIPTION
Changes made:

.config/zepter.yaml

expose → exposes: fixed incorrect verb form for third-person singular (“B exposes that feature”)

it → is: corrected grammar in the phrase (“A is outside of the workspace”)

.github/workflows/release-plz.yml

dectect → detect: fixed spelling error in the word "detect"

incremneted → incremented: corrected typo in "incremented"

These changes ensure clearer documentation and prevent confusion when reading workflow comments. No functional changes to code behavior.