### PR TITLE
chore(bytecode): remove unused Debug import

### DIFF
--- a/crates/bytecode/src/bytecode.rs
+++ b/crates/bytecode/src/bytecode.rs
@@ -8,7 +8,6 @@ use crate::{
     eip7702::{Eip7702Bytecode, EIP7702_MAGIC_BYTES},
     BytecodeDecodeError, JumpTable, LegacyAnalyzedBytecode, LegacyRawBytecode,
 };
-use core::fmt::Debug;
 use primitives::{keccak256, Address, Bytes, B256, KECCAK_EMPTY};
 
 /// Main bytecode structure with all variants.


### PR DESCRIPTION
Removed use core::fmt::Debug; from crates/bytecode/src/bytecode.rs since #[derive(Debug)] does not require it. No functional changes; cleans up an unused import warning.