### PR TITLE
test: update compare_or_save_testdata test helper fn signature

### DIFF
--- a/crates/revm/tests/common.rs
+++ b/crates/revm/tests/common.rs
@@ -12,10 +12,7 @@ use revm::{
 pub(crate) const TESTS_TESTDATA: &str = "tests/testdata";
 
 #[cfg(not(feature = "serde"))]
-pub(crate) fn compare_or_save_testdata<HaltReasonTy>(
-    _filename: &str,
-    _output: &ResultAndState<HaltReasonTy>,
-) {
+pub(crate) fn compare_or_save_testdata<I>(_filename: &str, _output: I) {
     // serde needs to be enabled to use this function
 }
 


### PR DESCRIPTION
fixes [compare_or_save_testdata](https://github.com/bluealloy/revm/blob/c66b841dca4c0f093fdb10ce4fccf1b4aa0b9995/crates/revm/tests/common.rs#L15-L18) signature when the serde feature is disabled to resolve compilation issues e.g when running `cargo test` or `cargo test --all-targets`

<img width="886" alt="Screenshot 2025-06-17 at 00 17 15" src="https://github.com/user-attachments/assets/1bdd36dc-f6b5-4b30-9162-ea9811362101" />
