### PR TITLE
feat: add system transaction inspection support

### DIFF
--- a/bins/revme/benches/evm.rs
+++ b/bins/revme/benches/evm.rs
@@ -9,6 +9,6 @@ fn evm(c: &mut Criterion) {
     bench::transfer_multi::run(c);
     bench::evm_build::run(c);
     bench::gas_cost_estimator::run(c);
-} 
+}
 criterion_group!(benches, evm);
 criterion_main!(benches);

--- a/bins/revme/benches/evm.rs
+++ b/bins/revme/benches/evm.rs
@@ -9,6 +9,6 @@ fn evm(c: &mut Criterion) {
     bench::transfer_multi::run(c);
     bench::evm_build::run(c);
     bench::gas_cost_estimator::run(c);
-}
+} 
 criterion_group!(benches, evm);
 criterion_main!(benches);

--- a/crates/inspector/src/inspect.rs
+++ b/crates/inspector/src/inspect.rs
@@ -1,5 +1,7 @@
 use context::result::ExecResultAndState;
-use handler::{system_call::SYSTEM_ADDRESS, ExecuteCommitEvm, ExecuteEvm, SystemCallEvm, SystemCallCommitEvm};
+use handler::{
+    system_call::SYSTEM_ADDRESS, ExecuteCommitEvm, ExecuteEvm, SystemCallCommitEvm, SystemCallEvm,
+};
 use primitives::{Address, Bytes};
 
 /// InspectEvm is a API that allows inspecting the EVM.
@@ -93,11 +95,7 @@ pub trait InspectSystemCallEvm: InspectEvm + SystemCallEvm {
         system_contract_address: Address,
         data: Bytes,
     ) -> Result<Self::ExecutionResult, Self::Error> {
-        self.inspect_system_call_with_caller_one(
-            SYSTEM_ADDRESS,
-            system_contract_address,
-            data,
-        )
+        self.inspect_system_call_with_caller_one(SYSTEM_ADDRESS, system_contract_address, data)
     }
 
     /// Inspect a system call with the current inspector and a custom caller.
@@ -160,11 +158,8 @@ pub trait InspectSystemCallEvm: InspectEvm + SystemCallEvm {
         data: Bytes,
         inspector: Self::Inspector,
     ) -> Result<ExecResultAndState<Self::ExecutionResult, Self::State>, Self::Error> {
-        let output = self.inspect_system_call_with_inspector_one(
-            system_contract_address,
-            data,
-            inspector,
-        )?;
+        let output =
+            self.inspect_system_call_with_inspector_one(system_contract_address, data, inspector)?;
         let state = self.finalize();
         Ok(ExecResultAndState::new(output, state))
     }
@@ -207,11 +202,8 @@ pub trait InspectSystemCallCommitEvm:
         data: Bytes,
         inspector: Self::Inspector,
     ) -> Result<Self::ExecutionResult, Self::Error> {
-        let output = self.inspect_system_call_with_inspector_one(
-            system_contract_address,
-            data,
-            inspector,
-        )?;
+        let output =
+            self.inspect_system_call_with_inspector_one(system_contract_address, data, inspector)?;
         self.commit_inner();
         Ok(output)
     }

--- a/crates/inspector/src/inspect.rs
+++ b/crates/inspector/src/inspect.rs
@@ -1,5 +1,6 @@
 use context::result::ExecResultAndState;
-use handler::{ExecuteCommitEvm, ExecuteEvm};
+use handler::{system_call::SYSTEM_ADDRESS, ExecuteCommitEvm, ExecuteEvm, SystemCallEvm, SystemCallCommitEvm};
+use primitives::{Address, Bytes};
 
 /// InspectEvm is a API that allows inspecting the EVM.
 ///
