### PR TITLE
feat: fix renamed function for system_call

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,3 +1,9 @@
+# v83 tag (revm v28.0.0) from v82 tag (revm v27.1.0)
+
+* `SystemCallEvm` functions got renamed and old ones are deprecated. Renaming is done to align it with other API calls.
+   * `transact_system_call_finalize` is now `system_call`.
+   * `transact_system_call` is now `system_call_one`.
+
 # v82 tag (revm v27.1.0) from v81 tag (revm v27.0.3)
 
 * `ContextTr` gained `Host` supertrait.

--- a/crates/ee-tests/src/op_revm_tests.rs
+++ b/crates/ee-tests/src/op_revm_tests.rs
@@ -1134,7 +1134,7 @@ fn test_system_call() {
 
     let mut evm = ctx.build_op();
 
-    let _ = evm.system_call_one(SYSTEM_ADDRESS, BENCH_TARGET, bytes!("0x0001"));
+    let _ = evm.system_call_one(BENCH_TARGET, bytes!("0x0001"));
     let state = evm.finalize();
 
     assert!(state.get(&SYSTEM_ADDRESS).is_none());

--- a/crates/inspector/src/inspect.rs
+++ b/crates/inspector/src/inspect.rs
@@ -161,4 +161,38 @@ pub trait InspectSystemCallEvm: InspectEvm + SystemCallEvm {
         let state = self.finalize();
         Ok(ExecResultAndState::new(output, state))
     }
+
+    /// Inspect a system call with a given inspector and caller.
+    ///
+    /// Similar to [`InspectEvm::inspect_one`] but for system calls.
+    fn inspect_one_system_call_with_inspector_and_caller(
+        &mut self,
+        caller: Address,
+        system_contract_address: Address,
+        data: Bytes,
+        inspector: Self::Inspector,
+    ) -> Result<Self::ExecutionResult, Self::Error> {
+        self.set_inspector(inspector);
+        self.inspect_one_system_call_with_caller(caller, system_contract_address, data)
+    }
+
+    /// Inspect a system call with a given inspector and finalize the state.
+    ///
+    /// Similar to [`InspectEvm::inspect`] but for system calls.
+    fn inspect_system_call_with_inspector_and_caller(
+        &mut self,
+        caller: Address,
+        system_contract_address: Address,
+        data: Bytes,
+        inspector: Self::Inspector,
+    ) -> Result<ExecResultAndState<Self::ExecutionResult, Self::State>, Self::Error> {
+        let output = self.inspect_one_system_call_with_inspector_and_caller(
+            caller,
+            system_contract_address,
+            data,
+            inspector,
+        )?;
+        let state = self.finalize();
+        Ok(ExecResultAndState::new(output, state))
+    }
 }

--- a/crates/op-revm/src/api/exec.rs
+++ b/crates/op-revm/src/api/exec.rs
@@ -129,7 +129,7 @@ where
     CTX: OpContextTr<Tx: SystemCallTx> + ContextSetters,
     PRECOMPILE: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
-    fn system_call_one(
+    fn system_call_one_with_caller(
         &mut self,
         caller: Address,
         system_contract_address: Address,


### PR DESCRIPTION
`system_call_one` should not have a caller. The main function that needs to be implemented became `system_call_one_with_caller`

Additionally added `inspect_one_system_call_with_inspector_and_caller` and `inspect_system_call_with_inspector_and_caller`