### PR TITLE
fix: gas deduction with `disable_balance_check`

### DIFF
--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -163,7 +163,10 @@ pub fn validate_against_state_and_deduct_caller<
     // subtracting max balance spending with value that is going to be deducted later in the call.
     let gas_balance_spending = effective_balance_spending - tx.value();
 
-    let mut new_balance = caller_account.info.balance.saturating_sub(gas_balance_spending);
+    let mut new_balance = caller_account
+        .info
+        .balance
+        .saturating_sub(gas_balance_spending);
 
     if is_balance_check_disabled {
         // Make sure the caller's balance is at least the value of the transaction.

--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -159,16 +159,16 @@ pub fn validate_against_state_and_deduct_caller<
             balance: Box::new(caller_account.info.balance),
         }
         .into());
-    } else {
-        let effective_balance_spending = tx
-            .effective_balance_spending(basefee, blob_price)
-            .expect("effective balance is always smaller than max balance so it can't overflow");
-
-        // subtracting max balance spending with value that is going to be deducted later in the call.
-        let gas_balance_spending = effective_balance_spending - tx.value();
-
-        new_balance = new_balance.saturating_sub(gas_balance_spending);
     }
+
+    let effective_balance_spending = tx
+        .effective_balance_spending(basefee, blob_price)
+        .expect("effective balance is always smaller than max balance so it can't overflow");
+
+    // subtracting max balance spending with value that is going to be deducted later in the call.
+    let gas_balance_spending = effective_balance_spending - tx.value();
+
+    new_balance = new_balance.saturating_sub(gas_balance_spending);
 
     let old_balance = caller_account.info.balance;
     // Touch account so we know it is changed.

--- a/crates/revm/tests/integration.rs
+++ b/crates/revm/tests/integration.rs
@@ -223,3 +223,43 @@ fn test_frame_stack_index() {
     assert_eq!(evm.frame_stack.index(), None);
     compare_or_save_testdata("test_frame_stack_index.json", result1);
 }
+
+#[test]
+#[cfg(feature = "optional_balance_check")]
+fn test_disable_balance_check_deduct() {
+    use database::BENCH_CALLER_BALANCE;
+
+    const RETURN_CALLER_BALANCE_BYTECODE: &[u8] = &[
+        opcode::CALLER,
+        opcode::BALANCE,
+        opcode::PUSH1, 0x00,
+        opcode::MSTORE,
+        opcode::PUSH1, 0x20,
+        opcode::PUSH1, 0x00,
+        opcode::RETURN,
+    ];
+
+    let mut evm = Context::mainnet()
+        .modify_cfg_chained(|cfg| cfg.disable_balance_check = true)
+        .with_db(BenchmarkDB::new_bytecode(Bytecode::new_legacy(
+            RETURN_CALLER_BALANCE_BYTECODE.into(),
+        )))
+        .build_mainnet();
+
+    let gas_limit = 100_000;
+
+    let result = evm
+        .transact_one(
+            TxEnv::builder_for_bench()
+                .gas_price(1)
+                .gas_limit(gas_limit)
+                .build_fill()
+        )
+        .unwrap();
+
+    assert!(result.is_success());
+
+    let returned_balance = U256::from_be_slice(result.output().unwrap().as_ref());
+    let expected_balance = BENCH_CALLER_BALANCE - U256::from(gas_limit);
+    assert_eq!(returned_balance, expected_balance);
+}

--- a/crates/revm/tests/integration.rs
+++ b/crates/revm/tests/integration.rs
@@ -232,10 +232,13 @@ fn test_disable_balance_check_deduct() {
     const RETURN_CALLER_BALANCE_BYTECODE: &[u8] = &[
         opcode::CALLER,
         opcode::BALANCE,
-        opcode::PUSH1, 0x00,
+        opcode::PUSH1,
+        0x00,
         opcode::MSTORE,
-        opcode::PUSH1, 0x20,
-        opcode::PUSH1, 0x00,
+        opcode::PUSH1,
+        0x20,
+        opcode::PUSH1,
+        0x00,
         opcode::RETURN,
     ];
 
@@ -253,7 +256,7 @@ fn test_disable_balance_check_deduct() {
             TxEnv::builder_for_bench()
                 .gas_price(1)
                 .gas_limit(gas_limit)
-                .build_fill()
+                .build_fill(),
         )
         .unwrap();
 


### PR DESCRIPTION
The merge of `validate_tx_against_state` and `deduct_caller` done in https://github.com/bluealloy/revm/pull/2460 seems to have broken gas deduction when `disable_balance_check` is enabled. This PR adds a test for this error and proposes a possible fix.

The result is that when balance checks are disabled the effective cost is first deducted with saturation from the caller balance, and then increased if necessary to cover the transaction value.