### PR TITLE
perf: store coinbase address separately to avoid cloning warm addresses in rare cases

### DIFF
--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -72,6 +72,9 @@ pub trait JournalTr {
     /// Warms the account.
     fn warm_account(&mut self, address: Address);
 
+    /// Warms the coinbase account.
+    fn warm_coinbase_account(&mut self, address: Address);
+
     /// Warms the precompiles.
     fn warm_precompiles(&mut self, addresses: HashSet<Address>);
 

--- a/crates/context/src/journal.rs
+++ b/crates/context/src/journal.rs
@@ -144,6 +144,10 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
         self.inner.warm_preloaded_addresses.insert(address);
     }
 
+    fn warm_coinbase_account(&mut self, address: Address) {
+        self.inner.warm_coinbase_address = Some(address);
+    }
+
     fn warm_precompiles(&mut self, precompiles: HashSet<Address>) {
         self.inner.precompiles = precompiles;
         self.inner

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -60,6 +60,8 @@ pub struct JournalInner<ENTRY> {
     /// Note that this not include newly loaded accounts, account and storage
     /// is considered warm if it is found in the `State`.
     pub warm_preloaded_addresses: HashSet<Address>,
+    /// Warm coinbase address, stored separately to avoid cloning preloaded addresses.
+    pub warm_coinbase_address: Option<Address>,
     /// Precompile addresses
     pub precompiles: HashSet<Address>,
 }
@@ -86,6 +88,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
             spec: SpecId::default(),
             warm_preloaded_addresses: HashSet::default(),
             precompiles: HashSet::default(),
+            warm_coinbase_address: None,
         }
     }
 
@@ -115,6 +118,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
             spec,
             warm_preloaded_addresses,
             precompiles,
+            warm_coinbase_address,
         } = self;
         // Spec precompiles and state are not changed. It is always set again execution.
         let _ = spec;
@@ -125,7 +129,9 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
 
         // Do nothing with journal history so we can skip cloning present journal.
         journal.clear();
-
+        //
+        // Clear coinbase address warming for next tx
+        *warm_coinbase_address = None;
         // Load precompiles into warm_preloaded_addresses.
         // TODO for precompiles we can use max transaction_id so they are always touched warm loaded.
         // at least after state clear EIP.
@@ -148,6 +154,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
             spec,
             warm_preloaded_addresses,
             precompiles,
+            warm_coinbase_address,
         } = self;
 
         let is_spurious_dragon_enabled = spec.is_enabled_in(SPURIOUS_DRAGON);
@@ -159,6 +166,8 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         *depth = 0;
         logs.clear();
         *transaction_id += 1;
+        // Clear coinbase address warming for next tx
+        *warm_coinbase_address = None;
         reset_preloaded_addresses(warm_preloaded_addresses, precompiles);
     }
 
@@ -180,9 +189,12 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
             spec,
             warm_preloaded_addresses,
             precompiles,
+            warm_coinbase_address,
         } = self;
         // Spec is not changed. And it is always set again in execution.
         let _ = spec;
+        // Clear coinbase address warming for next tx
+        *warm_coinbase_address = None;
         // Load precompiles into warm_preloaded_addresses.
         reset_preloaded_addresses(warm_preloaded_addresses, precompiles);
 
@@ -666,8 +678,9 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
                     Account::new_not_existing(self.transaction_id)
                 };
 
-                // Precompiles among some other account are warm loaded so we need to take that into account
-                let is_cold = !self.warm_preloaded_addresses.contains(&address);
+                // Precompiles among some other account(coinbase included) are warm loaded so we need to take that into account
+                let is_cold = !self.warm_preloaded_addresses.contains(&address)
+                    && self.warm_coinbase_address.as_ref() != Some(&address);
 
                 StateLoad {
                     data: vac.insert(account),

--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -45,7 +45,7 @@ pub fn load_accounts<
     // EIP-3651: Warm COINBASE. Starts the `COINBASE` address warm
     if spec.is_enabled_in(SpecId::SHANGHAI) {
         let coinbase = context.block().beneficiary();
-        context.journal_mut().warm_account(coinbase);
+        context.journal_mut().warm_coinbase_account(coinbase);
     }
 
     // Load access list

--- a/examples/cheatcode_inspector/src/main.rs
+++ b/examples/cheatcode_inspector/src/main.rs
@@ -123,6 +123,10 @@ impl JournalTr for Backend {
             .insert(address);
     }
 
+    fn warm_coinbase_account(&mut self, address: Address) {
+        self.journaled_state.warm_coinbase_address = Some(address)
+    }
+
     fn warm_precompiles(&mut self, addresses: HashSet<Address>) {
         self.journaled_state.warm_precompiles(addresses)
     }


### PR DESCRIPTION
separate coinbase address warming from preloaded addresses to avoid unnecessary cloning on every transaction(in coinbase address was warmed ofc). Fixes #2627 