### PR TITLE
Change modexp repricing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
 
+# v78
+date 20.05.2025
+
+Quick fix for not calling `frame_stack.clear()` https://github.com/bluealloy/revm/pull/2656
+
+* `revm-context`: 7.0.0 -> 7.0.1 (✓ API compatible changes)
+* `revm-interpreter`: 22.0.0 -> 22.0.1 (✓ API compatible changes)
+* `revm-precompile`: 23.0.0 -> 23.0.1 (✓ API compatible changes)
+* `revm-handler`: 7.0.0 -> 7.0.1 (✓ API compatible changes)
+* `revm-inspector`: 7.0.0 -> 7.0.1
+* `revm`: 26.0.0 -> 26.0.1
+* `revm-statetest-types`: 8.0.0 -> 8.0.1
+* `revme`: 7.0.0 -> 7.0.1
+* `op-revm`: 7.0.0 -> 7.0.1
+
 # v77
 date: 19.05.2025
 

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -176,6 +176,7 @@ impl Precompiles {
 
             precompiles.extend([
                 precompile,
+                modexp::OSAKA,
             ]);
 
             Box::new(precompiles)

--- a/crates/precompile/src/modexp.rs
+++ b/crates/precompile/src/modexp.rs
@@ -201,7 +201,7 @@ pub fn berlin_gas_calc(base_len: u64, exp_len: u64, mod_len: u64, exp_highp: &U2
 /// 2. Increase cost when exponent is larger than 32 bytes
 /// 3. Increase cost when base or modulus is larger than 32 bytes
 pub fn osaka_gas_calc(base_len: u64, exp_len: u64, mod_len: u64, exp_highp: &U256) -> u64 {
-    gas_calc::<500, 16, 3, _>(base_len, exp_len, mod_len, exp_highp, |max_len| -> U256 {
+    gas_calc::<500, 16, 1, _>(base_len, exp_len, mod_len, exp_highp, |max_len| -> U256 {
         if max_len <= 32 {
             return U256::from(16); // multiplication_complexity = 16
         }


### PR DESCRIPTION
This implements the following change:
https://github.com/ethereum/EIPs/pull/9969

by changing the `GAS_DIVISOR` to `1`