### PR TITLE
fix incorrect StorageKey and StorageValue parameter order in burntpix…

### DIFF
--- a/bins/revme/src/cmd/bench/burntpix.rs
+++ b/bins/revme/src/cmd/bench/burntpix.rs
@@ -163,8 +163,8 @@ fn init_db() -> CacheDB<EmptyDB> {
     cache_db
         .insert_account_storage(
             BURNTPIX_MAIN_ADDRESS,
-            StorageValue::from(2),
-            StorageKey::from_be_bytes(*STORAGE_TWO),
+            StorageKey::from(2),
+            StorageValue::from_be_bytes(*STORAGE_TWO),
         )
         .unwrap();
 


### PR DESCRIPTION
Fixes an issue in the burntpix benchmark where StorageKey and StorageValue parameters were swapped in the third call to insert_account_storage. The first two calls used the correct parameter order (StorageKey as the key and StorageValue as the value), but the third call incorrectly used StorageValue as the key and StorageKey as the value.

The fix ensures consistent parameter ordering across all storage operations, preventing potential runtime errors or incorrect benchmark results.