### PR TITLE
feat: implement Database traits for either::Either

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3847,6 +3847,7 @@ version = "6.0.0"
 dependencies = [
  "anyhow",
  "auto_impl",
+ "either",
  "revm-primitives",
  "revm-state",
  "rstest",

--- a/crates/database/interface/Cargo.toml
+++ b/crates/database/interface/Cargo.toml
@@ -23,6 +23,7 @@ primitives.workspace = true
 
 # misc
 auto_impl.workspace = true
+either.workspace = true
 
 # Optional
 serde = { workspace = true, features = ["derive", "rc"], optional = true }

--- a/crates/database/interface/src/either.rs
+++ b/crates/database/interface/src/either.rs
@@ -1,0 +1,99 @@
+//! Database implementations for `either::Either` type.
+
+use crate::{Database, DatabaseCommit, DatabaseRef};
+use either::Either;
+use primitives::{Address, HashMap, StorageKey, StorageValue, B256};
+use state::{Account, AccountInfo, Bytecode};
+
+impl<L, R> Database for Either<L, R>
+where
+    L: Database,
+    R: Database<Error = L::Error>,
+{
+    type Error = L::Error;
+
+    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        match self {
+            Self::Left(db) => db.basic(address),
+            Self::Right(db) => db.basic(address),
+        }
+    }
+
+    fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        match self {
+            Self::Left(db) => db.code_by_hash(code_hash),
+            Self::Right(db) => db.code_by_hash(code_hash),
+        }
+    }
+
+    fn storage(
+        &mut self,
+        address: Address,
+        index: StorageKey,
+    ) -> Result<StorageValue, Self::Error> {
+        match self {
+            Self::Left(db) => db.storage(address, index),
+            Self::Right(db) => db.storage(address, index),
+        }
+    }
+
+    fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error> {
+        match self {
+            Self::Left(db) => db.block_hash(number),
+            Self::Right(db) => db.block_hash(number),
+        }
+    }
+}
+
+impl<L, R> DatabaseCommit for Either<L, R>
+where
+    L: DatabaseCommit,
+    R: DatabaseCommit,
+{
+    fn commit(&mut self, changes: HashMap<Address, Account>) {
+        match self {
+            Self::Left(db) => db.commit(changes),
+            Self::Right(db) => db.commit(changes),
+        }
+    }
+}
+
+impl<L, R> DatabaseRef for Either<L, R>
+where
+    L: DatabaseRef,
+    R: DatabaseRef<Error = L::Error>,
+{
+    type Error = L::Error;
+
+    fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        match self {
+            Self::Left(db) => db.basic_ref(address),
+            Self::Right(db) => db.basic_ref(address),
+        }
+    }
+
+    fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        match self {
+            Self::Left(db) => db.code_by_hash_ref(code_hash),
+            Self::Right(db) => db.code_by_hash_ref(code_hash),
+        }
+    }
+
+    fn storage_ref(
+        &self,
+        address: Address,
+        index: StorageKey,
+    ) -> Result<StorageValue, Self::Error> {
+        match self {
+            Self::Left(db) => db.storage_ref(address, index),
+            Self::Right(db) => db.storage_ref(address, index),
+        }
+    }
+
+    fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
+        match self {
+            Self::Left(db) => db.block_hash_ref(number),
+            Self::Right(db) => db.block_hash_ref(number),
+        }
+    }
+}

--- a/crates/database/interface/src/lib.rs
+++ b/crates/database/interface/src/lib.rs
@@ -28,6 +28,7 @@ pub const BENCH_CALLER_BALANCE: U256 = U256::from_limbs([10_000_000_000_000_000,
 
 #[cfg(feature = "asyncdb")]
 pub mod async_db;
+pub mod either;
 pub mod empty_db;
 pub mod try_commit;
 


### PR DESCRIPTION
Adds Database, DatabaseCommit, and DatabaseRef trait implementations for the either::Either type.

This allows using `Either<L, R>` as a database where:
- For `Database` and `DatabaseRef`: Both L and R must implement the respective trait with the same error type
- For `DatabaseCommit`: Both L and R must implement the trait

The implementation delegates all calls to either the left or right variant based on the enum value.