### PR TITLE
chore: Copy Dragan benchmarking code into criterion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,6 +1477,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
 name = "criterion-plot"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3907,6 +3933,7 @@ name = "revm-interpreter"
 version = "23.0.1"
 dependencies = [
  "bincode 2.0.1",
+ "criterion",
  "revm-bytecode",
  "revm-context-interface",
  "revm-primitives",

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -27,6 +27,7 @@ serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
 [dev-dependencies]
 bincode.workspace = true
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [features]
 default = ["std"]
@@ -47,3 +48,7 @@ serde = [
 arbitrary = ["std", "primitives/arbitrary"]
 # TODO : Should be set from Context or from crate that consumes this PR.
 memory_limit = []
+
+[[bench]]
+name = "instructions"
+harness = false

--- a/crates/interpreter/benches/instructions.rs
+++ b/crates/interpreter/benches/instructions.rs
@@ -1,0 +1,93 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use primitives::{hardfork::SpecId, U256};
+use revm_interpreter::{
+    host::DummyHost,
+    instructions::{
+        arithmetic::mul,
+        bitwise::{clz, iszero},
+    },
+    InstructionContext, Interpreter,
+};
+use std::time::{Duration, Instant};
+
+fn bench_isolated_operations(c: &mut Criterion) {
+    let mut group = c.benchmark_group("isolated_operations");
+
+    let test_value = U256::from(0x1_u128);
+
+    group.bench_function("iszero_only", |b| {
+        b.iter_custom(|iters| {
+            let mut total_duration = Duration::ZERO;
+
+            for _ in 0..iters {
+                // Setup (not timed)
+                let mut interpreter = Interpreter::default();
+                let _ = interpreter.stack.push(test_value);
+                let mut host = DummyHost;
+                let context = InstructionContext {
+                    host: &mut host,
+                    interpreter: &mut interpreter,
+                };
+
+                let start = Instant::now();
+                iszero(context);
+                total_duration += start.elapsed();
+            }
+
+            total_duration
+        });
+    });
+
+    group.bench_function("clz_only", |b| {
+        b.iter_custom(|iters| {
+            let mut total_duration = Duration::ZERO;
+
+            for _ in 0..iters {
+                // Setup (not timed)
+                let mut interpreter = Interpreter::default();
+                interpreter.set_spec_id(SpecId::OSAKA);
+                let _ = interpreter.stack.push(test_value);
+                let mut host = DummyHost;
+                let context = InstructionContext {
+                    host: &mut host,
+                    interpreter: &mut interpreter,
+                };
+
+                let start = Instant::now();
+                clz(context);
+                total_duration += start.elapsed();
+            }
+
+            total_duration
+        });
+    });
+
+    group.bench_function("mul_only", |b| {
+        b.iter_custom(|iters| {
+            let mut total_duration = Duration::ZERO;
+
+            for _ in 0..iters {
+                // Setup (not timed)
+                let mut interpreter = Interpreter::default();
+                let _ = interpreter.stack.push(test_value);
+                let _ = interpreter.stack.push(test_value);
+                let mut host = DummyHost;
+                let context = InstructionContext {
+                    host: &mut host,
+                    interpreter: &mut interpreter,
+                };
+
+                let start = Instant::now();
+                mul(context);
+                total_duration += start.elapsed();
+            }
+
+            total_duration
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_isolated_operations);
+criterion_main!(benches);


### PR DESCRIPTION
This aims to copy Dragan's code from #2742 to see what criterion spits out.

Had to use `iter_custom` to replicate it exactly -- using iter_batched would be better, but then the context creation would need to be timed.

Opening it up as a reference on this repo, will close it as I didn't intend for it to be merged