### PR TITLE
perf: un-Box frames

### DIFF
--- a/crates/interpreter/src/interpreter/ext_bytecode.rs
+++ b/crates/interpreter/src/interpreter/ext_bytecode.rs
@@ -31,6 +31,7 @@ impl Deref for ExtBytecode {
 }
 
 impl Default for ExtBytecode {
+    #[inline]
     fn default() -> Self {
         Self::new(Bytecode::default())
     }
@@ -38,6 +39,7 @@ impl Default for ExtBytecode {
 
 impl ExtBytecode {
     /// Create new extended bytecode and set the instruction pointer to the start of the bytecode.
+    #[inline]
     pub fn new(base: Bytecode) -> Self {
         let instruction_pointer = base.bytecode_ptr();
         Self {


### PR DESCRIPTION
I believe this change was made to reduce memory consumption, however the initial problem was a memory leak which was fixed. So I don't think this is necessary anymore, and it should slightly improve performance because of cache locality of the frames inside of the Vec, as well as removing an initial allocation when creating the frame.