### PR TITLE
docs: fix typos in CHANGELOGs and one code comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Reverting: "feat: removed padding in case last opcode is terminal (#2816)" (#288
 # v84
 date: 07.08.2025
 
-Small perf and maintainance release.
+Small perf and maintenance release.
 
 revm-inspector@9.0.0 revm@28.0.0 revm-statetest-types@9.0.0
 
@@ -48,7 +48,7 @@ revm-inspector@9.0.0 revm@28.0.0 revm-statetest-types@9.0.0
 # v83 
 date: 23.07.2025
 
-Fusaka devnet-3 support. Performance regresion fixes.
+Fusaka devnet-3 support. Performance regression fixes.
 
 * `revm-primitives`: 20.0.0 -> 20.1.0 (✓ API compatible changes)
 * `revm-bytecode`: 6.0.1 -> 6.1.0 (✓ API compatible changes)
@@ -194,7 +194,7 @@ Introduction of multi transaction.
 # v75 tag
 date: 31.05.2025
 
-Maintainance release.
+Maintenance release.
 
 * `revm-context`: 5.0.0 -> 5.0.1
 * `revm-handler`: 5.0.0 -> 5.0.1
@@ -242,7 +242,7 @@ op-revm fix.
 # v71 tag
 date: 07.05.2025
 
-Maintanance release that fixes last v70 version bump.
+Maintenance release that fixes last v70 version bump.
 
 
 * `revm-state`: 3.0.1 -> 4.0.0 
@@ -262,7 +262,7 @@ Maintanance release that fixes last v70 version bump.
 # v70 tag
 date: 07.05.2025
 
-Yanked release as dependency bump was done incorrectly. Maintanance release.
+Yanked release as dependency bump was done incorrectly. Maintenance release.
 
 * `revm-primitives`: 18.0.0 -> 19.0.0 (⚠️ API breaking changes)
 * `revm-bytecode`: 3.0.0 -> 4.0.0 (⚠️ API breaking changes)

--- a/bins/revme/CHANGELOG.md
+++ b/bins/revme/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- *(benches)* rename anaysis-inspector to snailtracer-inspect ([#2834](https://github.com/bluealloy/revm/pull/2834))
+- *(benches)* rename analysis-inspector to snailtracer-inspect ([#2834](https://github.com/bluealloy/revm/pull/2834))
 - *(benches)* clean up criterion callsites ([#2833](https://github.com/bluealloy/revm/pull/2833))
 - add rust-version and note about MSRV ([#2789](https://github.com/bluealloy/revm/pull/2789))
 - fix clippy ([#2785](https://github.com/bluealloy/revm/pull/2785))
@@ -469,7 +469,7 @@ Dependency bump
 ## [0.2.1](https://github.com/bluealloy/revm/compare/revme-v0.2.0...revme-v0.2.1) - 2024-02-07
 
 ### Added
-- tweeks for v4.0 revm release ([#1048](https://github.com/bluealloy/revm/pull/1048))
+- tweaks for v4.0 revm release ([#1048](https://github.com/bluealloy/revm/pull/1048))
 - *(revme)* make it runnable by goevmlab ([#990](https://github.com/bluealloy/revm/pull/990))
 - EvmBuilder and External Contexts ([#888](https://github.com/bluealloy/revm/pull/888))
 - Loop call stack ([#851](https://github.com/bluealloy/revm/pull/851))

--- a/crates/bytecode/CHANGELOG.md
+++ b/crates/bytecode/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- *(bytecode)* add version getter + make versoin dynamic ([#2751](https://github.com/bluealloy/revm/pull/2751))
+- *(bytecode)* add version getter + make version dynamic ([#2751](https://github.com/bluealloy/revm/pull/2751))
 
 ### Fixed
 
@@ -177,9 +177,9 @@ Stable version
 - EthHandler trait (#2001)
 - *(eip7702)* apply latest EIP-7702 changes, backport from v52 (#1969)
 - *(database)* implement order-independent equality for Reverts (#1827)
-- Restucturing Part7 Handler and Context rework (#1865)
+- Restructuring Part7 Handler and Context rework (#1865)
 - restructuring Part6 transaction crate (#1814)
-- Merge validation/analyzis with Bytecode (#1793)
+- Merge validation/analysis with Bytecode (#1793)
 - restructure Part2 database crate (#1784)
 - project restructuring Part1 (#1776)
 - *(examples)* generate block traces (#895)
@@ -203,7 +203,7 @@ Stable version
 - fix `constants` module typo (#1801)
 - Bump new logo (#1735)
 - *(README)* add rbuilder to used-by (#1585)
-- added simular to used-by (#1521)
+- added similar to used-by (#1521)
 - add Trin to used by list (#1393)
 - Fix typo in readme ([#1185](https://github.com/bluealloy/revm/pull/1185))
 - Add Hardhat to the "Used by" list ([#1164](https://github.com/bluealloy/revm/pull/1164))

--- a/crates/context/CHANGELOG.md
+++ b/crates/context/CHANGELOG.md
@@ -281,7 +281,7 @@ Dependency bump
 - align Block trait (#1957)
 - expose precompile address in Journal, DB::Error: StdError (#1956)
 - Make Ctx journal generic (#1933)
-- Restucturing Part7 Handler and Context rework (#1865)
+- Restructuring Part7 Handler and Context rework (#1865)
 - restructuring Part6 transaction crate (#1814)
 - *(examples)* generate block traces (#895)
 - implement EIP-4844 (#668)
@@ -309,7 +309,7 @@ Dependency bump
 - Move CfgEnv from context-interface to context crate (#1910)
 - Bump new logo (#1735)
 - *(README)* add rbuilder to used-by (#1585)
-- added simular to used-by (#1521)
+- added similar to used-by (#1521)
 - add Trin to used by list (#1393)
 - Fix typo in readme ([#1185](https://github.com/bluealloy/revm/pull/1185))
 - Add Hardhat to the "Used by" list ([#1164](https://github.com/bluealloy/revm/pull/1164))
@@ -332,7 +332,7 @@ Dependency bump
 - typo fixes
 - fix readme typo
 - Big Refactor. Machine to Interpreter. refactor instructions. call/create struct ([#52](https://github.com/bluealloy/revm/pull/52))
-- readme. debuger update
+- readme. debugger update
 - Bump revm v0.3.0. README updated
 - readme
 - Add time elapsed for tests

--- a/crates/context/interface/CHANGELOG.md
+++ b/crates/context/interface/CHANGELOG.md
@@ -244,7 +244,7 @@ Stable version
 - Move CfgEnv from context-interface to context crate (#1910)
 - Bump new logo (#1735)
 - *(README)* add rbuilder to used-by (#1585)
-- added simular to used-by (#1521)
+- added similar to used-by (#1521)
 - add Trin to used by list (#1393)
 - Fix typo in readme ([#1185](https://github.com/bluealloy/revm/pull/1185))
 - Add Hardhat to the "Used by" list ([#1164](https://github.com/bluealloy/revm/pull/1164))

--- a/crates/database/CHANGELOG.md
+++ b/crates/database/CHANGELOG.md
@@ -98,7 +98,7 @@ Dependency bump
 
 ### Other
 
-- clean unsed indicatif ([#2379](https://github.com/bluealloy/revm/pull/2379))
+- clean unused indicatif ([#2379](https://github.com/bluealloy/revm/pull/2379))
 - add 0x prefix to b256! and address! calls ([#2345](https://github.com/bluealloy/revm/pull/2345))
 - *(database)* remove auto_impl dependency ([#2344](https://github.com/bluealloy/revm/pull/2344))
 

--- a/crates/database/interface/CHANGELOG.md
+++ b/crates/database/interface/CHANGELOG.md
@@ -83,7 +83,7 @@ Dependency bump
 
 ### Other
 
-- clean unsed indicatif ([#2379](https://github.com/bluealloy/revm/pull/2379))
+- clean unused indicatif ([#2379](https://github.com/bluealloy/revm/pull/2379))
 - add 0x prefix to b256! and address! calls ([#2345](https://github.com/bluealloy/revm/pull/2345))
 
 ## [2.0.0](https://github.com/bluealloy/revm/compare/revm-database-interface-v1.0.0...revm-database-interface-v2.0.0) - 2025-03-28

--- a/crates/ee-tests/CHANGELOG.md
+++ b/crates/ee-tests/CHANGELOG.md
@@ -17,4 +17,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- *(op-revm)* Adds caller nonce assertion to op-revm intergation tests ([#2815](https://github.com/bluealloy/revm/pull/2815))
+- *(op-revm)* Adds caller nonce assertion to op-revm integration tests ([#2815](https://github.com/bluealloy/revm/pull/2815))

--- a/crates/handler/CHANGELOG.md
+++ b/crates/handler/CHANGELOG.md
@@ -313,7 +313,7 @@ Dependency bump
 - expose precompile address in Journal, DB::Error: StdError (#1956)
 - Make Ctx journal generic (#1933)
 - removed create address collision check (#1928)
-- Restucturing Part7 Handler and Context rework (#1865)
+- Restructuring Part7 Handler and Context rework (#1865)
 - *(examples)* generate block traces (#895)
 - implement EIP-4844 (#668)
 - *(Shanghai)* All EIPs: push0, warm coinbase, limit/measure initcode (#376)
@@ -364,7 +364,7 @@ Dependency bump
 - typo fixes
 - fix readme typo
 - Big Refactor. Machine to Interpreter. refactor instructions. call/create struct ([#52](https://github.com/bluealloy/revm/pull/52))
-- readme. debuger update
+- readme. debugger update
 - Bump revm v0.3.0. README updated
 - readme
 - Add time elapsed for tests

--- a/crates/inspector/CHANGELOG.md
+++ b/crates/inspector/CHANGELOG.md
@@ -52,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- *(Inspector)* call_end not calle on first call fast return ([#2697](https://github.com/bluealloy/revm/pull/2697))
+- *(Inspector)* call_end not called on first call fast return ([#2697](https://github.com/bluealloy/revm/pull/2697))
 
 ## [8.0.2](https://github.com/bluealloy/revm/compare/revm-inspector-v8.0.1...revm-inspector-v8.0.2) - 2025-07-03
 
@@ -243,9 +243,9 @@ Dependency bump
 - Split inspector.rs (#1958)
 - expose precompile address in Journal, DB::Error: StdError (#1956)
 - Make Ctx journal generic (#1933)
-- Restucturing Part7 Handler and Context rework (#1865)
+- Restructuring Part7 Handler and Context rework (#1865)
 - restructuring Part6 transaction crate (#1814)
-- Merge validation/analyzis with Bytecode (#1793)
+- Merge validation/analysis with Bytecode (#1793)
 - Restructuring Part3 inspector crate (#1788)
 - restructure Part2 database crate (#1784)
 - project restructuring Part1 (#1776)
@@ -276,7 +276,7 @@ Dependency bump
 - Move CfgEnv from context-interface to context crate (#1910)
 - Bump new logo (#1735)
 - *(README)* add rbuilder to used-by (#1585)
-- added simular to used-by (#1521)
+- added similar to used-by (#1521)
 - add Trin to used by list (#1393)
 - Fix typo in readme ([#1185](https://github.com/bluealloy/revm/pull/1185))
 - Add Hardhat to the "Used by" list ([#1164](https://github.com/bluealloy/revm/pull/1164))

--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -170,7 +170,7 @@ Dependency bump
 
 ### Added
 
-- *(tests)* Add dupn, swapn and exhange tests ([#2343](https://github.com/bluealloy/revm/pull/2343))
+- *(tests)* Add dupn, swapn and exchange tests ([#2343](https://github.com/bluealloy/revm/pull/2343))
 - support for system calls ([#2350](https://github.com/bluealloy/revm/pull/2350))
 
 ### Other
@@ -435,7 +435,7 @@ Stable version
 - *(EOF)* set CallOrCreate result in EOFCREATE ([#1535](https://github.com/bluealloy/revm/pull/1535))
 - *(EOF)* target needed for EOFCREATE created address ([#1536](https://github.com/bluealloy/revm/pull/1536))
 - *(EOF)* ext*call return values ([#1515](https://github.com/bluealloy/revm/pull/1515))
-- *(EOF)* Remove redundunt ext call gas cost ([#1513](https://github.com/bluealloy/revm/pull/1513))
+- *(EOF)* Remove redundant ext call gas cost ([#1513](https://github.com/bluealloy/revm/pull/1513))
 - *(EOF)* add DATACOPY copy gas ([#1510](https://github.com/bluealloy/revm/pull/1510))
 - *(EOF)* extstaticcall make static ([#1508](https://github.com/bluealloy/revm/pull/1508))
 - *(EOF)* jumpf gas was changes ([#1507](https://github.com/bluealloy/revm/pull/1507))
@@ -445,7 +445,7 @@ Stable version
 - *(EOF)* returncontract immediate is one byte ([#1468](https://github.com/bluealloy/revm/pull/1468))
 - *(Interpreter)* wrong block number used ([#1458](https://github.com/bluealloy/revm/pull/1458))
 - *(interpreter)* avoid overflow when checking if mem limit reached ([#1429](https://github.com/bluealloy/revm/pull/1429))
-- blockchash for devnet-0  ([#1427](https://github.com/bluealloy/revm/pull/1427))
+- blockhash for devnet-0  ([#1427](https://github.com/bluealloy/revm/pull/1427))
 
 ### Other
 - replace TransactTo with TxKind ([#1542](https://github.com/bluealloy/revm/pull/1542))
@@ -573,10 +573,10 @@ Stable version
 
 ## [2.0.0](https://github.com/bluealloy/revm/compare/revm-interpreter-v1.3.0...revm-interpreter-v2.0.0) - 2024-02-07
 
-Iterpreter will not be called in recursive calls but would return Action ( CALL/CREATE) that will be executed by the main loop.
+Interpreter will not be called in recursive calls but would return Action ( CALL/CREATE) that will be executed by the main loop.
 
 ### Added
-- tweeks for v4.0 revm release ([#1048](https://github.com/bluealloy/revm/pull/1048))
+- tweaks for v4.0 revm release ([#1048](https://github.com/bluealloy/revm/pull/1048))
 - add `BytecodeLocked::original_bytecode` ([#1037](https://github.com/bluealloy/revm/pull/1037))
 - *(op)* Ecotone hardfork ([#1009](https://github.com/bluealloy/revm/pull/1009))
 - EvmBuilder and External Contexts ([#888](https://github.com/bluealloy/revm/pull/888))

--- a/crates/op-revm/CHANGELOG.md
+++ b/crates/op-revm/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - update README.md ([#2842](https://github.com/bluealloy/revm/pull/2842))
-- *(op-revm)* Adds caller nonce assertion to op-revm intergation tests ([#2815](https://github.com/bluealloy/revm/pull/2815))
+- *(op-revm)* Adds caller nonce assertion to op-revm integration tests ([#2815](https://github.com/bluealloy/revm/pull/2815))
 - *(op-revm)* Full test coverage `OpTransactionError` ([#2818](https://github.com/bluealloy/revm/pull/2818))
 - Update test data for renamed tests ([#2817](https://github.com/bluealloy/revm/pull/2817))
 - reuse global crypto provide idea ([#2786](https://github.com/bluealloy/revm/pull/2786))
@@ -255,7 +255,7 @@ Dependency bump
 - remove wrong `&mut` and duplicated spec ([#2276](https://github.com/bluealloy/revm/pull/2276))
 - *(op-precompiles)* clean up op tx tests ([#2242](https://github.com/bluealloy/revm/pull/2242))
 - make str to SpecId conversion fallible ([#2236](https://github.com/bluealloy/revm/pull/2236))
-- *(op-precompiles)* Add tests for bls12-381 map fp to g ([#2241](https://github.com/bluealloy/revm/pull/2241))
+- *(op-precompiles)* Add tests for bls12-381 map fp to g1 ([#2241](https://github.com/bluealloy/revm/pull/2241))
 - add a safe blst wrapper ([#2223](https://github.com/bluealloy/revm/pull/2223))
 - *(op-precompiles)* Reuse tests for bls12-381 msm tests for pairing ([#2239](https://github.com/bluealloy/revm/pull/2239))
 - *(op-precompiles)* add bls12-381 g2 add and msm tests ([#2231](https://github.com/bluealloy/revm/pull/2231))

--- a/crates/precompile/CHANGELOG.md
+++ b/crates/precompile/CHANGELOG.md
@@ -256,7 +256,7 @@ Dependency bump
 
 - *(eip7702)* apply latest EIP-7702 changes, backport from v52 (#1969)
 - integrate codspeed (#1935)
-- Restucturing Part7 Handler and Context rework (#1865)
+- Restructuring Part7 Handler and Context rework (#1865)
 - restructuring Part6 transaction crate (#1814)
 - restructure Part2 database crate (#1784)
 - project restructuring Part1 (#1776)
@@ -593,7 +593,7 @@ Promoting it to stable version, and i dont expect for precompiles to change in a
 # v0.4.0
 date: 20.1.2022
 
-* Added feature for k256 lib. We now have choise to use bitcoin c lib and k256 for ecrecovery.
+* Added feature for k256 lib. We now have choice to use bitcoin c lib and k256 for ecrecovery.
 
 # v0.3.0
 
@@ -601,7 +601,7 @@ date: 20.1.2022
 * Error type is changed to `Return` in revm so it is in precompiles.
 # v0.2.0
 
-Removed parity-crypto and use only needed secp256k1 lib. Added `ecrecover` feature to allow dissabling it for wasm windows builds.
+Removed parity-crypto and use only needed secp256k1 lib. Added `ecrecover` feature to allow disabling it for wasm windows builds.
 
 # v0.1.0
 

--- a/crates/precompile/src/modexp.rs
+++ b/crates/precompile/src/modexp.rs
@@ -117,7 +117,7 @@ where
     // cast exp len to the max size, it will fail later in gas calculation if it is too large.
     let exp_len = usize::try_from(exp_len).unwrap_or(usize::MAX);
 
-    // for EIP-7823 we need to check size of imputs
+    // for EIP-7823 we need to check size of inputs
     if OSAKA
         && (base_len > eip7823::INPUT_SIZE_LIMIT
             || mod_len > eip7823::INPUT_SIZE_LIMIT

--- a/crates/primitives/CHANGELOG.md
+++ b/crates/primitives/CHANGELOG.md
@@ -285,7 +285,7 @@ Stable version
 ### Added
 - *(Precompiles)* Throw fatal error if c-kzg is disabled ([#1589](https://github.com/bluealloy/revm/pull/1589))
 - *(Prague)* Add EIP-7702 ([#1565](https://github.com/bluealloy/revm/pull/1565))
-- add helper function to mape EVMError's Database error variant ([#1567](https://github.com/bluealloy/revm/pull/1567))
+- add helper function to map EVMError's Database error variant ([#1567](https://github.com/bluealloy/revm/pull/1567))
 
 ### Other
 - *(README)* add rbuilder to used-by ([#1585](https://github.com/bluealloy/revm/pull/1585))
@@ -313,7 +313,7 @@ Stable version
 - replace TransactTo with TxKind ([#1542](https://github.com/bluealloy/revm/pull/1542))
 - remove DatabaseWithDebugError ([#1545](https://github.com/bluealloy/revm/pull/1545))
 - avoid cloning precompiles ([#1486](https://github.com/bluealloy/revm/pull/1486))
-- added simular to used-by ([#1521](https://github.com/bluealloy/revm/pull/1521))
+- added similar to used-by ([#1521](https://github.com/bluealloy/revm/pull/1521))
 - derive PartialEq and Hash on EnvKzgSettings ([#1494](https://github.com/bluealloy/revm/pull/1494))
 - remove old deprecated items ([#1489](https://github.com/bluealloy/revm/pull/1489))
 - *(primitives)* rename State/Storage to EvmState/EvmStorage ([#1459](https://github.com/bluealloy/revm/pull/1459))
@@ -563,7 +563,7 @@ One change:
 # v1.1.0
 date: 04.04.2023
 
-Mosty utility functions, additional checks and convenience changes.
+Mostly utility functions, additional checks and convenience changes.
 Old bytecode that supported gas block was replaced with jumpmap only bitvec.
 
 Changelog: 
@@ -574,7 +574,7 @@ Changelog:
 * 3d8ca66 - feat: add Output::into_data (#420) (3 weeks ago) <Matthias Seitz>
 * dd0e227 - feat: Add all internals results to Halt (#413) (4 weeks ago) <rakita>
 * d8dc652 - fix(interpreter): halt on CreateInitcodeSizeLimit (#412) (4 weeks ago) <Roman Krasiuk>
-* a193d79 - chore: enabled primtive default feature in precompile (#409) (4 weeks ago) <Matthias Seitz>
+* a193d79 - chore: enabled primitive default feature in precompile (#409) (4 weeks ago) <Matthias Seitz>
 * 33bf8a8 - feat: use singular bytes for the jumpmap (#402) (4 weeks ago) <Bjerg>
 * 394e8e9 - feat: extend SuccessOrHalt (#405) (4 weeks ago) <Matthias Seitz>
 * cff1070 - Update readmdoc of `perf_analyse_created_bytecodes` (#404) (4 weeks ago) <rakita>

--- a/crates/revm/CHANGELOG.md
+++ b/crates/revm/CHANGELOG.md
@@ -221,10 +221,10 @@ Dependency bump
 - expose precompile address in Journal, DB::Error: StdError (#1956)
 - integrate codspeed (#1935)
 - Make Ctx journal generic (#1933)
-- Restucturing Part7 Handler and Context rework (#1865)
+- Restructuring Part7 Handler and Context rework (#1865)
 - restructuring Part6 transaction crate (#1814)
 - push NonceChange to Journal in deduct_caller (#1804)
-- Merge validation/analyzis with Bytecode (#1793)
+- Merge validation/analysis with Bytecode (#1793)
 - Restructuring Part3 inspector crate (#1788)
 - restructure Part2 database crate (#1784)
 - project restructuring Part1 (#1776)
@@ -643,8 +643,8 @@ Few major renaming: EVMImpl to Evm, EVM to EvmFactory and EVMData to EvmContext.
 
 ### Added
 - *(handler)* Change spec id on &mut ([#1055](https://github.com/bluealloy/revm/pull/1055))
-- *(Handler)* add push and pop of hanler registers ([#1053](https://github.com/bluealloy/revm/pull/1053))
-- tweeks for v4.0 revm release ([#1048](https://github.com/bluealloy/revm/pull/1048))
+- *(Handler)* add push and pop of handler registers ([#1053](https://github.com/bluealloy/revm/pull/1053))
+- tweaks for v4.0 revm release ([#1048](https://github.com/bluealloy/revm/pull/1048))
 - *(op)* Ecotone hardfork ([#1009](https://github.com/bluealloy/revm/pull/1009))
 - *(inspector)* Share call/create inputs in Inspector call_end/create_end ([#1003](https://github.com/bluealloy/revm/pull/1003))
 - Convert optimism panic into graceful error ([#982](https://github.com/bluealloy/revm/pull/982))
@@ -808,7 +808,7 @@ Full git log:
 * 175aaec - Removed the last dependencies breaking no-std build. (#669) (4 weeks ago) <Lucas Clemente Vella>
 * 4272535 - fix(state): retain destroyed account status on bundle extend (#667) (4 weeks ago) <rakita>
 * bef9edd - chore(state): bundle retention (#666) (4 weeks ago) <Roman Krasiuk>
-* 1053d0e - fix(state): Regresion, remove present info on selfdestruct (#664) (4 weeks ago) <rakita>
+* 1053d0e - fix(state): Regression, remove present info on selfdestruct (#664) (4 weeks ago) <rakita>
 * 6c4cd31 - feat: add BundleState::revert_latest (#661) (4 weeks ago) <Matthias Seitz>
 * fd2cc88 - fix(state): state transition regression (#662) (4 weeks ago) <Roman Krasiuk>
 * c14f8a9 - feat(state): add a flag allowing transition merge without reverts (#657) (4 weeks ago) <Roman Krasiuk>
@@ -1173,7 +1173,7 @@ Changes:
 # v1.1.0
 date: 14.1.2022
 
-There is bug introduced in last release with gas blcok optimization, it will crash revm if anywhere in contract is unknown OpCode. And now returning log after execution (ups) included them in eth/tests verification.
+There is bug introduced in last release with gas block optimization, it will crash revm if anywhere in contract is unknown OpCode. And now returning log after execution (ups) included them in eth/tests verification.
 
 Changes:
 * Bug fix for unknown OpCode
@@ -1210,7 +1210,7 @@ Changes:
 * clippy/warnings/fmt cleanup
 * Bump auto_impl to v0.5
 * opcode renaming
-* Gas measurment can be removed with rust features.
+* Gas measurement can be removed with rust features.
 
 # v0.4.1
 date: 02.11.2021

--- a/crates/state/CHANGELOG.md
+++ b/crates/state/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- manally implementation PartialOrd and Ord for AccountInfo ([#2835](https://github.com/bluealloy/revm/pull/2835))
+- manually implementation PartialOrd and Ord for AccountInfo ([#2835](https://github.com/bluealloy/revm/pull/2835))
 
 ### Other
 
@@ -150,7 +150,7 @@ Stable version
 ### Added
 
 - *(database)* implement order-independent equality for Reverts (#1827)
-- Restucturing Part7 Handler and Context rework (#1865)
+- Restructuring Part7 Handler and Context rework (#1865)
 - restructuring Part6 transaction crate (#1814)
 - restructure Part2 database crate (#1784)
 - project restructuring Part1 (#1776)
@@ -173,7 +173,7 @@ Stable version
 - *(primitives)* replace HashMap re-exports with alloy_primitives::map (#1805)
 - Bump new logo (#1735)
 - *(README)* add rbuilder to used-by (#1585)
-- added simular to used-by (#1521)
+- added similar to used-by (#1521)
 - add Trin to used by list (#1393)
 - Fix typo in readme ([#1185](https://github.com/bluealloy/revm/pull/1185))
 - Add Hardhat to the "Used by" list ([#1164](https://github.com/bluealloy/revm/pull/1164))
@@ -196,7 +196,7 @@ Stable version
 - typo fixes
 - fix readme typo
 - Big Refactor. Machine to Interpreter. refactor instructions. call/create struct ([#52](https://github.com/bluealloy/revm/pull/52))
-- readme. debuger update
+- readme. debugger update
 - Bump revm v0.3.0. README updated
 - readme
 - Add time elapsed for tests

--- a/crates/statetest-types/CHANGELOG.md
+++ b/crates/statetest-types/CHANGELOG.md
@@ -163,7 +163,7 @@ Stable version
 - *(EIP-7840)* Add blob schedule to execution client cfg (#1980)
 - *(eip7702)* apply latest EIP-7702 changes, backport from v52 (#1969)
 - simplify Transaction trait (#1959)
-- Restucturing Part7 Handler and Context rework (#1865)
+- Restructuring Part7 Handler and Context rework (#1865)
 - restructuring Part6 transaction crate (#1814)
 - extract statetest models/structs to standalone crate (#1808)
 - *(examples)* generate block traces (#895)
@@ -186,7 +186,7 @@ Stable version
 - fix comments and docs into more sensible (#1920)
 - Bump new logo (#1735)
 - *(README)* add rbuilder to used-by (#1585)
-- added simular to used-by (#1521)
+- added similar to used-by (#1521)
 - add Trin to used by list (#1393)
 - Fix typo in readme ([#1185](https://github.com/bluealloy/revm/pull/1185))
 - Add Hardhat to the "Used by" list ([#1164](https://github.com/bluealloy/revm/pull/1164))
@@ -209,7 +209,7 @@ Stable version
 - typo fixes
 - fix readme typo
 - Big Refactor. Machine to Interpreter. refactor instructions. call/create struct ([#52](https://github.com/bluealloy/revm/pull/52))
-- readme. debuger update
+- readme. debugger update
 - Bump revm v0.3.0. README updated
 - readme
 - Add time elapsed for tests


### PR DESCRIPTION
Summary
- Fix spelling in top-level and crate CHANGELOGs; no content changes beyond wording.
- Correct a single code comment in `crates/precompile/src/modexp.rs` (“imputs” → “inputs”).
- No functional or API changes.

Why
- Improve clarity and professionalism in documentation.
- Remove common misspellings (maintenance, regression, restructuring, analysis, tweaks, similar, debugger, version, integration, map, mostly, primitive, redundant, blockhash, handler, manually, called).
- Keep changelogs consistent for release notes and references.

Scope
- Edited: workspace `CHANGELOG.md`, and crate changelogs under `bins/revme`, `crates/{bytecode,context,context/interface,database,database/interface,ee-tests,handler,inspector,interpreter,op-revm,precompile,primitives,revm,state,statetest-types}`.
- Code: `crates/precompile/src/modexp.rs` (comment only).
