### PR TITLE
docs: fix copy-pasted inner doc comments

### DIFF
--- a/crates/context/interface/src/lib.rs
+++ b/crates/context/interface/src/lib.rs
@@ -1,4 +1,4 @@
-//! Optimism-specific constants, types, and helpers.
+//! EVM execution context interface.
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -1,4 +1,4 @@
-//! Optimism-specific constants, types, and helpers.
+//! EVM execution context.
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/crates/database/interface/src/lib.rs
+++ b/crates/database/interface/src/lib.rs
@@ -1,4 +1,4 @@
-//! Optimism-specific constants, types, and helpers.
+//! Database interface.
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/crates/handler/src/lib.rs
+++ b/crates/handler/src/lib.rs
@@ -1,4 +1,4 @@
-//! Optimism-specific constants, types, and helpers.
+//! EVM execution handling.
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -1,4 +1,4 @@
-//! Optimism-specific constants, types, and helpers.
+//! Account and storage state.
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
 


### PR DESCRIPTION
Hi, the inner doc comment for a few `lib.rs` were probably copy-pasted from https://github.com/bluealloy/revm/blob/435153d1b3e708bf48100fd2bf73a07aa02e1f94/crates/op-revm/src/lib.rs#L1

I quickly inferred better descriptions, better suggestions welcomed.