### PR TITLE
perf: small performance and safety improvements

### DIFF
--- a/crates/database/src/states/bundle_state.rs
+++ b/crates/database/src/states/bundle_state.rs
@@ -307,7 +307,7 @@ impl BundleBuilder {
                     reverts_size += account_revert.size_hint();
                     reverts_map
                         .entry(block_number)
-                        .or_insert(Vec::new())
+                        .or_insert_with(Vec::new)
                         .push((address, account_revert));
                 }
             });
@@ -618,7 +618,7 @@ impl BundleState {
             // database so we can check if plain state was wiped or not.
             let mut account_storage_changed = Vec::with_capacity(account.storage.len());
 
-            for (key, slot) in account.storage.iter().map(|(k, v)| (*k, *v)) {
+            for (&key, &slot) in account.storage.iter() {
                 // If storage was destroyed that means that storage was wiped.
                 // In that case we need to check if present storage value is different then ZERO.
                 let destroyed_and_not_zero = was_destroyed && !slot.present_value.is_zero();

--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -93,7 +93,8 @@ impl<DB: Database> State<DB> {
         balances: impl IntoIterator<Item = (Address, u128)>,
     ) -> Result<(), DB::Error> {
         // Make transition and update cache state
-        let mut transitions = Vec::new();
+        let balances = balances.into_iter();
+        let mut transitions = Vec::with_capacity(balances.size_hint().0);
         for (address, balance) in balances {
             if balance == 0 {
                 continue;

--- a/crates/inspector/src/count_inspector.rs
+++ b/crates/inspector/src/count_inspector.rs
@@ -47,7 +47,7 @@ impl CountInspector {
 
     /// Get the count for a specific opcode.
     pub fn get_count(&self, opcode: u8) -> u64 {
-        self.opcode_counts.get(&opcode).copied().unwrap_or(0)
+        self.opcode_counts.get(&opcode).copied().unwrap_or_default()
     }
 
     /// Get a reference to all opcode counts.

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -56,7 +56,7 @@ pub const SHORT_ADDRESS_CAP: usize = 300;
 #[inline]
 pub fn short_address(address: &Address) -> Option<usize> {
     if address.0[..18].iter().all(|b| *b == 0) {
-        let short_address = u16::from_be_bytes(address.0[18..].try_into().unwrap()) as usize;
+        let short_address = u16::from_be_bytes([address.0[18], address.0[19]]) as usize;
         if short_address < SHORT_ADDRESS_CAP {
             return Some(short_address);
         }

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -52,46 +52,55 @@ impl Account {
     }
 
     /// Marks the account as self destructed.
+    #[inline]
     pub fn mark_selfdestruct(&mut self) {
         self.status |= AccountStatus::SelfDestructed;
     }
 
     /// Unmarks the account as self destructed.
+    #[inline]
     pub fn unmark_selfdestruct(&mut self) {
         self.status -= AccountStatus::SelfDestructed;
     }
 
     /// Is account marked for self destruct.
+    #[inline]
     pub fn is_selfdestructed(&self) -> bool {
         self.status.contains(AccountStatus::SelfDestructed)
     }
 
     /// Marks the account as touched
+    #[inline]
     pub fn mark_touch(&mut self) {
         self.status |= AccountStatus::Touched;
     }
 
     /// Unmarks the touch flag.
+    #[inline]
     pub fn unmark_touch(&mut self) {
         self.status -= AccountStatus::Touched;
     }
 
     /// If account status is marked as touched.
+    #[inline]
     pub fn is_touched(&self) -> bool {
         self.status.contains(AccountStatus::Touched)
     }
 
     /// Marks the account as newly created.
+    #[inline]
     pub fn mark_created(&mut self) {
         self.status |= AccountStatus::Created;
     }
 
     /// Unmarks the created flag.
+    #[inline]
     pub fn unmark_created(&mut self) {
         self.status -= AccountStatus::Created;
     }
 
     /// Marks the account as cold.
+    #[inline]
     pub fn mark_cold(&mut self) {
         self.status |= AccountStatus::Cold;
     }
@@ -393,7 +402,7 @@ impl EvmStorageSlot {
     pub fn mark_warm_with_transaction_id(&mut self, transaction_id: usize) -> bool {
         let same_id = self.transaction_id == transaction_id;
         self.transaction_id = transaction_id;
-        let was_cold = core::mem::replace(&mut self.is_cold, false);
+        let was_cold = core::mem::take(&mut self.is_cold);
 
         if same_id {
             // only if transaction id is same we are returning was_cold.


### PR DESCRIPTION
- Remove unwrap() in primitives::short_address by using direct array indexing
- Use lazy allocation with or_insert_with to avoid unnecessary Vec allocations
- Pre-allocate Vec capacity in State::increment_balances based on iterator hint
- Simplify iterator pattern in bundle_state to use destructuring
- Use mem::take instead of mem::replace for bool values
- Add #[inline] attributes to small hot-path functions in state module
- Use unwrap_or_default() instead of unwrap_or(0) for cleaner code

These are small incremental improvements that enhance performance and code safety without changing functionality.