### PR TITLE
chore: add rust-version and note about MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ["stable", "beta", "nightly"]
+        rust: ["1.88", "stable", "nightly"]
         flags: ["--no-default-features", "", "--all-features"]
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,8 +133,9 @@ categories = ["no-std", "compilers", "cryptography::cryptocurrencies"]
 keywords = ["revm", "evm", "ethereum", "blockchain", "no_std"]
 repository = "https://github.com/bluealloy/revm"
 documentation = "https://bluealloy.github.io/revm/"
-homepage = ""
+homepage = "https://github.com/bluealloy/revm"
 edition = "2021"
+rust-version = "1.88.0"
 
 [workspace.lints]
 rust.missing_debug_implementations = "warn"

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Some quick links can be found here. Some point to code documentation or the book
 * How to run Ethereum test can be found here: [book](https://bluealloy.github.io/revm/revme.html#running-eth-tests)
 * If there is more need for explanations please open a PR request.
 
+## Supported Rust Versions (MSRV)
+
+Revm always aims to stay up-to-date with the latest stable Rust release.
+
+The Minimum Supported Rust Version (MSRV) may be updated at any time, so we can take advantage of new features and improvements in Rust.
+
 ### Community:
 For questions please open a github issue or join the public telegram group: [https://t.me/+Ig4WDWOzikA3MzA0](https://t.me/+Ig4WDWOzikA3MzA0)
 

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 keywords.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 # revm

--- a/crates/bytecode/Cargo.toml
+++ b/crates/bytecode/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/context/interface/Cargo.toml
+++ b/crates/context/interface/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
@@ -27,8 +28,8 @@ serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
 # alloydb
 tokio = { workspace = true, features = [
-    "rt-multi-thread",
-    "macros",
+	"rt-multi-thread",
+	"macros",
 ], optional = true }
 alloy-provider = { workspace = true, optional = true }
 alloy-eips = { workspace = true, optional = true }
@@ -48,7 +49,7 @@ std = [
 	"database-interface/std",
 	"primitives/std",
 	"state/std",
-	"serde_json/std"
+	"serde_json/std",
 ]
 serde = [
 	"dep:serde",
@@ -56,13 +57,13 @@ serde = [
 	"bytecode/serde",
 	"database-interface/serde",
 	"primitives/serde",
-	"state/serde"
+	"state/serde",
 ]
 alloydb = [
-    "std",
-    "database-interface/asyncdb",
-    "dep:tokio",
-    "dep:alloy-provider",
-    "dep:alloy-eips",
-    "dep:alloy-transport",
+	"std",
+	"database-interface/asyncdb",
+	"dep:tokio",
+	"dep:alloy-provider",
+	"dep:alloy-eips",
+	"dep:alloy-transport",
 ]

--- a/crates/database/interface/Cargo.toml
+++ b/crates/database/interface/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
@@ -37,16 +38,6 @@ rstest.workspace = true
 
 [features]
 default = ["std"]
-std = [
-	"serde?/std",
-	"primitives/std",
-	"state/std",
-	"either/std"
-]
-serde = [
-	"dep:serde",
-	"primitives/serde",
-	"state/serde",
-	"either/serde"
-]
+std = ["serde?/std", "primitives/std", "state/std", "either/std"]
+serde = ["dep:serde", "primitives/serde", "state/serde", "either/serde"]
 asyncdb = ["dep:tokio", "tokio/rt-multi-thread"]

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/inspector/Cargo.toml
+++ b/crates/inspector/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
@@ -30,12 +31,7 @@ bincode.workspace = true
 
 [features]
 default = ["std"]
-std = [
-	"serde?/std",
-	"primitives/std",
-	"context-interface/std",
-	"bytecode/std"
-]
+std = ["serde?/std", "primitives/std", "context-interface/std", "bytecode/std"]
 hashbrown = ["primitives/hashbrown"]
 serde = [
 	"dep:serde",

--- a/crates/op-revm/Cargo.toml
+++ b/crates/op-revm/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
@@ -29,10 +30,5 @@ serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
 [features]
 default = ["std"]
-std = [
-	"serde?/std",
-	"primitives/std",
-	"bitflags/std",
-	"bytecode/std"
-]
+std = ["serde?/std", "primitives/std", "bitflags/std", "bytecode/std"]
 serde = ["dep:serde", "primitives/serde", "bitflags/serde", "bytecode/serde"]

--- a/crates/statetest-types/Cargo.toml
+++ b/crates/statetest-types/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/block_traces/Cargo.toml
+++ b/examples/block_traces/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/cheatcode_inspector/Cargo.toml
+++ b/examples/cheatcode_inspector/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/contract_deployment/Cargo.toml
+++ b/examples/contract_deployment/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/custom_opcodes/Cargo.toml
+++ b/examples/custom_opcodes/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
@@ -17,4 +18,4 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-revm = {workspace = true, features = ["std", "tracer"]}
+revm = { workspace = true, features = ["std", "tracer"] }

--- a/examples/database_components/Cargo.toml
+++ b/examples/database_components/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/erc20_gas/Cargo.toml
+++ b/examples/erc20_gas/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/my_evm/Cargo.toml
+++ b/examples/my_evm/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/uniswap_get_reserves/Cargo.toml
+++ b/examples/uniswap_get_reserves/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/uniswap_v2_usdc_swap/Cargo.toml
+++ b/examples/uniswap_v2_usdc_swap/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Having rust-version set helps Cargo produce better error messages if the installed version is lower than the minimum specified.