### PR TITLE
chore: clean up bytecode analysis

### DIFF
--- a/crates/bytecode/src/legacy/raw.rs
+++ b/crates/bytecode/src/legacy/raw.rs
@@ -1,22 +1,18 @@
-use super::{analyze_legacy, LegacyAnalyzedBytecode};
+use super::LegacyAnalyzedBytecode;
 use core::ops::Deref;
 use primitives::Bytes;
 
 /// Used only as intermediate representation for legacy bytecode.
-/// Please check [`LegacyAnalyzedBytecode`] for the main structure that is used in Revm.
+///
+/// See [`LegacyAnalyzedBytecode`] for the main structure that is used in Revm.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LegacyRawBytecode(pub Bytes);
 
 impl LegacyRawBytecode {
-    /// Converts the raw bytecode into an analyzed bytecode.
-    ///
-    /// It extends the bytecode with 33 zero bytes and analyzes it to find the jumpdests.
+    /// Analyzes the bytecode, instantiating a [`LegacyAnalyzedBytecode`].
     pub fn into_analyzed(self) -> LegacyAnalyzedBytecode {
-        let bytecode = self.0;
-        let len = bytecode.len();
-        let (jump_table, padded_bytecode) = analyze_legacy(bytecode);
-        LegacyAnalyzedBytecode::new(padded_bytecode, len, jump_table)
+        LegacyAnalyzedBytecode::analyze(self.0)
     }
 }
 


### PR DESCRIPTION
Remove vec! allocation when padding; clean up docs and instantiation flow.