### PR TITLE
Remove debug macro from test code

### DIFF
--- a/crates/inspector/src/lib.rs
+++ b/crates/inspector/src/lib.rs
@@ -56,7 +56,6 @@ mod tests {
     fn test_step_halt() {
         let bytecode = [opcode::INVALID];
         let r = run(&bytecode, HaltInspector);
-        dbg!(&r);
         assert!(r.is_success());
     }
 


### PR DESCRIPTION
Remove accidentally left dbg! macro from test_step_halt test function. The debug output is not needed as the test already has proper assertions to verify the expected behavior