### PR TITLE
docs: update outdated opcode memory reference link

### DIFF
--- a/crates/bytecode/src/opcode.rs
+++ b/crates/bytecode/src/opcode.rs
@@ -174,7 +174,7 @@ impl OpCode {
 
     /// Returns true if the opcode modifies memory.
     ///
-    /// <https://bluealloy.github.io/revm/crates/interpreter/memory.html#opcodes>
+    /// <https://docs.rs/revm-interpreter/latest/revm_interpreter/instructions/index.html>
     ///
     /// <https://github.com/crytic/evm-opcodes>
     #[inline]


### PR DESCRIPTION
Replaced outdated REVM opcode memory link (bluealloy.github.io) with the official docs.rs reference for revm_interpreter.
wrong link: https://bluealloy.github.io/revm/crates/interpreter/memory.html#opcodes
correct link: https://docs.rs/revm-interpreter/latest/revm_interpreter/instructions/index.html