### PR TITLE
fix: correct typos across codebase

### DIFF
--- a/crates/bytecode/src/opcode.rs
+++ b/crates/bytecode/src/opcode.rs
@@ -160,7 +160,7 @@ impl OpCode {
 
     /// Returns the number of both input and output stack elements.
     ///
-    /// Can be slightly faster that calling `inputs` and `outputs` separately.
+    /// Can be slightly faster than calling `inputs` and `outputs` separately.
     pub const fn input_output(&self) -> (u8, u8) {
         let info = self.info();
         (info.inputs, info.outputs)
@@ -225,9 +225,9 @@ pub struct OpCodeInfo {
     /// Number of intermediate bytes
     ///
     /// RJUMPV is a special case where the bytes len depends on bytecode value,
-    /// for RJUMV size will be set to one byte as it is the minimum immediate size.
+    /// for RJUMPV size will be set to one byte as it is the minimum immediate size.
     immediate_size: u8,
-    /// If the opcode stops execution. aka STOP, RETURN, ..
+    /// If the opcode stops execution. aka STOP, RETURN, etc.
     terminating: bool,
 }
 
@@ -304,7 +304,7 @@ impl OpCodeInfo {
 
 /// Used for [`OPCODE_INFO`] to set the immediate bytes number in the [`OpCodeInfo`].
 ///
-/// RJUMPV is special case where the bytes len is depending on bytecode value,
+/// RJUMPV is a special case where the bytes len depends on bytecode value,
 /// for RJUMPV size will be set to one byte while minimum is two.
 #[inline]
 pub const fn immediate_size(mut op: OpCodeInfo, n: u8) -> OpCodeInfo {
@@ -319,7 +319,7 @@ pub const fn terminating(mut op: OpCodeInfo) -> OpCodeInfo {
     op
 }
 
-/// Use for [`OPCODE_INFO`] to sets the number of stack inputs and outputs in the [`OpCodeInfo`].
+/// Used for [`OPCODE_INFO`] to set the number of stack inputs and outputs in the [`OpCodeInfo`].
 #[inline]
 pub const fn stack_io(mut op: OpCodeInfo, inputs: u8, outputs: u8) -> OpCodeInfo {
     op.inputs = inputs;

--- a/crates/context/interface/src/block.rs
+++ b/crates/context/interface/src/block.rs
@@ -16,7 +16,7 @@ pub trait Block {
     /// The number of ancestor blocks of this block (block height).
     fn number(&self) -> U256;
 
-    /// Beneficiary (Coinbase, miner) is a address that have signed the block.
+    /// Beneficiary (Coinbase, miner) is an address that has signed the block.
     ///
     /// This is the receiver address of priority gas rewards.
     fn beneficiary(&self) -> Address;

--- a/crates/context/interface/src/block/blob.rs
+++ b/crates/context/interface/src/block/blob.rs
@@ -43,7 +43,7 @@ impl BlobExcessGasAndPrice {
     /// Calculate this block excess gas and price from the parent excess gas and gas used
     /// and the target blob gas per block.
     ///
-    /// This fields will be used to calculate `excess_blob_gas` with [`calc_excess_blob_gas`] func.
+    /// These fields will be used to calculate `excess_blob_gas` with [`calc_excess_blob_gas`] func.
     #[deprecated(
         note = "Use `calc_excess_blob_gas` and `BlobExcessGasAndPrice::new` instead. Only works for forks before Osaka."
     )]

--- a/crates/context/interface/src/cfg.rs
+++ b/crates/context/interface/src/cfg.rs
@@ -7,7 +7,7 @@ use primitives::{hardfork::SpecId, Address, TxKind, U256};
 /// Configuration for the EVM.
 #[auto_impl(&, &mut, Box, Arc)]
 pub trait Cfg {
-    /// Specification id type, in requires to be convertible to `SpecId` so it can be used
+    /// Specification id type, it requires to be convertible to `SpecId` so it can be used
     /// by default in mainnet.
     type Spec: Into<SpecId> + Clone;
 

--- a/crates/context/interface/src/context.rs
+++ b/crates/context/interface/src/context.rs
@@ -13,7 +13,7 @@ use std::string::String;
 /// It is used to access the transaction, block, configuration, database, journal, and chain.
 /// It is also used to set the error of the EVM.
 ///
-/// All function has a `*_mut` variant except the function for [`ContextTr::tx`] and [`ContextTr::block`].
+/// All functions have a `*_mut` variant except the functions for [`ContextTr::tx`] and [`ContextTr::block`].
 #[auto_impl(&mut, Box)]
 pub trait ContextTr: Host {
     /// Block type
@@ -79,7 +79,7 @@ pub trait ContextTr: Host {
     fn tx_local_mut(&mut self) -> (&Self::Tx, &mut Self::Local);
 }
 
-/// Inner Context error used for Interpreter to set error without returning it frm instruction
+/// Inner Context error used for Interpreter to set error without returning it from instruction
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ContextError<DbError> {

--- a/crates/context/interface/src/transaction/eip7702.rs
+++ b/crates/context/interface/src/transaction/eip7702.rs
@@ -16,7 +16,7 @@ pub trait AuthorizationTr {
     /// signature s-value should be less than SECP256K1N_HALF.
     fn authority(&self) -> Option<Address>;
 
-    /// Returns authorization the chain id.
+    /// Returns the chain id from the authorization.
     fn chain_id(&self) -> U256;
 
     /// Returns the nonce.

--- a/crates/context/interface/src/transaction/transaction_type.rs
+++ b/crates/context/interface/src/transaction/transaction_type.rs
@@ -1,6 +1,6 @@
 //! Transaction type enum.
 
-/// Transaction types of all Ethereum transaction
+/// Transaction types of all Ethereum transactions
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]


### PR DESCRIPTION
Fix various typos in comments and documentation, such as:

- “Can be slightly faster that” → “Can be slightly faster than”
- “RJUMV” → “RJUMPV”
- “a address” → “an address”
- “this fields” → “these fields”
- “has a *_mut variant” → “have a *_mut variant”
- “frm instruction” → “from instruction”
- “Returns authorization the chain id” → “Returns the chain id from the authorization”
- “all Ethereum transaction” → “all Ethereum transactions”

…and similar typo fixes throughout the codebase.