### PR TITLE
Fix typo in variable name

### DIFF
--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -137,9 +137,9 @@ impl Account {
     #[inline]
     pub fn mark_created_locally(&mut self) -> bool {
         self.status |= AccountStatus::CreatedLocal;
-        let is_created_globaly = !self.status.contains(AccountStatus::Created);
+        let is_created_globally = !self.status.contains(AccountStatus::Created);
         self.status |= AccountStatus::Created;
-        is_created_globaly
+        is_created_globally
     }
 
     /// Unmark account as locally created


### PR DESCRIPTION


---



## Description
- Corrected a typo in the variable name from created_globaly to created_globally in the Account implementation.

---