### PR TITLE
chore: rename custom-precompile-journal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,14 +1561,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "custom_precompile_journal"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "revm",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1866,6 +1858,14 @@ dependencies = [
 name = "example-custom-opcodes"
 version = "0.0.0"
 dependencies = [
+ "revm",
+]
+
+[[package]]
+name = "example-custom-precompile-journal"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
  "revm",
 ]
 

--- a/examples/custom_precompile_journal/Cargo.toml
+++ b/examples/custom_precompile_journal/Cargo.toml
@@ -1,11 +1,7 @@
 [package]
-name = "custom_precompile_journal"
+name = "example-custom-precompile-journal"
 version = "0.1.0"
 edition = "2021"
-
-[[bin]]
-name = "custom_precompile_journal"
-path = "src/main.rs"
 
 [dependencies]
 revm = { path = "../../crates/revm", features = ["optional_eip3607"] }

--- a/examples/custom_precompile_journal/src/main.rs
+++ b/examples/custom_precompile_journal/src/main.rs
@@ -6,7 +6,9 @@
 //! 3. Modifying account balances and storage from within a precompile
 //! 4. Integrating the custom precompile into a custom EVM implementation
 
-use custom_precompile_journal::{precompile_provider::CUSTOM_PRECOMPILE_ADDRESS, CustomEvm};
+use example_custom_precompile_journal::{
+    precompile_provider::CUSTOM_PRECOMPILE_ADDRESS, CustomEvm,
+};
 use revm::{
     context::{result::InvalidTransaction, Context, ContextSetters, ContextTr, TxEnv},
     context_interface::result::EVMError,


### PR DESCRIPTION
Same format as all the others.
The name actually matters for the bench workflow to skip building.