@@ -72,6 +73,145 @@ pub trait InspectCommitEvm: InspectEvm + ExecuteCommitEvm {
         inspector: Self::Inspector,
     ) -> Result<Self::ExecutionResult, Self::Error> {
         let output = self.inspect_one(tx, inspector)?;
+        self.commit_inner();
+        Ok(output)
+    }
+}
+
+/// InspectSystemCallEvm is an API that allows inspecting system calls in the EVM.
+///
+/// It extends [`InspectEvm`] and [`SystemCallEvm`] traits to provide inspection
+/// capabilities for system transactions, enabling tracing and debugging of
+/// system calls similar to regular transactions.
+pub trait InspectSystemCallEvm: InspectEvm + SystemCallEvm {
+    /// Inspect a system call with the current inspector.
+    ///
+    /// Similar to [`InspectEvm::inspect_one_tx`] but for system calls.
+    /// Uses [`SYSTEM_ADDRESS`] as the caller.
+    fn inspect_system_call_one(
+        &mut self,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> Result<Self::ExecutionResult, Self::Error> {
+        self.inspect_system_call_with_caller_one(
+            SYSTEM_ADDRESS,
+            system_contract_address,
+            data,
+        )
+    }
+
+    /// Inspect a system call with the current inspector and a custom caller.
+    ///
+    /// Similar to [`InspectEvm::inspect_one_tx`] but for system calls with a custom caller.
+    fn inspect_system_call_with_caller_one(
+        &mut self,
+        caller: Address,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> Result<Self::ExecutionResult, Self::Error>;
+
+    /// Inspect a system call and finalize the state.
+    ///
+    /// Similar to [`InspectEvm::inspect_tx`] but for system calls.
+    fn inspect_system_call(
+        &mut self,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> Result<ExecResultAndState<Self::ExecutionResult, Self::State>, Self::Error> {
+        let output = self.inspect_system_call_one(system_contract_address, data)?;
+        let state = self.finalize();
+        Ok(ExecResultAndState::new(output, state))
+    }
+
+    /// Inspect a system call with a custom caller and finalize the state.
+    ///
+    /// Similar to [`InspectEvm::inspect_tx`] but for system calls with a custom caller.
+    fn inspect_system_call_with_caller(
+        &mut self,
+        caller: Address,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> Result<ExecResultAndState<Self::ExecutionResult, Self::State>, Self::Error> {
+        let output =
+            self.inspect_system_call_with_caller_one(caller, system_contract_address, data)?;
+        let state = self.finalize();
+        Ok(ExecResultAndState::new(output, state))
+    }
+
+    /// Inspect a system call with a given inspector.
+    ///
+    /// Similar to [`InspectEvm::inspect_one`] but for system calls.
+    fn inspect_system_call_with_inspector_one(
+        &mut self,
+        system_contract_address: Address,
+        data: Bytes,
+        inspector: Self::Inspector,
+    ) -> Result<Self::ExecutionResult, Self::Error> {
+        self.set_inspector(inspector);
+        self.inspect_system_call_one(system_contract_address, data)
+    }
+
+    /// Inspect a system call with a given inspector and finalize the state.
+    ///
+    /// Similar to [`InspectEvm::inspect`] but for system calls.
+    fn inspect_system_call_with_inspector(
+        &mut self,
+        system_contract_address: Address,
+        data: Bytes,
+        inspector: Self::Inspector,
+    ) -> Result<ExecResultAndState<Self::ExecutionResult, Self::State>, Self::Error> {
+        let output = self.inspect_system_call_with_inspector_one(
+            system_contract_address,
+            data,
+            inspector,
+        )?;
+        let state = self.finalize();
+        Ok(ExecResultAndState::new(output, state))
+    }
+}
+
+/// InspectSystemCallCommitEvm is an API that allows inspecting system calls similar to
+/// [`InspectSystemCallEvm`] but commits the state diff to the database.
+pub trait InspectSystemCallCommitEvm:
+    InspectSystemCallEvm + SystemCallCommitEvm + InspectCommitEvm
+{
+    /// Inspect a system call with the current inspector and commit the state diff to the database.
+    fn inspect_system_call_commit(
+        &mut self,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> Result<Self::ExecutionResult, Self::Error> {
+        let output = self.inspect_system_call_one(system_contract_address, data)?;
+        self.commit_inner();
+        Ok(output)
+    }
+
+    /// Inspect a system call with the current inspector and a custom caller,
+    /// then commit the state diff to the database.
+    fn inspect_system_call_with_caller_commit(
+        &mut self,
+        caller: Address,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> Result<Self::ExecutionResult, Self::Error> {
+        let output =
+            self.inspect_system_call_with_caller_one(caller, system_contract_address, data)?;
+        self.commit_inner();
+        Ok(output)
+    }
+
+    /// Inspect a system call with a given inspector and commit the state diff to the database.
+    fn inspect_system_call_with_inspector_commit(
+        &mut self,
+        system_contract_address: Address,
+        data: Bytes,
+        inspector: Self::Inspector,
+    ) -> Result<Self::ExecutionResult, Self::Error> {
+        let output = self.inspect_system_call_with_inspector_one(
+            system_contract_address,
+            data,
+            inspector,
+        )?;
         self.commit_inner();
         Ok(output)
     }

--- a/crates/inspector/src/inspect.rs
+++ b/crates/inspector/src/inspect.rs
@@ -1,7 +1,5 @@
 use context::result::ExecResultAndState;
-use handler::{
-    system_call::SYSTEM_ADDRESS, ExecuteCommitEvm, ExecuteEvm, SystemCallCommitEvm, SystemCallEvm,
-};
+use handler::{system_call::SYSTEM_ADDRESS, ExecuteCommitEvm, ExecuteEvm, SystemCallEvm};
 use primitives::{Address, Bytes};
 
 /// InspectEvm is a API that allows inspecting the EVM.
@@ -162,49 +160,5 @@ pub trait InspectSystemCallEvm: InspectEvm + SystemCallEvm {
             self.inspect_system_call_with_inspector_one(system_contract_address, data, inspector)?;
         let state = self.finalize();
         Ok(ExecResultAndState::new(output, state))
-    }
-}
-
-/// InspectSystemCallCommitEvm is an API that allows inspecting system calls similar to
-/// [`InspectSystemCallEvm`] but commits the state diff to the database.
-pub trait InspectSystemCallCommitEvm:
-    InspectSystemCallEvm + SystemCallCommitEvm + InspectCommitEvm
-{
-    /// Inspect a system call with the current inspector and commit the state diff to the database.
-    fn inspect_system_call_commit(
-        &mut self,
-        system_contract_address: Address,
-        data: Bytes,
-    ) -> Result<Self::ExecutionResult, Self::Error> {
-        let output = self.inspect_system_call_one(system_contract_address, data)?;
-        self.commit_inner();
-        Ok(output)
-    }
-
-    /// Inspect a system call with the current inspector and a custom caller,
-    /// then commit the state diff to the database.
-    fn inspect_system_call_with_caller_commit(
-        &mut self,
-        caller: Address,
-        system_contract_address: Address,
-        data: Bytes,
-    ) -> Result<Self::ExecutionResult, Self::Error> {
-        let output =
-            self.inspect_system_call_with_caller_one(caller, system_contract_address, data)?;
-        self.commit_inner();
-        Ok(output)
-    }
-
-    /// Inspect a system call with a given inspector and commit the state diff to the database.
-    fn inspect_system_call_with_inspector_commit(
-        &mut self,
-        system_contract_address: Address,
-        data: Bytes,
-        inspector: Self::Inspector,
-    ) -> Result<Self::ExecutionResult, Self::Error> {
-        let output =
-            self.inspect_system_call_with_inspector_one(system_contract_address, data, inspector)?;
-        self.commit_inner();
-        Ok(output)
     }
 }

--- a/crates/inspector/src/inspect.rs
+++ b/crates/inspector/src/inspect.rs
@@ -88,18 +88,18 @@ pub trait InspectSystemCallEvm: InspectEvm + SystemCallEvm {
     ///
     /// Similar to [`InspectEvm::inspect_one_tx`] but for system calls.
     /// Uses [`SYSTEM_ADDRESS`] as the caller.
-    fn inspect_system_call_one(
+    fn inspect_one_system_call(
         &mut self,
         system_contract_address: Address,
         data: Bytes,
     ) -> Result<Self::ExecutionResult, Self::Error> {
-        self.inspect_system_call_with_caller_one(SYSTEM_ADDRESS, system_contract_address, data)
+        self.inspect_one_system_call_with_caller(SYSTEM_ADDRESS, system_contract_address, data)
     }
 
     /// Inspect a system call with the current inspector and a custom caller.
     ///
     /// Similar to [`InspectEvm::inspect_one_tx`] but for system calls with a custom caller.
-    fn inspect_system_call_with_caller_one(
+    fn inspect_one_system_call_with_caller(
         &mut self,
         caller: Address,
         system_contract_address: Address,
@@ -114,7 +114,7 @@ pub trait InspectSystemCallEvm: InspectEvm + SystemCallEvm {
         system_contract_address: Address,
         data: Bytes,
     ) -> Result<ExecResultAndState<Self::ExecutionResult, Self::State>, Self::Error> {
-        let output = self.inspect_system_call_one(system_contract_address, data)?;
+        let output = self.inspect_one_system_call(system_contract_address, data)?;
         let state = self.finalize();
         Ok(ExecResultAndState::new(output, state))
     }
@@ -129,7 +129,7 @@ pub trait InspectSystemCallEvm: InspectEvm + SystemCallEvm {
         data: Bytes,
     ) -> Result<ExecResultAndState<Self::ExecutionResult, Self::State>, Self::Error> {
         let output =
-            self.inspect_system_call_with_caller_one(caller, system_contract_address, data)?;
+            self.inspect_one_system_call_with_caller(caller, system_contract_address, data)?;
         let state = self.finalize();
         Ok(ExecResultAndState::new(output, state))
     }
@@ -137,14 +137,14 @@ pub trait InspectSystemCallEvm: InspectEvm + SystemCallEvm {
     /// Inspect a system call with a given inspector.
     ///
     /// Similar to [`InspectEvm::inspect_one`] but for system calls.
-    fn inspect_system_call_with_inspector_one(
+    fn inspect_one_system_call_with_inspector(
         &mut self,
         system_contract_address: Address,
         data: Bytes,
         inspector: Self::Inspector,
     ) -> Result<Self::ExecutionResult, Self::Error> {
         self.set_inspector(inspector);
-        self.inspect_system_call_one(system_contract_address, data)
+        self.inspect_one_system_call(system_contract_address, data)
     }
 
     /// Inspect a system call with a given inspector and finalize the state.
@@ -157,7 +157,7 @@ pub trait InspectSystemCallEvm: InspectEvm + SystemCallEvm {
         inspector: Self::Inspector,
     ) -> Result<ExecResultAndState<Self::ExecutionResult, Self::State>, Self::Error> {
         let output =
-            self.inspect_system_call_with_inspector_one(system_contract_address, data, inspector)?;
+            self.inspect_one_system_call_with_inspector(system_contract_address, data, inspector)?;
         let state = self.finalize();
         Ok(ExecResultAndState::new(output, state))
     }

--- a/crates/inspector/src/inspector_tests.rs
+++ b/crates/inspector/src/inspector_tests.rs
@@ -735,7 +735,8 @@ mod tests {
     #[test]
     fn test_system_call_inspection_basic() {
         // Test that system calls can be inspected similar to regular transactions
-        const HISTORY_STORAGE_ADDRESS: Address = address!("0x0000F90827F1C53a10cb7A02335B175320002935");
+        const HISTORY_STORAGE_ADDRESS: Address =
+            address!("0x0000F90827F1C53a10cb7A02335B175320002935");
         static HISTORY_STORAGE_CODE: Bytes = bytes!("0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500");
 
         let mut db = InMemoryDB::default();
@@ -763,15 +764,18 @@ mod tests {
         // Verify that inspection captured events
         let inspector = &evm.inspector;
         let events = inspector.get_events();
-        
+
         // Should have captured step events from system call execution
         let step_count = events
             .iter()
             .filter(|e| matches!(e, InspectorEvent::Step(_)))
             .count();
-        
-        assert!(step_count > 0, "System call inspection should capture step events");
-        
+
+        assert!(
+            step_count > 0,
+            "System call inspection should capture step events"
+        );
+
         // Verify system call was properly executed by checking state
         assert_eq!(result.state.len(), 1);
         assert_eq!(
@@ -790,25 +794,31 @@ mod tests {
         // Test system call inspection with a custom caller address
         // Use a simple contract that doesn't check caller address
         const SIMPLE_CONTRACT: Address = address!("0x1000000000000000000000000000000000000001");
-        
+
         // Simple contract that stores the input data and returns the caller address
         let code = vec![
             // Store input data at storage slot 0
             opcode::CALLDATASIZE,
             opcode::ISZERO,
-            opcode::PUSH1, 0x0C, // Skip storage if no calldata
+            opcode::PUSH1,
+            0x0C, // Skip storage if no calldata
             opcode::JUMPI,
-            opcode::PUSH1, 0x00, // calldata offset
+            opcode::PUSH1,
+            0x00, // calldata offset
             opcode::CALLDATALOAD,
-            opcode::PUSH1, 0x00, // storage slot
+            opcode::PUSH1,
+            0x00, // storage slot
             opcode::SSTORE,
             opcode::JUMPDEST,
             // Return caller address
             opcode::CALLER,
-            opcode::PUSH1, 0x00, // Memory offset
+            opcode::PUSH1,
+            0x00, // Memory offset
             opcode::MSTORE,
-            opcode::PUSH1, 0x20, // Return size (32 bytes)
-            opcode::PUSH1, 0x00, // Return offset
+            opcode::PUSH1,
+            0x20, // Return size (32 bytes)
+            opcode::PUSH1,
+            0x00, // Return offset
             opcode::RETURN,
         ];
 
@@ -827,11 +837,7 @@ mod tests {
 
         // Inspect system call with custom caller
         let result = evm
-            .inspect_system_call_with_caller(
-                custom_caller,
-                SIMPLE_CONTRACT,
-                test_data.0.into(),
-            )
+            .inspect_system_call_with_caller(custom_caller, SIMPLE_CONTRACT, test_data.0.into())
             .unwrap();
 
         // Verify execution success
@@ -844,15 +850,22 @@ mod tests {
             .iter()
             .filter(|e| matches!(e, InspectorEvent::Step(_)))
             .count();
-        
-        assert!(step_count > 0, "System call with custom caller should capture step events");
+
+        assert!(
+            step_count > 0,
+            "System call with custom caller should capture step events"
+        );
 
         // Verify the custom caller was used
         let output = result.result.output().unwrap();
         let mut expected_caller = [0u8; 32];
         expected_caller[12..].copy_from_slice(custom_caller.as_slice());
         assert_eq!(output.len(), 32, "Should return 32 bytes (address)");
-        assert_eq!(output.as_ref(), &expected_caller, "Caller should be custom_caller");
+        assert_eq!(
+            output.as_ref(),
+            &expected_caller,
+            "Caller should be custom_caller"
+        );
 
         // Verify storage was updated with input data
         assert_eq!(
@@ -869,7 +882,8 @@ mod tests {
     #[test]
     fn test_system_call_inspection_with_custom_inspector() {
         // Test system call inspection with a custom inspector provided at call time
-        const HISTORY_STORAGE_ADDRESS: Address = address!("0x0000F90827F1C53a10cb7A02335B175320002935");
+        const HISTORY_STORAGE_ADDRESS: Address =
+            address!("0x0000F90827F1C53a10cb7A02335B175320002935");
         static HISTORY_STORAGE_CODE: Bytes = bytes!("0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500");
 
         let mut db = InMemoryDB::default();
@@ -908,8 +922,11 @@ mod tests {
             .iter()
             .filter(|e| matches!(e, InspectorEvent::Step(_)))
             .count();
-        
-        assert!(step_count > 0, "System call with custom inspector should capture step events");
+
+        assert!(
+            step_count > 0,
+            "System call with custom inspector should capture step events"
+        );
 
         // Verify state was updated correctly
         assert_eq!(
@@ -926,7 +943,8 @@ mod tests {
     #[test]
     fn test_system_call_inspection_one_vs_finalized() {
         // Test the difference between inspect_system_call_one and inspect_system_call
-        const HISTORY_STORAGE_ADDRESS: Address = address!("0x0000F90827F1C53a10cb7A02335B175320002935");
+        const HISTORY_STORAGE_ADDRESS: Address =
+            address!("0x0000F90827F1C53a10cb7A02335B175320002935");
         static HISTORY_STORAGE_CODE: Bytes = bytes!("0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500");
 
         let mut db = InMemoryDB::default();
@@ -957,13 +975,16 @@ mod tests {
             .iter()
             .filter(|e| matches!(e, InspectorEvent::Step(_)))
             .count();
-        
-        assert!(step_count > 0, "inspect_system_call_one should capture step events");
+
+        assert!(
+            step_count > 0,
+            "inspect_system_call_one should capture step events"
+        );
 
         // Now test inspect_system_call (execution result + finalized state)
         // Reset inspector for clean test
         evm.inspector = TestInspector::new();
-        
+
         let result_and_state = evm
             .inspect_system_call(HISTORY_STORAGE_ADDRESS, block_hash.0.into())
             .unwrap();
@@ -971,7 +992,7 @@ mod tests {
         // Verify both execution result and state are returned
         assert!(result_and_state.result.is_success());
         assert!(!result_and_state.state.is_empty());
-        
+
         // Verify state contains the expected storage update
         assert_eq!(
             result_and_state.state[&HISTORY_STORAGE_ADDRESS]
@@ -989,15 +1010,18 @@ mod tests {
         // Test that system call inspection uses SYSTEM_ADDRESS as default caller
         // This is verified by checking the transaction context during inspection
         const SIMPLE_CONTRACT: Address = address!("0x1000000000000000000000000000000000000001");
-        
+
         // Simple contract that returns the caller address
         let code = vec![
-            opcode::CALLER,     // Get caller address
-            opcode::PUSH1, 0x00, // Memory offset
-            opcode::MSTORE,     // Store caller in memory
-            opcode::PUSH1, 0x20, // Return size (32 bytes)
-            opcode::PUSH1, 0x00, // Return offset
-            opcode::RETURN,     // Return the caller address
+            opcode::CALLER, // Get caller address
+            opcode::PUSH1,
+            0x00,           // Memory offset
+            opcode::MSTORE, // Store caller in memory
+            opcode::PUSH1,
+            0x20, // Return size (32 bytes)
+            opcode::PUSH1,
+            0x00,           // Return offset
+            opcode::RETURN, // Return the caller address
         ];
 
         let mut db = InMemoryDB::default();
@@ -1017,7 +1041,7 @@ mod tests {
 
         // Verify execution was successful
         assert!(result.result.is_success());
-        
+
         // Verify inspection captured the execution
         let inspector = &evm.inspector;
         let events = inspector.get_events();
@@ -1025,8 +1049,11 @@ mod tests {
             .iter()
             .filter(|e| matches!(e, InspectorEvent::Step(_)))
             .count();
-        
-        assert!(step_count > 0, "System call inspection should capture execution steps");
+
+        assert!(
+            step_count > 0,
+            "System call inspection should capture execution steps"
+        );
 
         // The returned data should be the SYSTEM_ADDRESS (caller)
         let output = result.result.output().unwrap();
@@ -1034,6 +1061,10 @@ mod tests {
         let mut expected_caller = [0u8; 32];
         expected_caller[12..].copy_from_slice(SYSTEM_ADDRESS.as_slice());
         assert_eq!(output.len(), 32, "Should return 32 bytes (address)");
-        assert_eq!(output.as_ref(), &expected_caller, "Caller should be SYSTEM_ADDRESS");
+        assert_eq!(
+            output.as_ref(),
+            &expected_caller,
+            "Caller should be SYSTEM_ADDRESS"
+        );
     }
 }

--- a/crates/inspector/src/inspector_tests.rs
+++ b/crates/inspector/src/inspector_tests.rs
@@ -1,14 +1,14 @@
 #[cfg(test)]
 mod tests {
-    use crate::{InspectEvm, Inspector};
+    use crate::{InspectEvm, InspectSystemCallEvm, Inspector};
     use context::{Context, TxEnv};
-    use database::{BenchmarkDB, BENCH_CALLER, BENCH_TARGET};
-    use handler::{MainBuilder, MainContext};
+    use database::{BenchmarkDB, InMemoryDB, BENCH_CALLER, BENCH_TARGET};
+    use handler::{system_call::SYSTEM_ADDRESS, MainBuilder, MainContext};
     use interpreter::{
         interpreter_types::{Jumps, MemoryTr, StackTr},
         CallInputs, CallOutcome, CreateInputs, CreateOutcome, Interpreter, InterpreterTypes,
     };
-    use primitives::{address, Address, Bytes, Log, TxKind, U256};
+    use primitives::{address, b256, bytes, Address, Bytes, Log, StorageKey, TxKind, U256};
     use state::{bytecode::opcode, AccountInfo, Bytecode};
 
     #[derive(Debug, Clone)]
@@ -730,5 +730,310 @@ mod tests {
             0x17,
             "Should have jumped to JUMPDEST"
         );
+    }
+
+    #[test]
+    fn test_system_call_inspection_basic() {
+        // Test that system calls can be inspected similar to regular transactions
+        const HISTORY_STORAGE_ADDRESS: Address = address!("0x0000F90827F1C53a10cb7A02335B175320002935");
+        static HISTORY_STORAGE_CODE: Bytes = bytes!("0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500");
+
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            HISTORY_STORAGE_ADDRESS,
+            AccountInfo::default().with_code(Bytecode::new_legacy(HISTORY_STORAGE_CODE.clone())),
+        );
+
+        let block_hash =
+            b256!("0x1111111111111111111111111111111111111111111111111111111111111111");
+
+        let mut evm = Context::mainnet()
+            .with_db(db)
+            .modify_block_chained(|b| b.number = U256::ONE)
+            .build_mainnet_with_inspector(TestInspector::new());
+
+        // Inspect system call
+        let result = evm
+            .inspect_system_call(HISTORY_STORAGE_ADDRESS, block_hash.0.into())
+            .unwrap();
+
+        // Verify that the system call was executed successfully
+        assert!(result.result.is_success());
+
+        // Verify that inspection captured events
+        let inspector = &evm.inspector;
+        let events = inspector.get_events();
+        
+        // Should have captured step events from system call execution
+        let step_count = events
+            .iter()
+            .filter(|e| matches!(e, InspectorEvent::Step(_)))
+            .count();
+        
+        assert!(step_count > 0, "System call inspection should capture step events");
+        
+        // Verify system call was properly executed by checking state
+        assert_eq!(result.state.len(), 1);
+        assert_eq!(
+            result.state[&HISTORY_STORAGE_ADDRESS]
+                .storage
+                .get(&StorageKey::from(0))
+                .map(|slot| slot.present_value)
+                .unwrap_or_default(),
+            U256::from_be_bytes(block_hash.0),
+            "System call should have updated state"
+        );
+    }
+
+    #[test]
+    fn test_system_call_inspection_with_custom_caller() {
+        // Test system call inspection with a custom caller address
+        // Use a simple contract that doesn't check caller address
+        const SIMPLE_CONTRACT: Address = address!("0x1000000000000000000000000000000000000001");
+        
+        // Simple contract that stores the input data and returns the caller address
+        let code = vec![
+            // Store input data at storage slot 0
+            opcode::CALLDATASIZE,
+            opcode::ISZERO,
+            opcode::PUSH1, 0x0C, // Skip storage if no calldata
+            opcode::JUMPI,
+            opcode::PUSH1, 0x00, // calldata offset
+            opcode::CALLDATALOAD,
+            opcode::PUSH1, 0x00, // storage slot
+            opcode::SSTORE,
+            opcode::JUMPDEST,
+            // Return caller address
+            opcode::CALLER,
+            opcode::PUSH1, 0x00, // Memory offset
+            opcode::MSTORE,
+            opcode::PUSH1, 0x20, // Return size (32 bytes)
+            opcode::PUSH1, 0x00, // Return offset
+            opcode::RETURN,
+        ];
+
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            SIMPLE_CONTRACT,
+            AccountInfo::default().with_code(Bytecode::new_raw(Bytes::from(code))),
+        );
+
+        let test_data = b256!("0x2222222222222222222222222222222222222222222222222222222222222222");
+        let custom_caller = address!("0x1000000000000000000000000000000000000001");
+
+        let mut evm = Context::mainnet()
+            .with_db(db)
+            .build_mainnet_with_inspector(TestInspector::new());
+
+        // Inspect system call with custom caller
+        let result = evm
+            .inspect_system_call_with_caller(
+                custom_caller,
+                SIMPLE_CONTRACT,
+                test_data.0.into(),
+            )
+            .unwrap();
+
+        // Verify execution success
+        assert!(result.result.is_success());
+
+        // Verify inspection captured events
+        let inspector = &evm.inspector;
+        let events = inspector.get_events();
+        let step_count = events
+            .iter()
+            .filter(|e| matches!(e, InspectorEvent::Step(_)))
+            .count();
+        
+        assert!(step_count > 0, "System call with custom caller should capture step events");
+
+        // Verify the custom caller was used
+        let output = result.result.output().unwrap();
+        let mut expected_caller = [0u8; 32];
+        expected_caller[12..].copy_from_slice(custom_caller.as_slice());
+        assert_eq!(output.len(), 32, "Should return 32 bytes (address)");
+        assert_eq!(output.as_ref(), &expected_caller, "Caller should be custom_caller");
+
+        // Verify storage was updated with input data
+        assert_eq!(
+            result.state[&SIMPLE_CONTRACT]
+                .storage
+                .get(&StorageKey::from(0))
+                .map(|slot| slot.present_value)
+                .unwrap_or_default(),
+            U256::from_be_bytes(test_data.0),
+            "System call with custom caller should store input data"
+        );
+    }
+
+    #[test]
+    fn test_system_call_inspection_with_custom_inspector() {
+        // Test system call inspection with a custom inspector provided at call time
+        const HISTORY_STORAGE_ADDRESS: Address = address!("0x0000F90827F1C53a10cb7A02335B175320002935");
+        static HISTORY_STORAGE_CODE: Bytes = bytes!("0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500");
+
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            HISTORY_STORAGE_ADDRESS,
+            AccountInfo::default().with_code(Bytecode::new_legacy(HISTORY_STORAGE_CODE.clone())),
+        );
+
+        let block_hash =
+            b256!("0x3333333333333333333333333333333333333333333333333333333333333333");
+
+        let mut evm = Context::mainnet()
+            .with_db(db)
+            .modify_block_chained(|b| b.number = U256::from(3))
+            .build_mainnet_with_inspector(TestInspector::new());
+
+        // Create a fresh inspector for this specific call
+        let custom_inspector = TestInspector::new();
+
+        // Inspect system call with custom inspector
+        let result = evm
+            .inspect_system_call_with_inspector(
+                HISTORY_STORAGE_ADDRESS,
+                block_hash.0.into(),
+                custom_inspector,
+            )
+            .unwrap();
+
+        // Verify execution success
+        assert!(result.result.is_success());
+
+        // Verify the EVM's inspector captured events from this call
+        let inspector = &evm.inspector;
+        let events = inspector.get_events();
+        let step_count = events
+            .iter()
+            .filter(|e| matches!(e, InspectorEvent::Step(_)))
+            .count();
+        
+        assert!(step_count > 0, "System call with custom inspector should capture step events");
+
+        // Verify state was updated correctly
+        assert_eq!(
+            result.state[&HISTORY_STORAGE_ADDRESS]
+                .storage
+                .get(&StorageKey::from(2))
+                .map(|slot| slot.present_value)
+                .unwrap_or_default(),
+            U256::from_be_bytes(block_hash.0),
+            "System call with custom inspector should update state correctly"
+        );
+    }
+
+    #[test]
+    fn test_system_call_inspection_one_vs_finalized() {
+        // Test the difference between inspect_system_call_one and inspect_system_call
+        const HISTORY_STORAGE_ADDRESS: Address = address!("0x0000F90827F1C53a10cb7A02335B175320002935");
+        static HISTORY_STORAGE_CODE: Bytes = bytes!("0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500");
+
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            HISTORY_STORAGE_ADDRESS,
+            AccountInfo::default().with_code(Bytecode::new_legacy(HISTORY_STORAGE_CODE.clone())),
+        );
+
+        let block_hash =
+            b256!("0x4444444444444444444444444444444444444444444444444444444444444444");
+
+        let mut evm = Context::mainnet()
+            .with_db(db)
+            .modify_block_chained(|b| b.number = U256::from(4))
+            .build_mainnet_with_inspector(TestInspector::new());
+
+        // Test inspect_system_call_one (execution result only)
+        let execution_result = evm
+            .inspect_system_call_one(HISTORY_STORAGE_ADDRESS, block_hash.0.into())
+            .unwrap();
+
+        assert!(execution_result.is_success());
+
+        // Verify inspection captured events
+        let inspector = &evm.inspector;
+        let events = inspector.get_events();
+        let step_count = events
+            .iter()
+            .filter(|e| matches!(e, InspectorEvent::Step(_)))
+            .count();
+        
+        assert!(step_count > 0, "inspect_system_call_one should capture step events");
+
+        // Now test inspect_system_call (execution result + finalized state)
+        // Reset inspector for clean test
+        evm.inspector = TestInspector::new();
+        
+        let result_and_state = evm
+            .inspect_system_call(HISTORY_STORAGE_ADDRESS, block_hash.0.into())
+            .unwrap();
+
+        // Verify both execution result and state are returned
+        assert!(result_and_state.result.is_success());
+        assert!(!result_and_state.state.is_empty());
+        
+        // Verify state contains the expected storage update
+        assert_eq!(
+            result_and_state.state[&HISTORY_STORAGE_ADDRESS]
+                .storage
+                .get(&StorageKey::from(3))
+                .map(|slot| slot.present_value)
+                .unwrap_or_default(),
+            U256::from_be_bytes(block_hash.0),
+            "inspect_system_call should return finalized state"
+        );
+    }
+
+    #[test]
+    fn test_system_call_inspection_uses_system_address() {
+        // Test that system call inspection uses SYSTEM_ADDRESS as default caller
+        // This is verified by checking the transaction context during inspection
+        const SIMPLE_CONTRACT: Address = address!("0x1000000000000000000000000000000000000001");
+        
+        // Simple contract that returns the caller address
+        let code = vec![
+            opcode::CALLER,     // Get caller address
+            opcode::PUSH1, 0x00, // Memory offset
+            opcode::MSTORE,     // Store caller in memory
+            opcode::PUSH1, 0x20, // Return size (32 bytes)
+            opcode::PUSH1, 0x00, // Return offset
+            opcode::RETURN,     // Return the caller address
+        ];
+
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            SIMPLE_CONTRACT,
+            AccountInfo::default().with_code(Bytecode::new_raw(Bytes::from(code))),
+        );
+
+        let mut evm = Context::mainnet()
+            .with_db(db)
+            .build_mainnet_with_inspector(TestInspector::new());
+
+        // Inspect system call (should use SYSTEM_ADDRESS as caller)
+        let result = evm
+            .inspect_system_call(SIMPLE_CONTRACT, Bytes::default())
+            .unwrap();
+
+        // Verify execution was successful
+        assert!(result.result.is_success());
+        
+        // Verify inspection captured the execution
+        let inspector = &evm.inspector;
+        let events = inspector.get_events();
+        let step_count = events
+            .iter()
+            .filter(|e| matches!(e, InspectorEvent::Step(_)))
+            .count();
+        
+        assert!(step_count > 0, "System call inspection should capture execution steps");
+
+        // The returned data should be the SYSTEM_ADDRESS (caller)
+        let output = result.result.output().unwrap();
+        // The output should contain the SYSTEM_ADDRESS as the caller
+        let mut expected_caller = [0u8; 32];
+        expected_caller[12..].copy_from_slice(SYSTEM_ADDRESS.as_slice());
+        assert_eq!(output.len(), 32, "Should return 32 bytes (address)");
+        assert_eq!(output.as_ref(), &expected_caller, "Caller should be SYSTEM_ADDRESS");
     }
 }

--- a/crates/inspector/src/inspector_tests.rs
+++ b/crates/inspector/src/inspector_tests.rs
@@ -775,22 +775,22 @@ mod tests {
         let ctx = Context::mainnet().with_db(BenchmarkDB::new_bytecode(bytecode));
         let mut evm = ctx.build_mainnet_with_inspector(TestInspector::new());
 
-        // Test inspect_system_call_one
+        // Test inspect_one_system_call
         let result = evm
-            .inspect_system_call_one(BENCH_TARGET, Bytes::default())
+            .inspect_one_system_call(BENCH_TARGET, Bytes::default())
             .unwrap();
         assert!(result.is_success());
 
-        // Test inspect_system_call_with_caller_one
+        // Test inspect_one_system_call_with_caller
         let custom_caller = address!("0x1234567890123456789012345678901234567890");
         let result = evm
-            .inspect_system_call_with_caller_one(custom_caller, BENCH_TARGET, Bytes::default())
+            .inspect_one_system_call_with_caller(custom_caller, BENCH_TARGET, Bytes::default())
             .unwrap();
         assert!(result.is_success());
 
-        // Test inspect_system_call_with_inspector_one
+        // Test inspect_one_system_call_with_inspector
         let result = evm
-            .inspect_system_call_with_inspector_one(
+            .inspect_one_system_call_with_inspector(
                 BENCH_TARGET,
                 Bytes::default(),
                 TestInspector::new(),

--- a/crates/inspector/src/inspector_tests.rs
+++ b/crates/inspector/src/inspector_tests.rs
@@ -2,13 +2,13 @@
 mod tests {
     use crate::{InspectEvm, InspectSystemCallEvm, Inspector};
     use context::{Context, TxEnv};
-    use database::{BenchmarkDB, InMemoryDB, BENCH_CALLER, BENCH_TARGET};
-    use handler::{system_call::SYSTEM_ADDRESS, MainBuilder, MainContext};
+    use database::{BenchmarkDB, BENCH_CALLER, BENCH_TARGET};
+    use handler::{MainBuilder, MainContext};
     use interpreter::{
         interpreter_types::{Jumps, MemoryTr, StackTr},
         CallInputs, CallOutcome, CreateInputs, CreateOutcome, Interpreter, InterpreterTypes,
     };
-    use primitives::{address, b256, bytes, Address, Bytes, Log, StorageKey, TxKind, U256};
+    use primitives::{address, Address, Bytes, Log, TxKind, U256};
     use state::{bytecode::opcode, AccountInfo, Bytecode};
 
     #[derive(Debug, Clone)]
@@ -734,337 +734,70 @@ mod tests {
 
     #[test]
     fn test_system_call_inspection_basic() {
-        // Test that system calls can be inspected similar to regular transactions
-        const HISTORY_STORAGE_ADDRESS: Address =
-            address!("0x0000F90827F1C53a10cb7A02335B175320002935");
-        static HISTORY_STORAGE_CODE: Bytes = bytes!("0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500");
+        // PUSH1 0x42, SSTORE, STOP
+        let code = Bytes::from(vec![
+            opcode::PUSH1,
+            0x42,
+            opcode::PUSH1,
+            0x00,
+            opcode::SSTORE,
+            opcode::STOP,
+        ]);
 
-        let mut db = InMemoryDB::default();
-        db.insert_account_info(
-            HISTORY_STORAGE_ADDRESS,
-            AccountInfo::default().with_code(Bytecode::new_legacy(HISTORY_STORAGE_CODE.clone())),
-        );
+        let bytecode = Bytecode::new_raw(code);
+        let ctx = Context::mainnet().with_db(BenchmarkDB::new_bytecode(bytecode));
+        let mut evm = ctx.build_mainnet_with_inspector(TestInspector::new());
 
-        let block_hash =
-            b256!("0x1111111111111111111111111111111111111111111111111111111111111111");
-
-        let mut evm = Context::mainnet()
-            .with_db(db)
-            .modify_block_chained(|b| b.number = U256::ONE)
-            .build_mainnet_with_inspector(TestInspector::new());
-
-        // Inspect system call
         let result = evm
-            .inspect_system_call(HISTORY_STORAGE_ADDRESS, block_hash.0.into())
+            .inspect_system_call(BENCH_TARGET, Bytes::default())
             .unwrap();
 
-        // Verify that the system call was executed successfully
         assert!(result.result.is_success());
-
-        // Verify that inspection captured events
-        let inspector = &evm.inspector;
-        let events = inspector.get_events();
-
-        // Should have captured step events from system call execution
-        let step_count = events
-            .iter()
-            .filter(|e| matches!(e, InspectorEvent::Step(_)))
-            .count();
-
-        assert!(
-            step_count > 0,
-            "System call inspection should capture step events"
-        );
-
-        // Verify system call was properly executed by checking state
-        assert_eq!(result.state.len(), 1);
-        assert_eq!(
-            result.state[&HISTORY_STORAGE_ADDRESS]
-                .storage
-                .get(&StorageKey::from(0))
-                .map(|slot| slot.present_value)
-                .unwrap_or_default(),
-            U256::from_be_bytes(block_hash.0),
-            "System call should have updated state"
-        );
+        assert!(evm.inspector.get_step_count() > 0);
+        assert!(!result.state.is_empty());
     }
 
     #[test]
-    fn test_system_call_inspection_with_custom_caller() {
-        // Test system call inspection with a custom caller address
-        // Use a simple contract that doesn't check caller address
-        const SIMPLE_CONTRACT: Address = address!("0x1000000000000000000000000000000000000001");
-
-        // Simple contract that stores the input data and returns the caller address
+    fn test_system_call_inspection_api_variants() {
         let code = vec![
-            // Store input data at storage slot 0
-            opcode::CALLDATASIZE,
-            opcode::ISZERO,
-            opcode::PUSH1,
-            0x0C, // Skip storage if no calldata
-            opcode::JUMPI,
-            opcode::PUSH1,
-            0x00, // calldata offset
-            opcode::CALLDATALOAD,
-            opcode::PUSH1,
-            0x00, // storage slot
-            opcode::SSTORE,
-            opcode::JUMPDEST,
-            // Return caller address
             opcode::CALLER,
             opcode::PUSH1,
-            0x00, // Memory offset
+            0x00,
             opcode::MSTORE,
             opcode::PUSH1,
-            0x20, // Return size (32 bytes)
+            0x20,
             opcode::PUSH1,
-            0x00, // Return offset
+            0x00,
             opcode::RETURN,
         ];
 
-        let mut db = InMemoryDB::default();
-        db.insert_account_info(
-            SIMPLE_CONTRACT,
-            AccountInfo::default().with_code(Bytecode::new_raw(Bytes::from(code))),
-        );
+        let bytecode = Bytecode::new_raw(Bytes::from(code));
+        let ctx = Context::mainnet().with_db(BenchmarkDB::new_bytecode(bytecode));
+        let mut evm = ctx.build_mainnet_with_inspector(TestInspector::new());
 
-        let test_data = b256!("0x2222222222222222222222222222222222222222222222222222222222222222");
-        let custom_caller = address!("0x1000000000000000000000000000000000000001");
-
-        let mut evm = Context::mainnet()
-            .with_db(db)
-            .build_mainnet_with_inspector(TestInspector::new());
-
-        // Inspect system call with custom caller
+        // Test inspect_system_call_one
         let result = evm
-            .inspect_system_call_with_caller(custom_caller, SIMPLE_CONTRACT, test_data.0.into())
+            .inspect_system_call_one(BENCH_TARGET, Bytes::default())
             .unwrap();
+        assert!(result.is_success());
 
-        // Verify execution success
-        assert!(result.result.is_success());
-
-        // Verify inspection captured events
-        let inspector = &evm.inspector;
-        let events = inspector.get_events();
-        let step_count = events
-            .iter()
-            .filter(|e| matches!(e, InspectorEvent::Step(_)))
-            .count();
-
-        assert!(
-            step_count > 0,
-            "System call with custom caller should capture step events"
-        );
-
-        // Verify the custom caller was used
-        let output = result.result.output().unwrap();
-        let mut expected_caller = [0u8; 32];
-        expected_caller[12..].copy_from_slice(custom_caller.as_slice());
-        assert_eq!(output.len(), 32, "Should return 32 bytes (address)");
-        assert_eq!(
-            output.as_ref(),
-            &expected_caller,
-            "Caller should be custom_caller"
-        );
-
-        // Verify storage was updated with input data
-        assert_eq!(
-            result.state[&SIMPLE_CONTRACT]
-                .storage
-                .get(&StorageKey::from(0))
-                .map(|slot| slot.present_value)
-                .unwrap_or_default(),
-            U256::from_be_bytes(test_data.0),
-            "System call with custom caller should store input data"
-        );
-    }
-
-    #[test]
-    fn test_system_call_inspection_with_custom_inspector() {
-        // Test system call inspection with a custom inspector provided at call time
-        const HISTORY_STORAGE_ADDRESS: Address =
-            address!("0x0000F90827F1C53a10cb7A02335B175320002935");
-        static HISTORY_STORAGE_CODE: Bytes = bytes!("0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500");
-
-        let mut db = InMemoryDB::default();
-        db.insert_account_info(
-            HISTORY_STORAGE_ADDRESS,
-            AccountInfo::default().with_code(Bytecode::new_legacy(HISTORY_STORAGE_CODE.clone())),
-        );
-
-        let block_hash =
-            b256!("0x3333333333333333333333333333333333333333333333333333333333333333");
-
-        let mut evm = Context::mainnet()
-            .with_db(db)
-            .modify_block_chained(|b| b.number = U256::from(3))
-            .build_mainnet_with_inspector(TestInspector::new());
-
-        // Create a fresh inspector for this specific call
-        let custom_inspector = TestInspector::new();
-
-        // Inspect system call with custom inspector
+        // Test inspect_system_call_with_caller_one
+        let custom_caller = address!("0x1234567890123456789012345678901234567890");
         let result = evm
-            .inspect_system_call_with_inspector(
-                HISTORY_STORAGE_ADDRESS,
-                block_hash.0.into(),
-                custom_inspector,
+            .inspect_system_call_with_caller_one(custom_caller, BENCH_TARGET, Bytes::default())
+            .unwrap();
+        assert!(result.is_success());
+
+        // Test inspect_system_call_with_inspector_one
+        let result = evm
+            .inspect_system_call_with_inspector_one(
+                BENCH_TARGET,
+                Bytes::default(),
+                TestInspector::new(),
             )
             .unwrap();
+        assert!(result.is_success());
 
-        // Verify execution success
-        assert!(result.result.is_success());
-
-        // Verify the EVM's inspector captured events from this call
-        let inspector = &evm.inspector;
-        let events = inspector.get_events();
-        let step_count = events
-            .iter()
-            .filter(|e| matches!(e, InspectorEvent::Step(_)))
-            .count();
-
-        assert!(
-            step_count > 0,
-            "System call with custom inspector should capture step events"
-        );
-
-        // Verify state was updated correctly
-        assert_eq!(
-            result.state[&HISTORY_STORAGE_ADDRESS]
-                .storage
-                .get(&StorageKey::from(2))
-                .map(|slot| slot.present_value)
-                .unwrap_or_default(),
-            U256::from_be_bytes(block_hash.0),
-            "System call with custom inspector should update state correctly"
-        );
-    }
-
-    #[test]
-    fn test_system_call_inspection_one_vs_finalized() {
-        // Test the difference between inspect_system_call_one and inspect_system_call
-        const HISTORY_STORAGE_ADDRESS: Address =
-            address!("0x0000F90827F1C53a10cb7A02335B175320002935");
-        static HISTORY_STORAGE_CODE: Bytes = bytes!("0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500");
-
-        let mut db = InMemoryDB::default();
-        db.insert_account_info(
-            HISTORY_STORAGE_ADDRESS,
-            AccountInfo::default().with_code(Bytecode::new_legacy(HISTORY_STORAGE_CODE.clone())),
-        );
-
-        let block_hash =
-            b256!("0x4444444444444444444444444444444444444444444444444444444444444444");
-
-        let mut evm = Context::mainnet()
-            .with_db(db)
-            .modify_block_chained(|b| b.number = U256::from(4))
-            .build_mainnet_with_inspector(TestInspector::new());
-
-        // Test inspect_system_call_one (execution result only)
-        let execution_result = evm
-            .inspect_system_call_one(HISTORY_STORAGE_ADDRESS, block_hash.0.into())
-            .unwrap();
-
-        assert!(execution_result.is_success());
-
-        // Verify inspection captured events
-        let inspector = &evm.inspector;
-        let events = inspector.get_events();
-        let step_count = events
-            .iter()
-            .filter(|e| matches!(e, InspectorEvent::Step(_)))
-            .count();
-
-        assert!(
-            step_count > 0,
-            "inspect_system_call_one should capture step events"
-        );
-
-        // Now test inspect_system_call (execution result + finalized state)
-        // Reset inspector for clean test
-        evm.inspector = TestInspector::new();
-
-        let result_and_state = evm
-            .inspect_system_call(HISTORY_STORAGE_ADDRESS, block_hash.0.into())
-            .unwrap();
-
-        // Verify both execution result and state are returned
-        assert!(result_and_state.result.is_success());
-        assert!(!result_and_state.state.is_empty());
-
-        // Verify state contains the expected storage update
-        assert_eq!(
-            result_and_state.state[&HISTORY_STORAGE_ADDRESS]
-                .storage
-                .get(&StorageKey::from(3))
-                .map(|slot| slot.present_value)
-                .unwrap_or_default(),
-            U256::from_be_bytes(block_hash.0),
-            "inspect_system_call should return finalized state"
-        );
-    }
-
-    #[test]
-    fn test_system_call_inspection_uses_system_address() {
-        // Test that system call inspection uses SYSTEM_ADDRESS as default caller
-        // This is verified by checking the transaction context during inspection
-        const SIMPLE_CONTRACT: Address = address!("0x1000000000000000000000000000000000000001");
-
-        // Simple contract that returns the caller address
-        let code = vec![
-            opcode::CALLER, // Get caller address
-            opcode::PUSH1,
-            0x00,           // Memory offset
-            opcode::MSTORE, // Store caller in memory
-            opcode::PUSH1,
-            0x20, // Return size (32 bytes)
-            opcode::PUSH1,
-            0x00,           // Return offset
-            opcode::RETURN, // Return the caller address
-        ];
-
-        let mut db = InMemoryDB::default();
-        db.insert_account_info(
-            SIMPLE_CONTRACT,
-            AccountInfo::default().with_code(Bytecode::new_raw(Bytes::from(code))),
-        );
-
-        let mut evm = Context::mainnet()
-            .with_db(db)
-            .build_mainnet_with_inspector(TestInspector::new());
-
-        // Inspect system call (should use SYSTEM_ADDRESS as caller)
-        let result = evm
-            .inspect_system_call(SIMPLE_CONTRACT, Bytes::default())
-            .unwrap();
-
-        // Verify execution was successful
-        assert!(result.result.is_success());
-
-        // Verify inspection captured the execution
-        let inspector = &evm.inspector;
-        let events = inspector.get_events();
-        let step_count = events
-            .iter()
-            .filter(|e| matches!(e, InspectorEvent::Step(_)))
-            .count();
-
-        assert!(
-            step_count > 0,
-            "System call inspection should capture execution steps"
-        );
-
-        // The returned data should be the SYSTEM_ADDRESS (caller)
-        let output = result.result.output().unwrap();
-        // The output should contain the SYSTEM_ADDRESS as the caller
-        let mut expected_caller = [0u8; 32];
-        expected_caller[12..].copy_from_slice(SYSTEM_ADDRESS.as_slice());
-        assert_eq!(output.len(), 32, "Should return 32 bytes (address)");
-        assert_eq!(
-            output.as_ref(),
-            &expected_caller,
-            "Caller should be SYSTEM_ADDRESS"
-        );
+        assert!(evm.inspector.get_step_count() > 0);
     }
 }

--- a/crates/inspector/src/lib.rs
+++ b/crates/inspector/src/lib.rs
@@ -30,7 +30,7 @@ pub mod inspectors {
 
 pub use count_inspector::CountInspector;
 pub use handler::{inspect_instructions, InspectorHandler};
-pub use inspect::{InspectCommitEvm, InspectEvm, InspectSystemCallEvm, InspectSystemCallCommitEvm};
+pub use inspect::{InspectCommitEvm, InspectEvm, InspectSystemCallCommitEvm, InspectSystemCallEvm};
 pub use inspector::*;
 pub use noop::NoOpInspector;
 pub use traits::*;

--- a/crates/inspector/src/lib.rs
+++ b/crates/inspector/src/lib.rs
@@ -30,7 +30,7 @@ pub mod inspectors {
 
 pub use count_inspector::CountInspector;
 pub use handler::{inspect_instructions, InspectorHandler};
-pub use inspect::{InspectCommitEvm, InspectEvm, InspectSystemCallCommitEvm, InspectSystemCallEvm};
+pub use inspect::{InspectCommitEvm, InspectEvm, InspectSystemCallEvm};
 pub use inspector::*;
 pub use noop::NoOpInspector;
 pub use traits::*;

--- a/crates/inspector/src/lib.rs
+++ b/crates/inspector/src/lib.rs
@@ -30,7 +30,7 @@ pub mod inspectors {
 
 pub use count_inspector::CountInspector;
 pub use handler::{inspect_instructions, InspectorHandler};
-pub use inspect::{InspectCommitEvm, InspectEvm};
+pub use inspect::{InspectCommitEvm, InspectEvm, InspectSystemCallEvm, InspectSystemCallCommitEvm};
 pub use inspector::*;
 pub use noop::NoOpInspector;
 pub use traits::*;

--- a/crates/inspector/src/mainnet_inspect.rs
+++ b/crates/inspector/src/mainnet_inspect.rs
@@ -68,7 +68,7 @@ where
     INST: InstructionProvider<Context = CTX, InterpreterTypes = EthInterpreter>,
     PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
-    fn inspect_system_call_with_caller_one(
+    fn inspect_one_system_call_with_caller(
         &mut self,
         caller: Address,
         system_contract_address: Address,

--- a/crates/inspector/src/mainnet_inspect.rs
+++ b/crates/inspector/src/mainnet_inspect.rs
@@ -1,14 +1,15 @@
 use crate::{
-    inspect::{InspectCommitEvm, InspectEvm},
+    inspect::{InspectCommitEvm, InspectEvm, InspectSystemCallEvm, InspectSystemCallCommitEvm},
     Inspector, InspectorEvmTr, InspectorHandler, JournalExt,
 };
 use context::{ContextSetters, ContextTr, Evm, JournalTr};
 use database_interface::DatabaseCommit;
 use handler::{
-    instructions::InstructionProvider, EthFrame, EvmTr, EvmTrError, Handler, MainnetHandler,
-    PrecompileProvider,
+    instructions::InstructionProvider, system_call::SystemCallTx, EthFrame, EvmTr, EvmTrError,
+    Handler, MainnetHandler, PrecompileProvider,
 };
 use interpreter::{interpreter::EthInterpreter, InterpreterResult};
+use primitives::{Address, Bytes};
 use state::EvmState;
 
 // Implementing InspectorHandler for MainnetHandler.
@@ -51,6 +52,49 @@ impl<CTX, INSP, INST, PRECOMPILES> InspectCommitEvm
 where
     CTX: ContextSetters
         + ContextTr<Journal: JournalTr<State = EvmState> + JournalExt, Db: DatabaseCommit>,
+    INSP: Inspector<CTX, EthInterpreter>,
+    INST: InstructionProvider<Context = CTX, InterpreterTypes = EthInterpreter>,
+    PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
+{
+}
+
+// Implementing InspectSystemCallEvm for Evm
+impl<CTX, INSP, INST, PRECOMPILES> InspectSystemCallEvm
+    for Evm<CTX, INSP, INST, PRECOMPILES, EthFrame<EthInterpreter>>
+where
+    CTX: ContextSetters
+        + ContextTr<Journal: JournalTr<State = EvmState> + JournalExt, Tx: SystemCallTx>,
+    INSP: Inspector<CTX, EthInterpreter>,
+    INST: InstructionProvider<Context = CTX, InterpreterTypes = EthInterpreter>,
+    PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
+{
+    fn inspect_system_call_with_caller_one(
+        &mut self,
+        caller: Address,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> Result<Self::ExecutionResult, Self::Error> {
+        // Set system call transaction fields similar to transact_system_call_with_caller
+        self.set_tx(CTX::Tx::new_system_tx_with_caller(
+            caller,
+            system_contract_address,
+            data,
+        ));
+        // Use inspect_run_system_call instead of run_system_call for inspection
+        MainnetHandler::default().inspect_run_system_call(self)
+    }
+}
+
+// Implementing InspectSystemCallCommitEvm for Evm
+impl<CTX, INSP, INST, PRECOMPILES> InspectSystemCallCommitEvm
+    for Evm<CTX, INSP, INST, PRECOMPILES, EthFrame<EthInterpreter>>
+where
+    CTX: ContextSetters
+        + ContextTr<
+            Journal: JournalTr<State = EvmState> + JournalExt,
+            Db: DatabaseCommit,
+            Tx: SystemCallTx,
+        >,
     INSP: Inspector<CTX, EthInterpreter>,
     INST: InstructionProvider<Context = CTX, InterpreterTypes = EthInterpreter>,
     PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,

--- a/crates/inspector/src/mainnet_inspect.rs
+++ b/crates/inspector/src/mainnet_inspect.rs
@@ -1,5 +1,5 @@
 use crate::{
-    inspect::{InspectCommitEvm, InspectEvm, InspectSystemCallEvm, InspectSystemCallCommitEvm},
+    inspect::{InspectCommitEvm, InspectEvm, InspectSystemCallCommitEvm, InspectSystemCallEvm},
     Inspector, InspectorEvmTr, InspectorHandler, JournalExt,
 };
 use context::{ContextSetters, ContextTr, Evm, JournalTr};

--- a/crates/inspector/src/mainnet_inspect.rs
+++ b/crates/inspector/src/mainnet_inspect.rs
@@ -1,5 +1,5 @@
 use crate::{
-    inspect::{InspectCommitEvm, InspectEvm, InspectSystemCallCommitEvm, InspectSystemCallEvm},
+    inspect::{InspectCommitEvm, InspectEvm, InspectSystemCallEvm},
     Inspector, InspectorEvmTr, InspectorHandler, JournalExt,
 };
 use context::{ContextSetters, ContextTr, Evm, JournalTr};
@@ -83,22 +83,6 @@ where
         // Use inspect_run_system_call instead of run_system_call for inspection
         MainnetHandler::default().inspect_run_system_call(self)
     }
-}
-
-// Implementing InspectSystemCallCommitEvm for Evm
-impl<CTX, INSP, INST, PRECOMPILES> InspectSystemCallCommitEvm
-    for Evm<CTX, INSP, INST, PRECOMPILES, EthFrame<EthInterpreter>>
-where
-    CTX: ContextSetters
-        + ContextTr<
-            Journal: JournalTr<State = EvmState> + JournalExt,
-            Db: DatabaseCommit,
-            Tx: SystemCallTx,
-        >,
-    INSP: Inspector<CTX, EthInterpreter>,
-    INST: InstructionProvider<Context = CTX, InterpreterTypes = EthInterpreter>,
-    PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
-{
 }
 
 // Implementing InspectorEvmTr for Evm

--- a/crates/op-revm/src/api/exec.rs
+++ b/crates/op-revm/src/api/exec.rs
@@ -13,7 +13,9 @@ use revm::{
         instructions::EthInstructions, system_call::SystemCallEvm, EthFrame, Handler,
         PrecompileProvider, SystemCallTx,
     },
-    inspector::{InspectCommitEvm, InspectEvm, InspectSystemCallEvm, Inspector, InspectorHandler, JournalExt},
+    inspector::{
+        InspectCommitEvm, InspectEvm, InspectSystemCallEvm, Inspector, InspectorHandler, JournalExt,
+    },
     interpreter::{interpreter::EthInterpreter, InterpreterResult},
     primitives::{Address, Bytes},
     state::EvmState,

--- a/crates/op-revm/src/api/exec.rs
+++ b/crates/op-revm/src/api/exec.rs
@@ -13,7 +13,7 @@ use revm::{
         instructions::EthInstructions, system_call::SystemCallEvm, EthFrame, Handler,
         PrecompileProvider, SystemCallTx,
     },
-    inspector::{InspectCommitEvm, InspectEvm, Inspector, InspectorHandler, JournalExt},
+    inspector::{InspectCommitEvm, InspectEvm, InspectSystemCallEvm, Inspector, InspectorHandler, JournalExt},
     interpreter::{interpreter::EthInterpreter, InterpreterResult},
     primitives::{Address, Bytes},
     state::EvmState,
@@ -140,5 +140,28 @@ where
         ));
         let mut h = OpHandler::<_, _, EthFrame<EthInterpreter>>::new();
         h.run_system_call(self)
+    }
+}
+
+impl<CTX, INSP, PRECOMPILE> InspectSystemCallEvm
+    for OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, PRECOMPILE>
+where
+    CTX: OpContextTr<Journal: JournalExt, Tx: SystemCallTx> + ContextSetters,
+    INSP: Inspector<CTX, EthInterpreter>,
+    PRECOMPILE: PrecompileProvider<CTX, Output = InterpreterResult>,
+{
+    fn inspect_one_system_call_with_caller(
+        &mut self,
+        caller: Address,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> Result<Self::ExecutionResult, Self::Error> {
+        self.0.ctx.set_tx(CTX::Tx::new_system_tx_with_caller(
+            caller,
+            system_contract_address,
+            data,
+        ));
+        let mut h = OpHandler::<_, _, EthFrame<EthInterpreter>>::new();
+        h.inspect_run_system_call(self)
     }
 }

--- a/crates/op-revm/tests/integration.rs
+++ b/crates/op-revm/tests/integration.rs
@@ -1079,11 +1079,7 @@ fn test_log_inspector() {
 fn test_system_call_inspection() {
     use revm::InspectSystemCallEvm;
     
-    // Create a simple contract that returns success (STOP opcode)
-    let contract_data = Bytes::from([opcode::STOP]);
-    let bytecode = Bytecode::new_raw(contract_data);
-    
-    let ctx = Context::op().with_db(BenchmarkDB::new_bytecode(bytecode));
+    let ctx = Context::op();
     
     let mut evm = ctx.build_op_with_inspector(LogInspector::default());
     

--- a/crates/op-revm/tests/integration.rs
+++ b/crates/op-revm/tests/integration.rs
@@ -1078,28 +1078,28 @@ fn test_log_inspector() {
 #[test]
 fn test_system_call_inspection() {
     use revm::InspectSystemCallEvm;
-    
+
     let ctx = Context::op();
-    
+
     let mut evm = ctx.build_op_with_inspector(LogInspector::default());
-    
+
     // Test system call inspection
     let result = evm
         .inspect_one_system_call(BENCH_TARGET, Bytes::default())
         .unwrap();
-    
+
     // Should succeed
     assert!(result.is_success());
-    
+
     // Test system call inspection with caller
     let custom_caller = Address::from([0x12; 20]);
     let result = evm
         .inspect_one_system_call_with_caller(custom_caller, BENCH_TARGET, Bytes::default())
         .unwrap();
-    
+
     // Should also succeed
     assert!(result.is_success());
-    
+
     // Test system call inspection with inspector
     let result = evm
         .inspect_one_system_call_with_inspector(
@@ -1108,7 +1108,7 @@ fn test_system_call_inspection() {
             LogInspector::default(),
         )
         .unwrap();
-    
+
     // Should succeed
     assert!(result.is_success());
 }

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -35,4 +35,6 @@ pub use handler::{
     ExecuteCommitEvm, ExecuteEvm, MainBuilder, MainContext, MainnetEvm, SystemCallCommitEvm,
     SystemCallEvm,
 };
-pub use inspector::{InspectCommitEvm, InspectEvm, Inspector};
+pub use inspector::{
+    InspectCommitEvm, InspectEvm, InspectSystemCallCommitEvm, InspectSystemCallEvm, Inspector,
+};

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -35,7 +35,5 @@ pub use handler::{
     ExecuteCommitEvm, ExecuteEvm, MainBuilder, MainContext, MainnetEvm, SystemCallCommitEvm,
     SystemCallEvm,
 };
-pub use inspector::{
-    InspectCommitEvm, InspectEvm, InspectSystemCallCommitEvm, InspectSystemCallEvm, Inspector,
-};
+pub use inspector::{InspectCommitEvm, InspectEvm, InspectSystemCallEvm, Inspector};
 pub use precompile::install_crypto;


### PR DESCRIPTION
Adds inspection support for system transactions to enable tracing with debug_traceTransaction and debug_traceBlock APIs.

## Changes

- Added InspectSystemCallEvm trait extending InspectEvm and SystemCallEvm
- Added InspectorHandler::inspect_run_system_call method for system call inspection
- Implemented inspection support for mainnet EVM with comprehensive test coverage
- Re-exported new traits in main revm crate


Closes #2798