### PR TITLE
fix(op-revm): system tx not enveloped

### DIFF
--- a/crates/op-revm/src/transaction/abstraction.rs
+++ b/crates/op-revm/src/transaction/abstraction.rs
@@ -89,11 +89,15 @@ impl<TX: Transaction + SystemCallTx> SystemCallTx for OpTransaction<TX> {
         system_contract_address: Address,
         data: Bytes,
     ) -> Self {
-        OpTransaction::new(TX::new_system_tx_with_caller(
+        let mut tx = OpTransaction::new(TX::new_system_tx_with_caller(
             caller,
             system_contract_address,
             data,
-        ))
+        ));
+
+        tx.enveloped_tx = Some(Bytes::default());
+
+        tx
     }
 }
 

--- a/crates/op-revm/tests/integration.rs
+++ b/crates/op-revm/tests/integration.rs
@@ -1,11 +1,13 @@
 //! Integration tests for the `op-revm` crate.
 mod common;
 
+use alloy_primitives::bytes;
 use common::compare_or_save_testdata;
 use op_revm::{
     precompiles::bn128_pair::GRANITE_MAX_INPUT_SIZE, DefaultOp, L1BlockInfo, OpBuilder,
     OpHaltReason, OpSpecId, OpTransaction,
 };
+use revm::SystemCallEvm;
 use revm::{
     bytecode::opcode,
     context::{
@@ -1071,4 +1073,19 @@ fn test_log_inspector() {
     assert!(!inspector.logs.is_empty());
 
     compare_or_save_testdata("test_log_inspector.json", &output);
+}
+
+#[test]
+fn test_system_call() {
+    let ctx = Context::op();
+
+    let mut evm = ctx.build_op();
+    
+    evm.transact_system_call(BENCH_TARGET, bytes!("0x0001"))
+        .unwrap();
+
+    // Run evm.
+    let output = evm.replay().unwrap();
+
+    compare_or_save_testdata("test_system_call.json", &output);
 }


### PR DESCRIPTION
Bug: system tx not enveloped, triggering panic `"all not deposit tx have enveloped tx"` in handler.
Fix: sets enveloped tx equal to `Some(Bytes::default())`

Adds test covering `OpEvm::transact_system_call_with_caller`, increasing coverage of _op-revm/src/api/exec.rs_ from 59% to 79%.