### PR TITLE
feat(precompile): triple the price of modexp

### DIFF
--- a/crates/precompile/src/modexp.rs
+++ b/crates/precompile/src/modexp.rs
@@ -201,7 +201,7 @@ pub fn berlin_gas_calc(base_len: u64, exp_len: u64, mod_len: u64, exp_highp: &U2
 /// 2. Increase cost when exponent is larger than 32 bytes
 /// 3. Increase cost when base or modulus is larger than 32 bytes
 pub fn osaka_gas_calc(base_len: u64, exp_len: u64, mod_len: u64, exp_highp: &U256) -> u64 {
-    gas_calc::<500, 16, 3, _>(base_len, exp_len, mod_len, exp_highp, |max_len| -> U256 {
+    gas_calc::<500, 16, 1, _>(base_len, exp_len, mod_len, exp_highp, |max_len| -> U256 {
         if max_len <= 32 {
             return U256::from(16); // multiplication_complexity = 16
         }


### PR DESCRIPTION
This implements the following change:
https://github.com/ethereum/EIPs/pull/9969

by changing the `GAS_DIVISOR` to `1` for osaka