### PR TITLE
bytecode: use core::fmt and remove unused Debug import

### DIFF
--- a/crates/bytecode/src/decode_errors.rs
+++ b/crates/bytecode/src/decode_errors.rs
@@ -1,6 +1,5 @@
 use crate::eip7702::Eip7702DecodeError;
-use core::fmt::Debug;
-use std::fmt;
+use core::fmt;
 
 /// Bytecode decode errors
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
Switch std::fmt to core::fmt in crates/bytecode/src/decode_errors.rs for consistency and potential no_std support. ( in eip7702.rs also used core::fmt )
Remove unused core::fmt::Debug import; #[derive(Debug)] does not require it, preventing unused_imports warnings.
No functional changes; aligns with eip7702.rs usage.