### PR TITLE
chore: remove State bound from JournalTr in Handler::Evm

### DIFF
--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -13,7 +13,6 @@ use context_interface::{
 use interpreter::interpreter_action::FrameInit;
 use interpreter::{Gas, InitialAndFloorGas, SharedMemory};
 use primitives::U256;
-use state::EvmState;
 
 /// Trait for errors that can occur during EVM execution.
 ///
@@ -68,7 +67,7 @@ impl<
 pub trait Handler {
     /// The EVM type containing Context, Instruction, and Precompiles implementations.
     type Evm: EvmTr<
-        Context: ContextTr<Journal: JournalTr<State = EvmState>, Local: LocalContextTr>,
+        Context: ContextTr<Journal: JournalTr, Local: LocalContextTr>,
         Frame: FrameTr<FrameInit = FrameInit, FrameResult = FrameResult>,
     >;
     /// The error type returned by this handler.

--- a/crates/handler/src/post_execution.rs
+++ b/crates/handler/src/post_execution.rs
@@ -6,7 +6,6 @@ use context_interface::{
 };
 use interpreter::{Gas, InitialAndFloorGas, SuccessOrHalt};
 use primitives::{hardfork::SpecId, U256};
-use state::EvmState;
 
 /// Ensures minimum gas floor is spent according to EIP-7623.
 pub fn eip7623_check_gas_floor(gas: &mut Gas, init_and_floor_gas: InitialAndFloorGas) {
@@ -80,7 +79,7 @@ pub fn reward_beneficiary<CTX: ContextTr>(
 /// Calculate last gas spent and transform internal reason to external.
 ///
 /// TODO make Journal FinalOutput more generic.
-pub fn output<CTX: ContextTr<Journal: JournalTr<State = EvmState>>, HALTREASON: HaltReasonTr>(
+pub fn output<CTX: ContextTr<Journal: JournalTr>, HALTREASON: HaltReasonTr>(
     context: &mut CTX,
     // TODO, make this more generic and nice.
     // FrameResult should be a generic that returns gas and interpreter result.


### PR DESCRIPTION
Removes the unused State bound from JournalTr in Handler::Evm. This removal allows journals to use the Handler trait even if they don't return EvmState from JournalTr::finalize. A concrete example is a JournalTr implementor that maintains some custom state in addition to EvmState.