### PR TITLE
fix: correct internal function reference in calc_excess_blob_gas comment

### DIFF
--- a/crates/context/interface/src/block/blob.rs
+++ b/crates/context/interface/src/block/blob.rs
@@ -65,7 +65,7 @@ impl BlobExcessGasAndPrice {
 }
 
 /// Calculates the `excess_blob_gas` from the parent header's `blob_gas_used` and `excess_blob_gas`.
-/// uses [`calc_excess_blob_gas`] internally.
+/// Uses [`calc_excess_blob_gas_osaka`] internally.
 #[inline]
 pub fn calc_excess_blob_gas(
     parent_excess_blob_gas: u64,


### PR DESCRIPTION
Fix incorrect comment in calc_excess_blob_gas function

The comment incorrectly stated that the function uses calc_excess_blob_gas 
internally, when it actually uses calc_excess_blob_gas_osaka. 
