### PR TITLE
feat(statetest-types): add no_std support for bare metal compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ indicatif = "0.17"
 plain_hasher = "0.2"
 rstest = "0.25.0"
 serde_derive = "1.0"
-thiserror = "2.0"
+thiserror = { version = "2.0", default-features = false }
 triehash = "0.8"
 walkdir = "2.5"
 

--- a/crates/statetest-types/Cargo.toml
+++ b/crates/statetest-types/Cargo.toml
@@ -16,10 +16,18 @@ rustdoc-args = ["--cfg", "docsrs"]
 [lints]
 workspace = true
 
+[features]
+default = ["std"]
+std = [
+    "revm/std",
+    "serde_json/preserve_order",
+]
+
 [dependencies]
 # revm
-revm = { workspace = true, features = ["std", "serde"] }
+revm = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive", "rc"] }
-serde_json = { workspace = true, features = ["preserve_order"] }
+serde_json = { workspace = true, features = ["alloc"] }
 k256 = { workspace = true }
 thiserror = { workspace = true }
+

--- a/crates/statetest-types/src/deserializer.rs
+++ b/crates/statetest-types/src/deserializer.rs
@@ -1,3 +1,5 @@
+use alloc::string::String;
+
 use revm::primitives::Address;
 use serde::{de, Deserialize};
 

--- a/crates/statetest-types/src/error.rs
+++ b/crates/statetest-types/src/error.rs
@@ -1,3 +1,5 @@
+use alloc::string::String;
+
 use revm::primitives::B256;
 use thiserror::Error;
 

--- a/crates/statetest-types/src/lib.rs
+++ b/crates/statetest-types/src/lib.rs
@@ -6,6 +6,11 @@
 //! It includes structures for representing account information, environment settings,
 //! test cases, and transaction data used in Ethereum state tests.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 mod account_info;
 mod deserializer;
 mod env;

--- a/crates/statetest-types/src/spec.rs
+++ b/crates/statetest-types/src/spec.rs
@@ -1,3 +1,4 @@
+use core::panic;
 use revm::primitives::hardfork::SpecId;
 use serde::Deserialize;
 

--- a/crates/statetest-types/src/test.rs
+++ b/crates/statetest-types/src/test.rs
@@ -1,6 +1,9 @@
+use alloc::collections::BTreeMap;
+use alloc::{string::String, string::ToString, vec::Vec};
+
 use revm::{
     context::tx::TxEnv,
-    primitives::{Address, Bytes, HashMap, TxKind, B256},
+    primitives::{Address, Bytes, TxKind, B256},
 };
 use serde::Deserialize;
 
@@ -25,7 +28,7 @@ pub struct Test {
     pub hash: B256,
     /// Post state
     #[serde(default)]
-    pub post_state: HashMap<Address, AccountInfo>,
+    pub post_state: BTreeMap<Address, AccountInfo>,
 
     /// Logs root
     pub logs: B256,
@@ -34,7 +37,7 @@ pub struct Test {
     ///
     /// Note: Not used.
     #[serde(default)]
-    state: HashMap<Address, AccountInfo>,
+    state: BTreeMap<Address, AccountInfo>,
 
     /// Tx bytes
     pub txbytes: Option<Bytes>,

--- a/crates/statetest-types/src/test_suite.rs
+++ b/crates/statetest-types/src/test_suite.rs
@@ -1,5 +1,7 @@
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+
 use serde::Deserialize;
-use std::collections::BTreeMap;
 
 use crate::TestUnit;
 

--- a/crates/statetest-types/src/test_unit.rs
+++ b/crates/statetest-types/src/test_unit.rs
@@ -1,5 +1,7 @@
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
+
 use serde::Deserialize;
-use std::collections::{BTreeMap, HashMap};
 
 use crate::{AccountInfo, Env, SpecName, Test, TransactionParts};
 use revm::{
@@ -34,7 +36,7 @@ pub struct TestUnit {
     /// A mapping of addresses to their account information before the transaction
     /// is executed. This represents the initial state of all accounts involved
     /// in the test, including their balances, nonces, code, and storage.
-    pub pre: HashMap<Address, AccountInfo>,
+    pub pre: BTreeMap<Address, AccountInfo>,
 
     /// Post-execution expectations per specification.
     ///

--- a/crates/statetest-types/src/transaction.rs
+++ b/crates/statetest-types/src/transaction.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use crate::{deserializer::deserialize_maybe_empty, TestAuthorization};
 use revm::{
     context::TransactionType,


### PR DESCRIPTION
This PR adds no_std support to the `revm-statetest-types` crate to enable usage in bare metal and embedded environments. It allows the crate to be used in environments without standard library support.