### PR TITLE
feat: change blob_max_count to max_blobs_per_tx

### DIFF
--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -321,9 +321,9 @@ pub fn execute_test_suite(
 
             // set default max blobs number to be 9 for prague
             if cfg.spec.is_enabled_in(SpecId::PRAGUE) {
-                cfg.set_blob_max_count(9);
+                cfg.set_max_blobs_per_tx(9);
             } else {
-                cfg.set_blob_max_count(6);
+                cfg.set_max_blobs_per_tx(6);
             }
 
             // EIP-4844

--- a/crates/context/interface/src/cfg.rs
+++ b/crates/context/interface/src/cfg.rs
@@ -28,11 +28,9 @@ pub trait Cfg {
     /// Specification id
     fn spec(&self) -> Self::Spec;
 
-    /// Returns the blob target and max count for the given spec id.
+    /// Returns the maximum number of blobs allowed per transaction.
     /// If it is None, check for max count will be skipped.
-    ///
-    /// EIP-7840: Add blob schedule to execution client configuration files
-    fn blob_max_count(&self) -> Option<u64>;
+    fn max_blobs_per_tx(&self) -> Option<u64>;
 
     /// Returns the maximum code size for the given spec id.
     fn max_code_size(&self) -> usize;

--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -31,7 +31,7 @@ pub struct CfgEnv<SPEC = SpecId> {
     /// Blob max count. EIP-7840 Add blob schedule to EL config files.
     ///
     /// If this config is not set, the check for max blobs will be skipped.
-    pub blob_max_count: Option<u64>,
+    pub max_blobs_per_tx: Option<u64>,
     /// Blob base fee update fraction. EIP-4844 Blob base fee update fraction.
     ///
     /// If this config is not set, the blob base fee update fraction will be set to the default value.
@@ -126,7 +126,7 @@ impl<SPEC> CfgEnv<SPEC> {
             limit_contract_code_size: None,
             spec,
             disable_nonce_check: false,
-            blob_max_count: None,
+            max_blobs_per_tx: None,
             tx_gas_limit_cap: None,
             blob_base_fee_update_fraction: None,
             #[cfg(feature = "memory_limit")]
@@ -171,7 +171,7 @@ impl<SPEC> CfgEnv<SPEC> {
             spec,
             disable_nonce_check: self.disable_nonce_check,
             tx_gas_limit_cap: self.tx_gas_limit_cap,
-            blob_max_count: self.blob_max_count,
+            max_blobs_per_tx: self.max_blobs_per_tx,
             blob_base_fee_update_fraction: self.blob_base_fee_update_fraction,
             #[cfg(feature = "memory_limit")]
             memory_limit: self.memory_limit,
@@ -189,19 +189,19 @@ impl<SPEC> CfgEnv<SPEC> {
     }
 
     /// Sets the blob target
-    pub fn with_blob_max_count(mut self, blob_max_count: u64) -> Self {
-        self.set_blob_max_count(blob_max_count);
+    pub fn with_max_blobs_per_tx(mut self, max_blobs_per_tx: u64) -> Self {
+        self.set_max_blobs_per_tx(max_blobs_per_tx);
         self
     }
 
     /// Sets the blob target
-    pub fn set_blob_max_count(&mut self, blob_max_count: u64) {
-        self.blob_max_count = Some(blob_max_count);
+    pub fn set_max_blobs_per_tx(&mut self, max_blobs_per_tx: u64) {
+        self.max_blobs_per_tx = Some(max_blobs_per_tx);
     }
 
     /// Clears the blob target and max count over hardforks.
-    pub fn clear_blob_max_count(&mut self) {
-        self.blob_max_count = None;
+    pub fn clear_max_blobs_per_tx(&mut self) {
+        self.max_blobs_per_tx = None;
     }
 
     /// Sets the disable priority fee check flag.
@@ -241,8 +241,8 @@ impl<SPEC: Into<SpecId> + Copy> Cfg for CfgEnv<SPEC> {
     }
 
     #[inline]
-    fn blob_max_count(&self) -> Option<u64> {
-        self.blob_max_count
+    fn max_blobs_per_tx(&self) -> Option<u64> {
+        self.max_blobs_per_tx
     }
 
     fn max_code_size(&self) -> usize {
@@ -318,6 +318,6 @@ mod test {
     #[test]
     fn blob_max_and_target_count() {
         let cfg: CfgEnv = Default::default();
-        assert_eq!(cfg.blob_max_count(), None);
+        assert_eq!(cfg.max_blobs_per_tx(), None);
     }
 }

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -172,7 +172,7 @@ pub fn validate_tx_env<CTX: ContextTr, Error>(
                 tx.blob_versioned_hashes(),
                 tx.max_fee_per_blob_gas(),
                 context.block().blob_gasprice().unwrap_or_default(),
-                context.cfg().blob_max_count(),
+                context.cfg().max_blobs_per_tx(),
             )?;
         }
         TransactionType::Eip7702 => {


### PR DESCRIPTION
No behavior changes, just renames this as preparation for integration of 

https://github.com/ethereum/EIPs/pull/9623
https://github.com/alloy-rs/alloy/pull/2564

Which defines a separate value for max number of blobs per tx
