### PR TITLE
feat(devnet2): revert double contract size limit change

### DIFF
--- a/crates/bytecode/src/eof/verification.rs
+++ b/crates/bytecode/src/eof/verification.rs
@@ -5,7 +5,7 @@ use crate::{
     opcode::{self, OPCODE_INFO},
     utils::{read_i16, read_u16},
 };
-use primitives::{constants::STACK_LIMIT, eip7907, Bytes};
+use primitives::{constants::STACK_LIMIT, eip3860, Bytes};
 
 use core::{convert::identity, mem};
 use std::{borrow::Cow, fmt, vec, vec::Vec};
@@ -21,7 +21,7 @@ pub fn validate_raw_eof_inner(
     raw: Bytes,
     first_code_type: Option<CodeType>,
 ) -> Result<Eof, EofError> {
-    if raw.len() > eip7907::MAX_INITCODE_SIZE {
+    if raw.len() > eip3860::MAX_INITCODE_SIZE {
         return Err(EofError::Decode(EofDecodeError::InvalidEOFSize));
     }
     let eof = Eof::decode(raw)?;

--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -1,7 +1,7 @@
 //! This module contains [`CfgEnv`] and implements [`Cfg`] trait for it.
 pub use context_interface::Cfg;
 
-use primitives::{eip170, eip3860, eip7825, eip7907, hardfork::SpecId};
+use primitives::{eip170, eip3860, eip7825, hardfork::SpecId};
 /// EVM configuration
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -188,13 +188,8 @@ impl<SPEC: Into<SpecId> + Copy> Cfg for CfgEnv<SPEC> {
     }
 
     fn max_code_size(&self) -> usize {
-        self.limit_contract_code_size.unwrap_or_else(|| {
-            if self.spec.into().is_enabled_in(SpecId::OSAKA) {
-                eip7907::MAX_CODE_SIZE
-            } else {
-                eip170::MAX_CODE_SIZE
-            }
-        })
+        self.limit_contract_code_size
+            .unwrap_or(eip170::MAX_CODE_SIZE)
     }
 
     fn max_initcode_size(&self) -> usize {
@@ -203,13 +198,7 @@ impl<SPEC: Into<SpecId> + Copy> Cfg for CfgEnv<SPEC> {
                 self.limit_contract_code_size
                     .map(|size| size.saturating_mul(2))
             })
-            .unwrap_or_else(|| {
-                if self.spec.into().is_enabled_in(SpecId::OSAKA) {
-                    eip7907::MAX_INITCODE_SIZE
-                } else {
-                    eip3860::MAX_INITCODE_SIZE
-                }
-            })
+            .unwrap_or(eip3860::MAX_INITCODE_SIZE)
     }
 
     fn is_eip3607_disabled(&self) -> bool {

--- a/crates/interpreter/src/lib.rs
+++ b/crates/interpreter/src/lib.rs
@@ -35,4 +35,4 @@ pub use interpreter_action::{
     EOFCreateInputs, EOFCreateKind, FrameInput, InterpreterAction,
 };
 pub use interpreter_types::InterpreterTypes;
-pub use primitives::{eip7907::MAX_CODE_SIZE, eip7907::MAX_INITCODE_SIZE};
+pub use primitives::eip3860;

--- a/crates/primitives/src/eip7907.rs
+++ b/crates/primitives/src/eip7907.rs
@@ -1,6 +1,0 @@
-//! TODO dont have specific EIP. It is part of: EIP-7907: Meter Contract Code Size And Increase Limit
-
-/// By default the limit is `0xC000` (49_152 bytes).
-pub const MAX_CODE_SIZE: usize = 0xC000;
-/// By default the limit is `0x12000` (73_728 bytes).
-pub const MAX_INITCODE_SIZE: usize = 0x12000;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -14,7 +14,6 @@ pub mod eip4844;
 pub mod eip7702;
 pub mod eip7823;
 pub mod eip7825;
-pub mod eip7907;
 pub mod eof;
 pub mod hardfork;
 


### PR DESCRIPTION
As discussed, this is getting removed from berlininterop devnet2