### PR TITLE
feat(osaka): modexp assume minimal base/mod length of 32 (#2613)

### DIFF
--- a/crates/precompile/src/modexp.rs
+++ b/crates/precompile/src/modexp.rs
@@ -202,12 +202,12 @@ pub fn berlin_gas_calc(base_len: u64, exp_len: u64, mod_len: u64, exp_highp: &U2
 /// 3. Increase cost when base or modulus is larger than 32 bytes
 pub fn osaka_gas_calc(base_len: u64, exp_len: u64, mod_len: u64, exp_highp: &U256) -> u64 {
     gas_calc::<500, 16, 3, _>(base_len, exp_len, mod_len, exp_highp, |max_len| -> U256 {
-        let words = U256::from(max_len.div_ceil(8));
-        let words_square = words * words;
-        if max_len > 32 {
-            return words_square * U256::from(2);
+        if max_len <= 32 {
+            return U256::from(16); // multiplication_complexity = 16
         }
-        words_square
+
+        let words = U256::from(max_len.div_ceil(8));
+        words * words * U256::from(2) // multiplication_complexity = 2 * words**2
     })
 }
 


### PR DESCRIPTION
Ref: https://github.com/bluealloy/revm/pull/2613