### PR TITLE
feat: add fallible conversion from OpHaltReason to HaltReason

### DIFF
--- a/crates/op-revm/src/result.rs
+++ b/crates/op-revm/src/result.rs
@@ -17,6 +17,17 @@ impl From<HaltReason> for OpHaltReason {
     }
 }
 
+impl TryFrom<OpHaltReason> for HaltReason {
+    type Error = OpHaltReason;
+
+    fn try_from(value: OpHaltReason) -> Result<HaltReason, OpHaltReason> {
+        match value {
+            OpHaltReason::Base(reason) => Ok(reason),
+            OpHaltReason::FailedDeposit => Err(value),
+        }
+    }
+}
+
 #[cfg(all(test, feature = "serde"))]
 mod tests {
     use super::*;


### PR DESCRIPTION
Adds a fallible conversion from an OP halt reason to an L1 halt reason.

We need this to convert an OP halt reason back to the `InstructionResult`.

Since `OpHaltReason::FailedDeposit` does not originate from an `InstructionResult`, we cannot map this to an `InstructionResult`. Instead I opted to add a fallible conversion for the halt reason types.