### PR TITLE
chore: add OnceLock re-export with no_std support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,7 +3039,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "auto_impl",
- "once_cell",
  "revm",
  "rstest",
  "serde",
@@ -3795,7 +3794,6 @@ name = "revm-bytecode"
 version = "6.1.0"
 dependencies = [
  "bitvec",
- "once_cell",
  "paste",
  "phf",
  "revm-primitives",
@@ -3932,7 +3930,6 @@ dependencies = [
  "k256",
  "kzg-rs",
  "libsecp256k1",
- "once_cell",
  "p256",
  "rand 0.9.1",
  "revm-primitives",
@@ -3950,6 +3947,7 @@ version = "20.1.0"
 dependencies = [
  "alloy-primitives",
  "num_enum",
+ "once_cell",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,6 @@ auto_impl = "1.3.0"
 bitflags = { version = "2.9.1", default-features = false }
 cfg-if = { version = "1.0", default-features = false }
 derive-where = { version = "1.5.0", default-features = false }
-once_cell = { version = "1.21", default-features = false }
 rand = "0.9"
 tokio = "1.45"
 either = { version = "1.15.0", default-features = false }

--- a/crates/bytecode/Cargo.toml
+++ b/crates/bytecode/Cargo.toml
@@ -22,7 +22,6 @@ primitives.workspace = true
 
 # Jumpmap
 bitvec = { workspace = true, features = ["alloc"] }
-once_cell = { workspace = true, features = ["alloc"] }
 
 # Optional
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
@@ -37,7 +36,6 @@ std = [
     "serde?/std",
     "primitives/std",
     "bitvec/std",
-    "once_cell/std",
     "phf?/std",
 ]
 hashbrown = ["primitives/hashbrown"]

--- a/crates/bytecode/src/legacy/jump_map.rs
+++ b/crates/bytecode/src/legacy/jump_map.rs
@@ -3,8 +3,7 @@ use core::{
     cmp::Ordering,
     hash::{Hash, Hasher},
 };
-use once_cell::race::OnceBox;
-use primitives::hex;
+use primitives::{hex, OnceLock};
 use std::{fmt::Debug, sync::Arc};
 
 /// A table of valid `jump` destinations.
@@ -80,10 +79,8 @@ impl Debug for JumpTable {
 impl Default for JumpTable {
     #[inline]
     fn default() -> Self {
-        static DEFAULT: OnceBox<JumpTable> = OnceBox::new();
-        DEFAULT
-            .get_or_init(|| Self::new(BitVec::default()).into())
-            .clone()
+        static DEFAULT: OnceLock<JumpTable> = OnceLock::new();
+        DEFAULT.get_or_init(|| Self::new(BitVec::default())).clone()
     }
 }
 

--- a/crates/op-revm/Cargo.toml
+++ b/crates/op-revm/Cargo.toml
@@ -21,9 +21,6 @@ workspace = true
 revm.workspace = true
 auto_impl.workspace = true
 
-# static precompile sets.
-once_cell = { workspace = true, features = ["alloc"] }
-
 # Optional
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
@@ -41,7 +38,6 @@ std = [
 	"serde?/std",
 	"revm/std",
 	"alloy-sol-types/std",
-	"once_cell/std",
 	"sha2/std",
 	"serde_json/std",
 	"alloy-primitives/std",

--- a/crates/op-revm/src/precompiles.rs
+++ b/crates/op-revm/src/precompiles.rs
@@ -1,6 +1,5 @@
 //! Contains Optimism specific precompiles.
 use crate::OpSpecId;
-use once_cell::race::OnceBox;
 use revm::{
     context::Cfg,
     context_interface::ContextTr,
@@ -10,7 +9,7 @@ use revm::{
         self, bn128, secp256r1, PrecompileError, PrecompileResult, PrecompileWithAddress,
         Precompiles,
     },
-    primitives::{hardfork::SpecId, Address},
+    primitives::{hardfork::SpecId, Address, OnceLock},
 };
 use std::boxed::Box;
 use std::string::String;
@@ -56,29 +55,29 @@ impl OpPrecompiles {
 
 /// Returns precompiles for Fjord spec.
 pub fn fjord() -> &'static Precompiles {
-    static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
+    static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
     INSTANCE.get_or_init(|| {
         let mut precompiles = Precompiles::cancun().clone();
         // RIP-7212: secp256r1 P256verify
         precompiles.extend([secp256r1::P256VERIFY]);
-        Box::new(precompiles)
+        precompiles
     })
 }
 
 /// Returns precompiles for Granite spec.
 pub fn granite() -> &'static Precompiles {
-    static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
+    static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
     INSTANCE.get_or_init(|| {
         let mut precompiles = fjord().clone();
         // Restrict bn256Pairing input size
         precompiles.extend([bn128_pair::GRANITE]);
-        Box::new(precompiles)
+        precompiles
     })
 }
 
 /// Returns precompiles for isthumus spec.
 pub fn isthmus() -> &'static Precompiles {
-    static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
+    static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
     INSTANCE.get_or_init(|| {
         let mut precompiles = granite().clone();
         // Prague bls12 precompiles
@@ -89,7 +88,7 @@ pub fn isthmus() -> &'static Precompiles {
             bls12_381::ISTHMUS_G2_MSM,
             bls12_381::ISTHMUS_PAIRING,
         ]);
-        Box::new(precompiles)
+        precompiles
     })
 }
 

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -25,9 +25,6 @@ aurora-engine-modexp.workspace = true
 # gmp wrapper
 rug = { workspace = true, features = ["integer"], optional = true }
 
-# static precompile sets.
-once_cell = { workspace = true, features = ["alloc"] }
-
 # ecRecover
 k256 = { workspace = true, features = ["ecdsa"] }
 secp256k1 = { workspace = true, features = [
@@ -85,7 +82,6 @@ default = ["std", "c-kzg", "secp256k1", "portable", "blst"]
 std = [
 	"primitives/std",
 	"k256/std",
-	"once_cell/std",
 	"ripemd/std",
 	"sha2/std",
 	"c-kzg?/std",

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -57,8 +57,7 @@ use aurora_engine_modexp as _;
 
 use cfg_if::cfg_if;
 use core::hash::Hash;
-use once_cell::race::OnceBox;
-use primitives::{hardfork::SpecId, Address, HashMap, HashSet};
+use primitives::{hardfork::SpecId, Address, HashMap, HashSet, OnceLock};
 use std::{boxed::Box, vec::Vec};
 
 /// Calculate the linear cost of a precompile.
@@ -133,7 +132,7 @@ impl Precompiles {
 
     /// Returns precompiles for Homestead spec.
     pub fn homestead() -> &'static Self {
-        static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
+        static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
         INSTANCE.get_or_init(|| {
             let mut precompiles = Precompiles::default();
             precompiles.extend([
@@ -142,7 +141,7 @@ impl Precompiles {
                 hash::RIPEMD160,
                 identity::FUN,
             ]);
-            Box::new(precompiles)
+            precompiles
         })
     }
 
@@ -153,7 +152,7 @@ impl Precompiles {
 
     /// Returns precompiles for Byzantium spec.
     pub fn byzantium() -> &'static Self {
-        static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
+        static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
         INSTANCE.get_or_init(|| {
             let mut precompiles = Self::homestead().clone();
             precompiles.extend([
@@ -165,13 +164,13 @@ impl Precompiles {
                 bn128::mul::BYZANTIUM,
                 bn128::pair::BYZANTIUM,
             ]);
-            Box::new(precompiles)
+            precompiles
         })
     }
 
     /// Returns precompiles for Istanbul spec.
     pub fn istanbul() -> &'static Self {
-        static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
+        static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
         INSTANCE.get_or_init(|| {
             let mut precompiles = Self::byzantium().clone();
             precompiles.extend([
@@ -182,20 +181,20 @@ impl Precompiles {
                 // EIP-152: Add BLAKE2 compression function `F` precompile.
                 blake2::FUN,
             ]);
-            Box::new(precompiles)
+            precompiles
         })
     }
 
     /// Returns precompiles for Berlin spec.
     pub fn berlin() -> &'static Self {
-        static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
+        static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
         INSTANCE.get_or_init(|| {
             let mut precompiles = Self::istanbul().clone();
             precompiles.extend([
                 // EIP-2565: ModExp Gas Cost.
                 modexp::BERLIN,
             ]);
-            Box::new(precompiles)
+            precompiles
         })
     }
 
@@ -204,7 +203,7 @@ impl Precompiles {
     /// If the `c-kzg` feature is not enabled KZG Point Evaluation precompile will not be included,
     /// effectively making this the same as Berlin.
     pub fn cancun() -> &'static Self {
-        static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
+        static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
         INSTANCE.get_or_init(|| {
             let mut precompiles = Self::berlin().clone();
 
@@ -222,27 +221,27 @@ impl Precompiles {
                 precompile,
             ]);
 
-            Box::new(precompiles)
+            precompiles
         })
     }
 
     /// Returns precompiles for Prague spec.
     pub fn prague() -> &'static Self {
-        static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
+        static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
         INSTANCE.get_or_init(|| {
             let mut precompiles = Self::cancun().clone();
             precompiles.extend(bls12_381::precompiles());
-            Box::new(precompiles)
+            precompiles
         })
     }
 
     /// Returns precompiles for Osaka spec.
     pub fn osaka() -> &'static Self {
-        static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
+        static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
         INSTANCE.get_or_init(|| {
             let mut precompiles = Self::prague().clone();
             precompiles.extend([modexp::OSAKA, secp256r1::P256VERIFY_OSAKA]);
-            Box::new(precompiles)
+            precompiles
         })
     }
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -22,13 +22,17 @@ alloy-primitives = { workspace = true, features = ["rlp", "map"] }
 
 # mics
 num_enum = { version = "0.7.3", default-features = false }
+once_cell = { version = "1.21", default-features = false, features = [
+    "alloc",
+    "race",
+] }
 
 # Optional
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
 [features]
 default = ["std"]
-std = ["alloy-primitives/std", "serde?/std", "num_enum/std"]
+std = ["alloy-primitives/std", "serde?/std", "num_enum/std", "once_cell/std"]
 serde = ["dep:serde", "alloy-primitives/serde"]
 map-foldhash = ["alloy-primitives/map-foldhash"]
 

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -17,8 +17,10 @@ pub mod eip7825;
 pub mod eip7907;
 pub mod eip7918;
 pub mod hardfork;
+mod once_lock;
 
 pub use constants::*;
+pub use once_lock::OnceLock;
 
 // Reexport alloy primitives.
 

--- a/crates/primitives/src/once_lock.rs
+++ b/crates/primitives/src/once_lock.rs
@@ -1,0 +1,45 @@
+//! `OnceLock` abstraction that uses [`std::sync::OnceLock`] when available, once_cell otherwise.
+
+#[cfg(not(feature = "std"))]
+mod no_std_impl {
+    use once_cell::race::OnceBox;
+    use std::boxed::Box;
+
+    /// A thread-safe cell which can be written to only once.
+    #[derive(Debug)]
+    pub struct OnceLock<T> {
+        inner: OnceBox<T>,
+    }
+
+    impl<T> Default for OnceLock<T> {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl<T> OnceLock<T> {
+        /// Creates a new empty OnceLock.
+        pub const fn new() -> Self {
+            Self {
+                inner: OnceBox::new(),
+            }
+        }
+
+        /// Gets the contents of the OnceLock, initializing it if necessary.
+        pub fn get_or_init<F>(&self, f: F) -> &T
+        where
+            F: FnOnce() -> T,
+            T: Into<Box<T>>,
+        {
+            self.inner.get_or_init(|| f().into())
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+use once_cell as _;
+#[cfg(feature = "std")]
+pub use std::sync::OnceLock;
+
+#[cfg(not(feature = "std"))]
+pub use no_std_impl::OnceLock;


### PR DESCRIPTION
Same as `alloy_primitives::map` that uses `hashbrown`, here we use `once_cell::race::OnceBox` for `no_std` `OnceLock`, while preferring `std::sync::OnceLock`.