### PR TITLE
perf: faster JumpTable bits lookup

### DIFF
--- a/crates/bytecode/src/legacy/analysis.rs
+++ b/crates/bytecode/src/legacy/analysis.rs
@@ -2,7 +2,7 @@ use super::JumpTable;
 use crate::opcode;
 use bitvec::{bitvec, order::Lsb0, vec::BitVec};
 use primitives::Bytes;
-use std::{sync::Arc, vec, vec::Vec};
+use std::{vec, vec::Vec};
 
 /// Analyze the bytecode to find the jumpdests. Used to create a jump table
 /// that is needed for [`crate::LegacyAnalyzedBytecode`].
@@ -54,9 +54,9 @@ pub fn analyze_legacy(bytecode: Bytes) -> (JumpTable, Bytes) {
         let mut padded_bytecode = Vec::with_capacity(bytecode.len() + padding_size);
         padded_bytecode.extend_from_slice(&bytecode);
         padded_bytecode.extend(vec![0; padding_size]);
-        (JumpTable(Arc::new(jumps)), Bytes::from(padded_bytecode))
+        (JumpTable::new(jumps), Bytes::from(padded_bytecode))
     } else {
-        (JumpTable(Arc::new(jumps)), bytecode)
+        (JumpTable::new(jumps), bytecode)
     }
 }
 
@@ -110,14 +110,14 @@ mod tests {
     fn test_bytecode_with_jumpdest_at_start() {
         let bytecode = vec![opcode::JUMPDEST, opcode::PUSH1, 0x01, opcode::STOP];
         let (jump_table, _) = analyze_legacy(bytecode.clone().into());
-        assert!(jump_table.0[0]); // First byte should be a valid jumpdest
+        assert!(jump_table.table[0]); // First byte should be a valid jumpdest
     }
 
     #[test]
     fn test_bytecode_with_jumpdest_after_push() {
         let bytecode = vec![opcode::PUSH1, 0x01, opcode::JUMPDEST, opcode::STOP];
         let (jump_table, _) = analyze_legacy(bytecode.clone().into());
-        assert!(jump_table.0[2]); // JUMPDEST should be at position 2
+        assert!(jump_table.table[2]); // JUMPDEST should be at position 2
     }
 
     #[test]
@@ -130,8 +130,8 @@ mod tests {
             opcode::STOP,
         ];
         let (jump_table, _) = analyze_legacy(bytecode.clone().into());
-        assert!(jump_table.0[0]); // First JUMPDEST
-        assert!(jump_table.0[3]); // Second JUMPDEST
+        assert!(jump_table.table[0]); // First JUMPDEST
+        assert!(jump_table.table[3]); // Second JUMPDEST
     }
 
     #[test]
@@ -145,7 +145,7 @@ mod tests {
     fn test_bytecode_with_invalid_opcode() {
         let bytecode = vec![0xFF, opcode::STOP]; // 0xFF is an invalid opcode
         let (jump_table, _) = analyze_legacy(bytecode.clone().into());
-        assert!(!jump_table.0[0]); // Invalid opcode should not be a jumpdest
+        assert!(!jump_table.table[0]); // Invalid opcode should not be a jumpdest
     }
 
     #[test]
@@ -165,9 +165,9 @@ mod tests {
         ];
         let (jump_table, padded_bytecode) = analyze_legacy(bytecode.clone().into());
         assert_eq!(padded_bytecode.len(), bytecode.len());
-        assert!(!jump_table.0[0]); // PUSH1
-        assert!(!jump_table.0[2]); // PUSH2
-        assert!(!jump_table.0[5]); // PUSH4
+        assert!(!jump_table.table[0]); // PUSH1
+        assert!(!jump_table.table[2]); // PUSH2
+        assert!(!jump_table.table[5]); // PUSH4
     }
 
     #[test]
@@ -179,6 +179,6 @@ mod tests {
             opcode::STOP,
         ];
         let (jump_table, _) = analyze_legacy(bytecode.clone().into());
