### PR TITLE
perf: optimize warm_preloaded_addresses reset

### DIFF
--- a/crates/context/src/journal.rs
+++ b/crates/context/src/journal.rs
@@ -144,9 +144,11 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
         self.inner.warm_preloaded_addresses.insert(address);
     }
 
-    fn warm_precompiles(&mut self, address: HashSet<Address>) {
-        self.inner.precompiles = address;
-        self.inner.warm_preloaded_addresses = self.inner.precompiles.clone();
+    fn warm_precompiles(&mut self, precompiles: HashSet<Address>) {
+        self.inner.precompiles = precompiles;
+        self.inner
+            .warm_preloaded_addresses
+            .clone_from(&self.inner.precompiles);
     }
 
     #[inline]

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -873,5 +873,5 @@ fn reset_preloaded_addresses(
     warm_preloaded_addresses: &mut HashSet<Address>,
     precompiles: &HashSet<Address>,
 ) {
-    warm_preloaded_addresses.retain(|a| precompiles.contains(a));
+    warm_preloaded_addresses.clone_from(precompiles);
 }

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -873,5 +873,8 @@ fn reset_preloaded_addresses(
     warm_preloaded_addresses: &mut HashSet<Address>,
     precompiles: &HashSet<Address>,
 ) {
+    if warm_preloaded_addresses.len() == precompiles.len() {
+        return;
+    }
     warm_preloaded_addresses.clone_from(precompiles);
 }

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -129,7 +129,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         // Load precompiles into warm_preloaded_addresses.
         // TODO for precompiles we can use max transaction_id so they are always touched warm loaded.
         // at least after state clear EIP.
-        warm_preloaded_addresses.clone_from(precompiles);
+        reset_preloaded_addresses(warm_preloaded_addresses, precompiles);
         // increment transaction id.
         *transaction_id += 1;
         logs.clear();
@@ -159,7 +159,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         *depth = 0;
         logs.clear();
         *transaction_id += 1;
-        warm_preloaded_addresses.clone_from(precompiles);
+        reset_preloaded_addresses(warm_preloaded_addresses, precompiles);
     }
 
     /// Take the [`EvmState`] and clears the journal by resetting it to initial state.
@@ -184,7 +184,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         // Spec is not changed. And it is always set again in execution.
         let _ = spec;
         // Load precompiles into warm_preloaded_addresses.
-        warm_preloaded_addresses.clone_from(precompiles);
+        reset_preloaded_addresses(warm_preloaded_addresses, precompiles);
 
         let state = mem::take(state);
         logs.clear();
@@ -867,4 +867,11 @@ pub fn sload_with_account<DB: Database, ENTRY: JournalEntryTr>(
     }
 
     Ok(StateLoad::new(value, is_cold))
+}
+
+fn reset_preloaded_addresses(
+    warm_preloaded_addresses: &mut HashSet<Address>,
+    precompiles: &HashSet<Address>,
+) {
+    warm_preloaded_addresses.retain(|a| precompiles.contains(a));
 }

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -873,7 +873,10 @@ fn reset_preloaded_addresses(
     warm_preloaded_addresses: &mut HashSet<Address>,
     precompiles: &HashSet<Address>,
 ) {
+    // `warm_preloaded_addresses` is append-only, and is initialized with `precompiles`.
+    // Avoid unnecessarily cloning if it hasn't changed.
     if warm_preloaded_addresses.len() == precompiles.len() {
+        debug_assert_eq!(warm_preloaded_addresses, precompiles);
         return;
     }
     warm_preloaded_addresses.clone_from(precompiles);


### PR DESCRIPTION
`cargo bench --profile dev --benches -p revme -- --test --nocapture | rg reset_preloaded_addresses` where yes is len == len:
- yes: 1028
- no: 2141

so decent enough for essentially a free comparison

