### PR TITLE
chore: make CallInput default 0..0

### DIFF
--- a/crates/interpreter/src/interpreter_action/call_inputs.rs
+++ b/crates/interpreter/src/interpreter_action/call_inputs.rs
@@ -58,10 +58,9 @@ impl CallInput {
 }
 
 impl Default for CallInput {
-    /// Returns a default `CallInput` with an empty `Bytes`.
     #[inline]
     fn default() -> Self {
-        CallInput::Bytes(Bytes::default())
+        CallInput::SharedBuffer(0..0)
     }
 }
 


### PR DESCRIPTION
Makes it all zeros in memory, shouldnt make a difference otherwise