### PR TITLE
feat: Use bytes API for underlying precompile library APIs

### DIFF
--- a/crates/precompile/src/bls12_381.rs
+++ b/crates/precompile/src/bls12_381.rs
@@ -12,6 +12,17 @@ cfg_if::cfg_if! {
     }
 }
 
+// Re-export type aliases for use in submodules
+use crate::bls12_381_const::FP_LENGTH;
+type G1Point = ([u8; FP_LENGTH], [u8; FP_LENGTH]);
+type G2Point = (
+    [u8; FP_LENGTH],
+    [u8; FP_LENGTH],
+    [u8; FP_LENGTH],
+    [u8; FP_LENGTH],
+);
+type PairingPair = (G1Point, G2Point);
+
 pub mod g1_add;
 pub mod g1_msm;
 pub mod g2_add;

--- a/crates/precompile/src/bls12_381/arkworks.rs
+++ b/crates/precompile/src/bls12_381/arkworks.rs
@@ -368,3 +368,68 @@ pub(super) fn pairing_check(pairs: &[(G1Affine, G2Affine)]) -> bool {
     let pairing_result = Bls12_381::multi_pairing(&g1_points, &g2_points);
     pairing_result.0.is_one()
 }
+
+// Byte-oriented versions of the functions for external API compatibility
+
+/// Performs point addition on two G1 points taking byte coordinates and returning encoded result.
+#[inline]
+pub(super) fn p1_add_affine_bytes(
+    a_x: &[u8; FP_LENGTH],
+    a_y: &[u8; FP_LENGTH],
+    b_x: &[u8; FP_LENGTH],
+    b_y: &[u8; FP_LENGTH],
+) -> Result<[u8; PADDED_G1_LENGTH], PrecompileError> {
+    // Parse first point
+    let p1 = read_g1_no_subgroup_check(a_x, a_y)?;
+
+    // Parse second point
+    let p2 = read_g1_no_subgroup_check(b_x, b_y)?;
+
+    // Perform addition
+    let result = p1_add_affine(&p1, &p2);
+
+    // Encode result
+    Ok(encode_g1_point(&result))
+}
+
+/// Performs point addition on two G2 points taking byte coordinates and returning encoded result.
+#[inline]
+#[allow(clippy::too_many_arguments)]
+pub(super) fn p2_add_affine_bytes(
+    a_x_0: &[u8; FP_LENGTH],
+    a_x_1: &[u8; FP_LENGTH],
+    a_y_0: &[u8; FP_LENGTH],
+    a_y_1: &[u8; FP_LENGTH],
+    b_x_0: &[u8; FP_LENGTH],
+    b_x_1: &[u8; FP_LENGTH],
+    b_y_0: &[u8; FP_LENGTH],
+    b_y_1: &[u8; FP_LENGTH],
+) -> Result<[u8; PADDED_G2_LENGTH], PrecompileError> {
+    // Parse first point
+    let p1 = read_g2_no_subgroup_check(a_x_0, a_x_1, a_y_0, a_y_1)?;
+
+    // Parse second point
+    let p2 = read_g2_no_subgroup_check(b_x_0, b_x_1, b_y_0, b_y_1)?;
+
+    // Perform addition
+    let result = p2_add_affine(&p1, &p2);
+
+    // Encode result
+    Ok(encode_g2_point(&result))
+}
+
+/// Maps a field element to a G1 point from bytes
+#[inline]
+pub(super) fn map_fp_to_g1_bytes(fp_bytes: &[u8; FP_LENGTH]) -> Result<[u8; PADDED_G1_LENGTH], PrecompileError> {
+    let fp = read_fp(fp_bytes)?;
+    let result = map_fp_to_g1(&fp);
+    Ok(encode_g1_point(&result))
+}
+
+/// Maps field elements to a G2 point from bytes
+#[inline]
+pub(super) fn map_fp2_to_g2_bytes(fp2_x: &[u8; FP_LENGTH], fp2_y: &[u8; FP_LENGTH]) -> Result<[u8; PADDED_G2_LENGTH], PrecompileError> {
+    let fp2 = read_fp2(fp2_x, fp2_y)?;
+    let result = map_fp2_to_g2(&fp2);
+    Ok(encode_g2_point(&result))
+}

