### PR TITLE
fix typo: Rename is_created_globaly to is_created_globally

### DIFF
--- a/crates/context/src/journal/entry.rs
+++ b/crates/context/src/journal/entry.rs
@@ -39,7 +39,7 @@ pub trait JournalEntryTr {
     fn nonce_changed(address: Address) -> Self;
 
     /// Creates a journal entry for when a new account is created
-    fn account_created(address: Address, is_created_globaly: bool) -> Self;
+    fn account_created(address: Address, is_created_globally: bool) -> Self;
 
     /// Creates a journal entry for when a storage slot is modified
     /// Records the previous value for reverting

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -433,10 +433,10 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         }
 
         // set account status to create.
-        let is_created_globaly = target_acc.mark_created_locally();
+        let is_created_globally = target_acc.mark_created_locally();
 
         // this entry will revert set nonce.
-        last_journal.push(ENTRY::account_created(target_address, is_created_globaly));
+        last_journal.push(ENTRY::account_created(target_address, is_created_globally));
         target_acc.info.code = None;
         // EIP-161: State trie clearing (invariant-preserving alternative)
         if spec_id.is_enabled_in(SPURIOUS_DRAGON) {


### PR DESCRIPTION


---


## Description
This pull request corrects a typo in the variable and parameter name is_created_globaly, changing it to is_created_globally across the codebase for improved clarity and consistency.


---

