### PR TITLE
fix: change account state to None if NotExisting on insert_account_info

### DIFF
--- a/crates/database/src/in_memory_db.rs
+++ b/crates/database/src/in_memory_db.rs
@@ -133,7 +133,11 @@ impl<ExtDB> CacheDB<ExtDB> {
     /// Inserts account info but not override storage
     pub fn insert_account_info(&mut self, address: Address, mut info: AccountInfo) {
         self.insert_contract(&mut info);
-        self.cache.accounts.entry(address).or_default().info = info;
+        let account_entry = self.cache.accounts.entry(address).or_default();
+        account_entry.info = info;
+        if account_entry.account_state == AccountState::NotExisting {
+            account_entry.account_state = AccountState::None;
+        }
     }
 
     /// Wraps the cache in a [CacheDB], creating a nested cache.

--- a/crates/database/src/in_memory_db.rs
+++ b/crates/database/src/in_memory_db.rs
@@ -134,9 +134,9 @@ impl<ExtDB> CacheDB<ExtDB> {
     pub fn insert_account_info(&mut self, address: Address, mut info: AccountInfo) {
         self.insert_contract(&mut info);
         let account_entry = self.cache.accounts.entry(address).or_default();
-        account_entry.info = info;
+        account_entry.update_info(info);
         if account_entry.account_state == AccountState::NotExisting {
-            account_entry.account_state = AccountState::None;
+            account_entry.update_account_state(AccountState::None);
         }
     }
 
@@ -385,6 +385,16 @@ impl DbAccount {
         } else {
             Some(self.info.clone())
         }
+    }
+
+    #[inline(always)]
+    pub fn update_info(&mut self, info: AccountInfo) {
+        self.info = info;
+    }
+
+    #[inline(always)]
+    pub fn update_account_state(&mut self, account_state: AccountState) {
+        self.account_state = account_state;
     }
 }
 


### PR DESCRIPTION
This change fixes the error reported [here](https://t.me/c/1543757393/5408) and resolves issue #2626.

By setting the AccountState to None, this ensures correct behavior when the previous state before calling set_existing_account was None.