### PR TITLE
feat: configurable contract size limit (#2611)

### DIFF
--- a/crates/bytecode/src/eof/verification.rs
+++ b/crates/bytecode/src/eof/verification.rs
@@ -5,10 +5,7 @@ use crate::{
     opcode::{self, OPCODE_INFO},
     utils::{read_i16, read_u16},
 };
-use primitives::{
-    constants::{MAX_INITCODE_SIZE, STACK_LIMIT},
-    Bytes,
-};
+use primitives::{constants::STACK_LIMIT, eip7907, Bytes};
 
 use core::{convert::identity, mem};
 use std::{borrow::Cow, fmt, vec, vec::Vec};
@@ -24,7 +21,7 @@ pub fn validate_raw_eof_inner(
     raw: Bytes,
     first_code_type: Option<CodeType>,
 ) -> Result<Eof, EofError> {
-    if raw.len() > MAX_INITCODE_SIZE {
+    if raw.len() > eip7907::MAX_INITCODE_SIZE {
         return Err(EofError::Decode(EofDecodeError::InvalidEOFSize));
     }
     let eof = Eof::decode(raw)?;

--- a/crates/context/interface/src/cfg.rs
+++ b/crates/context/interface/src/cfg.rs
@@ -35,6 +35,9 @@ pub trait Cfg {
     /// Returns the maximum code size for the given spec id.
     fn max_code_size(&self) -> usize;
 
+    /// Returns the max initcode size for the given spec id.
+    fn max_initcode_size(&self) -> usize;
+
     /// Returns whether the EIP-3607 (account clearing) is disabled.
     fn is_eip3607_disabled(&self) -> bool;
 

--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -1,8 +1,7 @@
 //! This module contains [`CfgEnv`] and implements [`Cfg`] trait for it.
 pub use context_interface::Cfg;
 
-use primitives::{eip170::MAX_CODE_SIZE, eip7825, hardfork::SpecId};
-
+use primitives::{eip170, eip3860, eip7825, hardfork::SpecId};
 /// EVM configuration
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -20,12 +19,21 @@ pub struct CfgEnv<SPEC = SpecId> {
 
     /// Specification for EVM represent the hardfork
     pub spec: SPEC,
-    /// If some it will effects EIP-170: Contract code size limit.
+    /// Contract code size limit override.
+    ///
+    /// If None, the limit will be determined by the SpecId (EIP-170 or EIP-7907) at runtime.
+    /// If Some, this specific limit will be used regardless of SpecId.
     ///
     /// Useful to increase this because of tests.
-    ///
-    /// By default it is `0x6000` (~25kb).
     pub limit_contract_code_size: Option<usize>,
+    /// Contract initcode size limit override.
+    ///
+    /// If None, the limit will check if `limit_contract_code_size` is set.
+    /// If it is set, it will double it for a limit.
+    /// If it is not set, the limit will be determined by the SpecId (EIP-170 or EIP-7907) at runtime.
+    ///
+    /// Useful to increase this because of tests.
+    pub limit_contract_initcode_size: Option<usize>,
     /// Skips the nonce validation against the account's nonce
     pub disable_nonce_check: bool,
     /// Blob max count. EIP-7840 Add blob schedule to EL config files.
@@ -124,6 +132,7 @@ impl<SPEC> CfgEnv<SPEC> {
             chain_id: 1,
             tx_chain_id_check: false,
             limit_contract_code_size: None,
+            limit_contract_initcode_size: None,
             spec,
             disable_nonce_check: false,
             max_blobs_per_tx: None,
@@ -168,6 +177,7 @@ impl<SPEC> CfgEnv<SPEC> {
             chain_id: self.chain_id,
             tx_chain_id_check: self.tx_chain_id_check,
             limit_contract_code_size: self.limit_contract_code_size,
+            limit_contract_initcode_size: self.limit_contract_initcode_size,
             spec,
             disable_nonce_check: self.disable_nonce_check,
             tx_gas_limit_cap: self.tx_gas_limit_cap,
@@ -246,7 +256,17 @@ impl<SPEC: Into<SpecId> + Copy> Cfg for CfgEnv<SPEC> {
     }
 
     fn max_code_size(&self) -> usize {
-        self.limit_contract_code_size.unwrap_or(MAX_CODE_SIZE)
+        self.limit_contract_code_size
+            .unwrap_or_else(|| eip170::MAX_CODE_SIZE)
+    }
+
+    fn max_initcode_size(&self) -> usize {
+        self.limit_contract_initcode_size
+            .or_else(|| {
+                self.limit_contract_code_size
+                    .map(|size| size.saturating_mul(2))
+            })
+            .unwrap_or_else(|| eip3860::MAX_INITCODE_SIZE)
     }
 
     fn is_eip3607_disabled(&self) -> bool {

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -761,8 +761,8 @@ pub fn return_create<JOURNAL: JournalTr>(
         return;
     }
 
-    // EIP-170: Contract code size limit
-    // By default limit is 0x6000 (~25kb)
+    // EIP-170: Contract code size limit to 0x6000 (~25kb)
+    // EIP-7907 increased this limit to 0xc000 (~49kb).
     if spec_id.is_enabled_in(SPURIOUS_DRAGON) && interpreter_result.output.len() > max_code_size {
         journal.checkpoint_revert(checkpoint);
         interpreter_result.result = InstructionResult::CreateContractSizeLimit;

--- a/crates/interpreter/src/host.rs
+++ b/crates/interpreter/src/host.rs
@@ -157,7 +157,7 @@ impl<CTX: ContextTr> Host for CTX {
     /* Config */
 
     fn max_initcode_size(&self) -> usize {
-        self.cfg().max_code_size().saturating_mul(2)
+        self.cfg().max_initcode_size()
     }
 
     /* Database */

--- a/crates/interpreter/src/lib.rs
+++ b/crates/interpreter/src/lib.rs
@@ -37,4 +37,4 @@ pub use interpreter_action::{
     EOFCreateInputs, EOFCreateKind, FrameInput, InterpreterAction,
 };
 pub use interpreter_types::InterpreterTypes;
-pub use primitives::{constants::MAX_INITCODE_SIZE, eip170::MAX_CODE_SIZE};
+pub use primitives::{eip7907::MAX_CODE_SIZE, eip7907::MAX_INITCODE_SIZE};

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -2,7 +2,6 @@
 //!
 //! Here you can find constants that dont belong to any EIP and are there for the genesis.
 
-use crate::eip170;
 use alloy_primitives::{b256, Address, B256};
 
 /// Number of block hashes that EVM can access in the past (pre-Prague)
@@ -14,11 +13,6 @@ pub const PRECOMPILE3: Address =
 
 /// EVM interpreter stack limit
 pub const STACK_LIMIT: usize = 1024;
-
-/// EIP-3860: Limit and meter initcode
-///
-/// Limit of maximum initcode size is `2 * MAX_CODE_SIZE`.
-pub const MAX_INITCODE_SIZE: usize = 2 * eip170::MAX_CODE_SIZE;
 
 /// EVM call stack limit
 pub const CALL_STACK_LIMIT: u64 = 1024;

--- a/crates/primitives/src/eip3860.rs
+++ b/crates/primitives/src/eip3860.rs
@@ -1,0 +1,8 @@
+//! EIP-3860: Limit and meter initcode
+
+use crate::eip170;
+
+/// EIP-3860: Limit and meter initcode
+///
+/// Limit of maximum initcode size is `2 * eip170::MAX_CODE_SIZE`.
+pub const MAX_INITCODE_SIZE: usize = 2 * eip170::MAX_CODE_SIZE;

--- a/crates/primitives/src/eip7907.rs
+++ b/crates/primitives/src/eip7907.rs
@@ -1,0 +1,6 @@
+//! TODO dont have specific EIP. It is part of: EIP-7907: Meter Contract Code Size And Increase Limit
+
+/// By default the limit is `0xC000` (49_152 bytes).
+pub const MAX_CODE_SIZE: usize = 0xC000;
+/// By default the limit is `0x12000` (73_728 bytes).
+pub const MAX_INITCODE_SIZE: usize = 0x12000;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -9,10 +9,12 @@ extern crate alloc as std;
 
 pub mod constants;
 pub mod eip170;
+pub mod eip3860;
 pub mod eip4844;
 pub mod eip7702;
 pub mod eip7823;
 pub mod eip7825;
+pub mod eip7907;
 pub mod eip7918;
 pub mod eof;
 pub mod hardfork;


### PR DESCRIPTION
Prep for EIP-7907 where both contract size limit and initcode size limit can be configurable from Cfg. 