### PR TITLE
chore: simplify the ecrecover test

### DIFF
--- a/crates/precompile/bench/ecrecover.rs
+++ b/crates/precompile/bench/ecrecover.rs
@@ -20,8 +20,7 @@ pub fn add_benches<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     message_and_signature[0..32].copy_from_slice(&hash[..]);
 
     // Fit signature into format the precompile expects
-    let rec_id = U256::from(rec_id as u64);
-    message_and_signature[32..64].copy_from_slice(&rec_id.to_be_bytes::<32>());
+    message_and_signature[63] = rec_id;
     message_and_signature[64..128].copy_from_slice(&data);
 
     let message_and_signature = Bytes::from(message_and_signature);

--- a/crates/precompile/bench/ecrecover.rs
+++ b/crates/precompile/bench/ecrecover.rs
@@ -1,6 +1,6 @@
 //! Benchmarks for the ecrecover precompile
 use criterion::{measurement::Measurement, BenchmarkGroup};
-use primitives::{hex, keccak256, Bytes, U256};
+use primitives::{hex, keccak256, Bytes};
 use revm_precompile::secp256k1::ec_recover_run;
 use secp256k1::{Message, SecretKey, SECP256K1};
 


### PR DESCRIPTION
 simplify the ecrecover test like alloy-core signature code

https://github.com/alloy-rs/core/blob/10aed0012d59a571f35235a5f9c6ad03076bf62b/crates/primitives/src/signature/sig.rs#L160-L165
```rust
    pub fn as_bytes(&self) -> [u8; 65] {
        let mut sig = [0u8; 65];
        sig[..32].copy_from_slice(&self.r.to_be_bytes::<32>());
        sig[32..64].copy_from_slice(&self.s.to_be_bytes::<32>());
        sig[64] = 27 + self.y_parity as u8;
}
```
rm unnecessary copy_from_slice and U256::from