### PR TITLE
chore: rename `transact` methods

### DIFF
--- a/bins/revme/src/cmd/bench/analysis.rs
+++ b/bins/revme/src/cmd/bench/analysis.rs
@@ -29,7 +29,7 @@ pub fn run(criterion: &mut Criterion) {
                 tx.clone()
             },
             |input| {
-                let _ = evm.transact(input);
+                let _ = evm.transact_one(input);
             },
             criterion::BatchSize::SmallInput,
         );

--- a/bins/revme/src/cmd/bench/burntpix.rs
+++ b/bins/revme/src/cmd/bench/burntpix.rs
@@ -56,7 +56,7 @@ pub fn run(criterion: &mut Criterion) {
                 tx.clone()
             },
             |input| {
-                evm.transact(input).unwrap();
+                evm.transact_one(input).unwrap();
             },
             criterion::BatchSize::SmallInput,
         );

--- a/bins/revme/src/cmd/bench/gas_cost_estimator.rs
+++ b/bins/revme/src/cmd/bench/gas_cost_estimator.rs
@@ -40,7 +40,7 @@ pub fn run(criterion: &mut Criterion) {
                     tx.clone()
                 },
                 |input| {
-                    let _ = evm.transact(input).unwrap();
+                    let _ = evm.transact_one(input).unwrap();
                 },
                 criterion::BatchSize::SmallInput,
             );

--- a/bins/revme/src/cmd/bench/snailtracer.rs
+++ b/bins/revme/src/cmd/bench/snailtracer.rs
@@ -30,7 +30,7 @@ pub fn run(criterion: &mut Criterion) {
                 tx.clone()
             },
             |input| {
-                let _ = evm.transact(input).unwrap();
+                let _ = evm.transact_one(input).unwrap();
             },
             criterion::BatchSize::SmallInput,
         );

--- a/bins/revme/src/cmd/bench/transfer.rs
+++ b/bins/revme/src/cmd/bench/transfer.rs
@@ -34,7 +34,7 @@ pub fn run(criterion: &mut Criterion) {
             },
             |input| {
                 i += 1;
-                evm.transact(input).unwrap();
+                evm.transact_one(input).unwrap();
             },
             criterion::BatchSize::SmallInput,
         );

