### PR TITLE
fix: implement `PartialEq` for `JumpTable` correctly

### DIFF
--- a/crates/bytecode/src/legacy/analysis.rs
+++ b/crates/bytecode/src/legacy/analysis.rs
@@ -110,14 +110,14 @@ mod tests {
     fn test_bytecode_with_jumpdest_at_start() {
         let bytecode = vec![opcode::JUMPDEST, opcode::PUSH1, 0x01, opcode::STOP];
         let (jump_table, _) = analyze_legacy(bytecode.clone().into());
-        assert!(jump_table.table[0]); // First byte should be a valid jumpdest
+        assert!(jump_table.is_valid(0)); // First byte should be a valid jumpdest
     }
 
     #[test]
     fn test_bytecode_with_jumpdest_after_push() {
         let bytecode = vec![opcode::PUSH1, 0x01, opcode::JUMPDEST, opcode::STOP];
         let (jump_table, _) = analyze_legacy(bytecode.clone().into());
-        assert!(jump_table.table[2]); // JUMPDEST should be at position 2
+        assert!(jump_table.is_valid(2)); // JUMPDEST should be at position 2
     }
 
     #[test]
@@ -130,8 +130,8 @@ mod tests {
             opcode::STOP,
         ];
         let (jump_table, _) = analyze_legacy(bytecode.clone().into());
-        assert!(jump_table.table[0]); // First JUMPDEST
-        assert!(jump_table.table[3]); // Second JUMPDEST
+        assert!(jump_table.is_valid(0)); // First JUMPDEST
+        assert!(jump_table.is_valid(3)); // Second JUMPDEST
     }
 
     #[test]
@@ -145,7 +145,7 @@ mod tests {
     fn test_bytecode_with_invalid_opcode() {
         let bytecode = vec![0xFF, opcode::STOP]; // 0xFF is an invalid opcode
         let (jump_table, _) = analyze_legacy(bytecode.clone().into());
-        assert!(!jump_table.table[0]); // Invalid opcode should not be a jumpdest
+        assert!(!jump_table.is_valid(0)); // Invalid opcode should not be a jumpdest
     }
 
     #[test]
@@ -165,9 +165,9 @@ mod tests {
         ];
         let (jump_table, padded_bytecode) = analyze_legacy(bytecode.clone().into());
         assert_eq!(padded_bytecode.len(), bytecode.len());
-        assert!(!jump_table.table[0]); // PUSH1
-        assert!(!jump_table.table[2]); // PUSH2
-        assert!(!jump_table.table[5]); // PUSH4
+        assert!(!jump_table.is_valid(0)); // PUSH1
+        assert!(!jump_table.is_valid(2)); // PUSH2
+        assert!(!jump_table.is_valid(5)); // PUSH4
     }
 
     #[test]
@@ -179,6 +179,6 @@ mod tests {
             opcode::STOP,
         ];
         let (jump_table, _) = analyze_legacy(bytecode.clone().into());
-        assert!(!jump_table.table[1]); // JUMPDEST in push data should not be valid
+        assert!(!jump_table.is_valid(1)); // JUMPDEST in push data should not be valid
     }
 }

--- a/crates/bytecode/src/legacy/analyzed.rs
+++ b/crates/bytecode/src/legacy/analyzed.rs
@@ -60,10 +60,11 @@ impl LegacyAnalyzedBytecode {
         if original_len > bytecode.len() {
             panic!("original_len is greater than bytecode length");
         }
-        if original_len > jump_table.len {
+        if original_len > jump_table.len() {
             panic!(
                 "jump table length {} is less than original length {}",
-                jump_table.len, original_len
+                jump_table.len(),
+                original_len
             );
         }
 

--- a/crates/bytecode/src/legacy/jump_map.rs
+++ b/crates/bytecode/src/legacy/jump_map.rs
@@ -1,10 +1,11 @@
 use bitvec::vec::BitVec;
 use once_cell::race::OnceBox;
 use primitives::hex;
+use core::hash::{Hash, Hasher};
 use std::{fmt::Debug, sync::Arc};
 
 /// A table of valid `jump` destinations. Cheap to clone and memory efficient, one bit per opcode.
-#[derive(Clone, Eq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Eq, Ord, PartialOrd)]
 pub struct JumpTable {
     /// Actual bit vec
     table: Arc<BitVec<u8>>,
@@ -17,6 +18,13 @@ pub struct JumpTable {
 impl PartialEq for JumpTable {
     fn eq(&self, other: &Self) -> bool {
         self.table.eq(&other.table) && self.len.eq(&other.len)
+    }
+}
+
+impl Hash for JumpTable {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.table.hash(state);
+        self.len.hash(state);
     }
 }
 
@@ -81,6 +89,18 @@ impl JumpTable {
     #[inline]
     pub fn as_slice(&self) -> &[u8] {
         self.table.as_raw_slice()
+    }
+
+    /// Gets the length of the jump map.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns true if the jump map is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
     }
 
     /// Constructs a jump map from raw bytes and length.

--- a/crates/bytecode/src/legacy/jump_map.rs
+++ b/crates/bytecode/src/legacy/jump_map.rs
@@ -4,14 +4,20 @@ use primitives::hex;
 use std::{fmt::Debug, sync::Arc};
 
 /// A table of valid `jump` destinations. Cheap to clone and memory efficient, one bit per opcode.
-#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Eq, Hash, Ord, PartialOrd)]
 pub struct JumpTable {
     /// Actual bit vec
-    pub table: Arc<BitVec<u8>>,
+    table: Arc<BitVec<u8>>,
     /// Fast pointer that skips Arc overhead
     table_ptr: *const u8,
     /// Number of bits in the table
-    pub len: usize,
+    len: usize,
+}
+
+impl PartialEq for JumpTable {
+    fn eq(&self, other: &Self) -> bool {
+        self.table.eq(&other.table) && self.len.eq(&other.len)
+    }
 }
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
Implements `PartialEq` and `Hash` manually for `JumpTable` to make sure we're not ending up comparing pointers

Also made `table` field private to ensure that pointer is always valid