### PR TITLE
refactor: use HashMap::is_empty() instead of len() == 0

### DIFF
--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -247,7 +247,7 @@ impl Precompiles {
 
     /// Is the precompiles list empty.
     pub fn is_empty(&self) -> bool {
-        self.inner.len() == 0
+        self.inner.is_empty()
     }
 
     /// Returns the number of precompiles.


### PR DESCRIPTION
Replace `self.inner.len() == 0` with `self.inner.is_empty()` in Precompiles::is_empty() method. This follows Rust idioms and best practices, potentially improving readability and performance