### PR TITLE
chore: collapse debug info for interpreter macros

### DIFF
--- a/crates/interpreter/src/instructions/macros.rs
+++ b/crates/interpreter/src/instructions/macros.rs
@@ -2,6 +2,7 @@
 
 /// `const` Option `?`.
 #[macro_export]
+#[collapse_debuginfo(yes)]
 macro_rules! tri {
     ($e:expr) => {
         match $e {
@@ -13,6 +14,7 @@ macro_rules! tri {
 
 /// Fails the instruction if the current call is static.
 #[macro_export]
+#[collapse_debuginfo(yes)]
 macro_rules! require_non_staticcall {
     ($interpreter:expr) => {
         if $interpreter.runtime_flag.is_static() {
@@ -25,6 +27,7 @@ macro_rules! require_non_staticcall {
 /// Macro for optional try - returns early if the expression evaluates to None.
 /// Similar to the `?` operator but for use in instruction implementations.
 #[macro_export]
+#[collapse_debuginfo(yes)]
 macro_rules! otry {
     ($expression: expr) => {{
         let Some(value) = $expression else {
@@ -34,19 +37,9 @@ macro_rules! otry {
     }};
 }
 
-/// Error if the current call is executing EOF.
-#[macro_export]
-macro_rules! require_eof {
-    ($interpreter:expr) => {
-        if !$interpreter.runtime_flag.is_eof() {
-            $interpreter.halt($crate::InstructionResult::EOFOpcodeDisabledInLegacy);
-            return;
-        }
-    };
-}
-
 /// Check if the `SPEC` is enabled, and fail the instruction if it is not.
 #[macro_export]
+#[collapse_debuginfo(yes)]
 macro_rules! check {
     ($interpreter:expr, $min:ident) => {
         if !$interpreter
@@ -62,6 +55,7 @@ macro_rules! check {
 
 /// Records a `gas` cost and fails the instruction if it would exceed the available gas.
 #[macro_export]
+#[collapse_debuginfo(yes)]
 macro_rules! gas {
     ($interpreter:expr, $gas:expr) => {
         $crate::gas!($interpreter, $gas, ())
@@ -76,6 +70,7 @@ macro_rules! gas {
 
 /// Same as [`gas!`], but with `gas` as an option.
 #[macro_export]
+#[collapse_debuginfo(yes)]
 macro_rules! gas_or_fail {
     ($interpreter:expr, $gas:expr) => {
         $crate::gas_or_fail!($interpreter, $gas, ())
@@ -94,6 +89,7 @@ macro_rules! gas_or_fail {
 /// Resizes the interpreterreter memory if necessary. Fails the instruction if the memory or gas limit
 /// is exceeded.
 #[macro_export]
+#[collapse_debuginfo(yes)]
 macro_rules! resize_memory {
     ($interpreter:expr, $offset:expr, $len:expr) => {
         $crate::resize_memory!($interpreter, $offset, $len, ())
@@ -113,6 +109,7 @@ macro_rules! resize_memory {
 
 /// Pops n values from the stack. Fails the instruction if n values can't be popped.
 #[macro_export]
+#[collapse_debuginfo(yes)]
 macro_rules! popn {
     ([ $($x:ident),* ],$interpreterreter:expr $(,$ret:expr)? ) => {
         let Some([$( $x ),*]) = $interpreterreter.stack.popn() else {
@@ -124,6 +121,7 @@ macro_rules! popn {
 
 #[doc(hidden)]
 #[macro_export]
+#[collapse_debuginfo(yes)]
 macro_rules! _count {
     (@count) => { 0 };
     (@count $head:tt $($tail:tt)*) => { 1 + _count!(@count $($tail)*) };
@@ -132,6 +130,7 @@ macro_rules! _count {
 
 /// Pops n values from the stack and returns the top value. Fails the instruction if n values can't be popped.
 #[macro_export]
+#[collapse_debuginfo(yes)]
 macro_rules! popn_top {
     ([ $($x:ident),* ], $top:ident, $interpreter:expr $(,$ret:expr)? ) => {
         /*
@@ -152,6 +151,7 @@ macro_rules! popn_top {
 
 /// Pushes a `B256` value onto the stack. Fails the instruction if the stack is full.
 #[macro_export]
+#[collapse_debuginfo(yes)]
 macro_rules! push {
     ($interpreter:expr, $x:expr $(,$ret:item)?) => (
         if !($interpreter.stack.push($x)) {
@@ -163,6 +163,7 @@ macro_rules! push {
 
 /// Converts a `U256` value to a `u64`, saturating to `MAX` if the value is too large.
 #[macro_export]
+#[collapse_debuginfo(yes)]
 macro_rules! as_u64_saturated {
     ($v:expr) => {
         match $v.as_limbs() {
@@ -179,6 +180,7 @@ macro_rules! as_u64_saturated {
 
 /// Converts a `U256` value to a `usize`, saturating to `MAX` if the value is too large.
 #[macro_export]
+#[collapse_debuginfo(yes)]
 macro_rules! as_usize_saturated {
     ($v:expr) => {
         usize::try_from($crate::as_u64_saturated!($v)).unwrap_or(usize::MAX)
@@ -187,6 +189,7 @@ macro_rules! as_usize_saturated {
 
 /// Converts a `U256` value to a `isize`, saturating to `isize::MAX` if the value is too large.
 #[macro_export]
+#[collapse_debuginfo(yes)]
 macro_rules! as_isize_saturated {
     ($v:expr) => {
         // `isize_try_from(u64::MAX)`` will fail and return isize::MAX
@@ -197,6 +200,7 @@ macro_rules! as_isize_saturated {
 
 /// Converts a `U256` value to a `usize`, failing the instruction if the value is too large.
 #[macro_export]
+#[collapse_debuginfo(yes)]
 macro_rules! as_usize_or_fail {
     ($interpreter:expr, $v:expr) => {
         $crate::as_usize_or_fail_ret!($interpreter, $v, ())
@@ -209,6 +213,7 @@ macro_rules! as_usize_or_fail {
 /// Converts a `U256` value to a `usize` and returns `ret`,
 /// failing the instruction if the value is too large.
 #[macro_export]
+#[collapse_debuginfo(yes)]
 macro_rules! as_usize_or_fail_ret {
     ($interpreter:expr, $v:expr, $ret:expr) => {
         $crate::as_usize_or_fail_ret!(

--- a/crates/interpreter/src/macros.rs
+++ b/crates/interpreter/src/macros.rs
@@ -1,6 +1,7 @@
 /// Macro that triggers `unreachable!` in debug builds but uses unchecked unreachable in release builds.
 /// This provides better error messages during development while optimizing for performance in release.
 #[macro_export]
+#[collapse_debuginfo(yes)]
 macro_rules! debug_unreachable {
     ($($t:tt)*) => {
         if cfg!(debug_assertions) {
@@ -15,6 +16,7 @@ macro_rules! debug_unreachable {
 /// In debug builds, this will trigger unreachable code if the assumption is false.
 /// In release builds, this serves as an optimization hint.
 #[macro_export]
+#[collapse_debuginfo(yes)]
 macro_rules! assume {
     ($e:expr $(,)?) => {
         if !$e {


### PR DESCRIPTION
Without this attribute, debug info will point into the macro, but this is quite annoying when debugging/profiling for simple macros. e.g. `gas!` will show up in a separate stack frame in `samply`.

Reference: https://doc.rust-lang.org/nightly/reference/attributes/debugger.html#r-attributes.debugger.collapse_debuginfo