### PR TITLE
improve link formatting and fix grammar in revme.md documentation

### DIFF
--- a/book/src/revme.md
+++ b/book/src/revme.md
@@ -22,12 +22,12 @@ Options:
 Eth tests are a suite of tests from the Ethereum Foundation that are used to test EVM implementations.
 Part of these tests are included in the revm repository in the `tests` folder.
 
-Test suites for the latest hardforks can be found in EEST releases https://github.com/ethereum/execution-spec-tests/releases, and there are additional tests that cover older hardforks in https://github.com/ethereum/legacytests
+est suites for the latest hardforks can be found in [EEST releases](https://github.com/ethereum/execution-spec-tests/releases), and there are additional tests that cover older hardforks in [legacytests](https://github.com/ethereum/legacytests)
 
 Revm can run statetest type of tests with `revme` using the following command:
 `cargo run --release -p revme -- statetest folder_path`
 
 For running EEST tests, we can use  the `./scripts/run-tests.sh.`
 
-For legacy tests, we need to first to download the repo `git clone https://github.com/ethereum/legacytests` and then run it with `cargo run --release -p revme -- statetest legacytests/Cancun/GeneralStateTests `
+For legacy tests, we need to first download the repo `git clone https://github.com/ethereum/legacytests` and then run it with `cargo run --release -p revme -- statetest legacytests/Cancun/GeneralStateTests`
 All statetest that can be run by revme can be found in the `GeneralStateTests` folder.

--- a/book/src/revme.md
+++ b/book/src/revme.md
@@ -22,7 +22,7 @@ Options:
 Eth tests are a suite of tests from the Ethereum Foundation that are used to test EVM implementations.
 Part of these tests are included in the revm repository in the `tests` folder.
 
-est suites for the latest hardforks can be found in [EEST releases](https://github.com/ethereum/execution-spec-tests/releases), and there are additional tests that cover older hardforks in [legacytests](https://github.com/ethereum/legacytests)
+Test suites for the latest hardforks can be found in [EEST releases](https://github.com/ethereum/execution-spec-tests/releases), and there are additional tests that cover older hardforks in [legacytests](https://github.com/ethereum/legacytests)
 
 Revm can run statetest type of tests with `revme` using the following command:
 `cargo run --release -p revme -- statetest folder_path`


### PR DESCRIPTION
## What Changed
- Converted raw URLs to proper markdown link format
- Fixed grammatical error in legacy tests section
- Improved overall documentation readability

## Technical Details
- **Before**: Plain URLs like `https://github.com/ethereum/execution-spec-tests/releases`
- **After**: Clean markdown links like `[EEST releases](https://github.com/ethereum/execution-spec-tests/releases)`
- **Grammar fix**: "first to download" → "first download"