-        assert!(!jump_table.0[1]); // JUMPDEST in push data should not be valid
+        assert!(!jump_table.table[1]); // JUMPDEST in push data should not be valid
     }
 }

--- a/crates/bytecode/src/legacy/analyzed.rs
+++ b/crates/bytecode/src/legacy/analyzed.rs
@@ -60,11 +60,10 @@ impl LegacyAnalyzedBytecode {
         if original_len > bytecode.len() {
             panic!("original_len is greater than bytecode length");
         }
-        if original_len > jump_table.0.len() {
+        if original_len > jump_table.len {
             panic!(
                 "jump table length {} is less than original length {}",
-                jump_table.0.len(),
-                original_len
+                jump_table.len, original_len
             );
         }
 
@@ -116,7 +115,6 @@ mod tests {
     use super::*;
     use crate::{opcode, LegacyRawBytecode};
     use bitvec::{bitvec, order::Lsb0};
-    use std::sync::Arc;
 
     #[test]
     fn test_bytecode_new() {
@@ -142,7 +140,7 @@ mod tests {
     fn test_panic_on_short_jump_table() {
         let bytecode = Bytes::from_static(&[opcode::PUSH1, 0x01]);
         let bytecode = LegacyRawBytecode(bytecode).into_analyzed();
-        let jump_table = JumpTable(Arc::new(bitvec![u8, Lsb0; 0; 1]));
+        let jump_table = JumpTable::new(bitvec![u8, Lsb0; 0; 1]);
         let _ = LegacyAnalyzedBytecode::new(bytecode.bytecode, bytecode.original_len, jump_table);
     }
 
@@ -150,7 +148,7 @@ mod tests {
     #[should_panic(expected = "last bytecode byte should be STOP (0x00)")]
     fn test_panic_on_non_stop_bytecode() {
         let bytecode = Bytes::from_static(&[opcode::PUSH1, 0x01]);
-        let jump_table = JumpTable(Arc::new(bitvec![u8, Lsb0; 0; 2]));
+        let jump_table = JumpTable::new(bitvec![u8, Lsb0; 0; 2]);
         let _ = LegacyAnalyzedBytecode::new(bytecode, 2, jump_table);
     }
 
@@ -158,7 +156,7 @@ mod tests {
     #[should_panic(expected = "bytecode cannot be empty")]
     fn test_panic_on_empty_bytecode() {
         let bytecode = Bytes::from_static(&[]);
-        let jump_table = JumpTable(Arc::new(bitvec![u8, Lsb0; 0; 0]));
+        let jump_table = JumpTable::new(bitvec![u8, Lsb0; 0; 0]);
         let _ = LegacyAnalyzedBytecode::new(bytecode, 0, jump_table);
     }
 }

--- a/crates/bytecode/src/legacy/jump_map.rs
+++ b/crates/bytecode/src/legacy/jump_map.rs
@@ -50,7 +50,7 @@ impl Default for JumpTable {
 }
 
 impl JumpTable {
-    // Create new JumpTable directly from an existing BitVec.
+    /// Create new JumpTable directly from an existing BitVec.
     pub fn new(jumps: BitVec<u8>) -> Self {
         let table = Arc::new(jumps);
         let cached = table.as_raw_slice().as_ptr();

--- a/crates/bytecode/src/legacy/jump_map.rs
+++ b/crates/bytecode/src/legacy/jump_map.rs
@@ -5,13 +5,36 @@ use std::{fmt::Debug, sync::Arc};
 
 /// A table of valid `jump` destinations. Cheap to clone and memory efficient, one bit per opcode.
 #[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct JumpTable(pub Arc<BitVec<u8>>);
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+pub struct JumpTable {
+    /// Actual bit vec
+    pub table: Arc<BitVec<u8>>,
+    /// Fast pointer that skips Arc overhead
+    #[cfg_attr(feature = "serde", serde(skip))]
+    cached: *const u8,
+    /// Number of bits in the table
+    pub len: usize,
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for JumpTable {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let bitvec = BitVec::deserialize(deserializer)?;
+        Ok(Self::new(bitvec))
+    }
+}
+
+// SAFETY: BitVec data is immutable through Arc, pointer won't be invalidated
+unsafe impl Send for JumpTable {}
+unsafe impl Sync for JumpTable {}
 
 impl Debug for JumpTable {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("JumpTable")
-            .field("map", &hex::encode(self.0.as_raw_slice()))
+            .field("map", &hex::encode(self.table.as_raw_slice()))
             .finish()
     }
 }
@@ -20,15 +43,26 @@ impl Default for JumpTable {
     #[inline]
     fn default() -> Self {
         static DEFAULT: OnceBox<JumpTable> = OnceBox::new();
-        DEFAULT.get_or_init(|| Self(Arc::default()).into()).clone()
+        DEFAULT
+            .get_or_init(|| Self::new(BitVec::default()).into())
+            .clone()
     }
 }
 
 impl JumpTable {
+    // Create new JumpTable directly from an existing BitVec.
+    pub fn new(jumps: BitVec<u8>) -> Self {
+        let table = Arc::new(jumps);
+        let cached = table.as_raw_slice().as_ptr();
+        let len = table.len();
+
+        Self { table, cached, len }
+    }
+
     /// Gets the raw bytes of the jump map.
     #[inline]
     pub fn as_slice(&self) -> &[u8] {
-        self.0.as_raw_slice()
+        self.table.as_raw_slice()
     }
 
     /// Constructs a jump map from raw bytes and length.
@@ -40,21 +74,28 @@ impl JumpTable {
     /// Panics if number of bits in slice is less than bit_len.
     #[inline]
     pub fn from_slice(slice: &[u8], bit_len: usize) -> Self {
+        const BYTE_LEN: usize = 8;
         assert!(
-            slice.len() * 8 >= bit_len,
+            slice.len() * BYTE_LEN >= bit_len,
             "slice bit length {} is less than bit_len {}",
-            slice.len() * 8,
+            slice.len() * BYTE_LEN,
             bit_len
         );
         let mut bitvec = BitVec::from_slice(slice);
         unsafe { bitvec.set_len(bit_len) };
-        Self(Arc::new(bitvec))
+
+        let table = Arc::new(bitvec);
+        let cached = table.as_raw_slice().as_ptr();
+        let len = table.len();
+
+        Self { table, cached, len }
     }
 
     /// Checks if `pc` is a valid jump destination.
+    /// Uses cached pointer and bit operations for faster access
     #[inline]
     pub fn is_valid(&self, pc: usize) -> bool {
-        pc < self.0.len() && unsafe { *self.0.get_unchecked(pc) }
+        pc < self.len && unsafe { *self.cached.add(pc >> 3) & (1 << (pc & 7)) != 0 }
     }
 }
 
@@ -73,6 +114,169 @@ mod tests {
     fn test_jump_table_from_slice() {
         let slice = &[0x00];
         let jumptable = JumpTable::from_slice(slice, 3);
-        assert_eq!(jumptable.0.len(), 3);
+        assert_eq!(jumptable.len, 3);
+    }
+
+    #[test]
+    fn test_is_valid() {
+        let jump_table = JumpTable::from_slice(&[0x0D], 8);
+
+        assert_eq!(jump_table.len, 8);
+
+        assert_eq!(jump_table.is_valid(0), true);
+        assert_eq!(jump_table.is_valid(1), false);
+        assert_eq!(jump_table.is_valid(2), true);
+        assert_eq!(jump_table.is_valid(3), true);
+        assert_eq!(jump_table.is_valid(4), false);
+        assert_eq!(jump_table.is_valid(5), false);
+        assert_eq!(jump_table.is_valid(6), false);
+        assert_eq!(jump_table.is_valid(7), false);
+    }
+}
+
+#[cfg(test)]
+mod bench_is_valid {
+    use super::*;
+    use std::time::Instant;
+
+    const ITERATIONS: usize = 1_000_000;
+    const TEST_SIZE: usize = 10_000;
+
+    fn create_test_table() -> BitVec<u8> {
+        let mut bitvec = BitVec::from_vec(vec![0u8; (TEST_SIZE + 7) / 8]);
+        bitvec.resize(TEST_SIZE, false);
+        for i in (0..TEST_SIZE).step_by(3) {
+            bitvec.set(i, true);
+        }
+        bitvec
+    }
+
+    #[derive(Clone)]
+    pub(super) struct JumpTableWithArcDeref(pub Arc<BitVec<u8>>);
+
+    impl JumpTableWithArcDeref {
+        #[inline]
+        pub(super) fn is_valid(&self, pc: usize) -> bool {
+            pc < self.0.len() && unsafe { *self.0.get_unchecked(pc) }
+        }
+    }
+
+    fn benchmark_implementation<F>(name: &str, table: &F, test_fn: impl Fn(&F, usize) -> bool)
+    where
+        F: Clone,
+    {
+        // Warmup
+        for i in 0..10_000 {
+            std::hint::black_box(test_fn(table, i % TEST_SIZE));
+        }
+
+        let start = Instant::now();
+        let mut count = 0;
+
+        for i in 0..ITERATIONS {
+            if test_fn(table, i % TEST_SIZE) {
+                count += 1;
+            }
+        }
+
+        let duration = start.elapsed();
+        let ns_per_op = duration.as_nanos() as f64 / ITERATIONS as f64;
+        let ops_per_sec = ITERATIONS as f64 / duration.as_secs_f64();
+
+        println!("{} Performance:", name);
+        println!("  Time per op: {:.2} ns", ns_per_op);
+        println!("  Ops per sec: {:.0}", ops_per_sec);
+        println!("  True count: {}", count);
+        println!();
+
+        std::hint::black_box(count);
+    }
+
+    #[test]
+    fn bench_is_valid() {
+        println!("JumpTable is_valid() Benchmark Comparison");
+        println!("=========================================");
+
+        let bitvec = create_test_table();
+
+        // Test cached pointer implementation
+        let cached_table = JumpTable::new(bitvec.clone());
+        benchmark_implementation("JumpTable (Cached Pointer)", &cached_table, |table, pc| {
+            table.is_valid(pc)
+        });
+
+        // Test Arc deref implementation
+        let arc_table = JumpTableWithArcDeref(Arc::new(bitvec));
+        benchmark_implementation("JumpTableWithArcDeref (Arc)", &arc_table, |table, pc| {
+            table.is_valid(pc)
+        });
+
+        // Performance assertions
+        println!("Benchmark completed successfully!");
+    }
+
+    #[test]
+    fn bench_different_access_patterns() {
+        let bitvec = create_test_table();
+        let cached_table = JumpTable::new(bitvec.clone());
+        let arc_table = JumpTableWithArcDeref(Arc::new(bitvec));
+
+        println!("Access Pattern Comparison");
+        println!("========================");
+
+        // Sequential access
+        let start = Instant::now();
+        for i in 0..ITERATIONS {
+            std::hint::black_box(cached_table.is_valid(i % TEST_SIZE));
+        }
+        let cached_sequential = start.elapsed();
+
+        let start = Instant::now();
+        for i in 0..ITERATIONS {
+            std::hint::black_box(arc_table.is_valid(i % TEST_SIZE));
+        }
+        let arc_sequential = start.elapsed();
+
+        // Random access
+        let start = Instant::now();
+        for i in 0..ITERATIONS {
+            std::hint::black_box(cached_table.is_valid((i * 17) % TEST_SIZE));
+        }
+        let cached_random = start.elapsed();
+
+        let start = Instant::now();
+        for i in 0..ITERATIONS {
+            std::hint::black_box(arc_table.is_valid((i * 17) % TEST_SIZE));
+        }
+        let arc_random = start.elapsed();
+
+        println!("Sequential Access:");
+        println!(
+            "  Cached: {:.2} ns/op",
+            cached_sequential.as_nanos() as f64 / ITERATIONS as f64
+        );
+        println!(
+            "  Arc:    {:.2} ns/op",
+            arc_sequential.as_nanos() as f64 / ITERATIONS as f64
+        );
+        println!(
+            "  Speedup: {:.1}x",
+            arc_sequential.as_nanos() as f64 / cached_sequential.as_nanos() as f64
+        );
+
+        println!();
+        println!("Random Access:");
+        println!(
+            "  Cached: {:.2} ns/op",
+            cached_random.as_nanos() as f64 / ITERATIONS as f64
+        );
+        println!(
+            "  Arc:    {:.2} ns/op",
+            arc_random.as_nanos() as f64 / ITERATIONS as f64
+        );
+        println!(
+            "  Speedup: {:.1}x",
+            arc_random.as_nanos() as f64 / cached_random.as_nanos() as f64
+        );
     }
 }

--- a/crates/bytecode/src/legacy/jump_map.rs
+++ b/crates/bytecode/src/legacy/jump_map.rs
@@ -131,14 +131,14 @@ mod tests {
 
         assert_eq!(jump_table.len, 8);
 
-        assert_eq!(jump_table.is_valid(0), true);
-        assert_eq!(jump_table.is_valid(1), false);
-        assert_eq!(jump_table.is_valid(2), true);
-        assert_eq!(jump_table.is_valid(3), true);
-        assert_eq!(jump_table.is_valid(4), false);
-        assert_eq!(jump_table.is_valid(5), false);
-        assert_eq!(jump_table.is_valid(6), false);
-        assert_eq!(jump_table.is_valid(7), false);
+        assert!(jump_table.is_valid(0));
+        assert!(!jump_table.is_valid(1));
+        assert!(jump_table.is_valid(2));
+        assert!(jump_table.is_valid(3));
+        assert!(!jump_table.is_valid(4));
+        assert!(!jump_table.is_valid(5));
+        assert!(!jump_table.is_valid(6));
+        assert!(!jump_table.is_valid(7));
     }
 }
 
@@ -151,7 +151,7 @@ mod bench_is_valid {
     const TEST_SIZE: usize = 10_000;
 
     fn create_test_table() -> BitVec<u8> {
-        let mut bitvec = BitVec::from_vec(vec![0u8; (TEST_SIZE + 7) / 8]);
+        let mut bitvec = BitVec::from_vec(vec![0u8; TEST_SIZE.div_ceil(8)]);
         bitvec.resize(TEST_SIZE, false);
         for i in (0..TEST_SIZE).step_by(3) {
             bitvec.set(i, true);

--- a/crates/bytecode/src/legacy/jump_map.rs
+++ b/crates/bytecode/src/legacy/jump_map.rs
@@ -5,15 +5,23 @@ use std::{fmt::Debug, sync::Arc};
 
 /// A table of valid `jump` destinations. Cheap to clone and memory efficient, one bit per opcode.
 #[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct JumpTable {
     /// Actual bit vec
     pub table: Arc<BitVec<u8>>,
     /// Fast pointer that skips Arc overhead
-    #[cfg_attr(feature = "serde", serde(skip))]
     cached: *const u8,
     /// Number of bits in the table
     pub len: usize,
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for JumpTable {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.table.serialize(serializer)
+    }
 }
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
Cache `Arc<BitVec<u8>>` raw pointer and use bit operations for 7-8x performance improvement in `JumpTable` access/lookups via `is_valid`. Fixes https://github.com/bluealloy/revm/issues/2437

## Benchmark

Implementation    | Time per op | Ops/sec | Speedup
------------------|-------------|---------|--------
Cached Pointer    | 13.40 ns    | 74.6M   | 7.9x faster
Arc Deref         | 106.26 ns   | 9.4M    | baseline

Pattern     | Cached    | Arc       | Speedup
------------|-----------|-----------|--------
Sequential  | 16.44 ns  | 100.77 ns | 6.1x
Random      | 12.57 ns  | 98.48 ns  | 7.8x

Both sequential and random access patterns show 6-8x speedup. All tests pass with identical results

PS: I included the benchmark test so anyone can run see the result <3