### PR TITLE
docs: inline documentation of revm top modules

### DIFF
--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -3,16 +3,27 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 // reexport dependencies
+#[doc(inline)]
 pub use bytecode;
+#[doc(inline)]
 pub use context;
+#[doc(inline)]
 pub use context_interface;
+#[doc(inline)]
 pub use database;
+#[doc(inline)]
 pub use database_interface;
+#[doc(inline)]
 pub use handler;
+#[doc(inline)]
 pub use inspector;
+#[doc(inline)]
 pub use interpreter;
+#[doc(inline)]
 pub use precompile;
+#[doc(inline)]
 pub use primitives;
+#[doc(inline)]
 pub use state;
 
 // Export items.


### PR DESCRIPTION
This unifies the documentation of all revm crates into the `revm` crate documentation.

It fixes a major pain-point when navigating the documentation (in my opinion): now the searchbox actually search into all crates.

Tested locally with `cargo doc --workspace --document-private-items --no-deps`:

## Before

![image](https://github.com/user-attachments/assets/1a0c6dae-0e3b-4bf3-8d32-4f2c5815b088)

## After

![image](https://github.com/user-attachments/assets/c87133c2-da4f-4572-aabe-c8647afe3a16)