--- a/crates/precompile/src/bls12_381/arkworks.rs
+++ b/crates/precompile/src/bls12_381/arkworks.rs
@@ -418,16 +418,16 @@ pub(super) fn pairing_check_bytes(pairs: &[PairingPair]) -> Result<bool, Precomp
 /// Performs point addition on two G1 points taking byte coordinates and returning encoded result.
 #[inline]
 pub(super) fn p1_add_affine_bytes(
-    a_x: &[u8; FP_LENGTH],
-    a_y: &[u8; FP_LENGTH],
-    b_x: &[u8; FP_LENGTH],
-    b_y: &[u8; FP_LENGTH],
+    a: G1Point,
+    b: G1Point,
 ) -> Result<[u8; PADDED_G1_LENGTH], PrecompileError> {
+    let (a_x, a_y) = a;
+    let (b_x, b_y) = b;
     // Parse first point
-    let p1 = read_g1_no_subgroup_check(a_x, a_y)?;
+    let p1 = read_g1_no_subgroup_check(&a_x, &a_y)?;
 
     // Parse second point
-    let p2 = read_g1_no_subgroup_check(b_x, b_y)?;
+    let p2 = read_g1_no_subgroup_check(&b_x, &b_y)?;
 
     // Perform addition
     let result = p1_add_affine(&p1, &p2);
@@ -438,22 +438,17 @@ pub(super) fn p1_add_affine_bytes(
 
 /// Performs point addition on two G2 points taking byte coordinates and returning encoded result.
 #[inline]
-#[allow(clippy::too_many_arguments)]
 pub(super) fn p2_add_affine_bytes(
-    a_x_0: &[u8; FP_LENGTH],
-    a_x_1: &[u8; FP_LENGTH],
-    a_y_0: &[u8; FP_LENGTH],
-    a_y_1: &[u8; FP_LENGTH],
-    b_x_0: &[u8; FP_LENGTH],
-    b_x_1: &[u8; FP_LENGTH],
-    b_y_0: &[u8; FP_LENGTH],
-    b_y_1: &[u8; FP_LENGTH],
+    a: G2Point,
+    b: G2Point,
 ) -> Result<[u8; PADDED_G2_LENGTH], PrecompileError> {
+    let (a_x_0, a_x_1, a_y_0, a_y_1) = a;
+    let (b_x_0, b_x_1, b_y_0, b_y_1) = b;
     // Parse first point
-    let p1 = read_g2_no_subgroup_check(a_x_0, a_x_1, a_y_0, a_y_1)?;
+    let p1 = read_g2_no_subgroup_check(&a_x_0, &a_x_1, &a_y_0, &a_y_1)?;
 
     // Parse second point
-    let p2 = read_g2_no_subgroup_check(b_x_0, b_x_1, b_y_0, b_y_1)?;
+    let p2 = read_g2_no_subgroup_check(&b_x_0, &b_x_1, &b_y_0, &b_y_1)?;
 
     // Perform addition
     let result = p2_add_affine(&p1, &p2);

--- a/crates/precompile/src/bls12_381/arkworks.rs
+++ b/crates/precompile/src/bls12_381/arkworks.rs
@@ -392,10 +392,10 @@ pub(super) fn pairing_check_bytes(pairs: &[PairingPair]) -> Result<bool, Precomp
         if g1_is_zero || g2_is_zero {
             // Still need to validate the non-zero point if one exists
             if !g1_is_zero {
-                read_g1(g1_x, g1_y)?;
+                let _ = read_g1(g1_x, g1_y)?;
             }
             if !g2_is_zero {
-                read_g2(g2_x_0, g2_x_1, g2_y_0, g2_y_1)?;
+                let _ = read_g2(g2_x_0, g2_x_1, g2_y_0, g2_y_1)?;
             }
             continue;
         }

--- a/crates/precompile/src/bls12_381/arkworks.rs
+++ b/crates/precompile/src/bls12_381/arkworks.rs
@@ -486,7 +486,7 @@ pub(super) fn map_fp2_to_g2_bytes(
 /// Performs multi-scalar multiplication (MSM) for G1 points taking byte inputs and returning encoded result.
 #[inline]
 pub(super) fn p1_msm_bytes(
-    point_scalar_pairs: &[(&G1Point, &[u8; SCALAR_LENGTH])],
+    point_scalar_pairs: &[(G1Point, [u8; SCALAR_LENGTH])],
 ) -> Result<[u8; PADDED_G1_LENGTH], PrecompileError> {
     if point_scalar_pairs.is_empty() {
         // Return point at infinity
@@ -499,7 +499,7 @@ pub(super) fn p1_msm_bytes(
     // Parse all points and scalars
     for ((x, y), scalar_bytes) in point_scalar_pairs {
         // NB: MSM requires subgroup check
-        let point = read_g1(x, y)?;
+        let point = read_g1(&x, &y)?;
 
         // Skip zero scalars after validating the point
         if scalar_bytes.iter().all(|&b| b == 0) {
@@ -526,7 +526,7 @@ pub(super) fn p1_msm_bytes(
 /// Performs multi-scalar multiplication (MSM) for G2 points taking byte inputs and returning encoded result.
 #[inline]
 pub(super) fn p2_msm_bytes(
-    point_scalar_pairs: &[(&G2Point, &[u8; SCALAR_LENGTH])],
+    point_scalar_pairs: &[(G2Point, [u8; SCALAR_LENGTH])],
 ) -> Result<[u8; PADDED_G2_LENGTH], PrecompileError> {
     if point_scalar_pairs.is_empty() {
         // Return point at infinity
@@ -539,7 +539,7 @@ pub(super) fn p2_msm_bytes(
     // Parse all points and scalars
     for ((x_0, x_1, y_0, y_1), scalar_bytes) in point_scalar_pairs {
         // NB: MSM requires subgroup check
-        let point = read_g2(x_0, x_1, y_0, y_1)?;
+        let point = read_g2(&x_0, &x_1, &y_0, &y_1)?;
 
         // Skip zero scalars after validating the point
         if scalar_bytes.iter().all(|&b| b == 0) {

--- a/crates/precompile/src/bls12_381/arkworks.rs
+++ b/crates/precompile/src/bls12_381/arkworks.rs
@@ -58,10 +58,7 @@ fn encode_fp(fp: &Fq) -> [u8; FP_LENGTH] {
 ///
 /// Panics if either input is not exactly 48 bytes long.
 #[inline]
-fn read_fp2(
-    input_1: &[u8; FP_LENGTH],
-    input_2: &[u8; FP_LENGTH],
-) -> Result<Fq2, PrecompileError> {
+fn read_fp2(input_1: &[u8; FP_LENGTH], input_2: &[u8; FP_LENGTH]) -> Result<Fq2, PrecompileError> {
     let fp_1 = read_fp(input_1)?;
     let fp_2 = read_fp(input_2)?;
 
@@ -126,10 +123,7 @@ fn new_g2_point_no_subgroup_check(x: Fq2, y: Fq2) -> Result<G2Affine, Precompile
 ///
 /// Panics if the inputs are not exactly 48 bytes long.
 #[inline]
-fn read_g1(
-    x: &[u8; FP_LENGTH],
-    y: &[u8; FP_LENGTH],
-) -> Result<G1Affine, PrecompileError> {
+fn read_g1(x: &[u8; FP_LENGTH], y: &[u8; FP_LENGTH]) -> Result<G1Affine, PrecompileError> {
     let point = read_g1_no_subgroup_check(x, y)?;
     if !point.is_in_correct_subgroup_assuming_on_curve() {
         return Err(PrecompileError::Other(

--- a/crates/precompile/src/bls12_381/arkworks.rs
+++ b/crates/precompile/src/bls12_381/arkworks.rs
@@ -499,7 +499,7 @@ pub(super) fn p1_msm_bytes(
     // Parse all points and scalars
     for ((x, y), scalar_bytes) in point_scalar_pairs {
         // NB: MSM requires subgroup check
-        let point = read_g1(&x, &y)?;
+        let point = read_g1(x, y)?;
 
         // Skip zero scalars after validating the point
         if scalar_bytes.iter().all(|&b| b == 0) {
@@ -539,7 +539,7 @@ pub(super) fn p2_msm_bytes(
     // Parse all points and scalars
     for ((x_0, x_1, y_0, y_1), scalar_bytes) in point_scalar_pairs {
         // NB: MSM requires subgroup check
-        let point = read_g2(&x_0, &x_1, &y_0, &y_1)?;
+        let point = read_g2(x_0, x_1, y_0, y_1)?;
 
         // Skip zero scalars after validating the point
         if scalar_bytes.iter().all(|&b| b == 0) {

--- a/crates/precompile/src/bls12_381/arkworks.rs
+++ b/crates/precompile/src/bls12_381/arkworks.rs
@@ -1,9 +1,6 @@
 use super::{G1Point, G2Point, PairingPair};
 use crate::{
-    bls12_381_const::{
-        FP_LENGTH, FP_PAD_BY, G1_LENGTH, G2_LENGTH, PADDED_FP_LENGTH, PADDED_G1_LENGTH,
-        PADDED_G2_LENGTH, SCALAR_LENGTH,
-    },
+    bls12_381_const::{FP_LENGTH, G1_LENGTH, G2_LENGTH, SCALAR_LENGTH},
     PrecompileError,
 };
 use ark_bls12_381::{Bls12_381, Fq, Fq2, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
@@ -27,7 +24,7 @@ use std::{string::ToString, vec::Vec};
 ///
 /// Panics if the input is not exactly 48 bytes long.
 #[inline]
-pub(super) fn read_fp(input_be: &[u8]) -> Result<Fq, PrecompileError> {
+fn read_fp(input_be: &[u8]) -> Result<Fq, PrecompileError> {
     assert_eq!(input_be.len(), FP_LENGTH, "input must be {FP_LENGTH} bytes");
 
     let mut input_le = [0u8; FP_LENGTH];
@@ -45,7 +42,7 @@ pub(super) fn read_fp(input_be: &[u8]) -> Result<Fq, PrecompileError> {
 /// # Panics
 ///
 /// Panics if serialization fails, which should not occur for a valid field element.
-pub(super) fn encode_fp(fp: &Fq) -> [u8; FP_LENGTH] {
+fn encode_fp(fp: &Fq) -> [u8; FP_LENGTH] {
     let mut bytes = [0u8; FP_LENGTH];
     fp.serialize_uncompressed(&mut bytes[..])
         .expect("Failed to serialize field element");
@@ -61,7 +58,7 @@ pub(super) fn encode_fp(fp: &Fq) -> [u8; FP_LENGTH] {
 ///
 /// Panics if either input is not exactly 48 bytes long.
 #[inline]
-pub(super) fn read_fp2(
+fn read_fp2(
     input_1: &[u8; FP_LENGTH],
     input_2: &[u8; FP_LENGTH],
 ) -> Result<Fq2, PrecompileError> {
@@ -129,7 +126,7 @@ fn new_g2_point_no_subgroup_check(x: Fq2, y: Fq2) -> Result<G2Affine, Precompile
 ///
 /// Panics if the inputs are not exactly 48 bytes long.
 #[inline]
-pub(super) fn read_g1(
+fn read_g1(
     x: &[u8; FP_LENGTH],
     y: &[u8; FP_LENGTH],
 ) -> Result<G1Affine, PrecompileError> {
@@ -149,7 +146,7 @@ pub(super) fn read_g1(
 ///     - The EIP specifies that no subgroup check should be performed
 ///     - One can be certain that the point is in the correct subgroup.
 #[inline]
-pub(super) fn read_g1_no_subgroup_check(
+fn read_g1_no_subgroup_check(
     x: &[u8; FP_LENGTH],
     y: &[u8; FP_LENGTH],
 ) -> Result<G1Affine, PrecompileError> {
@@ -163,7 +160,7 @@ pub(super) fn read_g1_no_subgroup_check(
 /// Converts a G1 point to affine coordinates and serializes the x and y coordinates
 /// as big-endian byte arrays.
 #[inline]
-pub(super) fn encode_g1_point(input: &G1Affine) -> [u8; G1_LENGTH] {
+fn encode_g1_point(input: &G1Affine) -> [u8; G1_LENGTH] {
     let mut output = [0u8; G1_LENGTH];
 
     let Some((x, y)) = input.xy() else {
@@ -186,7 +183,7 @@ pub(super) fn encode_g1_point(input: &G1Affine) -> [u8; G1_LENGTH] {
 /// representing the x and y coordinates in Big Endian format.
 /// Also performs a subgroup check to ensure the point is in the correct subgroup.
 #[inline]
-pub(super) fn read_g2(
+fn read_g2(
     a_x_0: &[u8; FP_LENGTH],
     a_x_1: &[u8; FP_LENGTH],
     a_y_0: &[u8; FP_LENGTH],
@@ -208,7 +205,7 @@ pub(super) fn read_g2(
 ///     - The EIP specifies that no subgroup check should be performed
 ///     - One can be certain that the point is in the correct subgroup.
 #[inline]
-pub(super) fn read_g2_no_subgroup_check(
+fn read_g2_no_subgroup_check(
     a_x_0: &[u8; FP_LENGTH],
     a_x_1: &[u8; FP_LENGTH],
     a_y_0: &[u8; FP_LENGTH],
@@ -224,7 +221,7 @@ pub(super) fn read_g2_no_subgroup_check(
 /// Converts a G2 point to affine coordinates and serializes the coordinates
 /// as big-endian byte arrays.
 #[inline]
-pub(super) fn encode_g2_point(input: &G2Affine) -> [u8; G2_LENGTH] {
+fn encode_g2_point(input: &G2Affine) -> [u8; G2_LENGTH] {
     let mut output = [0u8; G2_LENGTH];
 
     let Some((x, y)) = input.xy() else {
@@ -250,7 +247,7 @@ pub(super) fn encode_g2_point(input: &G2Affine) -> [u8; G2_LENGTH] {
 /// Note: We do not check that the scalar is a canonical Fr element, because the EIP specifies:
 /// * The corresponding integer is not required to be less than or equal than main subgroup order.
 #[inline]
-pub(super) fn read_scalar(input: &[u8]) -> Result<Fr, PrecompileError> {
+fn read_scalar(input: &[u8]) -> Result<Fr, PrecompileError> {
     if input.len() != SCALAR_LENGTH {
         return Err(PrecompileError::Other(format!(
             "Input should be {SCALAR_LENGTH} bytes, was {}",
@@ -263,7 +260,7 @@ pub(super) fn read_scalar(input: &[u8]) -> Result<Fr, PrecompileError> {
 
 /// Performs point addition on two G1 points.
 #[inline]
-pub(super) fn p1_add_affine(p1: &G1Affine, p2: &G1Affine) -> G1Affine {
+fn p1_add_affine(p1: &G1Affine, p2: &G1Affine) -> G1Affine {
     let p1_proj: G1Projective = (*p1).into();
     let p3 = p1_proj + p2;
     p3.into_affine()
@@ -271,7 +268,7 @@ pub(super) fn p1_add_affine(p1: &G1Affine, p2: &G1Affine) -> G1Affine {
 
 /// Performs point addition on two G2 points.
 #[inline]
-pub(super) fn p2_add_affine(p1: &G2Affine, p2: &G2Affine) -> G2Affine {
+fn p2_add_affine(p1: &G2Affine, p2: &G2Affine) -> G2Affine {
     let p1_proj: G2Projective = (*p1).into();
     let p3 = p1_proj + p2;
     p3.into_affine()
@@ -283,7 +280,7 @@ pub(super) fn p2_add_affine(p1: &G2Affine, p2: &G2Affine) -> G2Affine {
 ///
 /// Note: This method assumes that `g1_points` does not contain any points at infinity.
 #[inline]
-pub(super) fn p1_msm(g1_points: Vec<G1Affine>, scalars: Vec<Fr>) -> G1Affine {
+fn p1_msm(g1_points: Vec<G1Affine>, scalars: Vec<Fr>) -> G1Affine {
     assert_eq!(
         g1_points.len(),
         scalars.len(),
@@ -311,7 +308,7 @@ pub(super) fn p1_msm(g1_points: Vec<G1Affine>, scalars: Vec<Fr>) -> G1Affine {
 ///
 /// Note: This method assumes that `g2_points` does not contain any points at infinity.
 #[inline]
-pub(super) fn p2_msm(g2_points: Vec<G2Affine>, scalars: Vec<Fr>) -> G2Affine {
+fn p2_msm(g2_points: Vec<G2Affine>, scalars: Vec<Fr>) -> G2Affine {
     assert_eq!(
         g2_points.len(),
         scalars.len(),
@@ -337,7 +334,7 @@ pub(super) fn p2_msm(g2_points: Vec<G2Affine>, scalars: Vec<Fr>) -> G2Affine {
 ///
 /// Takes a field element (Fq) and returns the corresponding G1 point in affine form
 #[inline]
-pub(super) fn map_fp_to_g1(fp: &Fq) -> G1Affine {
+fn map_fp_to_g1(fp: &Fq) -> G1Affine {
     WBMap::map_to_curve(*fp)
         .expect("map_to_curve is infallible")
         .clear_cofactor()
@@ -347,7 +344,7 @@ pub(super) fn map_fp_to_g1(fp: &Fq) -> G1Affine {
 ///
 /// Takes a field element (Fq2) and returns the corresponding G2 point in affine form
 #[inline]
-pub(super) fn map_fp2_to_g2(fp2: &Fq2) -> G2Affine {
+fn map_fp2_to_g2(fp2: &Fq2) -> G2Affine {
     WBMap::map_to_curve(*fp2)
         .expect("map_to_curve is infallible")
         .clear_cofactor()
@@ -356,7 +353,7 @@ pub(super) fn map_fp2_to_g2(fp2: &Fq2) -> G2Affine {
 /// pairing_check performs a pairing check on a list of G1 and G2 point pairs and
 /// returns true if the result is equal to the identity element.
 #[inline]
-pub(super) fn pairing_check(pairs: &[(G1Affine, G2Affine)]) -> bool {
+fn pairing_check(pairs: &[(G1Affine, G2Affine)]) -> bool {
     if pairs.is_empty() {
         return true;
     }

--- a/crates/precompile/src/bls12_381/arkworks.rs
+++ b/crates/precompile/src/bls12_381/arkworks.rs
@@ -469,32 +469,29 @@ pub(super) fn map_fp2_to_g2_bytes(
 /// Performs multi-scalar multiplication (MSM) for G1 points taking byte inputs.
 #[inline]
 pub(super) fn p1_msm_bytes(
-    point_scalar_pairs: &[(G1Point, [u8; SCALAR_LENGTH])],
+    point_scalar_pairs: impl Iterator<Item = Result<(G1Point, [u8; SCALAR_LENGTH]), PrecompileError>>,
 ) -> Result<[u8; G1_LENGTH], PrecompileError> {
-    if point_scalar_pairs.is_empty() {
-        // Return point at infinity
-        return Ok([0u8; G1_LENGTH]);
-    }
-
-    let mut g1_points = Vec::with_capacity(point_scalar_pairs.len());
-    let mut scalars = Vec::with_capacity(point_scalar_pairs.len());
+    let mut g1_points = Vec::new();
+    let mut scalars = Vec::new();
 
     // Parse all points and scalars
-    for ((x, y), scalar_bytes) in point_scalar_pairs {
+    for pair_result in point_scalar_pairs {
+        let ((x, y), scalar_bytes) = pair_result?;
+
         // NB: MSM requires subgroup check
-        let point = read_g1(x, y)?;
+        let point = read_g1(&x, &y)?;
 
         // Skip zero scalars after validating the point
         if scalar_bytes.iter().all(|&b| b == 0) {
             continue;
         }
 
-        let scalar = read_scalar(scalar_bytes)?;
+        let scalar = read_scalar(&scalar_bytes)?;
         g1_points.push(point);
         scalars.push(scalar);
     }
 
-    // Return point at infinity if all scalars were zero
+    // Return point at infinity if no pairs were provided or all scalars were zero
     if g1_points.is_empty() {
         return Ok([0u8; G1_LENGTH]);
     }
@@ -509,32 +506,29 @@ pub(super) fn p1_msm_bytes(
 /// Performs multi-scalar multiplication (MSM) for G2 points taking byte inputs.
 #[inline]
 pub(super) fn p2_msm_bytes(
-    point_scalar_pairs: &[(G2Point, [u8; SCALAR_LENGTH])],
+    point_scalar_pairs: impl Iterator<Item = Result<(G2Point, [u8; SCALAR_LENGTH]), PrecompileError>>,
 ) -> Result<[u8; G2_LENGTH], PrecompileError> {
-    if point_scalar_pairs.is_empty() {
-        // Return point at infinity
-        return Ok([0u8; G2_LENGTH]);
-    }
-
-    let mut g2_points = Vec::with_capacity(point_scalar_pairs.len());
-    let mut scalars = Vec::with_capacity(point_scalar_pairs.len());
+    let mut g2_points = Vec::new();
+    let mut scalars = Vec::new();
 
     // Parse all points and scalars
-    for ((x_0, x_1, y_0, y_1), scalar_bytes) in point_scalar_pairs {
+    for pair_result in point_scalar_pairs {
+        let ((x_0, x_1, y_0, y_1), scalar_bytes) = pair_result?;
+
         // NB: MSM requires subgroup check
-        let point = read_g2(x_0, x_1, y_0, y_1)?;
+        let point = read_g2(&x_0, &x_1, &y_0, &y_1)?;
 
         // Skip zero scalars after validating the point
         if scalar_bytes.iter().all(|&b| b == 0) {
             continue;
         }
 
-        let scalar = read_scalar(scalar_bytes)?;
+        let scalar = read_scalar(&scalar_bytes)?;
         g2_points.push(point);
         scalars.push(scalar);
     }
 
-    // Return point at infinity if all scalars were zero
+    // Return point at infinity if no pairs were provided or all scalars were zero
     if g2_points.is_empty() {
         return Ok([0u8; G2_LENGTH]);
     }

--- a/crates/precompile/src/bls12_381/blst.rs
+++ b/crates/precompile/src/bls12_381/blst.rs
@@ -7,6 +7,21 @@ use crate::{
     },
     PrecompileError,
 };
+
+// Type aliases for MSM byte-oriented API
+pub(super) type G1PointScalarPairRef<'a> = (
+    (&'a [u8; FP_LENGTH], &'a [u8; FP_LENGTH]),
+    &'a [u8; SCALAR_LENGTH],
+);
+pub(super) type G2PointScalarPairRef<'a> = (
+    (
+        &'a [u8; FP_LENGTH],
+        &'a [u8; FP_LENGTH], 
+        &'a [u8; FP_LENGTH],
+        &'a [u8; FP_LENGTH],
+    ),
+    &'a [u8; SCALAR_LENGTH],
+);
 use blst::{
     blst_bendian_from_fp, blst_final_exp, blst_fp, blst_fp12, blst_fp12_is_one, blst_fp12_mul,
     blst_fp2, blst_fp_from_bendian, blst_map_to_g1, blst_map_to_g2, blst_miller_loop, blst_p1,
@@ -696,5 +711,85 @@ pub(super) fn map_fp_to_g1_bytes(fp_bytes: &[u8; FP_LENGTH]) -> Result<[u8; PADD
 pub(super) fn map_fp2_to_g2_bytes(fp2_x: &[u8; FP_LENGTH], fp2_y: &[u8; FP_LENGTH]) -> Result<[u8; PADDED_G2_LENGTH], crate::PrecompileError> {
     let fp2 = read_fp2(fp2_x, fp2_y)?;
     let result = map_fp2_to_g2(&fp2);
+    Ok(encode_g2_point(&result))
+}
+
+/// Performs multi-scalar multiplication (MSM) for G1 points taking byte inputs and returning encoded result.
+#[inline]
+pub(super) fn p1_msm_bytes(
+    point_scalar_pairs: &[G1PointScalarPairRef<'_>],
+) -> Result<[u8; PADDED_G1_LENGTH], crate::PrecompileError> {
+    if point_scalar_pairs.is_empty() {
+        // Return point at infinity
+        return Ok([0u8; PADDED_G1_LENGTH]);
+    }
+
+    let mut g1_points = Vec::with_capacity(point_scalar_pairs.len());
+    let mut scalars = Vec::with_capacity(point_scalar_pairs.len());
+
+    // Parse all points and scalars
+    for ((x, y), scalar_bytes) in point_scalar_pairs {
+        // NB: MSM requires subgroup check
+        let point = read_g1(x, y)?;
+        
+        // Skip zero scalars after validating the point
+        if scalar_bytes.iter().all(|&b| b == 0) {
+            continue;
+        }
+        
+        let scalar = read_scalar(*scalar_bytes)?;
+        g1_points.push(point);
+        scalars.push(scalar);
+    }
+
+    // Return point at infinity if all scalars were zero
+    if g1_points.is_empty() {
+        return Ok([0u8; PADDED_G1_LENGTH]);
+    }
+
+    // Perform MSM
+    let result = p1_msm(g1_points, scalars);
+
+    // Encode result
+    Ok(encode_g1_point(&result))
+}
+
+/// Performs multi-scalar multiplication (MSM) for G2 points taking byte inputs and returning encoded result.
+#[inline]
+pub(super) fn p2_msm_bytes(
+    point_scalar_pairs: &[G2PointScalarPairRef<'_>],
+) -> Result<[u8; PADDED_G2_LENGTH], crate::PrecompileError> {
+    if point_scalar_pairs.is_empty() {
+        // Return point at infinity
+        return Ok([0u8; PADDED_G2_LENGTH]);
+    }
+
+    let mut g2_points = Vec::with_capacity(point_scalar_pairs.len());
+    let mut scalars = Vec::with_capacity(point_scalar_pairs.len());
+
+    // Parse all points and scalars
+    for ((x_0, x_1, y_0, y_1), scalar_bytes) in point_scalar_pairs {
+        // NB: MSM requires subgroup check
+        let point = read_g2(x_0, x_1, y_0, y_1)?;
+        
+        // Skip zero scalars after validating the point
+        if scalar_bytes.iter().all(|&b| b == 0) {
+            continue;
+        }
+        
+        let scalar = read_scalar(*scalar_bytes)?;
+        g2_points.push(point);
+        scalars.push(scalar);
+    }
+
+    // Return point at infinity if all scalars were zero
+    if g2_points.is_empty() {
+        return Ok([0u8; PADDED_G2_LENGTH]);
+    }
+
+    // Perform MSM
+    let result = p2_msm(g2_points, scalars);
+
+    // Encode result
     Ok(encode_g2_point(&result))
 }

--- a/crates/precompile/src/bls12_381/blst.rs
+++ b/crates/precompile/src/bls12_381/blst.rs
@@ -807,10 +807,10 @@ pub(super) fn pairing_check_bytes(pairs: &[PairingPair]) -> Result<bool, crate::
         if g1_is_zero || g2_is_zero {
             // Still need to validate the non-zero point if one exists
             if !g1_is_zero {
-                read_g1(g1_x, g1_y)?;
+                let _ = read_g1(g1_x, g1_y)?;
             }
             if !g2_is_zero {
-                read_g2(g2_x_0, g2_x_1, g2_y_0, g2_y_1)?;
+                let _ = read_g2(g2_x_0, g2_x_1, g2_y_0, g2_y_1)?;
             }
             continue;
         }

--- a/crates/precompile/src/bls12_381/blst.rs
+++ b/crates/precompile/src/bls12_381/blst.rs
@@ -76,7 +76,7 @@ fn p2_add_or_double(p: &blst_p2, p_affine: &blst_p2_affine) -> blst_p2 {
 /// Note: `a` and `b` can be the same, ie this method is safe to call if one wants
 /// to essentially double a point
 #[inline]
-pub(super) fn p1_add_affine(a: &blst_p1_affine, b: &blst_p1_affine) -> blst_p1_affine {
+fn p1_add_affine(a: &blst_p1_affine, b: &blst_p1_affine) -> blst_p1_affine {
     // Convert first point to Jacobian coordinates
     let a_jacobian = p1_from_affine(a);
 
@@ -89,7 +89,7 @@ pub(super) fn p1_add_affine(a: &blst_p1_affine, b: &blst_p1_affine) -> blst_p1_a
 
 /// Add two G2 points in affine form, returning the result in affine form
 #[inline]
-pub(super) fn p2_add_affine(a: &blst_p2_affine, b: &blst_p2_affine) -> blst_p2_affine {
+fn p2_add_affine(a: &blst_p2_affine, b: &blst_p2_affine) -> blst_p2_affine {
     // Convert first point to Jacobian coordinates
     let a_jacobian = p2_from_affine(a);
 
@@ -159,7 +159,7 @@ fn p2_scalar_mul(p: &blst_p2_affine, scalar: &blst_scalar) -> blst_p2_affine {
 ///
 /// Note: This method assumes that `g1_points` does not contain any points at infinity.
 #[inline]
-pub(super) fn p1_msm(g1_points: Vec<blst_p1_affine>, scalars: Vec<blst_scalar>) -> blst_p1_affine {
+fn p1_msm(g1_points: Vec<blst_p1_affine>, scalars: Vec<blst_scalar>) -> blst_p1_affine {
     assert_eq!(
         g1_points.len(),
         scalars.len(),
@@ -197,7 +197,7 @@ pub(super) fn p1_msm(g1_points: Vec<blst_p1_affine>, scalars: Vec<blst_scalar>) 
 /// Note: Scalars are expected to be in Big Endian format.
 /// This method assumes that `g2_points` does not contain any points at infinity.
 #[inline]
-pub(super) fn p2_msm(g2_points: Vec<blst_p2_affine>, scalars: Vec<blst_scalar>) -> blst_p2_affine {
+fn p2_msm(g2_points: Vec<blst_p2_affine>, scalars: Vec<blst_scalar>) -> blst_p2_affine {
     assert_eq!(
         g2_points.len(),
         scalars.len(),
@@ -233,7 +233,7 @@ pub(super) fn p2_msm(g2_points: Vec<blst_p2_affine>, scalars: Vec<blst_scalar>) 
 ///
 /// Takes a field element (blst_fp) and returns the corresponding G1 point in affine form
 #[inline]
-pub(super) fn map_fp_to_g1(fp: &blst_fp) -> blst_p1_affine {
+fn map_fp_to_g1(fp: &blst_fp) -> blst_p1_affine {
     // Create a new G1 point in Jacobian coordinates
     let mut p = blst_p1::default();
 
@@ -250,7 +250,7 @@ pub(super) fn map_fp_to_g1(fp: &blst_fp) -> blst_p1_affine {
 ///
 /// Takes a field element (blst_fp2) and returns the corresponding G2 point in affine form
 #[inline]
-pub(super) fn map_fp2_to_g2(fp2: &blst_fp2) -> blst_p2_affine {
+fn map_fp2_to_g2(fp2: &blst_fp2) -> blst_p2_affine {
     // Create a new G2 point in Jacobian coordinates
     let mut p = blst_p2::default();
 
@@ -307,7 +307,7 @@ fn is_fp12_one(f: &blst_fp12) -> bool {
 /// pairing_check performs a pairing check on a list of G1 and G2 point pairs and
 /// returns true if the result is equal to the identity element.
 #[inline]
-pub(super) fn pairing_check(pairs: &[(blst_p1_affine, blst_p2_affine)]) -> bool {
+fn pairing_check(pairs: &[(blst_p1_affine, blst_p2_affine)]) -> bool {
     // When no inputs are given, we return true
     // This case can only trigger, if the initial pairing components
     // all had, either the G1 element as the point at infinity
@@ -338,7 +338,7 @@ pub(super) fn pairing_check(pairs: &[(blst_p1_affine, blst_p2_affine)]) -> bool 
 /// Encodes a G1 point in affine format into byte slice.
 ///
 /// Note: The encoded bytes are in Big Endian format.
-pub(super) fn encode_g1_point(input: &blst_p1_affine) -> [u8; G1_LENGTH] {
+fn encode_g1_point(input: &blst_p1_affine) -> [u8; G1_LENGTH] {
     let mut out = [0u8; G1_LENGTH];
     fp_to_bytes(&mut out[..FP_LENGTH], &input.x);
     fp_to_bytes(&mut out[FP_LENGTH..], &input.y);
@@ -393,10 +393,7 @@ fn decode_g1_on_curve(
 ///
 /// Note: Coordinates are expected to be in Big Endian format.
 /// By default, subgroup checks are performed.
-pub(super) fn read_g1(
-    x: &[u8; FP_LENGTH],
-    y: &[u8; FP_LENGTH],
-) -> Result<blst_p1_affine, PrecompileError> {
+fn read_g1(x: &[u8; FP_LENGTH], y: &[u8; FP_LENGTH]) -> Result<blst_p1_affine, PrecompileError> {
     _extract_g1_input(x, y, true)
 }
 /// Extracts a G1 point in Affine format from the x and y coordinates
@@ -407,7 +404,7 @@ pub(super) fn read_g1(
 /// This method should only be called if:
 ///     - The EIP specifies that no subgroup check should be performed
 ///     - One can be certain that the point is in the correct subgroup.
-pub(super) fn read_g1_no_subgroup_check(
+fn read_g1_no_subgroup_check(
     x: &[u8; FP_LENGTH],
     y: &[u8; FP_LENGTH],
 ) -> Result<blst_p1_affine, PrecompileError> {
@@ -447,7 +444,7 @@ fn _extract_g1_input(
 /// Encodes a G2 point in affine format into byte slice.
 ///
 /// Note: The encoded bytes are in Big Endian format.
-pub(super) fn encode_g2_point(input: &blst_p2_affine) -> [u8; G2_LENGTH] {
+fn encode_g2_point(input: &blst_p2_affine) -> [u8; G2_LENGTH] {
     let mut out = [0u8; G2_LENGTH];
     fp_to_bytes(&mut out[..FP_LENGTH], &input.x.fp[0]);
     fp_to_bytes(&mut out[FP_LENGTH..2 * FP_LENGTH], &input.x.fp[1]);
@@ -495,7 +492,7 @@ fn decode_g2_on_curve(
 ///
 /// Field elements are expected to be in Big Endian format.
 /// Returns an error if either of the input field elements is not canonical.
-pub(super) fn read_fp2(
+fn read_fp2(
     input_1: &[u8; FP_LENGTH],
     input_2: &[u8; FP_LENGTH],
 ) -> Result<blst_fp2, PrecompileError> {
@@ -510,7 +507,7 @@ pub(super) fn read_fp2(
 ///
 /// Note: Coordinates are expected to be in Big Endian format.
 /// By default, subgroup checks are performed.
-pub(super) fn read_g2(
+fn read_g2(
     a_x_0: &[u8; FP_LENGTH],
     a_x_1: &[u8; FP_LENGTH],
     a_y_0: &[u8; FP_LENGTH],
@@ -526,7 +523,7 @@ pub(super) fn read_g2(
 /// This method should only be called if:
 ///     - The EIP specifies that no subgroup check should be performed
 ///     - One can be certain that the point is in the correct subgroup.
-pub(super) fn read_g2_no_subgroup_check(
+fn read_g2_no_subgroup_check(
     a_x_0: &[u8; FP_LENGTH],
     a_x_1: &[u8; FP_LENGTH],
     a_y_0: &[u8; FP_LENGTH],
@@ -571,7 +568,7 @@ fn _extract_g2_input(
 /// returning the field element if successful.
 ///
 /// Note: The field element is expected to be in big endian format.
-pub(super) fn read_fp(input: &[u8; FP_LENGTH]) -> Result<blst_fp, PrecompileError> {
+fn read_fp(input: &[u8; FP_LENGTH]) -> Result<blst_fp, PrecompileError> {
     if !is_valid_be(input) {
         return Err(PrecompileError::Other("non-canonical fp value".to_string()));
     }
@@ -595,7 +592,7 @@ pub(super) fn read_fp(input: &[u8; FP_LENGTH]) -> Result<blst_fp, PrecompileErro
 /// We do not check that the scalar is a canonical Fr element, because the EIP specifies:
 /// * The corresponding integer is not required to be less than or equal than main subgroup order
 ///   `q`.
-pub(super) fn read_scalar(input: &[u8]) -> Result<blst_scalar, PrecompileError> {
+fn read_scalar(input: &[u8]) -> Result<blst_scalar, PrecompileError> {
     if input.len() != SCALAR_LENGTH {
         return Err(PrecompileError::Other(format!(
             "Input should be {SCALAR_LENGTH} bytes, was {}",

--- a/crates/precompile/src/bls12_381/blst.rs
+++ b/crates/precompile/src/bls12_381/blst.rs
@@ -1,5 +1,6 @@
 // This module contains a safe wrapper around the blst library.
 
+use super::{G1Point, G2Point, PairingPair};
 use crate::{
     bls12_381_const::{
         FP_LENGTH, FP_PAD_BY, PADDED_FP_LENGTH, PADDED_G1_LENGTH, PADDED_G2_LENGTH, SCALAR_LENGTH,
@@ -7,21 +8,6 @@ use crate::{
     },
     PrecompileError,
 };
-
-// Type aliases for MSM byte-oriented API
-pub(super) type G1PointScalarPairRef<'a> = (
-    (&'a [u8; FP_LENGTH], &'a [u8; FP_LENGTH]),
-    &'a [u8; SCALAR_LENGTH],
-);
-pub(super) type G2PointScalarPairRef<'a> = (
-    (
-        &'a [u8; FP_LENGTH],
-        &'a [u8; FP_LENGTH], 
-        &'a [u8; FP_LENGTH],
-        &'a [u8; FP_LENGTH],
-    ),
-    &'a [u8; SCALAR_LENGTH],
-);
 use blst::{
     blst_bendian_from_fp, blst_final_exp, blst_fp, blst_fp12, blst_fp12_is_one, blst_fp12_mul,
     blst_fp2, blst_fp_from_bendian, blst_map_to_g1, blst_map_to_g2, blst_miller_loop, blst_p1,
@@ -700,7 +686,9 @@ pub(super) fn p2_add_affine_bytes(
 
 /// Maps a field element to a G1 point from bytes
 #[inline]
-pub(super) fn map_fp_to_g1_bytes(fp_bytes: &[u8; FP_LENGTH]) -> Result<[u8; PADDED_G1_LENGTH], crate::PrecompileError> {
+pub(super) fn map_fp_to_g1_bytes(
+    fp_bytes: &[u8; FP_LENGTH],
+) -> Result<[u8; PADDED_G1_LENGTH], crate::PrecompileError> {
     let fp = read_fp(fp_bytes)?;
     let result = map_fp_to_g1(&fp);
     Ok(encode_g1_point(&result))
@@ -708,7 +696,10 @@ pub(super) fn map_fp_to_g1_bytes(fp_bytes: &[u8; FP_LENGTH]) -> Result<[u8; PADD
 
 /// Maps field elements to a G2 point from bytes
 #[inline]
-pub(super) fn map_fp2_to_g2_bytes(fp2_x: &[u8; FP_LENGTH], fp2_y: &[u8; FP_LENGTH]) -> Result<[u8; PADDED_G2_LENGTH], crate::PrecompileError> {
+pub(super) fn map_fp2_to_g2_bytes(
+    fp2_x: &[u8; FP_LENGTH],
+    fp2_y: &[u8; FP_LENGTH],
+) -> Result<[u8; PADDED_G2_LENGTH], crate::PrecompileError> {
     let fp2 = read_fp2(fp2_x, fp2_y)?;
     let result = map_fp2_to_g2(&fp2);
     Ok(encode_g2_point(&result))
@@ -717,7 +708,7 @@ pub(super) fn map_fp2_to_g2_bytes(fp2_x: &[u8; FP_LENGTH], fp2_y: &[u8; FP_LENGT
 /// Performs multi-scalar multiplication (MSM) for G1 points taking byte inputs and returning encoded result.
 #[inline]
 pub(super) fn p1_msm_bytes(
-    point_scalar_pairs: &[G1PointScalarPairRef<'_>],
+    point_scalar_pairs: &[(&G1Point, &[u8; SCALAR_LENGTH])],
 ) -> Result<[u8; PADDED_G1_LENGTH], crate::PrecompileError> {
     if point_scalar_pairs.is_empty() {
         // Return point at infinity
@@ -731,12 +722,12 @@ pub(super) fn p1_msm_bytes(
     for ((x, y), scalar_bytes) in point_scalar_pairs {
         // NB: MSM requires subgroup check
         let point = read_g1(x, y)?;
-        
+
         // Skip zero scalars after validating the point
         if scalar_bytes.iter().all(|&b| b == 0) {
             continue;
         }
-        
+
         let scalar = read_scalar(*scalar_bytes)?;
         g1_points.push(point);
         scalars.push(scalar);
@@ -757,7 +748,7 @@ pub(super) fn p1_msm_bytes(
 /// Performs multi-scalar multiplication (MSM) for G2 points taking byte inputs and returning encoded result.
 #[inline]
 pub(super) fn p2_msm_bytes(
-    point_scalar_pairs: &[G2PointScalarPairRef<'_>],
+    point_scalar_pairs: &[(&G2Point, &[u8; SCALAR_LENGTH])],
 ) -> Result<[u8; PADDED_G2_LENGTH], crate::PrecompileError> {
     if point_scalar_pairs.is_empty() {
         // Return point at infinity
@@ -771,12 +762,12 @@ pub(super) fn p2_msm_bytes(
     for ((x_0, x_1, y_0, y_1), scalar_bytes) in point_scalar_pairs {
         // NB: MSM requires subgroup check
         let point = read_g2(x_0, x_1, y_0, y_1)?;
-        
+
         // Skip zero scalars after validating the point
         if scalar_bytes.iter().all(|&b| b == 0) {
             continue;
         }
-        
+
         let scalar = read_scalar(*scalar_bytes)?;
         g2_points.push(point);
         scalars.push(scalar);
@@ -792,4 +783,47 @@ pub(super) fn p2_msm_bytes(
 
     // Encode result
     Ok(encode_g2_point(&result))
+}
+
+/// pairing_check_bytes performs a pairing check on a list of G1 and G2 point pairs taking byte inputs.
+#[inline]
+pub(super) fn pairing_check_bytes(pairs: &[PairingPair]) -> Result<bool, crate::PrecompileError> {
+    if pairs.is_empty() {
+        return Ok(true);
+    }
+
+    let mut parsed_pairs = Vec::with_capacity(pairs.len());
+    for ((g1_x, g1_y), (g2_x_0, g2_x_1, g2_y_0, g2_y_1)) in pairs {
+        // Check if G1 point is zero (point at infinity)
+        let g1_is_zero = g1_x.iter().all(|&b| b == 0) && g1_y.iter().all(|&b| b == 0);
+
+        // Check if G2 point is zero (point at infinity)
+        let g2_is_zero = g2_x_0.iter().all(|&b| b == 0)
+            && g2_x_1.iter().all(|&b| b == 0)
+            && g2_y_0.iter().all(|&b| b == 0)
+            && g2_y_1.iter().all(|&b| b == 0);
+
+        // Skip this pair if either point is at infinity as it's a no-op
+        if g1_is_zero || g2_is_zero {
+            // Still need to validate the non-zero point if one exists
+            if !g1_is_zero {
+                read_g1(g1_x, g1_y)?;
+            }
+            if !g2_is_zero {
+                read_g2(g2_x_0, g2_x_1, g2_y_0, g2_y_1)?;
+            }
+            continue;
+        }
+
+        let g1_point = read_g1(g1_x, g1_y)?;
+        let g2_point = read_g2(g2_x_0, g2_x_1, g2_y_0, g2_y_1)?;
+        parsed_pairs.push((g1_point, g2_point));
+    }
+
+    // If all pairs were filtered out, return true (identity element)
+    if parsed_pairs.is_empty() {
+        return Ok(true);
+    }
+
+    Ok(pairing_check(&parsed_pairs))
 }

--- a/crates/precompile/src/bls12_381/blst.rs
+++ b/crates/precompile/src/bls12_381/blst.rs
@@ -640,16 +640,16 @@ fn is_valid_be(input: &[u8; 48]) -> bool {
 /// Performs point addition on two G1 points taking byte coordinates and returning encoded result.
 #[inline]
 pub(super) fn p1_add_affine_bytes(
-    a_x: &[u8; FP_LENGTH],
-    a_y: &[u8; FP_LENGTH],
-    b_x: &[u8; FP_LENGTH],
-    b_y: &[u8; FP_LENGTH],
+    a: G1Point,
+    b: G1Point,
 ) -> Result<[u8; PADDED_G1_LENGTH], crate::PrecompileError> {
+    let (a_x, a_y) = a;
+    let (b_x, b_y) = b;
     // Parse first point
-    let p1 = read_g1_no_subgroup_check(a_x, a_y)?;
+    let p1 = read_g1_no_subgroup_check(&a_x, &a_y)?;
 
     // Parse second point
-    let p2 = read_g1_no_subgroup_check(b_x, b_y)?;
+    let p2 = read_g1_no_subgroup_check(&b_x, &b_y)?;
 
     // Perform addition
     let result = p1_add_affine(&p1, &p2);
@@ -660,22 +660,17 @@ pub(super) fn p1_add_affine_bytes(
 
 /// Performs point addition on two G2 points taking byte coordinates and returning encoded result.
 #[inline]
-#[allow(clippy::too_many_arguments)]
 pub(super) fn p2_add_affine_bytes(
-    a_x_0: &[u8; FP_LENGTH],
-    a_x_1: &[u8; FP_LENGTH],
-    a_y_0: &[u8; FP_LENGTH],
-    a_y_1: &[u8; FP_LENGTH],
-    b_x_0: &[u8; FP_LENGTH],
-    b_x_1: &[u8; FP_LENGTH],
-    b_y_0: &[u8; FP_LENGTH],
-    b_y_1: &[u8; FP_LENGTH],
+    a: G2Point,
+    b: G2Point,
 ) -> Result<[u8; PADDED_G2_LENGTH], crate::PrecompileError> {
+    let (a_x_0, a_x_1, a_y_0, a_y_1) = a;
+    let (b_x_0, b_x_1, b_y_0, b_y_1) = b;
     // Parse first point
-    let p1 = read_g2_no_subgroup_check(a_x_0, a_x_1, a_y_0, a_y_1)?;
+    let p1 = read_g2_no_subgroup_check(&a_x_0, &a_x_1, &a_y_0, &a_y_1)?;
 
     // Parse second point
-    let p2 = read_g2_no_subgroup_check(b_x_0, b_x_1, b_y_0, b_y_1)?;
+    let p2 = read_g2_no_subgroup_check(&b_x_0, &b_x_1, &b_y_0, &b_y_1)?;
 
     // Perform addition
     let result = p2_add_affine(&p1, &p2);

--- a/crates/precompile/src/bls12_381/blst.rs
+++ b/crates/precompile/src/bls12_381/blst.rs
@@ -721,7 +721,7 @@ pub(super) fn p1_msm_bytes(
     // Parse all points and scalars
     for ((x, y), scalar_bytes) in point_scalar_pairs {
         // NB: MSM requires subgroup check
-        let point = read_g1(&x, &y)?;
+        let point = read_g1(x, y)?;
 
         // Skip zero scalars after validating the point
         if scalar_bytes.iter().all(|&b| b == 0) {
@@ -761,7 +761,7 @@ pub(super) fn p2_msm_bytes(
     // Parse all points and scalars
     for ((x_0, x_1, y_0, y_1), scalar_bytes) in point_scalar_pairs {
         // NB: MSM requires subgroup check
-        let point = read_g2(&x_0, &x_1, &y_0, &y_1)?;
+        let point = read_g2(x_0, x_1, y_0, y_1)?;
 
         // Skip zero scalars after validating the point
         if scalar_bytes.iter().all(|&b| b == 0) {

--- a/crates/precompile/src/bls12_381/blst.rs
+++ b/crates/precompile/src/bls12_381/blst.rs
@@ -686,32 +686,31 @@ pub(super) fn map_fp2_to_g2_bytes(
 /// Performs multi-scalar multiplication (MSM) for G1 points taking byte inputs.
 #[inline]
 pub(super) fn p1_msm_bytes(
-    point_scalar_pairs: &[(G1Point, [u8; SCALAR_LENGTH])],
+    point_scalar_pairs: impl Iterator<
+        Item = Result<(G1Point, [u8; SCALAR_LENGTH]), crate::PrecompileError>,
+    >,
 ) -> Result<[u8; G1_LENGTH], crate::PrecompileError> {
-    if point_scalar_pairs.is_empty() {
-        // Return point at infinity
-        return Ok([0u8; G1_LENGTH]);
-    }
-
-    let mut g1_points = Vec::with_capacity(point_scalar_pairs.len());
-    let mut scalars = Vec::with_capacity(point_scalar_pairs.len());
+    let mut g1_points = Vec::new();
+    let mut scalars = Vec::new();
 
     // Parse all points and scalars
-    for ((x, y), scalar_bytes) in point_scalar_pairs {
+    for pair_result in point_scalar_pairs {
+        let ((x, y), scalar_bytes) = pair_result?;
+
         // NB: MSM requires subgroup check
-        let point = read_g1(x, y)?;
+        let point = read_g1(&x, &y)?;
 
         // Skip zero scalars after validating the point
         if scalar_bytes.iter().all(|&b| b == 0) {
             continue;
         }
 
-        let scalar = read_scalar(scalar_bytes)?;
+        let scalar = read_scalar(&scalar_bytes)?;
         g1_points.push(point);
         scalars.push(scalar);
     }
 
-    // Return point at infinity if all scalars were zero
+    // Return point at infinity if no pairs were provided or all scalars were zero
     if g1_points.is_empty() {
         return Ok([0u8; G1_LENGTH]);
     }
@@ -726,32 +725,31 @@ pub(super) fn p1_msm_bytes(
 /// Performs multi-scalar multiplication (MSM) for G2 points taking byte inputs.
 #[inline]
 pub(super) fn p2_msm_bytes(
-    point_scalar_pairs: &[(G2Point, [u8; SCALAR_LENGTH])],
+    point_scalar_pairs: impl Iterator<
+        Item = Result<(G2Point, [u8; SCALAR_LENGTH]), crate::PrecompileError>,
+    >,
 ) -> Result<[u8; G2_LENGTH], crate::PrecompileError> {
-    if point_scalar_pairs.is_empty() {
-        // Return point at infinity
-        return Ok([0u8; G2_LENGTH]);
-    }
-
-    let mut g2_points = Vec::with_capacity(point_scalar_pairs.len());
-    let mut scalars = Vec::with_capacity(point_scalar_pairs.len());
+    let mut g2_points = Vec::new();
+    let mut scalars = Vec::new();
 
     // Parse all points and scalars
-    for ((x_0, x_1, y_0, y_1), scalar_bytes) in point_scalar_pairs {
+    for pair_result in point_scalar_pairs {
+        let ((x_0, x_1, y_0, y_1), scalar_bytes) = pair_result?;
+
         // NB: MSM requires subgroup check
-        let point = read_g2(x_0, x_1, y_0, y_1)?;
+        let point = read_g2(&x_0, &x_1, &y_0, &y_1)?;
 
         // Skip zero scalars after validating the point
         if scalar_bytes.iter().all(|&b| b == 0) {
             continue;
         }
 
-        let scalar = read_scalar(scalar_bytes)?;
+        let scalar = read_scalar(&scalar_bytes)?;
         g2_points.push(point);
         scalars.push(scalar);
     }
 
-    // Return point at infinity if all scalars were zero
+    // Return point at infinity if no pairs were provided or all scalars were zero
     if g2_points.is_empty() {
         return Ok([0u8; G2_LENGTH]);
     }

--- a/crates/precompile/src/bls12_381/blst.rs
+++ b/crates/precompile/src/bls12_381/blst.rs
@@ -708,7 +708,7 @@ pub(super) fn map_fp2_to_g2_bytes(
 /// Performs multi-scalar multiplication (MSM) for G1 points taking byte inputs and returning encoded result.
 #[inline]
 pub(super) fn p1_msm_bytes(
-    point_scalar_pairs: &[(&G1Point, &[u8; SCALAR_LENGTH])],
+    point_scalar_pairs: &[(G1Point, [u8; SCALAR_LENGTH])],
 ) -> Result<[u8; PADDED_G1_LENGTH], crate::PrecompileError> {
     if point_scalar_pairs.is_empty() {
         // Return point at infinity
@@ -721,14 +721,14 @@ pub(super) fn p1_msm_bytes(
     // Parse all points and scalars
     for ((x, y), scalar_bytes) in point_scalar_pairs {
         // NB: MSM requires subgroup check
-        let point = read_g1(x, y)?;
+        let point = read_g1(&x, &y)?;
 
         // Skip zero scalars after validating the point
         if scalar_bytes.iter().all(|&b| b == 0) {
             continue;
         }
 
-        let scalar = read_scalar(*scalar_bytes)?;
+        let scalar = read_scalar(scalar_bytes)?;
         g1_points.push(point);
         scalars.push(scalar);
     }
@@ -748,7 +748,7 @@ pub(super) fn p1_msm_bytes(
 /// Performs multi-scalar multiplication (MSM) for G2 points taking byte inputs and returning encoded result.
 #[inline]
 pub(super) fn p2_msm_bytes(
-    point_scalar_pairs: &[(&G2Point, &[u8; SCALAR_LENGTH])],
+    point_scalar_pairs: &[(G2Point, [u8; SCALAR_LENGTH])],
 ) -> Result<[u8; PADDED_G2_LENGTH], crate::PrecompileError> {
     if point_scalar_pairs.is_empty() {
         // Return point at infinity
@@ -761,14 +761,14 @@ pub(super) fn p2_msm_bytes(
     // Parse all points and scalars
     for ((x_0, x_1, y_0, y_1), scalar_bytes) in point_scalar_pairs {
         // NB: MSM requires subgroup check
-        let point = read_g2(x_0, x_1, y_0, y_1)?;
+        let point = read_g2(&x_0, &x_1, &y_0, &y_1)?;
 
         // Skip zero scalars after validating the point
         if scalar_bytes.iter().all(|&b| b == 0) {
             continue;
         }
 
-        let scalar = read_scalar(*scalar_bytes)?;
+        let scalar = read_scalar(scalar_bytes)?;
         g2_points.push(point);
         scalars.push(scalar);
     }

--- a/crates/precompile/src/bls12_381/blst.rs
+++ b/crates/precompile/src/bls12_381/blst.rs
@@ -633,3 +633,68 @@ pub(super) fn read_scalar(input: &[u8]) -> Result<blst_scalar, PrecompileError> 
 fn is_valid_be(input: &[u8; 48]) -> bool {
     *input < MODULUS_REPR
 }
+
+// Byte-oriented versions of the functions for external API compatibility
+
+/// Performs point addition on two G1 points taking byte coordinates and returning encoded result.
+#[inline]
+pub(super) fn p1_add_affine_bytes(
+    a_x: &[u8; FP_LENGTH],
+    a_y: &[u8; FP_LENGTH],
+    b_x: &[u8; FP_LENGTH],
+    b_y: &[u8; FP_LENGTH],
+) -> Result<[u8; PADDED_G1_LENGTH], crate::PrecompileError> {
+    // Parse first point
+    let p1 = read_g1_no_subgroup_check(a_x, a_y)?;
+
+    // Parse second point
+    let p2 = read_g1_no_subgroup_check(b_x, b_y)?;
+
+    // Perform addition
+    let result = p1_add_affine(&p1, &p2);
+
+    // Encode result
+    Ok(encode_g1_point(&result))
+}
+
+/// Performs point addition on two G2 points taking byte coordinates and returning encoded result.
+#[inline]
+#[allow(clippy::too_many_arguments)]
+pub(super) fn p2_add_affine_bytes(
+    a_x_0: &[u8; FP_LENGTH],
+    a_x_1: &[u8; FP_LENGTH],
+    a_y_0: &[u8; FP_LENGTH],
+    a_y_1: &[u8; FP_LENGTH],
+    b_x_0: &[u8; FP_LENGTH],
+    b_x_1: &[u8; FP_LENGTH],
+    b_y_0: &[u8; FP_LENGTH],
+    b_y_1: &[u8; FP_LENGTH],
+) -> Result<[u8; PADDED_G2_LENGTH], crate::PrecompileError> {
+    // Parse first point
+    let p1 = read_g2_no_subgroup_check(a_x_0, a_x_1, a_y_0, a_y_1)?;
+
+    // Parse second point
+    let p2 = read_g2_no_subgroup_check(b_x_0, b_x_1, b_y_0, b_y_1)?;
+
+    // Perform addition
+    let result = p2_add_affine(&p1, &p2);
+
+    // Encode result
+    Ok(encode_g2_point(&result))
+}
+
+/// Maps a field element to a G1 point from bytes
+#[inline]
+pub(super) fn map_fp_to_g1_bytes(fp_bytes: &[u8; FP_LENGTH]) -> Result<[u8; PADDED_G1_LENGTH], crate::PrecompileError> {
+    let fp = read_fp(fp_bytes)?;
+    let result = map_fp_to_g1(&fp);
+    Ok(encode_g1_point(&result))
+}
+
+/// Maps field elements to a G2 point from bytes
+#[inline]
+pub(super) fn map_fp2_to_g2_bytes(fp2_x: &[u8; FP_LENGTH], fp2_y: &[u8; FP_LENGTH]) -> Result<[u8; PADDED_G2_LENGTH], crate::PrecompileError> {
+    let fp2 = read_fp2(fp2_x, fp2_y)?;
+    let result = map_fp2_to_g2(&fp2);
+    Ok(encode_g2_point(&result))
+}

--- a/crates/precompile/src/bls12_381/g1_add.rs
+++ b/crates/precompile/src/bls12_381/g1_add.rs
@@ -1,6 +1,6 @@
 //! BLS12-381 G1 add precompile. More details in [`g1_add`]
 use super::crypto_backend::p1_add_affine_bytes;
-use super::utils::remove_g1_padding;
+use super::utils::{pad_g1_point, remove_g1_padding};
 use crate::bls12_381_const::{
     G1_ADD_ADDRESS, G1_ADD_BASE_GAS_FEE, G1_ADD_INPUT_LENGTH, PADDED_G1_LENGTH,
 };
@@ -32,7 +32,15 @@ pub fn g1_add(input: &[u8], gas_limit: u64) -> PrecompileResult {
 
     let a = (*a_x, *a_y);
     let b = (*b_x, *b_y);
-    let out = p1_add_affine_bytes(a, b)?;
 
-    Ok(PrecompileOutput::new(G1_ADD_BASE_GAS_FEE, out.into()))
+    // Get unpadded result from crypto backend
+    let unpadded_result = p1_add_affine_bytes(a, b)?;
+
+    // Pad the result for EVM compatibility
+    let padded_result = pad_g1_point(&unpadded_result);
+
+    Ok(PrecompileOutput::new(
+        G1_ADD_BASE_GAS_FEE,
+        padded_result.into(),
+    ))
 }

--- a/crates/precompile/src/bls12_381/g1_add.rs
+++ b/crates/precompile/src/bls12_381/g1_add.rs
@@ -30,8 +30,9 @@ pub fn g1_add(input: &[u8], gas_limit: u64) -> PrecompileResult {
     let [a_x, a_y] = remove_g1_padding(&input[..PADDED_G1_LENGTH])?;
     let [b_x, b_y] = remove_g1_padding(&input[PADDED_G1_LENGTH..])?;
 
-    // Use the byte-oriented API
-    let out = p1_add_affine_bytes(a_x, a_y, b_x, b_y)?;
+    let a = (*a_x, *a_y);
+    let b = (*b_x, *b_y);
+    let out = p1_add_affine_bytes(a, b)?;
 
     Ok(PrecompileOutput::new(G1_ADD_BASE_GAS_FEE, out.into()))
 }

--- a/crates/precompile/src/bls12_381/g1_msm.rs
+++ b/crates/precompile/src/bls12_381/g1_msm.rs
@@ -8,7 +8,6 @@ use crate::bls12_381_const::{
 };
 use crate::bls12_381_utils::msm_required_gas;
 use crate::{PrecompileError, PrecompileOutput, PrecompileResult, PrecompileWithAddress};
-use std::string::ToString;
 use std::vec::Vec;
 
 /// [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#specification) BLS12_G1MSM precompile.

--- a/crates/precompile/src/bls12_381/g1_msm.rs
+++ b/crates/precompile/src/bls12_381/g1_msm.rs
@@ -49,7 +49,7 @@ pub fn g1_msm(input: &[u8], gas_limit: u64) -> PrecompileResult {
         // Convert scalar to fixed-size array
         let scalar_array: [u8; SCALAR_LENGTH] = encoded_scalar
             .try_into()
-            .map_err(|_| PrecompileError::Other("Invalid scalar length".to_string()))?;
+            .unwrap();
 
         // Note: We include zero scalars to ensure point validation happens
         // The actual filtering will be done inside p1_msm_bytes if needed

--- a/crates/precompile/src/bls12_381/g1_msm.rs
+++ b/crates/precompile/src/bls12_381/g1_msm.rs
@@ -46,9 +46,7 @@ pub fn g1_msm(input: &[u8], gas_limit: u64) -> PrecompileResult {
         let [a_x, a_y] = remove_g1_padding(encoded_g1_element)?;
 
         // Convert scalar to fixed-size array
-        let scalar_array: [u8; SCALAR_LENGTH] = encoded_scalar
-            .try_into()
-            .unwrap();
+        let scalar_array: [u8; SCALAR_LENGTH] = encoded_scalar.try_into().unwrap();
 
         // Note: We include zero scalars to ensure point validation happens
         // The actual filtering will be done inside p1_msm_bytes if needed

--- a/crates/precompile/src/bls12_381/g1_msm.rs
+++ b/crates/precompile/src/bls12_381/g1_msm.rs
@@ -8,6 +8,7 @@ use crate::bls12_381_const::{
 };
 use crate::bls12_381_utils::msm_required_gas;
 use crate::{PrecompileError, PrecompileOutput, PrecompileResult, PrecompileWithAddress};
+use std::string::ToString;
 use std::vec::Vec;
 
 /// [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#specification) BLS12_G1MSM precompile.

--- a/crates/precompile/src/bls12_381/g1_msm.rs
+++ b/crates/precompile/src/bls12_381/g1_msm.rs
@@ -35,7 +35,7 @@ pub fn g1_msm(input: &[u8], gas_limit: u64) -> PrecompileResult {
         return Err(PrecompileError::OutOfGas);
     }
 
-    let mut point_scalar_pairs: Vec<(G1Point, &[u8; SCALAR_LENGTH])> = Vec::with_capacity(k);
+    let mut point_scalar_pairs: Vec<(G1Point, [u8; SCALAR_LENGTH])> = Vec::with_capacity(k);
 
     for i in 0..k {
         let encoded_g1_element =
@@ -46,7 +46,7 @@ pub fn g1_msm(input: &[u8], gas_limit: u64) -> PrecompileResult {
         let [a_x, a_y] = remove_g1_padding(encoded_g1_element)?;
 
         // Convert scalar to fixed-size array
-        let scalar_array: &[u8; SCALAR_LENGTH] = encoded_scalar
+        let scalar_array: [u8; SCALAR_LENGTH] = encoded_scalar
             .try_into()
             .map_err(|_| PrecompileError::Other("Invalid scalar length".to_string()))?;
 
@@ -55,8 +55,7 @@ pub fn g1_msm(input: &[u8], gas_limit: u64) -> PrecompileResult {
         point_scalar_pairs.push(((*a_x, *a_y), scalar_array));
     }
 
-    let pairs_ref: Vec<_> = point_scalar_pairs.iter().map(|(p, s)| (p, *s)).collect();
-    let out = p1_msm_bytes(&pairs_ref)?;
+    let out = p1_msm_bytes(&point_scalar_pairs)?;
     Ok(PrecompileOutput::new(required_gas, out.into()))
 }
 

--- a/crates/precompile/src/bls12_381/g1_msm.rs
+++ b/crates/precompile/src/bls12_381/g1_msm.rs
@@ -8,7 +8,6 @@ use crate::bls12_381_const::{
 };
 use crate::bls12_381_utils::msm_required_gas;
 use crate::{PrecompileError, PrecompileOutput, PrecompileResult, PrecompileWithAddress};
-use std::vec::Vec;
 
 /// [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#specification) BLS12_G1MSM precompile.
 pub const PRECOMPILE: PrecompileWithAddress = PrecompileWithAddress(G1_MSM_ADDRESS, g1_msm);
@@ -35,26 +34,20 @@ pub fn g1_msm(input: &[u8], gas_limit: u64) -> PrecompileResult {
         return Err(PrecompileError::OutOfGas);
     }
 
-    let mut point_scalar_pairs: Vec<(G1Point, [u8; SCALAR_LENGTH])> = Vec::with_capacity(k);
+    let valid_pairs_iter = (0..k).map(|i| {
+        let start = i * G1_MSM_INPUT_LENGTH;
+        let padded_g1 = &input[start..start + PADDED_G1_LENGTH];
+        let scalar_bytes = &input[start + PADDED_G1_LENGTH..start + G1_MSM_INPUT_LENGTH];
 
-    for i in 0..k {
-        let encoded_g1_element =
-            &input[i * G1_MSM_INPUT_LENGTH..i * G1_MSM_INPUT_LENGTH + PADDED_G1_LENGTH];
-        let encoded_scalar = &input[i * G1_MSM_INPUT_LENGTH + PADDED_G1_LENGTH
-            ..i * G1_MSM_INPUT_LENGTH + PADDED_G1_LENGTH + SCALAR_LENGTH];
+        // Remove padding from G1 point - this validates padding format
+        let [x, y] = remove_g1_padding(padded_g1)?;
+        let scalar_array: [u8; SCALAR_LENGTH] = scalar_bytes.try_into().unwrap();
 
-        let [a_x, a_y] = remove_g1_padding(encoded_g1_element)?;
+        let point: G1Point = (*x, *y);
+        Ok((point, scalar_array))
+    });
 
-        // Convert scalar to fixed-size array
-        let scalar_array: [u8; SCALAR_LENGTH] = encoded_scalar.try_into().unwrap();
-
-        // Note: We include zero scalars to ensure point validation happens
-        // The actual filtering will be done inside p1_msm_bytes if needed
-        point_scalar_pairs.push(((*a_x, *a_y), scalar_array));
-    }
-
-    // Get unpadded result from crypto backend
-    let unpadded_result = p1_msm_bytes(&point_scalar_pairs)?;
+    let unpadded_result = p1_msm_bytes(valid_pairs_iter)?;
 
     // Pad the result for EVM compatibility
     let padded_result = pad_g1_point(&unpadded_result);

--- a/crates/precompile/src/bls12_381/g2_add.rs
+++ b/crates/precompile/src/bls12_381/g2_add.rs
@@ -31,8 +31,9 @@ pub fn g2_add(input: &[u8], gas_limit: u64) -> PrecompileResult {
     let [a_x_0, a_x_1, a_y_0, a_y_1] = remove_g2_padding(&input[..PADDED_G2_LENGTH])?;
     let [b_x_0, b_x_1, b_y_0, b_y_1] = remove_g2_padding(&input[PADDED_G2_LENGTH..])?;
 
-    // Use the byte-oriented API
-    let out = p2_add_affine_bytes(a_x_0, a_x_1, a_y_0, a_y_1, b_x_0, b_x_1, b_y_0, b_y_1)?;
+    let a = (*a_x_0, *a_x_1, *a_y_0, *a_y_1);
+    let b = (*b_x_0, *b_x_1, *b_y_0, *b_y_1);
+    let out = p2_add_affine_bytes(a, b)?;
 
     Ok(PrecompileOutput::new(G2_ADD_BASE_GAS_FEE, out.into()))
 }

--- a/crates/precompile/src/bls12_381/g2_add.rs
+++ b/crates/precompile/src/bls12_381/g2_add.rs
@@ -1,6 +1,6 @@
 //! BLS12-381 G2 add precompile. More details in [`g2_add`]
 use super::crypto_backend::p2_add_affine_bytes;
-use super::utils::remove_g2_padding;
+use super::utils::{pad_g2_point, remove_g2_padding};
 use crate::bls12_381_const::{
     G2_ADD_ADDRESS, G2_ADD_BASE_GAS_FEE, G2_ADD_INPUT_LENGTH, PADDED_G2_LENGTH,
 };
@@ -33,7 +33,15 @@ pub fn g2_add(input: &[u8], gas_limit: u64) -> PrecompileResult {
 
     let a = (*a_x_0, *a_x_1, *a_y_0, *a_y_1);
     let b = (*b_x_0, *b_x_1, *b_y_0, *b_y_1);
-    let out = p2_add_affine_bytes(a, b)?;
 
-    Ok(PrecompileOutput::new(G2_ADD_BASE_GAS_FEE, out.into()))
+    // Get unpadded result from crypto backend
+    let unpadded_result = p2_add_affine_bytes(a, b)?;
+
+    // Pad the result for EVM compatibility
+    let padded_result = pad_g2_point(&unpadded_result);
+
+    Ok(PrecompileOutput::new(
+        G2_ADD_BASE_GAS_FEE,
+        padded_result.into(),
+    ))
 }

--- a/crates/precompile/src/bls12_381/g2_add.rs
+++ b/crates/precompile/src/bls12_381/g2_add.rs
@@ -1,5 +1,5 @@
 //! BLS12-381 G2 add precompile. More details in [`g2_add`]
-use super::crypto_backend::{encode_g2_point, p2_add_affine, read_g2_no_subgroup_check};
+use super::crypto_backend::p2_add_affine_bytes;
 use super::utils::remove_g2_padding;
 use crate::bls12_381_const::{
     G2_ADD_ADDRESS, G2_ADD_BASE_GAS_FEE, G2_ADD_INPUT_LENGTH, PADDED_G2_LENGTH,
@@ -27,19 +27,12 @@ pub fn g2_add(input: &[u8], gas_limit: u64) -> PrecompileResult {
         )));
     }
 
+    // Extract coordinates from padded input
     let [a_x_0, a_x_1, a_y_0, a_y_1] = remove_g2_padding(&input[..PADDED_G2_LENGTH])?;
     let [b_x_0, b_x_1, b_y_0, b_y_1] = remove_g2_padding(&input[PADDED_G2_LENGTH..])?;
 
-    // NB: There is no subgroup check for the G2 addition precompile because the time to do the subgroup
-    // check would be more than the time it takes to do the g1 addition.
-    //
-    // Users should be careful to note whether the points being added are indeed in the right subgroup.
-    let a_aff = &read_g2_no_subgroup_check(a_x_0, a_x_1, a_y_0, a_y_1)?;
-    let b_aff = &read_g2_no_subgroup_check(b_x_0, b_x_1, b_y_0, b_y_1)?;
+    // Use the byte-oriented API
+    let out = p2_add_affine_bytes(a_x_0, a_x_1, a_y_0, a_y_1, b_x_0, b_x_1, b_y_0, b_y_1)?;
 
-    // Use the safe wrapper for G2 point addition
-    let p_aff = p2_add_affine(a_aff, b_aff);
-
-    let out = encode_g2_point(&p_aff);
     Ok(PrecompileOutput::new(G2_ADD_BASE_GAS_FEE, out.into()))
 }

--- a/crates/precompile/src/bls12_381/g2_msm.rs
+++ b/crates/precompile/src/bls12_381/g2_msm.rs
@@ -1,6 +1,6 @@
 //! BLS12-381 G2 msm precompile. More details in [`g2_msm`]
 use super::crypto_backend::p2_msm_bytes;
-use super::utils::remove_g2_padding;
+use super::utils::{pad_g2_point, remove_g2_padding};
 use super::G2Point;
 use crate::bls12_381_const::{
     DISCOUNT_TABLE_G2_MSM, G2_MSM_ADDRESS, G2_MSM_BASE_GAS_FEE, G2_MSM_INPUT_LENGTH,
@@ -54,7 +54,11 @@ pub fn g2_msm(input: &[u8], gas_limit: u64) -> PrecompileResult {
         point_scalar_pairs.push(((*a_x_0, *a_x_1, *a_y_0, *a_y_1), scalar_array));
     }
 
-    // Use the byte-oriented API
-    let out = p2_msm_bytes(&point_scalar_pairs)?;
-    Ok(PrecompileOutput::new(required_gas, out.into()))
+    // Use the byte-oriented API to get unpadded result
+    let unpadded_result = p2_msm_bytes(&point_scalar_pairs)?;
+
+    // Pad the result for EVM compatibility
+    let padded_result = pad_g2_point(&unpadded_result);
+
+    Ok(PrecompileOutput::new(required_gas, padded_result.into()))
 }

--- a/crates/precompile/src/bls12_381/g2_msm.rs
+++ b/crates/precompile/src/bls12_381/g2_msm.rs
@@ -1,6 +1,7 @@
 //! BLS12-381 G2 msm precompile. More details in [`g2_msm`]
-use super::crypto_backend::{p2_msm_bytes, G2PointScalarPairRef};
+use super::crypto_backend::p2_msm_bytes;
 use super::utils::remove_g2_padding;
+use super::G2Point;
 use crate::bls12_381_const::{
     DISCOUNT_TABLE_G2_MSM, G2_MSM_ADDRESS, G2_MSM_BASE_GAS_FEE, G2_MSM_INPUT_LENGTH,
     PADDED_G2_LENGTH, SCALAR_LENGTH,
@@ -34,37 +35,26 @@ pub fn g2_msm(input: &[u8], gas_limit: u64) -> PrecompileResult {
         return Err(PrecompileError::OutOfGas);
     }
 
-    let mut point_scalar_pairs: Vec<G2PointScalarPairRef<'_>> = Vec::with_capacity(k);
-    
+    let mut point_scalar_pairs: Vec<(G2Point, &[u8; SCALAR_LENGTH])> = Vec::with_capacity(k);
+
     for i in 0..k {
         let encoded_g2_element =
             &input[i * G2_MSM_INPUT_LENGTH..i * G2_MSM_INPUT_LENGTH + PADDED_G2_LENGTH];
         let encoded_scalar = &input[i * G2_MSM_INPUT_LENGTH + PADDED_G2_LENGTH
             ..i * G2_MSM_INPUT_LENGTH + PADDED_G2_LENGTH + SCALAR_LENGTH];
 
-        // Filter out points infinity as an optimization, since it is a no-op.
-        if encoded_g2_element.iter().all(|i| *i == 0) {
-            continue;
-        }
-
         let [a_x_0, a_x_1, a_y_0, a_y_1] = remove_g2_padding(encoded_g2_element)?;
 
-        // If the scalar is zero, then this is a no-op.
-        // Note: We still need to parse the point first to validate it
-        if encoded_scalar.iter().all(|i| *i == 0) {
-            // Validate the point by trying to parse it
-            // This is done by p2_msm_bytes internally
-            continue;
-        }
-
         // Convert scalar to fixed-size array
-        let scalar_array: &[u8; SCALAR_LENGTH] = encoded_scalar.try_into()
+        let scalar_array: &[u8; SCALAR_LENGTH] = encoded_scalar
+            .try_into()
             .map_err(|_| PrecompileError::Other("Invalid scalar length".to_string()))?;
-            
-        point_scalar_pairs.push(((a_x_0, a_x_1, a_y_0, a_y_1), scalar_array));
+
+        point_scalar_pairs.push(((*a_x_0, *a_x_1, *a_y_0, *a_y_1), scalar_array));
     }
 
     // Use the byte-oriented API
-    let out = p2_msm_bytes(&point_scalar_pairs)?;
+    let pairs_ref: Vec<_> = point_scalar_pairs.iter().map(|(p, s)| (p, *s)).collect();
+    let out = p2_msm_bytes(&pairs_ref)?;
     Ok(PrecompileOutput::new(required_gas, out.into()))
 }

--- a/crates/precompile/src/bls12_381/g2_msm.rs
+++ b/crates/precompile/src/bls12_381/g2_msm.rs
@@ -35,7 +35,7 @@ pub fn g2_msm(input: &[u8], gas_limit: u64) -> PrecompileResult {
         return Err(PrecompileError::OutOfGas);
     }
 
-    let mut point_scalar_pairs: Vec<(G2Point, &[u8; SCALAR_LENGTH])> = Vec::with_capacity(k);
+    let mut point_scalar_pairs: Vec<(G2Point, [u8; SCALAR_LENGTH])> = Vec::with_capacity(k);
 
     for i in 0..k {
         let encoded_g2_element =
@@ -46,7 +46,7 @@ pub fn g2_msm(input: &[u8], gas_limit: u64) -> PrecompileResult {
         let [a_x_0, a_x_1, a_y_0, a_y_1] = remove_g2_padding(encoded_g2_element)?;
 
         // Convert scalar to fixed-size array
-        let scalar_array: &[u8; SCALAR_LENGTH] = encoded_scalar
+        let scalar_array: [u8; SCALAR_LENGTH] = encoded_scalar
             .try_into()
             .map_err(|_| PrecompileError::Other("Invalid scalar length".to_string()))?;
 
@@ -54,7 +54,6 @@ pub fn g2_msm(input: &[u8], gas_limit: u64) -> PrecompileResult {
     }
 
     // Use the byte-oriented API
-    let pairs_ref: Vec<_> = point_scalar_pairs.iter().map(|(p, s)| (p, *s)).collect();
-    let out = p2_msm_bytes(&pairs_ref)?;
+    let out = p2_msm_bytes(&point_scalar_pairs)?;
     Ok(PrecompileOutput::new(required_gas, out.into()))
 }

--- a/crates/precompile/src/bls12_381/g2_msm.rs
+++ b/crates/precompile/src/bls12_381/g2_msm.rs
@@ -8,7 +8,6 @@ use crate::bls12_381_const::{
 };
 use crate::bls12_381_utils::msm_required_gas;
 use crate::{PrecompileError, PrecompileOutput, PrecompileResult, PrecompileWithAddress};
-use std::string::ToString;
 use std::vec::Vec;
 
 /// [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#specification) BLS12_G2MSM precompile.
@@ -47,9 +46,7 @@ pub fn g2_msm(input: &[u8], gas_limit: u64) -> PrecompileResult {
         let [a_x_0, a_x_1, a_y_0, a_y_1] = remove_g2_padding(encoded_g2_element)?;
 
         // Convert scalar to fixed-size array
-        let scalar_array: [u8; SCALAR_LENGTH] = encoded_scalar
-            .try_into()
-            .map_err(|_| PrecompileError::Other("Invalid scalar length".to_string()))?;
+        let scalar_array: [u8; SCALAR_LENGTH] = encoded_scalar.try_into().unwrap();
 
         point_scalar_pairs.push(((*a_x_0, *a_x_1, *a_y_0, *a_y_1), scalar_array));
     }

--- a/crates/precompile/src/bls12_381/g2_msm.rs
+++ b/crates/precompile/src/bls12_381/g2_msm.rs
@@ -8,6 +8,7 @@ use crate::bls12_381_const::{
 };
 use crate::bls12_381_utils::msm_required_gas;
 use crate::{PrecompileError, PrecompileOutput, PrecompileResult, PrecompileWithAddress};
+use std::string::ToString;
 use std::vec::Vec;
 
 /// [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#specification) BLS12_G2MSM precompile.

--- a/crates/precompile/src/bls12_381/g2_msm.rs
+++ b/crates/precompile/src/bls12_381/g2_msm.rs
@@ -8,7 +8,6 @@ use crate::bls12_381_const::{
 };
 use crate::bls12_381_utils::msm_required_gas;
 use crate::{PrecompileError, PrecompileOutput, PrecompileResult, PrecompileWithAddress};
-use std::vec::Vec;
 
 /// [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#specification) BLS12_G2MSM precompile.
 pub const PRECOMPILE: PrecompileWithAddress = PrecompileWithAddress(G2_MSM_ADDRESS, g2_msm);
@@ -35,24 +34,20 @@ pub fn g2_msm(input: &[u8], gas_limit: u64) -> PrecompileResult {
         return Err(PrecompileError::OutOfGas);
     }
 
-    let mut point_scalar_pairs: Vec<(G2Point, [u8; SCALAR_LENGTH])> = Vec::with_capacity(k);
+    let valid_pairs_iter = (0..k).map(|i| {
+        let start = i * G2_MSM_INPUT_LENGTH;
+        let padded_g2 = &input[start..start + PADDED_G2_LENGTH];
+        let scalar_bytes = &input[start + PADDED_G2_LENGTH..start + G2_MSM_INPUT_LENGTH];
 
-    for i in 0..k {
-        let encoded_g2_element =
-            &input[i * G2_MSM_INPUT_LENGTH..i * G2_MSM_INPUT_LENGTH + PADDED_G2_LENGTH];
-        let encoded_scalar = &input[i * G2_MSM_INPUT_LENGTH + PADDED_G2_LENGTH
-            ..i * G2_MSM_INPUT_LENGTH + PADDED_G2_LENGTH + SCALAR_LENGTH];
+        // Remove padding from G2 point - this validates padding format
+        let [x_0, x_1, y_0, y_1] = remove_g2_padding(padded_g2)?;
+        let scalar_array: [u8; SCALAR_LENGTH] = scalar_bytes.try_into().unwrap();
 
-        let [a_x_0, a_x_1, a_y_0, a_y_1] = remove_g2_padding(encoded_g2_element)?;
+        let point: G2Point = (*x_0, *x_1, *y_0, *y_1);
+        Ok((point, scalar_array))
+    });
 
-        // Convert scalar to fixed-size array
-        let scalar_array: [u8; SCALAR_LENGTH] = encoded_scalar.try_into().unwrap();
-
-        point_scalar_pairs.push(((*a_x_0, *a_x_1, *a_y_0, *a_y_1), scalar_array));
-    }
-
-    // Use the byte-oriented API to get unpadded result
-    let unpadded_result = p2_msm_bytes(&point_scalar_pairs)?;
+    let unpadded_result = p2_msm_bytes(valid_pairs_iter)?;
 
     // Pad the result for EVM compatibility
     let padded_result = pad_g2_point(&unpadded_result);

--- a/crates/precompile/src/bls12_381/map_fp2_to_g2.rs
+++ b/crates/precompile/src/bls12_381/map_fp2_to_g2.rs
@@ -1,8 +1,5 @@
 //! BLS12-381 map fp2 to g2 precompile. More details in [`map_fp2_to_g2`]
-use super::{
-    crypto_backend::{encode_g2_point, map_fp2_to_g2 as blst_map_fp2_to_g2, read_fp2},
-    utils::remove_fp_padding,
-};
+use super::{crypto_backend::map_fp2_to_g2_bytes, utils::remove_fp_padding};
 use crate::bls12_381_const::{
     MAP_FP2_TO_G2_ADDRESS, MAP_FP2_TO_G2_BASE_GAS_FEE, PADDED_FP2_LENGTH, PADDED_FP_LENGTH,
 };
@@ -31,10 +28,7 @@ pub fn map_fp2_to_g2(input: &[u8], gas_limit: u64) -> PrecompileResult {
 
     let input_p0_x = remove_fp_padding(&input[..PADDED_FP_LENGTH])?;
     let input_p0_y = remove_fp_padding(&input[PADDED_FP_LENGTH..PADDED_FP2_LENGTH])?;
-    let fp2 = read_fp2(input_p0_x, input_p0_y)?;
-    let p_aff = blst_map_fp2_to_g2(&fp2);
-
-    let out = encode_g2_point(&p_aff);
+    let out = map_fp2_to_g2_bytes(input_p0_x, input_p0_y)?;
     Ok(PrecompileOutput::new(
         MAP_FP2_TO_G2_BASE_GAS_FEE,
         out.into(),

--- a/crates/precompile/src/bls12_381/map_fp_to_g1.rs
+++ b/crates/precompile/src/bls12_381/map_fp_to_g1.rs
@@ -1,5 +1,8 @@
 //! BLS12-381 map fp to g1 precompile. More details in [`map_fp_to_g1`]
-use super::{crypto_backend::map_fp_to_g1_bytes, utils::remove_fp_padding};
+use super::{
+    crypto_backend::map_fp_to_g1_bytes,
+    utils::{pad_g1_point, remove_fp_padding},
+};
 use crate::bls12_381_const::{MAP_FP_TO_G1_ADDRESS, MAP_FP_TO_G1_BASE_GAS_FEE, PADDED_FP_LENGTH};
 use crate::{PrecompileError, PrecompileOutput, PrecompileResult, PrecompileWithAddress};
 
@@ -23,8 +26,17 @@ pub fn map_fp_to_g1(input: &[u8], gas_limit: u64) -> PrecompileResult {
     }
 
     let input_p0 = remove_fp_padding(input)?;
-    let out = map_fp_to_g1_bytes(input_p0)?;
-    Ok(PrecompileOutput::new(MAP_FP_TO_G1_BASE_GAS_FEE, out.into()))
+
+    // Get unpadded result from crypto backend
+    let unpadded_result = map_fp_to_g1_bytes(input_p0)?;
+
+    // Pad the result for EVM compatibility
+    let padded_result = pad_g1_point(&unpadded_result);
+
+    Ok(PrecompileOutput::new(
+        MAP_FP_TO_G1_BASE_GAS_FEE,
+        padded_result.into(),
+    ))
 }
 
 #[cfg(test)]

--- a/crates/precompile/src/bls12_381/map_fp_to_g1.rs
+++ b/crates/precompile/src/bls12_381/map_fp_to_g1.rs
@@ -1,8 +1,5 @@
 //! BLS12-381 map fp to g1 precompile. More details in [`map_fp_to_g1`]
-use super::{
-    crypto_backend::{encode_g1_point, map_fp_to_g1 as blst_map_fp_to_g1, read_fp},
-    utils::remove_fp_padding,
-};
+use super::{crypto_backend::map_fp_to_g1_bytes, utils::remove_fp_padding};
 use crate::bls12_381_const::{MAP_FP_TO_G1_ADDRESS, MAP_FP_TO_G1_BASE_GAS_FEE, PADDED_FP_LENGTH};
 use crate::{PrecompileError, PrecompileOutput, PrecompileResult, PrecompileWithAddress};
 
@@ -26,10 +23,7 @@ pub fn map_fp_to_g1(input: &[u8], gas_limit: u64) -> PrecompileResult {
     }
 
     let input_p0 = remove_fp_padding(input)?;
-    let fp = read_fp(input_p0)?;
-    let p_aff = blst_map_fp_to_g1(&fp);
-
-    let out = encode_g1_point(&p_aff);
+    let out = map_fp_to_g1_bytes(input_p0)?;
     Ok(PrecompileOutput::new(MAP_FP_TO_G1_BASE_GAS_FEE, out.into()))
 }
 

--- a/crates/precompile/src/bls12_381/pairing.rs
+++ b/crates/precompile/src/bls12_381/pairing.rs
@@ -1,6 +1,7 @@
 //! BLS12-381 pairing precompile. More details in [`pairing`]
-use super::crypto_backend::{pairing_check, read_g1, read_g2};
+use super::crypto_backend::pairing_check_bytes;
 use super::utils::{remove_g1_padding, remove_g2_padding};
+use super::PairingPair;
 use crate::bls12_381_const::{
     PADDED_G1_LENGTH, PADDED_G2_LENGTH, PAIRING_ADDRESS, PAIRING_INPUT_LENGTH,
     PAIRING_MULTIPLIER_BASE, PAIRING_OFFSET_BASE,
@@ -39,38 +40,21 @@ pub fn pairing(input: &[u8], gas_limit: u64) -> PrecompileResult {
     }
 
     // Collect pairs of points for the pairing check
-    let mut pairs = Vec::with_capacity(k);
+    let mut pairs: Vec<PairingPair> = Vec::with_capacity(k);
     for i in 0..k {
         let encoded_g1_element =
             &input[i * PAIRING_INPUT_LENGTH..i * PAIRING_INPUT_LENGTH + PADDED_G1_LENGTH];
         let encoded_g2_element = &input[i * PAIRING_INPUT_LENGTH + PADDED_G1_LENGTH
             ..i * PAIRING_INPUT_LENGTH + PADDED_G1_LENGTH + PADDED_G2_LENGTH];
 
-        // If either the G1 or G2 element is the encoded representation
-        // of the point at infinity, then these two points are no-ops
-        // in the pairing computation.
-        //
-        // Note: we do not skip the validation of these two elements even if
-        // one of them is the point at infinity because we could have G1 be
-        // the point at infinity and G2 be an invalid element or vice versa.
-        // In that case, the precompile should error because one of the elements
-        // was invalid.
-        let g1_is_zero = encoded_g1_element.iter().all(|i| *i == 0);
-        let g2_is_zero = encoded_g2_element.iter().all(|i| *i == 0);
-
         let [a_x, a_y] = remove_g1_padding(encoded_g1_element)?;
         let [b_x_0, b_x_1, b_y_0, b_y_1] = remove_g2_padding(encoded_g2_element)?;
 
-        // NB: Scalar multiplications, MSMs and pairings MUST perform a subgroup check.
-        // extract_g1_input and extract_g2_input perform the necessary checks
-        let p1_aff = read_g1(a_x, a_y)?;
-        let p2_aff = read_g2(b_x_0, b_x_1, b_y_0, b_y_1)?;
-
-        if !g1_is_zero & !g2_is_zero {
-            pairs.push((p1_aff, p2_aff));
-        }
+        pairs.push(((*a_x, *a_y), (*b_x_0, *b_x_1, *b_y_0, *b_y_1)));
     }
-    let result = if pairing_check(&pairs) { 1 } else { 0 };
+
+    let result = pairing_check_bytes(&pairs)?;
+    let result = if result { 1 } else { 0 };
 
     Ok(PrecompileOutput::new(
         required_gas,

--- a/crates/precompile/src/bls12_381/utils.rs
+++ b/crates/precompile/src/bls12_381/utils.rs
@@ -65,11 +65,11 @@ pub(super) fn pad_g1_point(unpadded: &[u8]) -> [u8; PADDED_G1_LENGTH] {
 
     let mut padded = [0u8; PADDED_G1_LENGTH];
 
-    // x
-    padded[FP_PAD_BY..PADDED_FP_LENGTH].copy_from_slice(&unpadded[0..FP_LENGTH]);
-    // y
-    padded[PADDED_FP_LENGTH + FP_PAD_BY..2 * PADDED_FP_LENGTH]
-        .copy_from_slice(&unpadded[FP_LENGTH..G1_LENGTH]);
+    // Copy each field element (x, y) with padding
+    for i in 0..2 {
+        padded[i * PADDED_FP_LENGTH + FP_PAD_BY..(i + 1) * PADDED_FP_LENGTH]
+            .copy_from_slice(&unpadded[i * FP_LENGTH..(i + 1) * FP_LENGTH]);
+    }
 
     padded
 }
@@ -87,17 +87,11 @@ pub(super) fn pad_g2_point(unpadded: &[u8]) -> [u8; PADDED_G2_LENGTH] {
 
     let mut padded = [0u8; PADDED_G2_LENGTH];
 
-    // x.c0
-    padded[FP_PAD_BY..PADDED_FP_LENGTH].copy_from_slice(&unpadded[0..FP_LENGTH]);
-    // x.c1
-    padded[PADDED_FP_LENGTH + FP_PAD_BY..2 * PADDED_FP_LENGTH]
-        .copy_from_slice(&unpadded[FP_LENGTH..2 * FP_LENGTH]);
-    // y.c0
-    padded[2 * PADDED_FP_LENGTH + FP_PAD_BY..3 * PADDED_FP_LENGTH]
-        .copy_from_slice(&unpadded[2 * FP_LENGTH..3 * FP_LENGTH]);
-    // y.c1
-    padded[3 * PADDED_FP_LENGTH + FP_PAD_BY..4 * PADDED_FP_LENGTH]
-        .copy_from_slice(&unpadded[3 * FP_LENGTH..4 * FP_LENGTH]);
+    // Copy each field element (x.c0, x.c1, y.c0, y.c1) with padding
+    for i in 0..4 {
+        padded[i * PADDED_FP_LENGTH + FP_PAD_BY..(i + 1) * PADDED_FP_LENGTH]
+            .copy_from_slice(&unpadded[i * FP_LENGTH..(i + 1) * FP_LENGTH]);
+    }
 
     padded
 }

--- a/crates/precompile/src/bls12_381/utils.rs
+++ b/crates/precompile/src/bls12_381/utils.rs
@@ -110,8 +110,8 @@ mod tests {
     fn test_pad_g1_point_roundtrip() {
         // Create test data
         let mut unpadded = [0u8; G1_LENGTH];
-        for i in 0..G1_LENGTH {
-            unpadded[i] = (i * 2 + 1) as u8;
+        for (i, byte) in unpadded.iter_mut().enumerate() {
+            *byte = (i * 2 + 1) as u8;
         }
 
         // Pad the point
@@ -129,8 +129,8 @@ mod tests {
     fn test_pad_g2_point_roundtrip() {
         // Create test data for G2 point (192 bytes = 4 * 48)
         let mut unpadded = [0u8; 4 * FP_LENGTH];
-        for i in 0..(4 * FP_LENGTH) {
-            unpadded[i] = (i * 2 + 1) as u8;
+        for (i, byte) in unpadded.iter_mut().enumerate() {
+            *byte = (i * 2 + 1) as u8;
         }
 
         // Pad the point

--- a/crates/precompile/src/bls12_381/utils.rs
+++ b/crates/precompile/src/bls12_381/utils.rs
@@ -57,7 +57,7 @@ pub(super) fn remove_g2_padding(input: &[u8]) -> Result<[&[u8; FP_LENGTH]; 4], P
 /// Takes a G1 point with 2 field elements of 48 bytes each and adds 16 bytes of
 /// zero padding before each field element.
 pub(super) fn pad_g1_point(unpadded: &[u8]) -> [u8; PADDED_G1_LENGTH] {
-    debug_assert_eq!(
+    assert_eq!(
         unpadded.len(),
         G1_LENGTH,
         "Invalid unpadded G1 point length"
@@ -79,7 +79,7 @@ pub(super) fn pad_g1_point(unpadded: &[u8]) -> [u8; PADDED_G1_LENGTH] {
 /// Takes a G2 point with 4 field elements of 48 bytes each and adds 16 bytes of
 /// zero padding before each field element.
 pub(super) fn pad_g2_point(unpadded: &[u8]) -> [u8; PADDED_G2_LENGTH] {
-    debug_assert_eq!(
+    assert_eq!(
         unpadded.len(),
         4 * FP_LENGTH,
         "Invalid unpadded G2 point length"

--- a/crates/precompile/src/bls12_381/utils.rs
+++ b/crates/precompile/src/bls12_381/utils.rs
@@ -1,6 +1,6 @@
 //! BLS12-381 utilities for padding and unpadding of input.
 use crate::bls12_381_const::{
-    FP_LENGTH, FP_PAD_BY, PADDED_FP_LENGTH, PADDED_G1_LENGTH, PADDED_G2_LENGTH,
+    FP_LENGTH, FP_PAD_BY, G1_LENGTH, PADDED_FP_LENGTH, PADDED_G1_LENGTH, PADDED_G2_LENGTH,
 };
 use crate::PrecompileError;
 
@@ -50,4 +50,99 @@ pub(super) fn remove_g2_padding(input: &[u8]) -> Result<[&[u8; FP_LENGTH]; 4], P
         input_fps[i] = remove_fp_padding(&input[i * PADDED_FP_LENGTH..(i + 1) * PADDED_FP_LENGTH])?;
     }
     Ok(input_fps)
+}
+
+/// Pads an unpadded G1 point (96 bytes) to the EVM-compatible format (128 bytes).
+///
+/// Takes a G1 point with 2 field elements of 48 bytes each and adds 16 bytes of
+/// zero padding before each field element.
+pub(super) fn pad_g1_point(unpadded: &[u8]) -> [u8; PADDED_G1_LENGTH] {
+    debug_assert_eq!(
+        unpadded.len(),
+        G1_LENGTH,
+        "Invalid unpadded G1 point length"
+    );
+
+    let mut padded = [0u8; PADDED_G1_LENGTH];
+
+    // x
+    padded[FP_PAD_BY..PADDED_FP_LENGTH].copy_from_slice(&unpadded[0..FP_LENGTH]);
+    // y
+    padded[PADDED_FP_LENGTH + FP_PAD_BY..2 * PADDED_FP_LENGTH]
+        .copy_from_slice(&unpadded[FP_LENGTH..G1_LENGTH]);
+
+    padded
+}
+
+/// Pads an unpadded G2 point (192 bytes) to the EVM-compatible format (256 bytes).
+///
+/// Takes a G2 point with 4 field elements of 48 bytes each and adds 16 bytes of
+/// zero padding before each field element.
+pub(super) fn pad_g2_point(unpadded: &[u8]) -> [u8; PADDED_G2_LENGTH] {
+    debug_assert_eq!(
+        unpadded.len(),
+        4 * FP_LENGTH,
+        "Invalid unpadded G2 point length"
+    );
+
+    let mut padded = [0u8; PADDED_G2_LENGTH];
+
+    // x.c0
+    padded[FP_PAD_BY..PADDED_FP_LENGTH].copy_from_slice(&unpadded[0..FP_LENGTH]);
+    // x.c1
+    padded[PADDED_FP_LENGTH + FP_PAD_BY..2 * PADDED_FP_LENGTH]
+        .copy_from_slice(&unpadded[FP_LENGTH..2 * FP_LENGTH]);
+    // y.c0
+    padded[2 * PADDED_FP_LENGTH + FP_PAD_BY..3 * PADDED_FP_LENGTH]
+        .copy_from_slice(&unpadded[2 * FP_LENGTH..3 * FP_LENGTH]);
+    // y.c1
+    padded[3 * PADDED_FP_LENGTH + FP_PAD_BY..4 * PADDED_FP_LENGTH]
+        .copy_from_slice(&unpadded[3 * FP_LENGTH..4 * FP_LENGTH]);
+
+    padded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pad_g1_point_roundtrip() {
+        // Create test data
+        let mut unpadded = [0u8; G1_LENGTH];
+        for i in 0..G1_LENGTH {
+            unpadded[i] = (i * 2 + 1) as u8;
+        }
+
+        // Pad the point
+        let padded = pad_g1_point(&unpadded);
+
+        // Remove padding
+        let result = remove_g1_padding(&padded).unwrap();
+
+        // Verify roundtrip
+        assert_eq!(result[0], &unpadded[0..FP_LENGTH]);
+        assert_eq!(result[1], &unpadded[FP_LENGTH..G1_LENGTH]);
+    }
+
+    #[test]
+    fn test_pad_g2_point_roundtrip() {
+        // Create test data for G2 point (192 bytes = 4 * 48)
+        let mut unpadded = [0u8; 4 * FP_LENGTH];
+        for i in 0..(4 * FP_LENGTH) {
+            unpadded[i] = (i * 2 + 1) as u8;
+        }
+
+        // Pad the point
+        let padded = pad_g2_point(&unpadded);
+
+        // Remove padding
+        let result = remove_g2_padding(&padded).unwrap();
+
+        // Verify roundtrip - G2 has 4 field elements
+        assert_eq!(result[0], &unpadded[0..FP_LENGTH]);
+        assert_eq!(result[1], &unpadded[FP_LENGTH..2 * FP_LENGTH]);
+        assert_eq!(result[2], &unpadded[2 * FP_LENGTH..3 * FP_LENGTH]);
+        assert_eq!(result[3], &unpadded[3 * FP_LENGTH..4 * FP_LENGTH]);
+    }
 }

--- a/crates/precompile/src/bls12_381_const.rs
+++ b/crates/precompile/src/bls12_381_const.rs
@@ -116,6 +116,12 @@ pub const G1_LENGTH: usize = 2 * FP_LENGTH;
 /// a G1 element according to padding rules specified in EIP-2537.
 pub const PADDED_G1_LENGTH: usize = 2 * PADDED_FP_LENGTH;
 
+/// FP2_LENGTH specifies the number of bytes needed to represent a Fp^2 element.
+///
+/// Note: This is the quadratic extension of Fp, and by definition
+/// means we need 2 Fp elements.
+pub const FP2_LENGTH: usize = 2 * FP_LENGTH;
+
 /// PADDED_FP2_LENGTH specifies the number of bytes that the EVM will use to represent
 /// a Fp^2 element according to the padding rules specified in EIP-2537.
 ///
@@ -142,6 +148,11 @@ pub const G1_ADD_INPUT_LENGTH: usize = 2 * PADDED_G1_LENGTH;
 /// Note: An MSM pair is a G1 element and a scalar. The input to the MSM precompile will have `n`
 /// of these pairs.
 pub const G1_MSM_INPUT_LENGTH: usize = PADDED_G1_LENGTH + SCALAR_LENGTH;
+
+/// G2_LENGTH specifies the number of bytes needed to represent a G2 element.
+///
+/// Note: A G2 element contains 2 Fp^2 elements.
+pub const G2_LENGTH: usize = 2 * FP2_LENGTH;
 
 /// PADDED_G2_LENGTH specifies the number of bytes that the EVM will use to represent
 /// a G2 element.

--- a/crates/precompile/src/bn128.rs
+++ b/crates/precompile/src/bn128.rs
@@ -504,5 +504,52 @@ mod tests {
             260_000,
         );
         assert!(matches!(res, Err(PrecompileError::Bn128PairLength)));
+
+        // Test with point at infinity - should return true (identity element)
+        // G1 point at infinity (0,0) followed by a valid G2 point
+        let input = hex::decode(
+            "\
+            0000000000000000000000000000000000000000000000000000000000000000\
+            0000000000000000000000000000000000000000000000000000000000000000\
+            209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf7\
+            04bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a41678\
+            2bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d\
+            120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550",
+        )
+        .unwrap();
+        let expected =
+            hex::decode("0000000000000000000000000000000000000000000000000000000000000001")
+                .unwrap();
+
+        let outcome = run_pair(
+            &input,
+            BYZANTIUM_PAIR_PER_POINT,
+            BYZANTIUM_PAIR_BASE,
+            260_000,
+        )
+        .unwrap();
+        assert_eq!(outcome.bytes, expected);
+
+        // Test with G2 point at infinity - should also return true
+        // Valid G1 point followed by G2 point at infinity (0,0,0,0)
+        let input = hex::decode(
+            "\
+            1c76476f4def4bb94541d57ebba1193381ffa7aa76ada664dd31c16024c43f59\
+            3034dd2920f673e204fee2811c678745fc819b55d3e9d294e45c9b03a76aef41\
+            0000000000000000000000000000000000000000000000000000000000000000\
+            0000000000000000000000000000000000000000000000000000000000000000\
+            0000000000000000000000000000000000000000000000000000000000000000\
+            0000000000000000000000000000000000000000000000000000000000000000",
+        )
+        .unwrap();
+
+        let outcome = run_pair(
+            &input,
+            BYZANTIUM_PAIR_PER_POINT,
+            BYZANTIUM_PAIR_BASE,
+            260_000,
+        )
+        .unwrap();
+        assert_eq!(outcome.bytes, expected);
     }
 }

--- a/crates/precompile/src/bn128/arkworks.rs
+++ b/crates/precompile/src/bn128/arkworks.rs
@@ -180,21 +180,33 @@ pub(super) fn read_scalar(input: &[u8]) -> Fr {
 
 /// Performs point addition on two G1 points.
 #[inline]
-pub(super) fn g1_point_add(p1: G1Affine, p2: G1Affine) -> G1Affine {
+pub(super) fn g1_point_add(p1_bytes: &[u8], p2_bytes: &[u8]) -> Result<[u8; 64], PrecompileError> {
+    let p1 = read_g1_point(p1_bytes)?;
+    let p2 = read_g1_point(p2_bytes)?;
+
     let p1_jacobian: G1Projective = p1.into();
 
     let p3 = p1_jacobian + p2;
+    let output = encode_g1_point(p3.into_affine());
 
-    p3.into_affine()
+    Ok(output)
 }
 
 /// Performs a G1 scalar multiplication.
 #[inline]
-pub(super) fn g1_point_mul(p: G1Affine, fr: Fr) -> G1Affine {
+pub(super) fn g1_point_mul(
+    point_bytes: &[u8],
+    fr_bytes: &[u8],
+) -> Result<[u8; 64], PrecompileError> {
+    let p = read_g1_point(point_bytes)?;
+    let fr = read_scalar(fr_bytes);
+
     let big_int = fr.into_bigint();
     let result = p.mul_bigint(big_int);
 
-    result.into_affine()
+    let output = encode_g1_point(result.into_affine());
+
+    Ok(output)
 }
 
 /// pairing_check performs a pairing check on a list of G1 and G2 point pairs and
@@ -203,13 +215,19 @@ pub(super) fn g1_point_mul(p: G1Affine, fr: Fr) -> G1Affine {
 /// Note: If the input is empty, this function returns true.
 /// This is different to EIP2537 which disallows the empty input.
 #[inline]
-pub(super) fn pairing_check(pairs: &[(G1Affine, G2Affine)]) -> bool {
+pub(super) fn pairing_check(pairs: &[(&[u8], &[u8])]) -> Result<bool, PrecompileError> {
+    let pairs: Vec<_> = pairs
+        .iter()
+        .map(|(g1_bytes, g2_bytes)| Ok((read_g1_point(g1_bytes)?, read_g2_point(g2_bytes)?)))
+        // TODO: Add a filter to remove points at infinity
+        .collect::<Result<Vec<_>, _>>()?;
+
     if pairs.is_empty() {
-        return true;
+        return Ok(true);
     }
 
     let (g1_points, g2_points): (Vec<G1Affine>, Vec<G2Affine>) = pairs.iter().copied().unzip();
 
     let pairing_result = Bn254::multi_pairing(&g1_points, &g2_points);
-    pairing_result.0.is_one()
+    Ok(pairing_result.0.is_one())
 }

--- a/crates/precompile/src/bn128/substrate.rs
+++ b/crates/precompile/src/bn128/substrate.rs
@@ -150,14 +150,23 @@ pub(super) fn read_scalar(input: &[u8]) -> bn::Fr {
 
 /// Performs point addition on two G1 points.
 #[inline]
-pub(super) fn g1_point_add(p1: G1, p2: G1) -> G1 {
-    p1 + p2
+pub(super) fn g1_point_add(p1_bytes: &[u8], p2_bytes: &[u8]) -> Result<[u8; 64], PrecompileError> {
+    let p1 = read_g1_point(p1_bytes)?;
+    let p2 = read_g1_point(p2_bytes)?;
+    let result = p1 + p2;
+    Ok(encode_g1_point(result))
 }
 
 /// Performs a G1 scalar multiplication.
 #[inline]
-pub(super) fn g1_point_mul(p: G1, fr: bn::Fr) -> G1 {
-    p * fr
+pub(super) fn g1_point_mul(
+    point_bytes: &[u8],
+    fr_bytes: &[u8],
+) -> Result<[u8; 64], PrecompileError> {
+    let p = read_g1_point(point_bytes)?;
+    let fr = read_scalar(fr_bytes);
+    let result = p * fr;
+    Ok(encode_g1_point(result))
 }
 
 /// pairing_check performs a pairing check on a list of G1 and G2 point pairs and
@@ -166,9 +175,16 @@ pub(super) fn g1_point_mul(p: G1, fr: bn::Fr) -> G1 {
 /// Note: If the input is empty, this function returns true.
 /// This is different to EIP2537 which disallows the empty input.
 #[inline]
-pub(super) fn pairing_check(pairs: &[(G1, G2)]) -> bool {
-    if pairs.is_empty() {
-        return true;
+pub(super) fn pairing_check(pairs: &[(&[u8], &[u8])]) -> Result<bool, PrecompileError> {
+    let parsed_pairs: Vec<_> = pairs
+        .iter()
+        .map(|(g1_bytes, g2_bytes)| Ok((read_g1_point(g1_bytes)?, read_g2_point(g2_bytes)?)))
+        // TODO: Add a filter to remove points at infinity
+        .collect::<Result<Vec<_>, _>>()?;
+
+    if parsed_pairs.is_empty() {
+        return Ok(true);
     }
-    bn::pairing_batch(pairs) == Gt::one()
+
+    Ok(bn::pairing_batch(&parsed_pairs) == Gt::one())
 }

--- a/crates/precompile/src/bn128/substrate.rs
+++ b/crates/precompile/src/bn128/substrate.rs
@@ -176,11 +176,17 @@ pub(super) fn g1_point_mul(
 /// This is different to EIP2537 which disallows the empty input.
 #[inline]
 pub(super) fn pairing_check(pairs: &[(&[u8], &[u8])]) -> Result<bool, PrecompileError> {
-    let parsed_pairs: Vec<_> = pairs
-        .iter()
-        .map(|(g1_bytes, g2_bytes)| Ok((read_g1_point(g1_bytes)?, read_g2_point(g2_bytes)?)))
-        // TODO: Add a filter to remove points at infinity
-        .collect::<Result<Vec<_>, _>>()?;
+    let mut parsed_pairs = Vec::with_capacity(pairs.len());
+
+    for (g1_bytes, g2_bytes) in pairs {
+        let g1 = read_g1_point(g1_bytes)?;
+        let g2 = read_g2_point(g2_bytes)?;
+
+        // Skip pairs where either point is at infinity
+        if !g1.is_zero() && !g2.is_zero() {
+            parsed_pairs.push((g1, g2));
+        }
+    }
 
     if parsed_pairs.is_empty() {
         return Ok(true);

--- a/crates/precompile/src/kzg_point_evaluation.rs
+++ b/crates/precompile/src/kzg_point_evaluation.rs
@@ -55,18 +55,10 @@ pub fn run(input: &[u8], gas_limit: u64) -> PrecompileResult {
     }
 
     // Verify KZG proof with z and y in big endian format
-    let commitment: &[u8; 48] = commitment
-        .try_into()
-        .expect("expected `commitment` to be 48 bytes");
-    let z = input[32..64]
-        .try_into()
-        .expect("expected `z` to be 32 bytes");
-    let y = input[64..96]
-        .try_into()
-        .expect("expected `y` to be 32 bytes");
-    let proof = input[144..192]
-        .try_into()
-        .expect("expected `proof` to be 48 bytes");
+    let commitment: &[u8; 48] = commitment.try_into().unwrap();
+    let z = input[32..64].try_into().unwrap();
+    let y = input[64..96].try_into().unwrap();
+    let proof = input[144..192].try_into().unwrap();
     if !verify_kzg_proof(commitment, z, y, proof) {
         return Err(PrecompileError::BlobVerifyKzgProofFailed);
     }

--- a/crates/precompile/src/kzg_point_evaluation.rs
+++ b/crates/precompile/src/kzg_point_evaluation.rs
@@ -55,10 +55,18 @@ pub fn run(input: &[u8], gas_limit: u64) -> PrecompileResult {
     }
 
     // Verify KZG proof with z and y in big endian format
-    let commitment = as_bytes48(commitment);
-    let z = as_bytes32(&input[32..64]);
-    let y = as_bytes32(&input[64..96]);
-    let proof = as_bytes48(&input[144..192]);
+    let commitment: &[u8; 48] = commitment
+        .try_into()
+        .expect("expected `commitment` to be 48 bytes");
+    let z = input[32..64]
+        .try_into()
+        .expect("expected `z` to be 32 bytes");
+    let y = input[64..96]
+        .try_into()
+        .expect("expected `y` to be 32 bytes");
+    let proof = input[144..192]
+        .try_into()
+        .expect("expected `proof` to be 48 bytes");
     if !verify_kzg_proof(commitment, z, y, proof) {
         return Err(PrecompileError::BlobVerifyKzgProofFailed);
     }
@@ -77,15 +85,20 @@ pub fn kzg_to_versioned_hash(commitment: &[u8]) -> [u8; 32] {
 
 /// Verify KZG proof.
 #[inline]
-pub fn verify_kzg_proof(commitment: &Bytes48, z: &Bytes32, y: &Bytes32, proof: &Bytes48) -> bool {
+pub fn verify_kzg_proof(
+    commitment: &[u8; 48],
+    z: &[u8; 32],
+    y: &[u8; 32],
+    proof: &[u8; 48],
+) -> bool {
     cfg_if::cfg_if! {
         if #[cfg(feature = "c-kzg")] {
             let kzg_settings = c_kzg::ethereum_kzg_settings(8);
-            kzg_settings.verify_kzg_proof(commitment, z, y, proof).unwrap_or(false)
+            kzg_settings.verify_kzg_proof(as_bytes48(commitment), as_bytes32(z), as_bytes32(y), as_bytes48(proof)).unwrap_or(false)
         } else if #[cfg(feature = "kzg-rs")] {
             let env = kzg_rs::EnvKzgSettings::default();
             let kzg_settings = env.get();
-            KzgProof::verify_kzg_proof(commitment, z, y, proof, kzg_settings).unwrap_or(false)
+            KzgProof::verify_kzg_proof(as_bytes48(commitment), as_bytes32(z), as_bytes32(y), as_bytes48(proof), kzg_settings).unwrap_or(false)
         }
     }
 }
@@ -93,14 +106,14 @@ pub fn verify_kzg_proof(commitment: &Bytes48, z: &Bytes32, y: &Bytes32, proof: &
 /// Convert a slice to an array of a specific size.
 #[inline]
 #[track_caller]
-pub fn as_array<const N: usize>(bytes: &[u8]) -> &[u8; N] {
+fn as_array<const N: usize>(bytes: &[u8]) -> &[u8; N] {
     bytes.try_into().expect("slice with incorrect length")
 }
 
 /// Convert a slice to a 32 byte big endian array.
 #[inline]
 #[track_caller]
-pub fn as_bytes32(bytes: &[u8]) -> &Bytes32 {
+fn as_bytes32(bytes: &[u8]) -> &Bytes32 {
     // SAFETY: `#[repr(C)] Bytes32([u8; 32])`
     unsafe { &*as_array::<32>(bytes).as_ptr().cast() }
 }
@@ -108,7 +121,7 @@ pub fn as_bytes32(bytes: &[u8]) -> &Bytes32 {
 /// Convert a slice to a 48 byte big endian array.
 #[inline]
 #[track_caller]
-pub fn as_bytes48(bytes: &[u8]) -> &Bytes48 {
+fn as_bytes48(bytes: &[u8]) -> &Bytes48 {
     // SAFETY: `#[repr(C)] Bytes48([u8; 48])`
     unsafe { &*as_array::<48>(bytes).as_ptr().cast() }
 }

--- a/crates/precompile/src/secp256k1.rs
+++ b/crates/precompile/src/secp256k1.rs
@@ -44,14 +44,23 @@ pub fn ec_recover_run(input: &[u8], gas_limit: u64) -> PrecompileResult {
         return Ok(PrecompileOutput::new(ECRECOVER_BASE, Bytes::new()));
     }
 
-    let msg = <&B256>::try_from(&input[0..32]).unwrap();
+    let msg: [u8; 32] = input[0..32].try_into().expect("expected 32 bytes");
     let recid = input[63] - 27;
-    let sig = <&B512>::try_from(&input[64..128]).unwrap();
+    let sig: [u8; 64] = input[64..128].try_into().expect("expected 64 bytes");
 
-    let res = ecrecover(sig, recid, msg);
-
+    let res = ecrecover_bytes(sig, recid, msg);
     let out = res.map(|o| o.to_vec().into()).unwrap_or_default();
     Ok(PrecompileOutput::new(ECRECOVER_BASE, out))
+}
+
+fn ecrecover_bytes(sig: [u8; 64], recid: u8, msg: [u8; 32]) -> Option<[u8; 32]> {
+    let sig = B512::from_slice(&sig);
+    let msg = B256::from_slice(&msg);
+
+    match ecrecover(&sig, recid, &msg) {
+        Ok(address) => Some(address.0),
+        Err(_) => None,
+    }
 }
 
 // Select the correct implementation based on the enabled features.

--- a/crates/precompile/src/secp256k1.rs
+++ b/crates/precompile/src/secp256k1.rs
@@ -44,11 +44,11 @@ pub fn ec_recover_run(input: &[u8], gas_limit: u64) -> PrecompileResult {
         return Ok(PrecompileOutput::new(ECRECOVER_BASE, Bytes::new()));
     }
 
-    let msg: [u8; 32] = input[0..32].try_into().unwrap();
+    let msg = <&B256>::try_from(&input[0..32]).unwrap();
     let recid = input[63] - 27;
-    let sig: [u8; 64] = input[64..128].try_into().unwrap();
+    let sig = <&B512>::try_from(&input[64..128]).unwrap();
 
-    let res = ecrecover_bytes(sig, recid, msg);
+    let res = ecrecover_bytes(sig.0, recid, msg.0);
     let out = res.map(|o| o.to_vec().into()).unwrap_or_default();
     Ok(PrecompileOutput::new(ECRECOVER_BASE, out))
 }

--- a/crates/precompile/src/secp256k1.rs
+++ b/crates/precompile/src/secp256k1.rs
@@ -44,9 +44,9 @@ pub fn ec_recover_run(input: &[u8], gas_limit: u64) -> PrecompileResult {
         return Ok(PrecompileOutput::new(ECRECOVER_BASE, Bytes::new()));
     }
 
-    let msg: [u8; 32] = input[0..32].try_into().expect("expected 32 bytes");
+    let msg: [u8; 32] = input[0..32].try_into().unwrap();
     let recid = input[63] - 27;
-    let sig: [u8; 64] = input[64..128].try_into().expect("expected 64 bytes");
+    let sig: [u8; 64] = input[64..128].try_into().unwrap();
 
     let res = ecrecover_bytes(sig, recid, msg);
     let out = res.map(|o| o.to_vec().into()).unwrap_or_default();

--- a/crates/precompile/src/secp256r1.rs
+++ b/crates/precompile/src/secp256r1.rs
@@ -56,9 +56,9 @@ pub fn verify_impl(input: &[u8]) -> Option<()> {
     }
 
     // msg signed (msg is already the hash of the original message)
-    let msg = &input[..32];
+    let msg: [u8; 32] = input[..32].try_into().expect("expected 32 bytes");
     // r, s: signature
-    let sig = &input[32..96];
+    let sig: [u8; 64] = input[32..96].try_into().expect("expected 64 bytes");
     // x, y: public key
     let pk = &input[96..160];
 
@@ -67,12 +67,16 @@ pub fn verify_impl(input: &[u8]) -> Option<()> {
     uncompressed_pk[0] = 0x04;
     uncompressed_pk[1..].copy_from_slice(pk);
 
+    verify_signature(msg, sig, uncompressed_pk)
+}
+
+fn verify_signature(msg: [u8; 32], sig: [u8; 64], uncompressed_pk: [u8; 65]) -> Option<()> {
     // Can fail only if the input is not exact length.
-    let signature = Signature::from_slice(sig).ok()?;
+    let signature = Signature::from_slice(&sig).ok()?;
     // Can fail if the input is not valid, so we have to propagate the error.
     let public_key = VerifyingKey::from_sec1_bytes(&uncompressed_pk).ok()?;
 
-    public_key.verify_prehash(msg, &signature).ok()
+    public_key.verify_prehash(&msg, &signature).ok()
 }
 
 #[cfg(test)]

--- a/crates/precompile/src/secp256r1.rs
+++ b/crates/precompile/src/secp256r1.rs
@@ -56,9 +56,9 @@ pub fn verify_impl(input: &[u8]) -> Option<()> {
     }
 
     // msg signed (msg is already the hash of the original message)
-    let msg: [u8; 32] = input[..32].try_into().expect("expected 32 bytes");
+    let msg: [u8; 32] = input[..32].try_into().unwrap();
     // r, s: signature
-    let sig: [u8; 64] = input[32..96].try_into().expect("expected 64 bytes");
+    let sig: [u8; 64] = input[32..96].try_into().unwrap();
     // x, y: public key
     let pk = &input[96..160];
 

--- a/crates/precompile/src/secp256r1.rs
+++ b/crates/precompile/src/secp256r1.rs
@@ -10,7 +10,7 @@ use crate::{
     u64_to_address, PrecompileError, PrecompileOutput, PrecompileResult, PrecompileWithAddress,
 };
 use p256::ecdsa::{signature::hazmat::PrehashVerifier, Signature, VerifyingKey};
-use primitives::{Bytes, B256};
+use primitives::{alloy_primitives::B512, Bytes, B256};
 
 /// Address of secp256r1 precompile.
 pub const P256VERIFY_ADDRESS: u64 = 256;
@@ -56,9 +56,9 @@ pub fn verify_impl(input: &[u8]) -> Option<()> {
     }
 
     // msg signed (msg is already the hash of the original message)
-    let msg: [u8; 32] = input[..32].try_into().unwrap();
+    let msg = <&B256>::try_from(&input[..32]).unwrap();
     // r, s: signature
-    let sig: [u8; 64] = input[32..96].try_into().unwrap();
+    let sig = <&B512>::try_from(&input[32..96]).unwrap();
     // x, y: public key
     let pk = &input[96..160];
 
@@ -67,7 +67,7 @@ pub fn verify_impl(input: &[u8]) -> Option<()> {
     uncompressed_pk[0] = 0x04;
     uncompressed_pk[1..].copy_from_slice(pk);
 
-    verify_signature(msg, sig, uncompressed_pk)
+    verify_signature(msg.0, sig.0, uncompressed_pk)
 }
 
 fn verify_signature(msg: [u8; 32], sig: [u8; 64], uncompressed_pk: [u8; 65]) -> Option<()> {


### PR DESCRIPTION
## Motivation

Using revm inside of a zkVM involves patching certain cryptographic libraries using patch-crates.io -- this is quite brittle because one needs to ensure that the versions match up and long term we would like these to be patched using extern C.

One could implement extern C methods under a feature flag, however the more general strategy would be to have a pluggable architecture like https://github.com/alloy-rs/alloy/pull/2634 -- This PR is a precursor to adding the pluggable architecture since the functions that are being plugged in shouldn't rely on the types of a particular library.