### PR TITLE
fix: swapped comments for db and db_mut methods in JournalTr trait

### DIFF
--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -20,10 +20,10 @@ pub trait JournalTr {
     /// Dont forget to set spec_id.
     fn new(database: Self::Database) -> Self;
 
-    /// Returns the database.
+    /// Returns a mutable reference to the database.
     fn db_mut(&mut self) -> &mut Self::Database;
 
-    /// Returns the mutable database.
+    /// Returns an immutable reference to the database.
     fn db(&self) -> &Self::Database;
 
     /// Returns the storage value from Journal state.


### PR DESCRIPTION
Corrected the doc comments for the db and db_mut methods in the JournalTr trait.
Now, db_mut is documented as returning a mutable reference to the database, and db as returning an immutable reference.
This improves code clarity and prevents confusion for implementers and users of the trait.