### PR TITLE
feat: impl inspector for tuple

### DIFF
--- a/crates/inspector/src/inspector.rs
+++ b/crates/inspector/src/inspector.rs
@@ -113,6 +113,64 @@ pub trait Inspector<CTX, INTR: InterpreterTypes = EthInterpreter> {
     }
 }
 
+impl<CTX, INTR: InterpreterTypes, L, R> Inspector<CTX, INTR> for (L, R)
+where
+    L: Inspector<CTX, INTR>,
+    R: Inspector<CTX, INTR>,
+{
+    fn initialize_interp(&mut self, interp: &mut Interpreter<INTR>, context: &mut CTX) {
+        self.0.initialize_interp(interp, context);
+        self.1.initialize_interp(interp, context);
+    }
+
+    fn step(&mut self, interp: &mut Interpreter<INTR>, context: &mut CTX) {
+        self.0.step(interp, context);
+        self.1.step(interp, context);
+    }
+
+    fn step_end(&mut self, interp: &mut Interpreter<INTR>, context: &mut CTX) {
+        self.0.step_end(interp, context);
+        self.1.step_end(interp, context);
+    }
+
+    fn log(&mut self, interp: &mut Interpreter<INTR>, context: &mut CTX, log: Log) {
+        self.0.log(interp, context, log.clone());
+        self.1.log(interp, context, log);
+    }
+
+    fn call(&mut self, context: &mut CTX, inputs: &mut CallInputs) -> Option<CallOutcome> {
+        self.0
+            .call(context, inputs)
+            .or_else(|| self.1.call(context, inputs))
+    }
+
+    fn call_end(&mut self, context: &mut CTX, inputs: &CallInputs, outcome: &mut CallOutcome) {
+        self.0.call_end(context, inputs, outcome);
+        self.1.call_end(context, inputs, outcome);
+    }
+
+    fn create(&mut self, context: &mut CTX, inputs: &mut CreateInputs) -> Option<CreateOutcome> {
+        self.0
+            .create(context, inputs)
+            .or_else(|| self.1.create(context, inputs))
+    }
+
+    fn create_end(
+        &mut self,
+        context: &mut CTX,
+        inputs: &CreateInputs,
+        outcome: &mut CreateOutcome,
+    ) {
+        self.0.create_end(context, inputs, outcome);
+        self.1.create_end(context, inputs, outcome);
+    }
+
+    fn selfdestruct(&mut self, contract: Address, target: Address, value: U256) {
+        self.0.selfdestruct(contract, target, value);
+        self.1.selfdestruct(contract, target, value);
+    }
+}
+
 /// Extends the journal with additional methods that are used by the inspector.
 #[auto_impl(&mut, Box)]
 pub trait JournalExt {


### PR DESCRIPTION
Implements `Inspector` for tuple of 2 inspectors that will be invoked one after another.

It seems that there's no other implementation allowing for combining 2 inspectors behaviors in that way