### PR TITLE
Revert "feat: removed padding in case last opcode is terminal (#2816)"

### DIFF
--- a/crates/bytecode/src/legacy/analysis.rs
+++ b/crates/bytecode/src/legacy/analysis.rs
@@ -39,14 +39,7 @@ pub fn analyze_legacy(bytecode: Bytes) -> (JumpTable, Bytes) {
         }
     }
 
-    let overflow_padding = (iterator as usize) - (end as usize);
-
-    let stop_padding = opcode::OpCode::info_by_op(opcode)
-        .map(|o| !o.is_terminating() as usize)
-        .unwrap_or(1);
-
-    let padding = overflow_padding + stop_padding;
-
+    let padding = (iterator as usize) - (end as usize) + (opcode != opcode::STOP) as usize;
     let bytecode = if padding > 0 {
         let mut padded = Vec::with_capacity(bytecode.len() + padding);
         padded.extend_from_slice(&bytecode);
@@ -179,23 +172,5 @@ mod tests {
         ];
         let (jump_table, _) = analyze_legacy(bytecode.clone().into());
         assert!(!jump_table.is_valid(1)); // JUMPDEST in push data should not be valid
-    }
-
-    #[test]
-    fn test_terminating_opcodes_behavior() {
-        // Test all known terminating opcodes
-        let terminating_opcodes = [
-            opcode::STOP,
-            opcode::RETURN,
-            opcode::REVERT,
-            opcode::INVALID,
-            opcode::SELFDESTRUCT,
-        ];
-
-        for &terminating_opcode in &terminating_opcodes {
-            let bytecode = vec![opcode::PUSH1, 0x01, terminating_opcode];
-            let (_, padded_bytecode) = analyze_legacy(bytecode.clone().into());
-            assert_eq!(padded_bytecode.len(), bytecode.len());
-        }
     }
 }

--- a/crates/bytecode/src/legacy/analyzed.rs
+++ b/crates/bytecode/src/legacy/analyzed.rs
@@ -77,16 +77,6 @@ impl LegacyAnalyzedBytecode {
             "jump table length is less than original length"
         );
         assert!(!bytecode.is_empty(), "bytecode cannot be empty");
-
-        if let Some(&last_opcode) = bytecode.last() {
-            assert!(
-                opcode::OpCode::info_by_op(last_opcode)
-                    .map(|o| o.is_terminating())
-                    .unwrap_or(false),
-                "last bytecode byte should be terminating"
-            );
-        }
-
         Self {
             bytecode,
             original_len,
@@ -157,18 +147,18 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "last bytecode byte should be STOP (0x00)")]
+    fn test_panic_on_non_stop_bytecode() {
+        let bytecode = Bytes::from_static(&[opcode::PUSH1, 0x01]);
+        let jump_table = JumpTable::new(bitvec![u8, Lsb0; 0; 2]);
+        let _ = LegacyAnalyzedBytecode::new(bytecode, 2, jump_table);
+    }
+
+    #[test]
     #[should_panic(expected = "bytecode cannot be empty")]
     fn test_panic_on_empty_bytecode() {
         let bytecode = Bytes::from_static(&[]);
         let jump_table = JumpTable::new(bitvec![u8, Lsb0; 0; 0]);
         let _ = LegacyAnalyzedBytecode::new(bytecode, 0, jump_table);
-    }
-
-    #[test]
-    #[should_panic(expected = "last bytecode byte should be terminating")]
-    fn test_panic_on_non_stop_bytecode() {
-        let bytecode = Bytes::from_static(&[opcode::PUSH1, 0x01]);
-        let jump_table = JumpTable::new(bitvec![u8, Lsb0; 0; 2]);
-        let _ = LegacyAnalyzedBytecode::new(bytecode, 2, jump_table);
     }
 }


### PR DESCRIPTION
This reverts commit 5f67c14ab9402ef896a725c348187c34afde5201.

Additionally, removes the check for last opcode being STOP so that we are forward compatible.