### PR TITLE
Aggregate cleanup changes from PRs #2866, #2867, and #2874

### DIFF
--- a/crates/context/interface/src/block/blob.rs
+++ b/crates/context/interface/src/block/blob.rs
@@ -65,7 +65,7 @@ impl BlobExcessGasAndPrice {
 }
 
 /// Calculates the `excess_blob_gas` from the parent header's `blob_gas_used` and `excess_blob_gas`.
-/// uses [`calc_excess_blob_gas`] internally.
+/// Uses [`calc_excess_blob_gas_osaka`] internally.
 #[inline]
 pub fn calc_excess_blob_gas(
     parent_excess_blob_gas: u64,

--- a/crates/inspector/src/lib.rs
+++ b/crates/inspector/src/lib.rs
@@ -56,7 +56,6 @@ mod tests {
     fn test_step_halt() {
         let bytecode = [opcode::INVALID];
         let r = run(&bytecode, HaltInspector);
-        dbg!(&r);
         assert!(r.is_success());
     }
 

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -247,7 +247,7 @@ impl Precompiles {
 
     /// Is the precompiles list empty.
     pub fn is_empty(&self) -> bool {
-        self.inner.len() == 0
+        self.inner.is_empty()
     }
 
     /// Returns the number of precompiles.


### PR DESCRIPTION
## Summary
- Aggregates three small cleanup PRs into a single PR
- Combines changes from #2866, #2867, and #2874

## Changes included

### From PR #2866
- Fix comment reference from `calc_excess_blob_gas` to `calc_excess_blob_gas_osaka` in blob.rs

### From PR #2867  
- Remove debug macro (`dbg\!(&r)`) from test code in inspector lib.rs

### From PR #2874
- Replace `self.inner.len() == 0` with idiomatic `self.inner.is_empty()` in precompile lib.rs

## Test plan
- [x] All existing tests pass
- [x] Changes are purely cosmetic/cleanup

🤖 Generated with [Claude Code](https://claude.ai/code)