### PR TITLE
perf: add asm-sha2 feature for sha2 precompile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4450,6 +4450,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -103,6 +103,7 @@ std = [
 ]
 hashbrown = ["primitives/hashbrown"]
 asm-keccak = ["primitives/asm-keccak"]
+asm-sha2 = ["sha2/asm"]
 
 # These libraries may not work on all no_std platforms as they depend on C.
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -99,6 +99,7 @@ c-kzg = [
 kzg-rs = ["precompile/kzg-rs"]
 blst = ["precompile/blst"]
 bn = ["precompile/bn"]
+asm-sha2 = ["precompile/asm-sha2"]
 
 # Compile in portable mode, without ISA extensions.
 # Binary can be executed on all systems.


### PR DESCRIPTION
Turns out `sha2` has an `asm` feature, added a feature for enabling this