### PR TITLE
fix(interpreter): correct CreateContractStartingWithEF halt mapping

### DIFF
--- a/crates/interpreter/src/instruction_result.rs
+++ b/crates/interpreter/src/instruction_result.rs
@@ -332,9 +332,11 @@ impl<HaltReasonTr: From<HaltReason>> From<InstructionResult> for SuccessOrHalt<H
             InstructionResult::OverflowPayment => Self::Halt(HaltReason::OverflowPayment.into()), // Check for first call is done separately.
             InstructionResult::PrecompileError => Self::Halt(HaltReason::PrecompileError.into()),
             InstructionResult::NonceOverflow => Self::Halt(HaltReason::NonceOverflow.into()),
-            InstructionResult::CreateContractSizeLimit
-            | InstructionResult::CreateContractStartingWithEF => {
+            InstructionResult::CreateContractSizeLimit => {
                 Self::Halt(HaltReason::CreateContractSizeLimit.into())
+            }
+            InstructionResult::CreateContractStartingWithEF => {
+                Self::Halt(HaltReason::CreateContractStartingWithEF.into())
             }
             InstructionResult::CreateInitCodeSizeLimit => {
                 Self::Halt(HaltReason::CreateInitCodeSizeLimit.into())


### PR DESCRIPTION
- Map InstructionResult::CreateContractStartingWithEF to HaltReason::CreateContractStartingWithEF instead of CreateContractSizeLimit.
- Keeps behavior consistent with distinct halt categories and improves error reporting accuracy.
- All revm-interpreter tests pass locally.