### PR TITLE
test: improve revm-bytecode unittest coverage

### DIFF
--- a/crates/bytecode/src/bytecode.rs
+++ b/crates/bytecode/src/bytecode.rs
@@ -437,7 +437,7 @@ mod tests {
     #[test]
     fn test_debug() {
         let bytecode = Bytecode::new();
-        let debug_str = format!("{:?}", bytecode);
+        let debug_str = format!("{bytecode:?}");
         assert!(debug_str.contains("LegacyAnalyzed"));
     }
 

--- a/crates/bytecode/src/bytecode.rs
+++ b/crates/bytecode/src/bytecode.rs
@@ -184,3 +184,308 @@ impl Bytecode {
         crate::BytecodeIterator::new(self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use primitives::bytes;
+
+    #[test]
+    fn test_default() {
+        let bytecode = Bytecode::default();
+        assert!(matches!(bytecode, Bytecode::LegacyAnalyzed(_)));
+        assert_eq!(bytecode.len(), 0); // Default is empty
+    }
+
+    #[test]
+    fn test_new() {
+        let bytecode = Bytecode::new();
+        assert!(matches!(bytecode, Bytecode::LegacyAnalyzed(_)));
+        assert_eq!(bytecode.len(), 0); // Default is empty
+    }
+
+    #[test]
+    fn test_new_legacy() {
+        let raw = bytes!("6060604052");
+        let bytecode = Bytecode::new_legacy(raw.clone());
+        assert!(matches!(bytecode, Bytecode::LegacyAnalyzed(_)));
+        assert_eq!(bytecode.original_bytes(), raw);
+    }
+
+    #[test]
+    fn test_new_eip7702() {
+        let address = Address::new([0x11; 20]);
+        let bytecode = Bytecode::new_eip7702(address);
+        assert!(bytecode.is_eip7702());
+
+        // Verify it matches the expected variant and extract the value
+        assert!(
+            matches!(&bytecode, Bytecode::Eip7702(eip7702) if eip7702.delegated_address == address)
+        );
+    }
+
+    #[test]
+    fn test_new_raw_legacy() {
+        let raw = bytes!("6060604052");
+        let bytecode = Bytecode::new_raw(raw.clone());
+        assert!(matches!(bytecode, Bytecode::LegacyAnalyzed(_)));
+        assert_eq!(bytecode.original_bytes(), raw);
+    }
+
+    #[test]
+    fn test_new_raw_eip7702() {
+        let address = Address::new([0x11; 20]);
+        let eip7702_raw = Eip7702Bytecode::new(address).raw().clone();
+        let bytecode = Bytecode::new_raw(eip7702_raw.clone());
+        assert!(matches!(bytecode, Bytecode::Eip7702(_)));
+        assert!(bytecode.is_eip7702());
+    }
+
+    #[test]
+    #[should_panic(expected = "Expect correct bytecode")]
+    fn test_new_raw_invalid_eip7702() {
+        // Invalid EIP7702: correct magic but wrong length
+        let invalid = bytes!("ef01");
+        Bytecode::new_raw(invalid);
+    }
+
+    #[test]
+    fn test_new_raw_checked_legacy() {
+        let raw = bytes!("6060604052");
+        let result = Bytecode::new_raw_checked(raw.clone());
+        assert!(result.is_ok());
+        let bytecode = result.unwrap();
+        assert!(matches!(bytecode, Bytecode::LegacyAnalyzed(_)));
+        assert_eq!(bytecode.original_bytes(), raw);
+    }
+
+    #[test]
+    fn test_new_raw_checked_eip7702() {
+        let address = Address::new([0x11; 20]);
+        let eip7702_raw = Eip7702Bytecode::new(address).raw().clone();
+        let result = Bytecode::new_raw_checked(eip7702_raw);
+        assert!(result.is_ok());
+        let bytecode = result.unwrap();
+        assert!(matches!(bytecode, Bytecode::Eip7702(_)));
+    }
+
+    #[test]
+    fn test_new_raw_checked_invalid_eip7702() {
+        // Invalid EIP7702: correct magic but wrong length
+        let invalid = bytes!("ef01");
+        let result = Bytecode::new_raw_checked(invalid);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_new_analyzed() {
+        let raw = bytes!("00");
+        // Create a BitVec with one bit for the STOP opcode
+        let mut bitvec = bitvec::vec::BitVec::new();
+        bitvec.push(false); // STOP is not a valid jump destination
+        let jump_table = JumpTable::new(bitvec);
+        let bytecode = Bytecode::new_analyzed(raw.clone(), 1, jump_table);
+        assert!(matches!(bytecode, Bytecode::LegacyAnalyzed(_)));
+        assert_eq!(bytecode.len(), 1);
+    }
+
+    #[test]
+    fn test_legacy_jump_table() {
+        // Test with legacy analyzed bytecode
+        let bytecode = Bytecode::new();
+        assert!(bytecode.legacy_jump_table().is_some());
+
+        // Test with EIP7702 bytecode
+        let address = Address::new([0x11; 20]);
+        let eip7702 = Bytecode::new_eip7702(address);
+        assert!(eip7702.legacy_jump_table().is_none());
+    }
+
+    #[test]
+    fn test_hash_slow() {
+        // Test empty bytecode
+        let empty = Bytecode::new_legacy(Bytes::new());
+        assert_eq!(empty.hash_slow(), KECCAK_EMPTY);
+
+        // Test non-empty bytecode
+        let bytecode = Bytecode::new_legacy(bytes!("6060604052"));
+        let hash = bytecode.hash_slow();
+        assert_ne!(hash, KECCAK_EMPTY);
+        assert_eq!(hash, keccak256(bytecode.original_byte_slice()));
+    }
+
+    #[test]
+    fn test_is_eip7702() {
+        let legacy = Bytecode::new();
+        assert!(!legacy.is_eip7702());
+
+        let address = Address::new([0x11; 20]);
+        let eip7702 = Bytecode::new_eip7702(address);
+        assert!(eip7702.is_eip7702());
+    }
+
+    #[test]
+    fn test_bytecode() {
+        let raw = bytes!("6060604052");
+        let legacy = Bytecode::new_legacy(raw.clone());
+        // Legacy bytecode gets STOP appended during analysis
+        let expected = bytes!("606060405200");
+        assert_eq!(legacy.bytecode(), &expected);
+
+        let address = Address::new([0x11; 20]);
+        let eip7702 = Bytecode::new_eip7702(address);
+        assert_eq!(eip7702.bytecode().len(), 23);
+    }
+
+    #[test]
+    fn test_bytecode_ptr() {
+        let bytecode = Bytecode::new();
+        let ptr = bytecode.bytecode_ptr();
+        assert!(!ptr.is_null());
+        assert_eq!(ptr, bytecode.bytecode().as_ptr());
+    }
+
+    #[test]
+    fn test_bytes() {
+        let raw = bytes!("6060604052");
+        let bytecode = Bytecode::new_legacy(raw.clone());
+        // Legacy bytecode gets STOP appended during analysis
+        let expected = bytes!("606060405200");
+        assert_eq!(bytecode.bytes(), expected);
+    }
+
+    #[test]
+    fn test_bytes_ref() {
+        // Test legacy bytecode
+        let raw = bytes!("6060604052");
+        let bytecode = Bytecode::new_legacy(raw.clone());
+        // Legacy bytecode gets STOP appended during analysis
+        let expected = bytes!("606060405200");
+        assert_eq!(bytecode.bytes_ref().as_ref(), expected.as_ref());
+
+        // Test EIP7702 bytecode
+        let address = Address::new([0x11; 20]);
+        let eip7702 = Bytecode::new_eip7702(address);
+        assert_eq!(eip7702.bytes_ref().len(), 23);
+    }
+
+    #[test]
+    fn test_bytes_slice() {
+        let raw = bytes!("6060604052");
+        let bytecode = Bytecode::new_legacy(raw.clone());
+        // Legacy bytecode gets STOP appended during analysis
+        let expected = bytes!("606060405200");
+        assert_eq!(bytecode.bytes_slice(), expected.as_ref());
+    }
+
+    #[test]
+    fn test_original_bytes() {
+        // Test legacy bytecode
+        let raw = bytes!("6060604052");
+        let legacy = Bytecode::new_legacy(raw.clone());
+        assert_eq!(legacy.original_bytes(), raw);
+
+        // Test EIP7702 bytecode
+        let address = Address::new([0x11; 20]);
+        let eip7702 = Bytecode::new_eip7702(address);
+        assert_eq!(eip7702.original_bytes().len(), 23);
+    }
+
+    #[test]
+    fn test_original_byte_slice() {
+        let raw = bytes!("6060604052");
+        let legacy = Bytecode::new_legacy(raw.clone());
+        assert_eq!(legacy.original_byte_slice(), raw.as_ref());
+
+        let address = Address::new([0x11; 20]);
+        let eip7702 = Bytecode::new_eip7702(address);
+        assert_eq!(eip7702.original_byte_slice().len(), 23);
+    }
+
+    #[test]
+    fn test_len() {
+        let empty = Bytecode::new_legacy(Bytes::new());
+        assert_eq!(empty.len(), 0);
+
+        let bytecode = Bytecode::new_legacy(bytes!("6060604052"));
+        assert_eq!(bytecode.len(), 5);
+    }
+
+    #[test]
+    fn test_is_empty() {
+        let empty = Bytecode::new_legacy(Bytes::new());
+        assert!(empty.is_empty());
+
+        let non_empty = Bytecode::new_legacy(bytes!("60"));
+        assert!(!non_empty.is_empty());
+    }
+
+    #[test]
+    fn test_iter_opcodes() {
+        let bytecode = Bytecode::new_legacy(bytes!("6001600201"));
+        let opcodes: Vec<_> = bytecode.iter_opcodes().collect();
+        assert_eq!(opcodes.len(), 4); // PUSH1, PUSH1, ADD, STOP (appended)
+    }
+
+    #[test]
+    fn test_clone() {
+        let bytecode = Bytecode::new_legacy(bytes!("6060604052"));
+        let cloned = bytecode.clone();
+        assert_eq!(bytecode, cloned);
+    }
+
+    #[test]
+    fn test_debug() {
+        let bytecode = Bytecode::new();
+        let debug_str = format!("{:?}", bytecode);
+        assert!(debug_str.contains("LegacyAnalyzed"));
+    }
+
+    #[test]
+    fn test_eq() {
+        let bytecode1 = Bytecode::new_legacy(bytes!("6060604052"));
+        let bytecode2 = Bytecode::new_legacy(bytes!("6060604052"));
+        let bytecode3 = Bytecode::new_legacy(bytes!("6001"));
+
+        assert_eq!(bytecode1, bytecode2);
+        assert_ne!(bytecode1, bytecode3);
+    }
+
+    #[test]
+    fn test_hash_trait() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let bytecode1 = Bytecode::new_legacy(bytes!("6060604052"));
+        let bytecode2 = Bytecode::new_legacy(bytes!("6060604052"));
+
+        let mut hasher1 = DefaultHasher::new();
+        bytecode1.hash(&mut hasher1);
+        let hash1 = hasher1.finish();
+
+        let mut hasher2 = DefaultHasher::new();
+        bytecode2.hash(&mut hasher2);
+        let hash2 = hasher2.finish();
+
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_ord() {
+        let bytecode1 = Bytecode::new_legacy(bytes!("00"));
+        let bytecode2 = Bytecode::new_legacy(bytes!("01"));
+
+        assert!(bytecode1 < bytecode2);
+        assert_eq!(bytecode1.cmp(&bytecode1), std::cmp::Ordering::Equal);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde() {
+        use serde::{Deserialize, Serialize};
+
+        // Test that the type implements Serialize and Deserialize traits
+        fn assert_serde<T: Serialize + for<'de> Deserialize<'de>>() {}
+        assert_serde::<Bytecode>();
+    }
+}

--- a/crates/bytecode/src/decode_errors.rs
+++ b/crates/bytecode/src/decode_errors.rs
@@ -25,3 +25,138 @@ impl fmt::Display for BytecodeDecodeError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_eip7702_decode_error() {
+        // Test conversion from each EIP7702 error variant
+        let invalid_length = BytecodeDecodeError::from(Eip7702DecodeError::InvalidLength);
+        assert_eq!(
+            invalid_length,
+            BytecodeDecodeError::Eip7702(Eip7702DecodeError::InvalidLength)
+        );
+
+        let invalid_magic = BytecodeDecodeError::from(Eip7702DecodeError::InvalidMagic);
+        assert_eq!(
+            invalid_magic,
+            BytecodeDecodeError::Eip7702(Eip7702DecodeError::InvalidMagic)
+        );
+
+        let unsupported_version = BytecodeDecodeError::from(Eip7702DecodeError::UnsupportedVersion);
+        assert_eq!(
+            unsupported_version,
+            BytecodeDecodeError::Eip7702(Eip7702DecodeError::UnsupportedVersion)
+        );
+    }
+
+    #[test]
+    fn test_display() {
+        // Test Display implementation for each error variant
+        let invalid_length = BytecodeDecodeError::Eip7702(Eip7702DecodeError::InvalidLength);
+        assert_eq!(
+            format!("{}", invalid_length),
+            "Eip7702 is not 23 bytes long"
+        );
+
+        let invalid_magic = BytecodeDecodeError::Eip7702(Eip7702DecodeError::InvalidMagic);
+        assert_eq!(
+            format!("{}", invalid_magic),
+            "Bytecode is not starting with 0xEF01"
+        );
+
+        let unsupported_version =
+            BytecodeDecodeError::Eip7702(Eip7702DecodeError::UnsupportedVersion);
+        assert_eq!(
+            format!("{}", unsupported_version),
+            "Unsupported Eip7702 version."
+        );
+    }
+
+    #[test]
+    fn test_error_trait() {
+        // Test that BytecodeDecodeError implements Error trait
+        let error = BytecodeDecodeError::Eip7702(Eip7702DecodeError::InvalidLength);
+        // This will fail to compile if Error trait is not implemented
+        let _: &dyn core::error::Error = &error;
+    }
+
+    #[test]
+    fn test_debug_trait() {
+        let error = BytecodeDecodeError::Eip7702(Eip7702DecodeError::InvalidMagic);
+        let debug_str = format!("{:?}", error);
+        assert!(debug_str.contains("Eip7702"));
+        assert!(debug_str.contains("InvalidMagic"));
+    }
+
+    #[test]
+    fn test_clone() {
+        let error = BytecodeDecodeError::Eip7702(Eip7702DecodeError::UnsupportedVersion);
+        let cloned = error.clone();
+        assert_eq!(error, cloned);
+    }
+
+    #[test]
+    fn test_copy() {
+        let error = BytecodeDecodeError::Eip7702(Eip7702DecodeError::InvalidLength);
+        let copied = error; // Copy trait allows this
+        assert_eq!(error, copied);
+    }
+
+    #[test]
+    fn test_eq_and_ne() {
+        let error1 = BytecodeDecodeError::Eip7702(Eip7702DecodeError::InvalidLength);
+        let error2 = BytecodeDecodeError::Eip7702(Eip7702DecodeError::InvalidLength);
+        let error3 = BytecodeDecodeError::Eip7702(Eip7702DecodeError::InvalidMagic);
+
+        assert_eq!(error1, error2);
+        assert_ne!(error1, error3);
+    }
+
+    #[test]
+    fn test_hash() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let error1 = BytecodeDecodeError::Eip7702(Eip7702DecodeError::InvalidLength);
+        let error2 = BytecodeDecodeError::Eip7702(Eip7702DecodeError::InvalidLength);
+
+        let mut hasher1 = DefaultHasher::new();
+        error1.hash(&mut hasher1);
+        let hash1 = hasher1.finish();
+
+        let mut hasher2 = DefaultHasher::new();
+        error2.hash(&mut hasher2);
+        let hash2 = hasher2.finish();
+
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_ord() {
+        let error1 = BytecodeDecodeError::Eip7702(Eip7702DecodeError::InvalidLength);
+        let error2 = BytecodeDecodeError::Eip7702(Eip7702DecodeError::InvalidMagic);
+        let error3 = BytecodeDecodeError::Eip7702(Eip7702DecodeError::UnsupportedVersion);
+
+        // Test Ord trait
+        assert!(error1 < error2);
+        assert!(error2 < error3);
+        assert!(error1 < error3);
+
+        // Test PartialOrd
+        assert_eq!(error1.partial_cmp(&error1), Some(std::cmp::Ordering::Equal));
+        assert_eq!(error1.partial_cmp(&error2), Some(std::cmp::Ordering::Less));
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde() {
+        use serde::{Deserialize, Serialize};
+
+        // Test that the type implements Serialize and Deserialize traits
+        fn assert_serde<T: Serialize + for<'de> Deserialize<'de>>() {}
+        assert_serde::<BytecodeDecodeError>();
+    }
+}

--- a/crates/bytecode/src/decode_errors.rs
+++ b/crates/bytecode/src/decode_errors.rs
@@ -56,21 +56,18 @@ mod tests {
     fn test_display() {
         // Test Display implementation for each error variant
         let invalid_length = BytecodeDecodeError::Eip7702(Eip7702DecodeError::InvalidLength);
-        assert_eq!(
-            format!("{}", invalid_length),
-            "Eip7702 is not 23 bytes long"
-        );
+        assert_eq!(format!("{invalid_length}"), "Eip7702 is not 23 bytes long");
 
         let invalid_magic = BytecodeDecodeError::Eip7702(Eip7702DecodeError::InvalidMagic);
         assert_eq!(
-            format!("{}", invalid_magic),
+            format!("{invalid_magic}"),
             "Bytecode is not starting with 0xEF01"
         );
 
         let unsupported_version =
             BytecodeDecodeError::Eip7702(Eip7702DecodeError::UnsupportedVersion);
         assert_eq!(
-            format!("{}", unsupported_version),
+            format!("{unsupported_version}"),
             "Unsupported Eip7702 version."
         );
     }
@@ -86,7 +83,7 @@ mod tests {
     #[test]
     fn test_debug_trait() {
         let error = BytecodeDecodeError::Eip7702(Eip7702DecodeError::InvalidMagic);
-        let debug_str = format!("{:?}", error);
+        let debug_str = format!("{error:?}");
         assert!(debug_str.contains("Eip7702"));
         assert!(debug_str.contains("InvalidMagic"));
     }
@@ -94,7 +91,7 @@ mod tests {
     #[test]
     fn test_clone() {
         let error = BytecodeDecodeError::Eip7702(Eip7702DecodeError::UnsupportedVersion);
-        let cloned = error.clone();
+        let cloned = error;
         assert_eq!(error, cloned);
     }
 

--- a/crates/bytecode/src/eip7702.rs
+++ b/crates/bytecode/src/eip7702.rs
@@ -214,7 +214,7 @@ mod tests {
         let _: &dyn core::error::Error = &err;
 
         // Test Display through error
-        let err_str = format!("{}", err);
+        let err_str = format!("{err}");
         assert_eq!(err_str, "Eip7702 is not 23 bytes long");
     }
 }

--- a/crates/bytecode/src/eip7702.rs
+++ b/crates/bytecode/src/eip7702.rs
@@ -154,4 +154,67 @@ mod tests {
             bytes!("ef01000101010101010101010101010101010101010101")
         );
     }
+
+    #[test]
+    fn test_invalid_magic() {
+        // Test bytecode that doesn't start with 0xEF01 but has correct length
+        let raw = bytes!("deadbeef00000000000000000000000000000000000000");
+        assert_eq!(raw.len(), 23); // Ensure it has correct length
+        assert_eq!(
+            Eip7702Bytecode::new_raw(raw),
+            Err(Eip7702DecodeError::InvalidMagic)
+        );
+    }
+
+    #[test]
+    fn test_address_method() {
+        let address = Address::new([0x42; 20]);
+        let bytecode = Eip7702Bytecode::new(address);
+        assert_eq!(bytecode.address(), address);
+    }
+
+    #[test]
+    fn test_version_method() {
+        let address = Address::new([0x42; 20]);
+        let bytecode = Eip7702Bytecode::new(address);
+        assert_eq!(bytecode.version(), EIP7702_VERSION);
+        assert_eq!(bytecode.version(), 0);
+    }
+
+    #[test]
+    fn test_raw_method() {
+        let address = Address::new([0x42; 20]);
+        let bytecode = Eip7702Bytecode::new(address);
+        let raw = bytecode.raw();
+        assert_eq!(raw.len(), 23);
+        assert!(raw.starts_with(&EIP7702_MAGIC_BYTES));
+        assert_eq!(raw[2], EIP7702_VERSION);
+    }
+
+    #[test]
+    fn test_decode_error_display() {
+        assert_eq!(
+            Eip7702DecodeError::InvalidLength.to_string(),
+            "Eip7702 is not 23 bytes long"
+        );
+        assert_eq!(
+            Eip7702DecodeError::InvalidMagic.to_string(),
+            "Bytecode is not starting with 0xEF01"
+        );
+        assert_eq!(
+            Eip7702DecodeError::UnsupportedVersion.to_string(),
+            "Unsupported Eip7702 version."
+        );
+    }
+
+    #[test]
+    fn test_decode_error_traits() {
+        // Test Error trait
+        let err = Eip7702DecodeError::InvalidLength;
+        let _: &dyn core::error::Error = &err;
+
+        // Test Display through error
+        let err_str = format!("{}", err);
+        assert_eq!(err_str, "Eip7702 is not 23 bytes long");
+    }
 }

--- a/crates/bytecode/src/iter.rs
+++ b/crates/bytecode/src/iter.rs
@@ -444,7 +444,7 @@ mod tests {
         let bytecode = Bytecode::new();
         let iter = bytecode.iter_opcodes();
 
-        let debug_str = format!("{:?}", iter);
+        let debug_str = format!("{iter:?}");
         assert!(debug_str.contains("BytecodeIterator"));
     }
 

--- a/crates/bytecode/src/legacy/analyzed.rs
+++ b/crates/bytecode/src/legacy/analyzed.rs
@@ -239,7 +239,7 @@ mod tests {
         let bytecode = Bytes::from_static(&[opcode::STOP]);
         let analyzed = LegacyAnalyzedBytecode::analyze(bytecode);
 
-        let debug_str = format!("{:?}", analyzed);
+        let debug_str = format!("{analyzed:?}");
         assert!(debug_str.contains("LegacyAnalyzedBytecode"));
     }
 
@@ -275,7 +275,8 @@ mod tests {
         let bytecode2 = Bytes::from_static(&[opcode::PUSH1, 0x01, opcode::STOP]);
         let analyzed2 = LegacyAnalyzedBytecode::analyze(bytecode2);
 
-        assert!(analyzed1 < analyzed2 || analyzed1 > analyzed2 || analyzed1 == analyzed2);
+        // Test that comparison operations work correctly
+        assert_ne!(analyzed1, analyzed2);
     }
 
     #[cfg(feature = "serde")]

--- a/crates/bytecode/src/legacy/jump_map.rs
+++ b/crates/bytecode/src/legacy/jump_map.rs
@@ -269,7 +269,7 @@ mod tests {
     #[test]
     fn test_debug() {
         let table = JumpTable::from_slice(&[0x0D, 0x06], 13);
-        let debug_str = format!("{:?}", table);
+        let debug_str = format!("{table:?}");
 
         assert!(debug_str.contains("JumpTable"));
         assert!(debug_str.contains("map"));

--- a/crates/bytecode/src/legacy/raw.rs
+++ b/crates/bytecode/src/legacy/raw.rs
@@ -88,7 +88,7 @@ mod tests {
     #[test]
     fn test_debug() {
         let raw = LegacyRawBytecode(bytes!("6060"));
-        let debug_str = format!("{:?}", raw);
+        let debug_str = format!("{raw:?}");
         assert!(debug_str.contains("LegacyRawBytecode"));
         assert!(debug_str.contains("6060"));
     }

--- a/crates/bytecode/src/legacy/raw.rs
+++ b/crates/bytecode/src/legacy/raw.rs
@@ -35,3 +35,135 @@ impl Deref for LegacyRawBytecode {
         &self.0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use primitives::bytes;
+
+    #[test]
+    fn test_into_analyzed() {
+        let raw_bytes = bytes!("6060604052");
+        let raw = LegacyRawBytecode(raw_bytes.clone());
+        let analyzed = raw.into_analyzed();
+
+        // Verify it was analyzed
+        assert_eq!(analyzed.original_len(), 5);
+        // Analyzed bytecode should have STOP appended
+        assert_eq!(analyzed.bytecode().len(), 6);
+    }
+
+    #[test]
+    fn test_from_bytes() {
+        let bytes = bytes!("6060604052");
+        let raw = LegacyRawBytecode::from(bytes.clone());
+        assert_eq!(raw.0, bytes);
+    }
+
+    #[test]
+    fn test_from_array() {
+        let array = [0x60, 0x60, 0x60, 0x40, 0x52];
+        let raw = LegacyRawBytecode::from(array);
+        assert_eq!(raw.0, bytes!("6060604052"));
+    }
+
+    #[test]
+    fn test_deref() {
+        let bytes = bytes!("6060604052");
+        let raw = LegacyRawBytecode(bytes.clone());
+
+        // Test that we can use Bytes methods via deref
+        assert_eq!(raw.len(), 5);
+        assert_eq!(raw.as_ref(), bytes.as_ref());
+        assert!(!raw.is_empty());
+    }
+
+    #[test]
+    fn test_clone() {
+        let raw = LegacyRawBytecode(bytes!("6060604052"));
+        let cloned = raw.clone();
+        assert_eq!(raw, cloned);
+    }
+
+    #[test]
+    fn test_debug() {
+        let raw = LegacyRawBytecode(bytes!("6060"));
+        let debug_str = format!("{:?}", raw);
+        assert!(debug_str.contains("LegacyRawBytecode"));
+        assert!(debug_str.contains("6060"));
+    }
+
+    #[test]
+    fn test_eq() {
+        let raw1 = LegacyRawBytecode(bytes!("6060604052"));
+        let raw2 = LegacyRawBytecode(bytes!("6060604052"));
+        let raw3 = LegacyRawBytecode(bytes!("6001"));
+
+        assert_eq!(raw1, raw2);
+        assert_ne!(raw1, raw3);
+    }
+
+    #[test]
+    fn test_hash() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let raw1 = LegacyRawBytecode(bytes!("6060604052"));
+        let raw2 = LegacyRawBytecode(bytes!("6060604052"));
+
+        let mut hasher1 = DefaultHasher::new();
+        raw1.hash(&mut hasher1);
+        let hash1 = hasher1.finish();
+
+        let mut hasher2 = DefaultHasher::new();
+        raw2.hash(&mut hasher2);
+        let hash2 = hasher2.finish();
+
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_ord() {
+        let raw1 = LegacyRawBytecode(bytes!("00"));
+        let raw2 = LegacyRawBytecode(bytes!("01"));
+
+        assert!(raw1 < raw2);
+        assert_eq!(raw1.cmp(&raw1), std::cmp::Ordering::Equal);
+    }
+
+    #[test]
+    fn test_empty_bytecode() {
+        let raw = LegacyRawBytecode(Bytes::new());
+        let analyzed = raw.into_analyzed();
+
+        // Even empty bytecode gets STOP appended
+        assert_eq!(analyzed.original_len(), 0);
+        assert_eq!(analyzed.bytecode().len(), 1);
+        assert_eq!(analyzed.bytecode()[0], 0x00); // STOP opcode
+    }
+
+    #[test]
+    fn test_from_small_array() {
+        let array: [u8; 1] = [0x00];
+        let raw = LegacyRawBytecode::from(array);
+        assert_eq!(raw.0, bytes!("00"));
+    }
+
+    #[test]
+    fn test_from_large_array() {
+        let array: [u8; 32] = [0x60; 32];
+        let raw = LegacyRawBytecode::from(array);
+        assert_eq!(raw.0.len(), 32);
+        assert!(raw.0.iter().all(|&b| b == 0x60));
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde() {
+        use serde::{Deserialize, Serialize};
+
+        // Test that the type implements Serialize and Deserialize traits
+        fn assert_serde<T: Serialize + for<'de> Deserialize<'de>>() {}
+        assert_serde::<LegacyRawBytecode>();
+    }
+}

--- a/crates/bytecode/src/opcode.rs
+++ b/crates/bytecode/src/opcode.rs
@@ -753,13 +753,13 @@ mod tests {
     fn test_opcode_display() {
         // Test valid opcodes
         let stop = OpCode::new(0x00).unwrap();
-        assert_eq!(format!("{}", stop), "STOP");
+        assert_eq!(format!("{stop}"), "STOP");
 
         let add = OpCode::new(0x01).unwrap();
-        assert_eq!(format!("{}", add), "ADD");
+        assert_eq!(format!("{add}"), "ADD");
 
         let push1 = OpCode::new(0x60).unwrap();
-        assert_eq!(format!("{}", push1), "PUSH1");
+        assert_eq!(format!("{push1}"), "PUSH1");
     }
 
     #[test]
@@ -914,7 +914,7 @@ mod tests {
     fn test_partial_eq_u8() {
         let stop = OpCode::new(0x00).unwrap();
         assert!(stop == 0x00);
-        assert!(!(stop == 0x01));
+        assert!((stop != 0x01));
     }
 
     #[test]
@@ -944,7 +944,7 @@ mod tests {
     #[test]
     fn test_opcode_info_debug() {
         let info = OpCodeInfo::new("TEST");
-        let debug_str = format!("{:?}", info);
+        let debug_str = format!("{info:?}");
         assert!(debug_str.contains("TEST"));
         assert!(debug_str.contains("inputs"));
         assert!(debug_str.contains("outputs"));
@@ -956,7 +956,7 @@ mod tests {
     fn test_invalid_opcode_display() {
         // Create an invalid opcode using unsafe
         let invalid = unsafe { OpCode::new_unchecked(0xEF) };
-        let display = format!("{}", invalid);
+        let display = format!("{invalid}");
         assert!(display.starts_with("UNKNOWN"));
         assert!(display.contains("0xEF"));
     }
@@ -990,9 +990,7 @@ mod tests {
             assert_eq!(
                 push_op.info().immediate_size(),
                 i,
-                "PUSH{} should have immediate size {}",
-                i,
-                i
+                "PUSH{i} should have immediate size {i}"
             );
         }
 
@@ -1029,14 +1027,12 @@ mod tests {
             assert_eq!(
                 op.inputs(),
                 expected_inputs,
-                "Opcode 0x{:02x} inputs mismatch",
-                opcode
+                "Opcode 0x{opcode:02x} inputs mismatch"
             );
             assert_eq!(
                 op.outputs(),
                 expected_outputs,
-                "Opcode 0x{:02x} outputs mismatch",
-                opcode
+                "Opcode 0x{opcode:02x} outputs mismatch"
             );
         }
     }
@@ -1064,7 +1060,7 @@ mod tests {
         let op3 = OpCode::new(0x01).unwrap();
 
         // Test Clone
-        let cloned = op1.clone();
+        let cloned = op1;
         assert_eq!(op1, cloned);
 
         // Test Copy

--- a/crates/bytecode/src/opcode/parse.rs
+++ b/crates/bytecode/src/opcode/parse.rs
@@ -37,3 +37,115 @@ impl OpCode {
         NAME_TO_OPCODE.get(s).copied()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::str::FromStr;
+
+    #[test]
+    fn test_opcode_error_display() {
+        let err = OpCodeError(());
+        assert_eq!(err.to_string(), "invalid opcode");
+    }
+
+    #[test]
+    fn test_opcode_error_debug() {
+        let err = OpCodeError(());
+        let debug_str = format!("{:?}", err);
+        assert_eq!(debug_str, "OpCodeError(())");
+    }
+
+    #[test]
+    fn test_opcode_error_is_error() {
+        let err = OpCodeError(());
+        // This will fail to compile if Error trait is not implemented
+        let _: &dyn core::error::Error = &err;
+    }
+
+    #[test]
+    fn test_parse_valid_opcodes() {
+        // Test some common opcodes
+        assert_eq!(OpCode::parse("STOP"), Some(OpCode::STOP));
+        assert_eq!(OpCode::parse("ADD"), Some(OpCode::ADD));
+        assert_eq!(OpCode::parse("MUL"), Some(OpCode::MUL));
+        assert_eq!(OpCode::parse("PUSH1"), Some(OpCode::PUSH1));
+        assert_eq!(OpCode::parse("PUSH32"), Some(OpCode::PUSH32));
+        assert_eq!(OpCode::parse("DUP1"), Some(OpCode::DUP1));
+        assert_eq!(OpCode::parse("SWAP1"), Some(OpCode::SWAP1));
+        assert_eq!(OpCode::parse("RETURN"), Some(OpCode::RETURN));
+        assert_eq!(OpCode::parse("REVERT"), Some(OpCode::REVERT));
+        assert_eq!(OpCode::parse("INVALID"), Some(OpCode::INVALID));
+    }
+
+    #[test]
+    fn test_parse_invalid_opcodes() {
+        assert_eq!(OpCode::parse("INVALID_OPCODE"), None);
+        assert_eq!(OpCode::parse(""), None);
+        assert_eq!(OpCode::parse("stop"), None); // Case sensitive
+        assert_eq!(OpCode::parse("ADD "), None); // With space
+        assert_eq!(OpCode::parse(" ADD"), None); // With space
+        assert_eq!(OpCode::parse("PUSH"), None); // Incomplete
+        assert_eq!(OpCode::parse("PUSH33"), None); // Out of range
+    }
+
+    #[test]
+    fn test_from_str_valid() {
+        assert_eq!(OpCode::from_str("STOP"), Ok(OpCode::STOP));
+        assert_eq!(OpCode::from_str("ADD"), Ok(OpCode::ADD));
+        assert_eq!(OpCode::from_str("PUSH1"), Ok(OpCode::PUSH1));
+    }
+
+    #[test]
+    fn test_from_str_invalid() {
+        assert_eq!(OpCode::from_str("INVALID_OPCODE"), Err(OpCodeError(())));
+        assert_eq!(OpCode::from_str(""), Err(OpCodeError(())));
+        assert_eq!(OpCode::from_str("stop"), Err(OpCodeError(())));
+    }
+
+    #[test]
+    fn test_parse_inverse_of_as_str() {
+        // Test that parse is the inverse of as_str for all valid opcodes
+        for byte in 0..=255u8 {
+            if let Some(opcode) = OpCode::new(byte) {
+                let name = opcode.as_str();
+                // Only test opcodes that have a proper name (not UNKNOWN)
+                if !name.starts_with("UNKNOWN") {
+                    assert_eq!(
+                        OpCode::parse(name),
+                        Some(opcode),
+                        "Failed to parse {} back to opcode 0x{:02x}",
+                        name,
+                        byte
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_all_named_opcodes_parseable() {
+        // Ensure all opcodes in NAME_TO_OPCODE can be parsed
+        for (name, &opcode) in NAME_TO_OPCODE.entries() {
+            assert_eq!(
+                OpCode::parse(name),
+                Some(opcode),
+                "Failed to parse {} from NAME_TO_OPCODE",
+                name
+            );
+            assert_eq!(
+                OpCode::from_str(name),
+                Ok(opcode),
+                "Failed to parse {} via FromStr",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn test_opcode_error_equality() {
+        let err1 = OpCodeError(());
+        let err2 = OpCodeError(());
+        assert_eq!(err1, err2);
+    }
+}

--- a/crates/bytecode/src/opcode/parse.rs
+++ b/crates/bytecode/src/opcode/parse.rs
@@ -52,7 +52,7 @@ mod tests {
     #[test]
     fn test_opcode_error_debug() {
         let err = OpCodeError(());
-        let debug_str = format!("{:?}", err);
+        let debug_str = format!("{err:?}");
         assert_eq!(debug_str, "OpCodeError(())");
     }
 
@@ -114,9 +114,7 @@ mod tests {
                     assert_eq!(
                         OpCode::parse(name),
                         Some(opcode),
-                        "Failed to parse {} back to opcode 0x{:02x}",
-                        name,
-                        byte
+                        "Failed to parse {name} back to opcode 0x{byte:02x}"
                     );
                 }
             }
@@ -130,14 +128,12 @@ mod tests {
             assert_eq!(
                 OpCode::parse(name),
                 Some(opcode),
-                "Failed to parse {} from NAME_TO_OPCODE",
-                name
+                "Failed to parse {name} from NAME_TO_OPCODE"
             );
             assert_eq!(
                 OpCode::from_str(name),
                 Ok(opcode),
-                "Failed to parse {} via FromStr",
-                name
+                "Failed to parse {name} via FromStr"
             );
         }
     }

--- a/crates/bytecode/src/utils.rs
+++ b/crates/bytecode/src/utils.rs
@@ -19,3 +19,135 @@ pub unsafe fn read_i16(ptr: *const u8) -> i16 {
 pub unsafe fn read_u16(ptr: *const u8) -> u16 {
     u16::from_be_bytes(unsafe { ptr.cast::<[u8; 2]>().read() })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_read_u16_big_endian() {
+        // These functions should always read big-endian regardless of CPU architecture
+        let data = [0x12, 0x34, 0x56, 0x78];
+        let ptr = data.as_ptr();
+
+        unsafe {
+            // Always reads as big-endian: first byte is MSB
+            assert_eq!(read_u16(ptr), 0x1234);
+            assert_eq!(read_u16(ptr.add(1)), 0x3456);
+            assert_eq!(read_u16(ptr.add(2)), 0x5678);
+
+            // Verify it matches explicit big-endian conversion
+            assert_eq!(read_u16(ptr), u16::from_be_bytes([0x12, 0x34]));
+        }
+    }
+
+    #[test]
+    fn test_read_i16_big_endian() {
+        let data = [0x12, 0x34, 0xFF, 0xFF, 0x80, 0x00];
+        let ptr = data.as_ptr();
+
+        unsafe {
+            assert_eq!(read_i16(ptr), 0x1234);
+            assert_eq!(read_i16(ptr.add(2)), -1);
+            assert_eq!(read_i16(ptr.add(4)), -32768);
+        }
+    }
+
+    #[test]
+    #[cfg(target_endian = "little")]
+    fn test_big_endian_on_little_endian_cpu() {
+        // On little-endian CPU, verify our functions still read big-endian
+        let data = [0x01, 0x02];
+        let ptr = data.as_ptr();
+
+        unsafe {
+            let result = read_u16(ptr);
+            let native = u16::from_ne_bytes([0x01, 0x02]);
+
+            // Our function returns big-endian
+            assert_eq!(result, 0x0102);
+            // Native on little-endian would be different
+            assert_eq!(native, 0x0201);
+            assert_ne!(result, native);
+        }
+    }
+
+    #[test]
+    #[cfg(target_endian = "big")]
+    fn test_big_endian_on_big_endian_cpu() {
+        // On big-endian CPU, verify our functions match native
+        let data = [0x01, 0x02];
+        let ptr = data.as_ptr();
+
+        unsafe {
+            let result = read_u16(ptr);
+            let native = u16::from_ne_bytes([0x01, 0x02]);
+
+            // Both should be big-endian
+            assert_eq!(result, 0x0102);
+            assert_eq!(native, 0x0102);
+            assert_eq!(result, native);
+        }
+    }
+
+    #[test]
+    fn test_read_u16_all_zeros() {
+        let data = [0x00, 0x00];
+        let ptr = data.as_ptr();
+
+        unsafe {
+            assert_eq!(read_u16(ptr), 0x0000);
+        }
+    }
+
+    #[test]
+    fn test_read_u16_all_ones() {
+        let data = [0xFF, 0xFF];
+        let ptr = data.as_ptr();
+
+        unsafe {
+            assert_eq!(read_u16(ptr), 0xFFFF);
+        }
+    }
+
+    #[test]
+    fn test_read_i16_boundary_values() {
+        // Test boundary values in big-endian format
+        unsafe {
+            // i16::MAX = 32767 = 0x7FFF in big-endian
+            let max_data = [0x7F, 0xFF];
+            assert_eq!(read_i16(max_data.as_ptr()), i16::MAX);
+
+            // i16::MIN = -32768 = 0x8000 in big-endian
+            let min_data = [0x80, 0x00];
+            assert_eq!(read_i16(min_data.as_ptr()), i16::MIN);
+
+            // -1 = 0xFFFF in big-endian
+            let neg_one_data = [0xFF, 0xFF];
+            assert_eq!(read_i16(neg_one_data.as_ptr()), -1);
+
+            // 0 = 0x0000
+            let zero_data = [0x00, 0x00];
+            assert_eq!(read_i16(zero_data.as_ptr()), 0);
+
+            // 1 = 0x0001 in big-endian
+            let one_data = [0x00, 0x01];
+            assert_eq!(read_i16(one_data.as_ptr()), 1);
+        }
+    }
+
+    #[test]
+    fn test_pointer_arithmetic() {
+        // Test reading from different offsets
+        let data = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF];
+        let ptr = data.as_ptr();
+
+        unsafe {
+            assert_eq!(read_u16(ptr), 0xAABB);
+            assert_eq!(read_u16(ptr.add(1)), 0xBBCC);
+            assert_eq!(read_u16(ptr.add(2)), 0xCCDD);
+            assert_eq!(read_u16(ptr.add(3)), 0xDDEE);
+            assert_eq!(read_u16(ptr.add(4)), 0xEEFF);
+        }
+    }
+}


### PR DESCRIPTION
test: improve revm-bytecode unittest coverage

- Add comprehensive tests for bytecode iterator methods (peek, as_slice, skip_to_next_opcode)
- Add tests for EIP7702 bytecode edge cases and error display
- Add tests for jump table trait implementations (PartialOrd, Hash, Debug)
- Add tests for legacy analyzed bytecode trait methods
- Add tests for opcode helper functions and edge cases

Remaining uncovered lines are assertion failure format strings and unreachable code branches.