### PR TITLE
docs(inspector): update obsolete current_opcode() comment

### DIFF
--- a/crates/inspector/src/inspector.rs
+++ b/crates/inspector/src/inspector.rs
@@ -31,7 +31,7 @@ pub trait Inspector<CTX, INTR: InterpreterTypes = EthInterpreter> {
     ///
     /// # Example
     ///
-    /// To get the current opcode, use `interp.current_opcode()`.
+    /// To get the current opcode, use `interp.bytecode.opcode()`.
     #[inline]
     fn step(&mut self, interp: &mut Interpreter<INTR>, context: &mut CTX) {
         let _ = interp;


### PR DESCRIPTION
Replace the non-existent `interp.current_opcode()` with the correct `interp.bytecode.opcode()` in the Inspector trait documentation.

Fixes #2717

🤖 Generated with [Claude Code](https://claude.ai/code)