### PR TITLE
feat: removed padding in case last opcode is terminating or unknown

### DIFF
--- a/crates/bytecode/src/legacy/analyzed.rs
+++ b/crates/bytecode/src/legacy/analyzed.rs
@@ -1,5 +1,4 @@
 use super::JumpTable;
-use crate::opcode;
 use primitives::Bytes;
 
 /// Legacy analyzed bytecode represents the original bytecode format used in Ethereum.
@@ -77,10 +76,6 @@ impl LegacyAnalyzedBytecode {
             "jump table length is less than original length"
         );
         assert!(!bytecode.is_empty(), "bytecode cannot be empty");
-        assert!(
-            bytecode.last() == Some(&opcode::STOP),
-            "last bytecode byte should be STOP (0x00)"
-        );
         Self {
             bytecode,
             original_len,
@@ -148,14 +143,6 @@ mod tests {
         let bytecode = LegacyRawBytecode(bytecode).into_analyzed();
         let jump_table = JumpTable::new(bitvec![u8, Lsb0; 0; 1]);
         let _ = LegacyAnalyzedBytecode::new(bytecode.bytecode, bytecode.original_len, jump_table);
-    }
-
-    #[test]
-    #[should_panic(expected = "last bytecode byte should be STOP (0x00)")]
-    fn test_panic_on_non_stop_bytecode() {
-        let bytecode = Bytes::from_static(&[opcode::PUSH1, 0x01]);
-        let jump_table = JumpTable::new(bitvec![u8, Lsb0; 0; 2]);
-        let _ = LegacyAnalyzedBytecode::new(bytecode, 2, jump_table);
     }
 
     #[test]


### PR DESCRIPTION
### Removes padding with `STOP` opcode in case last opcode is terminating or unknown

- Creates a wrapper function around already existing `is_terminating` function to check if the last opcode is unknown or terminating
- Introduces a new test to check the implementation
- Removes failing tests.



Fixes #2796 