### PR TITLE
Fix typos in documentation comments

### DIFF
--- a/crates/bytecode/src/eof.rs
+++ b/crates/bytecode/src/eof.rs
@@ -7,7 +7,7 @@ mod body;
 mod code_info;
 mod decode_helpers;
 mod header;
-/// Pritty printer for the EOF bytecode. Enabled by `std` feature.
+/// Pretty printer for the EOF bytecode. Enabled by `std` feature.
 pub mod printer;
 /// Verification logic for the EOF bytecode.
 pub mod verification;

--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -208,7 +208,7 @@ impl<DB: Database> State<DB> {
     }
 
     // TODO : Make cache aware of transitions dropping by having global transition counter.
-    /// Takess the [`BundleState`] changeset from the [`State`], replacing it
+    /// Takes the [`BundleState`] changeset from the [`State`], replacing it
     /// with an empty one.
     ///
     /// This will not apply any pending [`TransitionState`].

--- a/crates/handler/src/api.rs
+++ b/crates/handler/src/api.rs
@@ -110,7 +110,7 @@ pub trait ExecuteEvm {
 
     /// Execute previous transaction and finalize it.
     ///
-    /// Doint it without finalization
+    /// Doing it without finalization
     fn replay(
         &mut self,
     ) -> Result<ExecResultAndState<Self::ExecutionResult, Self::State>, Self::Error>;

--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -111,7 +111,7 @@ pub trait Handler {
     /// It is used to call a system contracts and it skips all the `validation` and `pre-execution` and most of `post-execution` phases.
     /// For example it will not deduct the caller or reward the beneficiary.
     ///
-    /// State changs can be obtained by calling [`JournalTr::finalize`] method from the [`EvmTr::Context`].
+    /// State changes can be obtained by calling [`JournalTr::finalize`] method from the [`EvmTr::Context`].
     ///
     /// # Error handling
     ///


### PR DESCRIPTION
Corrected several typos in Rust doc comments across the codebase:
- Fixed "Pritty printer" to "Pretty printer" in crates/bytecode/src/eof.rs.
- Fixed "Doint it without finalization" to "Doing it without finalization" in crates/handler/src/api.rs.
- Fixed "State changs" to "State changes" in crates/handler/src/handler.rs.
These changes improve the clarity and professionalism of the documentation. No functional code was modified.