### PR TITLE
test(op-revm): Update test data for renamed tests

### DIFF
--- a/crates/op-revm/tests/testdata/test_halted_tx_call_bn254_pair_fjord.json
+++ b/crates/op-revm/tests/testdata/test_halted_tx_call_bn254_pair_fjord.json
@@ -2,16 +2,18 @@
   "result": {
     "Halt": {
       "reason": {
-        "Base": "PrecompileError"
+        "Base": {
+          "OutOfGas": "Precompile"
+        }
       },
       "gas_used": 1824024
     }
   },
   "state": {
-    "0x4200000000000000000000000000000000000019": {
+    "0x0000000000000000000000000000000000000000": {
       "info": {
         "balance": "0x0",
-        "nonce": 0,
+        "nonce": 1,
         "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "code": {
           "LegacyAnalyzed": {
@@ -33,7 +35,7 @@
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
     },
-    "0x420000000000000000000000000000000000001b": {
+    "0x4200000000000000000000000000000000000019": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
@@ -83,10 +85,10 @@
       "storage": {},
       "status": "Touched | LoadedAsNotExisting"
     },
-    "0x0000000000000000000000000000000000000000": {
+    "0x420000000000000000000000000000000000001b": {
       "info": {
         "balance": "0x0",
-        "nonce": 1,
+        "nonce": 0,
         "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "code": {
           "LegacyAnalyzed": {

--- a/crates/op-revm/tests/testdata/test_halted_tx_call_bn254_pair_granite.json
+++ b/crates/op-revm/tests/testdata/test_halted_tx_call_bn254_pair_granite.json
@@ -2,68 +2,16 @@
   "result": {
     "Halt": {
       "reason": {
-        "Base": {
-          "OutOfGas": "Precompile"
-        }
+        "Base": "PrecompileError"
       },
       "gas_used": 1824024
     }
   },
   "state": {
-    "0x4200000000000000000000000000000000000019": {
+    "0x420000000000000000000000000000000000001a": {
       "info": {
         "balance": "0x0",
         "nonce": 0,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "transaction_id": 0,
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
-    },
-    "0x420000000000000000000000000000000000001b": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 0,
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "original_len": 0,
-            "jump_table": {
-              "order": "bitvec::order::Lsb0",
-              "head": {
-                "width": 8,
-                "index": 0
-              },
-              "bits": 0,
-              "data": []
-            }
-          }
-        }
-      },
-      "transaction_id": 0,
-      "storage": {},
-      "status": "Touched | LoadedAsNotExisting"
-    },
-    "0x0000000000000000000000000000000000000000": {
-      "info": {
-        "balance": "0x0",
-        "nonce": 1,
         "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "code": {
           "LegacyAnalyzed": {
@@ -110,7 +58,57 @@
       "storage": {},
       "status": "LoadedAsNotExisting"
     },
-    "0x420000000000000000000000000000000000001a": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 1,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "transaction_id": 0,
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "nonce": 0,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "original_len": 0,
+            "jump_table": {
+              "order": "bitvec::order::Lsb0",
+              "head": {
+                "width": 8,
+                "index": 0
+              },
+              "bits": 0,
+              "data": []
+            }
+          }
+        }
+      },
+      "transaction_id": 0,
+      "storage": {},
+      "status": "Touched | LoadedAsNotExisting"
+    },
+    "0x4200000000000000000000000000000000000019": {
       "info": {
         "balance": "0x0",
         "nonce": 0,


### PR DESCRIPTION
Ref https://github.com/bluealloy/revm/pull/2810, https://github.com/bluealloy/revm/issues/2189

Dedups test data for renamed tests `bn128` -> `bn254`