### PR TITLE
Fix typo in EIP-7702 bytecode format comment (magic byte)

### DIFF
--- a/crates/bytecode/src/eip7702.rs
+++ b/crates/bytecode/src/eip7702.rs
@@ -17,7 +17,7 @@ pub const EIP7702_VERSION: u8 = 0;
 /// Bytecode of delegated account, specified in EIP-7702
 ///
 /// Format of EIP-7702 bytecode consist of:
-/// `0xEF00` (MAGIC) + `0x00` (VERSION) + 20 bytes of address.
+/// `0xEF01` (MAGIC) + `0x00` (VERSION) + 20 bytes of address.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Eip7702Bytecode {


### PR DESCRIPTION
Corrected a typo in the documentation comment for the EIP-7702 bytecode format. The magic byte was incorrectly listed as 0xEF00 and is now properly stated as 0xEF01 to match the actual implementation and specification. No functional code changes were made.