--- a/bins/revme/src/cmd/bench/transfer_multi.rs
+++ b/bins/revme/src/cmd/bench/transfer_multi.rs
@@ -73,7 +73,7 @@ pub fn run(criterion: &mut Criterion) {
             },
             |inputs| {
                 for (i, tx) in inputs.into_iter().enumerate() {
-                    let _ = evm.transact(tx).unwrap();
+                    let _ = evm.transact_one(tx).unwrap();
                     if i % 40 == 0 {
                         evm.commit_inner();
                     }

--- a/bins/revme/src/cmd/evmrunner.rs
+++ b/bins/revme/src/cmd/evmrunner.rs
@@ -103,7 +103,7 @@ impl Cmd {
             let mut criterion_group = criterion.benchmark_group("revme");
             criterion_group.bench_function("evm", |b| {
                 b.iter(|| {
-                    let _ = evm.transact_finalize(tx.clone()).unwrap();
+                    let _ = evm.transact(tx.clone()).unwrap();
                 })
             });
             criterion_group.finish();
@@ -118,7 +118,7 @@ impl Cmd {
                 .state
         } else {
             let out = evm
-                .transact_finalize(tx.clone())
+                .transact(tx.clone())
                 .map_err(|_| Errors::EVMError)?;
             println!("Result: {:#?}", out.result);
             out.state

--- a/bins/revme/src/cmd/evmrunner.rs
+++ b/bins/revme/src/cmd/evmrunner.rs
@@ -117,9 +117,7 @@ impl Cmd {
                 .map_err(|_| Errors::EVMError)?
                 .state
         } else {
-            let out = evm
-                .transact(tx.clone())
-                .map_err(|_| Errors::EVMError)?;
+            let out = evm.transact(tx.clone()).map_err(|_| Errors::EVMError)?;
             println!("Result: {:#?}", out.result);
             out.state
         };

--- a/bins/revme/src/cmd/evmrunner.rs
+++ b/bins/revme/src/cmd/evmrunner.rs
@@ -113,7 +113,7 @@ impl Cmd {
 
         let time = Instant::now();
         let state = if self.trace {
-            evm.inspect_tx_finalize(tx.clone())
+            evm.inspect_tx(tx.clone())
                 .map_err(|_| Errors::EVMError)?
                 .state
         } else {

--- a/crates/context/interface/src/result.rs
+++ b/crates/context/interface/src/result.rs
@@ -11,6 +11,7 @@ use crate::transaction::TransactionError;
 use core::fmt::{self, Debug};
 use database_interface::DBErrorMarker;
 use primitives::{Address, Bytes, Log, U256};
+use state::EvmState;
 use std::{boxed::Box, string::String, vec::Vec};
 
 /// Trait for the halt reason.
@@ -21,7 +22,7 @@ impl<T> HaltReasonTr for T where T: Clone + Debug + PartialEq + Eq + From<HaltRe
 /// Tuple containing evm execution result and state.s
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ResultAndState<R, S> {
+pub struct ResultAndState<R, S = EvmState> {
     /// Execution result
     pub result: R,
     /// Output State.

--- a/crates/handler/src/api.rs
+++ b/crates/handler/src/api.rs
@@ -81,7 +81,7 @@ pub trait ExecuteEvm {
     /// If any transaction fails, the journal is finalized and the last error is returned.
     ///
     /// TODO add tx index to the error.
-    fn transact_multi(
+    fn transact_many(
         &mut self,
         txs: impl Iterator<Item = Self::Tx>,
     ) -> Result<Vec<Self::ExecutionResult>, Self::Error> {
@@ -98,12 +98,12 @@ pub trait ExecuteEvm {
     ///
     /// Internally calls [`ExecuteEvm::transact_multi`] followed by [`ExecuteEvm::finalize`].
     //#[allow(clippy::type_complexity)]
-    fn transact_multi_finalize(
+    fn transact_many_finalize(
         &mut self,
         txs: impl Iterator<Item = Self::Tx>,
     ) -> Result<ResultVecAndState<Self::ExecutionResult, Self::State>, Self::Error> {
         // on error transact_multi will clear the journal
-        let result = self.transact_multi(txs)?;
+        let result = self.transact_many(txs)?;
         let state = self.finalize();
         Ok(ResultAndState::new(result, state))
     }
@@ -138,11 +138,11 @@ pub trait ExecuteCommitEvm: ExecuteEvm {
     /// Transact multiple transactions and commit to the state.
     ///
     /// Internally calls `transact_multi` and `commit` functions.
-    fn transact_multi_commit(
+    fn transact_many_commit(
         &mut self,
         txs: impl Iterator<Item = Self::Tx>,
     ) -> Result<Vec<Self::ExecutionResult>, Self::Error> {
-        let outputs = self.transact_multi(txs)?;
+        let outputs = self.transact_many(txs)?;
         self.commit_inner();
         Ok(outputs)
     }

--- a/crates/handler/src/mainnet_builder.rs
+++ b/crates/handler/src/mainnet_builder.rs
@@ -98,7 +98,7 @@ mod test {
         let mut evm = ctx.build_mainnet();
 
         let state = evm
-            .transact_finalize(TxEnv {
+            .transact(TxEnv {
                 tx_type: TransactionType::Eip7702.into(),
                 gas_limit: 100_000,
                 authorization_list: vec![Either::Left(auth)],

--- a/crates/inspector/src/gas.rs
+++ b/crates/inspector/src/gas.rs
@@ -145,7 +145,7 @@ mod tests {
         let mut evm = ctx.build_mainnet_with_inspector(StackInspector::default());
 
         // Run evm.
-        evm.inspect_tx(TxEnv {
+        evm.inspect_one_tx(TxEnv {
             caller: BENCH_CALLER,
             kind: TxKind::Call(BENCH_TARGET),
             gas_limit: 21100,
@@ -256,7 +256,7 @@ mod tests {
         let mut evm = ctx.build_mainnet_with_inspector(inspector);
 
         let _ = evm
-            .inspect_tx(TxEnv {
+            .inspect_one_tx(TxEnv {
                 caller: BENCH_CALLER,
                 kind: TxKind::Call(BENCH_TARGET),
                 ..Default::default()

--- a/crates/inspector/src/inspect.rs
+++ b/crates/inspector/src/inspect.rs
@@ -16,14 +16,14 @@ pub trait InspectEvm: ExecuteEvm {
     fn set_inspector(&mut self, inspector: Self::Inspector);
 
     /// Inspect the EVM with the given transaction.
-    fn inspect_tx(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error>;
+    fn inspect_one_tx(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error>;
 
     /// Inspect the EVM and finalize the state.
-    fn inspect_tx_finalize(
+    fn inspect_tx(
         &mut self,
         tx: Self::Tx,
     ) -> Result<ResultAndState<Self::ExecutionResult, Self::State>, Self::Error> {
-        let output = self.inspect_tx(tx)?;
+        let output = self.inspect_one_tx(tx)?;
         let state = self.finalize();
         Ok(ResultAndState::new(output, state))
     }
@@ -46,7 +46,7 @@ pub trait InspectEvm: ExecuteEvm {
         inspector: Self::Inspector,
     ) -> Result<Self::ExecutionResult, Self::Error> {
         self.set_inspector(inspector);
-        self.inspect_tx(tx)
+        self.inspect_one_tx(tx)
     }
 }
 
@@ -58,7 +58,7 @@ pub trait InspectCommitEvm: InspectEvm + ExecuteCommitEvm {
     /// Inspect the EVM with the current inspector and previous transaction by replaying,similar to [`InspectEvm::inspect_tx`]
     /// and commit the state diff to the database.
     fn inspect_tx_commit(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
-        let output = self.inspect_tx(tx)?;
+        let output = self.inspect_one_tx(tx)?;
         self.commit_inner();
         Ok(output)
     }

--- a/crates/inspector/src/inspect.rs
+++ b/crates/inspector/src/inspect.rs
@@ -29,18 +29,18 @@ pub trait InspectEvm: ExecuteEvm {
     }
 
     /// Inspect the EVM with the given inspector and transaction, and finalize the state.
-    fn inspect_finalize(
+    fn inspect(
         &mut self,
         tx: Self::Tx,
         inspector: Self::Inspector,
     ) -> Result<ResultAndState<Self::ExecutionResult, Self::State>, Self::Error> {
-        let output = self.inspect(tx, inspector)?;
+        let output = self.inspect_one(tx, inspector)?;
         let state = self.finalize();
         Ok(ResultAndState::new(output, state))
     }
 
     /// Inspect the EVM with the given inspector and transaction.
-    fn inspect(
+    fn inspect_one(
         &mut self,
         tx: Self::Tx,
         inspector: Self::Inspector,
@@ -70,7 +70,7 @@ pub trait InspectCommitEvm: InspectEvm + ExecuteCommitEvm {
         tx: Self::Tx,
         inspector: Self::Inspector,
     ) -> Result<Self::ExecutionResult, Self::Error> {
-        let output = self.inspect(tx, inspector)?;
+        let output = self.inspect_one(tx, inspector)?;
         self.commit_inner();
         Ok(output)
     }

--- a/crates/inspector/src/mainnet_inspect.rs
+++ b/crates/inspector/src/mainnet_inspect.rs
@@ -43,7 +43,7 @@ where
         self.inspector = inspector;
     }
 
-    fn inspect_tx(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
+    fn inspect_one_tx(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
         self.set_tx(tx);
         let mut t = MainnetHandler::<_, _, EthFrame<_, _, _>> {
             _phantom: core::marker::PhantomData,

--- a/crates/op-revm/src/api/default_ctx.rs
+++ b/crates/op-revm/src/api/default_ctx.rs
@@ -42,6 +42,6 @@ mod test {
         // execute
         let _ = evm.transact(OpTransaction::default());
         // inspect
-        let _ = evm.inspect_tx(OpTransaction::default());
+        let _ = evm.inspect_one_tx(OpTransaction::default());
     }
 }

--- a/crates/op-revm/src/api/default_ctx.rs
+++ b/crates/op-revm/src/api/default_ctx.rs
@@ -40,7 +40,7 @@ mod test {
         // convert to optimism context
         let mut evm = ctx.build_op_with_inspector(NoOpInspector {});
         // execute
-        let _ = evm.transact_finalize(OpTransaction::default());
+        let _ = evm.transact(OpTransaction::default());
         // inspect
         let _ = evm.inspect_tx(OpTransaction::default());
     }

--- a/crates/op-revm/src/api/exec.rs
+++ b/crates/op-revm/src/api/exec.rs
@@ -60,7 +60,7 @@ where
         self.0.ctx.set_block(block);
     }
 
-    fn transact(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
+    fn transact_one(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
         self.0.ctx.set_tx(tx);
         let mut h = OpHandler::<_, _, EthFrame<_, _, _>>::new();
         h.run(self)

--- a/crates/op-revm/src/api/exec.rs
+++ b/crates/op-revm/src/api/exec.rs
@@ -105,7 +105,7 @@ where
         self.0.inspector = inspector;
     }
 
-    fn inspect_tx(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
+    fn inspect_one_tx(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
         self.0.ctx.set_tx(tx);
         let mut h = OpHandler::<_, _, EthFrame<_, _, _>>::new();
         h.inspect_run(self)

--- a/crates/op-revm/src/fast_lz.rs
+++ b/crates/op-revm/src/fast_lz.rs
@@ -182,7 +182,7 @@ mod tests {
         tx.base.gas_limit = 3_000_000;
         tx.enveloped_tx = Some(Bytes::default());
 
-        let result = evm.transact(tx).unwrap();
+        let result = evm.transact_one(tx).unwrap();
 
         let output = result.output().unwrap();
         let evm_val = FastLz::fastLzCall::abi_decode_returns(output).unwrap();

--- a/crates/op-revm/tests/integration.rs
+++ b/crates/op-revm/tests/integration.rs
@@ -771,7 +771,7 @@ fn test_log_inspector() {
     };
 
     // Run evm.
-    let output = evm.inspect_tx_finalize(tx).unwrap();
+    let output = evm.inspect_tx(tx).unwrap();
 
     let inspector = &evm.0.inspector;
     assert!(!inspector.logs.is_empty());

--- a/crates/revm/tests/integration.rs
+++ b/crates/revm/tests/integration.rs
@@ -34,7 +34,7 @@ fn test_selfdestruct_multi_tx() {
 
     // trigger selfdestruct
     let result1 = evm
-        .transact(TxEnv::builder_for_bench().build_fill())
+        .transact_one(TxEnv::builder_for_bench().build_fill())
         .unwrap();
 
     let destroyed_acc = evm.ctx.journal_mut().state.get_mut(&BENCH_TARGET).unwrap();
@@ -49,7 +49,7 @@ fn test_selfdestruct_multi_tx() {
 
     // call on destroyed account. This accounts gets loaded and should contain empty code_hash afterwards.
     let result2 = evm
-        .transact(TxEnv::builder_for_bench().nonce(1).build_fill())
+        .transact_one(TxEnv::builder_for_bench().nonce(1).build_fill())
         .unwrap();
 
     let destroyed_acc = evm.ctx.journal_mut().state.get_mut(&BENCH_TARGET).unwrap();
@@ -77,7 +77,7 @@ pub fn test_multi_tx_create() {
         .build_mainnet();
 
     let result1 = evm
-        .transact(
+        .transact_one(
             TxEnv::builder_for_bench()
                 .kind(TxKind::Create)
                 .data(deployment_contract(SELFDESTRUCT_BYTECODE))
@@ -103,7 +103,7 @@ pub fn test_multi_tx_create() {
     );
 
     let result2 = evm
-        .transact(
+        .transact_one(
             TxEnv::builder_for_bench()
                 .nonce(1)
                 .kind(TxKind::Call(created_address))
@@ -139,7 +139,7 @@ pub fn test_multi_tx_create() {
 
     // re create the contract.
     let result3 = evm
-        .transact(
+        .transact_one(
             TxEnv::builder_for_bench()
                 .nonce(0)
                 .kind(TxKind::Create)

--- a/examples/block_traces/src/main.rs
+++ b/examples/block_traces/src/main.rs
@@ -148,7 +148,7 @@ async fn main() -> anyhow::Result<()> {
         let writer = FlushWriter::new(Arc::clone(&inner));
 
         // Inspect and commit the transaction to the EVM
-        let res: Result<_, _> = evm.inspect(tx, TracerEip3155::new(Box::new(writer)));
+        let res: Result<_, _> = evm.inspect_one(tx, TracerEip3155::new(Box::new(writer)));
 
         if let Err(error) = res {
             println!("Got error: {:?}", error);

--- a/examples/cheatcode_inspector/src/main.rs
+++ b/examples/cheatcode_inspector/src/main.rs
@@ -545,7 +545,7 @@ where
         PrecompileT::default(),
     );
 
-    let state = evm.inspect_tx_finalize(tx)?.state;
+    let state = evm.inspect_tx(tx)?.state;
 
     // Persist the changes to the original backend.
     backend.journaled_state.database.commit(state);
@@ -598,7 +598,7 @@ fn main() -> anyhow::Result<()> {
         EthInstructions::default(),
         EthPrecompiles::default(),
     );
-    evm.inspect_tx_finalize(tx)?;
+    evm.inspect_tx(tx)?;
 
     // Sanity check
     assert_eq!(evm.inspector.call_count, 2);

--- a/examples/contract_deployment/src/main.rs
+++ b/examples/contract_deployment/src/main.rs
@@ -66,7 +66,7 @@ fn main() -> anyhow::Result<()> {
     };
 
     println!("Created contract at {address}");
-    let output = evm.transact_finalize(TxEnv {
+    let output = evm.transact(TxEnv {
         kind: TxKind::Call(address),
         data: Default::default(),
         nonce: 1,

--- a/examples/custom_opcodes/src/main.rs
+++ b/examples/custom_opcodes/src/main.rs
@@ -49,7 +49,7 @@ pub fn main() {
         .with_inspector(TracerEip3155::new_stdout().without_summary());
 
     // inspect the transaction.
-    let _ = evm.inspect_tx(TxEnv {
+    let _ = evm.inspect_one_tx(TxEnv {
         kind: TxKind::Call(BENCH_TARGET),
         ..Default::default()
     });

--- a/examples/my_evm/src/api.rs
+++ b/examples/my_evm/src/api.rs
@@ -78,7 +78,7 @@ where
         self.0.inspector = inspector;
     }
 
-    fn inspect_tx(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
+    fn inspect_one_tx(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
         self.0.ctx.set_tx(tx);
         let mut handler = MyHandler::default();
         handler.inspect_run(self)

--- a/examples/my_evm/src/api.rs
+++ b/examples/my_evm/src/api.rs
@@ -35,7 +35,7 @@ where
         self.0.ctx.set_block(block);
     }
 
-    fn transact(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
+    fn transact_one(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
         self.0.ctx.set_tx(tx);
         let mut handler = MyHandler::default();
         handler.run(self)

--- a/examples/my_evm/src/main.rs
+++ b/examples/my_evm/src/main.rs
@@ -22,7 +22,7 @@ pub fn main() {
 
     // Evm Execute example
     let mut my_evm = MyEvm::new(Context::mainnet(), ());
-    let _result = my_evm.transact(TxEnv::default());
+    let _result = my_evm.transact_one(TxEnv::default());
     // or if you want to obtain the state by finalizing execution
     let _state = my_evm.finalize();
 

--- a/examples/uniswap_get_reserves/src/main.rs
+++ b/examples/uniswap_get_reserves/src/main.rs
@@ -70,7 +70,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Execute transaction without writing to the DB
     let result = evm
-        .transact(TxEnv {
+        .transact_one(TxEnv {
             // fill in missing bits of env struct
             // change that to whatever caller you want to be
             caller: address!("0000000000000000000000000000000000000000"),

--- a/examples/uniswap_v2_usdc_swap/src/main.rs
+++ b/examples/uniswap_v2_usdc_swap/src/main.rs
@@ -95,7 +95,7 @@ fn balance_of(token: Address, address: Address, alloy_db: &mut AlloyCacheDB) -> 
     let mut evm = Context::mainnet().with_db(alloy_db).build_mainnet();
 
     let result = evm
-        .transact(TxEnv {
+        .transact_one(TxEnv {
             // 0x1 because calling USDC proxy from zero address fails
             caller: address!("0000000000000000000000000000000000000001"),
             kind: TxKind::Call(token),
@@ -139,7 +139,7 @@ async fn get_amount_out(
     let mut evm = Context::mainnet().with_db(cache_db).build_mainnet();
 
     let result = evm
-        .transact(TxEnv {
+        .transact_one(TxEnv {
             caller: address!("0000000000000000000000000000000000000000"),
             kind: TxKind::Call(uniswap_v2_router),
             data: encoded.into(),
@@ -171,7 +171,7 @@ fn get_reserves(pair_address: Address, cache_db: &mut AlloyCacheDB) -> Result<(U
     let mut evm = Context::mainnet().with_db(cache_db).build_mainnet();
 
     let result = evm
-        .transact(TxEnv {
+        .transact_one(TxEnv {
             caller: address!("0000000000000000000000000000000000000000"),
             kind: TxKind::Call(pair_address),
             data: encoded.into(),


### PR DESCRIPTION
transact -> transact_one
transact_finalize -> transact
transact_multi -> transact_many