### PR TITLE
chore: build less stuff in codspeed ci

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           tool: cargo-codspeed
       - name: Build the benchmark target(s)
-        run: cargo codspeed build --profile profiling --workspace
+        run: cargo codspeed build --profile profiling --workspace --exclude '*example*'
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v3
         with:


### PR DESCRIPTION
--workspace builds all the examples with optimizations on which takes quite a bit in CI unnecessarily