### PR TITLE
feat: add a way for precompiles to revert

### DIFF
--- a/crates/handler/src/precompile_provider.rs
+++ b/crates/handler/src/precompile_provider.rs
@@ -124,7 +124,11 @@ impl<CTX: ContextTr> PrecompileProvider<CTX> for EthPrecompiles {
             Ok(output) => {
                 let underflow = result.gas.record_cost(output.gas_used);
                 assert!(underflow, "Gas underflow is not possible");
-                result.result = InstructionResult::Return;
+                result.result = if output.reverted {
+                    InstructionResult::Revert
+                } else {
+                    InstructionResult::Return
+                };
                 result.output = output.bytes;
             }
             Err(PrecompileError::Fatal(e)) => return Err(e),

--- a/crates/precompile/src/interface.rs
+++ b/crates/precompile/src/interface.rs
@@ -16,12 +16,33 @@ pub struct PrecompileOutput {
     pub gas_used: u64,
     /// Output bytes
     pub bytes: Bytes,
+    /// Whether the precompile reverted
+    pub reverted: bool,
 }
 
 impl PrecompileOutput {
     /// Returns new precompile output with the given gas used and output bytes.
     pub fn new(gas_used: u64, bytes: Bytes) -> Self {
-        Self { gas_used, bytes }
+        Self {
+            gas_used,
+            bytes,
+            reverted: false,
+        }
+    }
+
+    /// Returns new precompile revert with the given gas used and output bytes.
+    pub fn new_reverted(gas_used: u64, bytes: Bytes) -> Self {
+        Self {
+            gas_used,
+            bytes,
+            reverted: true,
+        }
+    }
+
+    /// Flips [`Self::reverted`] to `true`.
+    pub fn reverted(mut self) -> Self {
+        self.reverted = true;
+        self
     }
 }
 

--- a/examples/custom_precompile_journal/src/precompile_provider.rs
+++ b/examples/custom_precompile_journal/src/precompile_provider.rs
@@ -119,7 +119,11 @@ fn run_custom_precompile<CTX: ContextTr>(
     match result {
         Ok(output) => {
             let mut interpreter_result = InterpreterResult {
-                result: InstructionResult::Return,
+                result: if output.reverted {
+                    InstructionResult::Revert
+                } else {
+                    InstructionResult::Return
+                },
                 gas: Gas::new(gas_limit),
                 output: output.bytes,
             };


### PR DESCRIPTION
Adds `reverted` flag to `PrecompileOutput` that allows precompiles to revert