### PR TITLE
feat: optimize access to precompile short addreesses

### DIFF
--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -64,7 +64,7 @@ pub fn calc_linear_cost_u32(len: usize, base: u64, word: u64) -> u64 {
 }
 
 /// Optimize short address access.
-const SHORT_ADDRESS_CAP: usize = 300;
+pub const SHORT_ADDRESS_CAP: usize = 300;
 
 /// Precompiles contain map of precompile addresses to functions and HashSet of precompile addresses.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
All mainnet precompiles are under the first 100 addresses, we can use this knowledge and optimise access to those functions so we dont need to access the hashmap