### PR TITLE
test(op-revm): Full test coverage `OpTransactionError`

### DIFF
--- a/crates/op-revm/src/transaction/error.rs
+++ b/crates/op-revm/src/transaction/error.rs
@@ -87,6 +87,11 @@ mod test {
     #[test]
     fn test_display_op_errors() {
         assert_eq!(
+            OpTransactionError::Base(InvalidTransaction::NonceTooHigh { tx: 2, state: 1 })
+                .to_string(),
+            "nonce 2 too high, expected 1"
+        );
+        assert_eq!(
             OpTransactionError::DepositSystemTxPostRegolith.to_string(),
             "deposit system transactions post regolith hardfork are not supported"
         );

--- a/crates/op-revm/src/transaction/error.rs
+++ b/crates/op-revm/src/transaction/error.rs
@@ -26,10 +26,10 @@ pub enum OpTransactionError {
     /// are cause for non-inclusion, so a special [OpHaltReason][crate::OpHaltReason] variant was introduced to handle this
     /// case for failed deposit transactions.
     DepositSystemTxPostRegolith,
-    /// Deposit transaction haults bubble up to the global main return handler, wiping state and
+    /// Deposit transaction halts bubble up to the global main return handler, wiping state and
     /// only increasing the nonce + persisting the mint value.
     ///
-    /// This is a catch-all error for any deposit transaction that is results in a [OpHaltReason][crate::OpHaltReason] error
+    /// This is a catch-all error for any deposit transaction that results in a [OpHaltReason][crate::OpHaltReason] error
     /// post-regolith hardfork. This allows for a consumer to easily handle special cases where
     /// a deposit transaction fails during validation, but must still be included in the block.
     ///


### PR DESCRIPTION
Ref https://github.com/bluealloy/revm/issues/2189

Increases test coverage of _op-revm/src/transaction/error.rs_ to 100% + smol typo fixes in docs