### PR TITLE
ci: rm op-revm from bench

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           tool: cargo-codspeed
       - name: Build the benchmark target(s)
-        run: cargo codspeed build --profile profiling --workspace --exclude '*example*'
+        run: cargo codspeed build --profile profiling --workspace --exclude '*example*' --exclude op-revm
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v3
         with:


### PR DESCRIPTION
slow, not a benchmark target