### PR TITLE
fix: ensure token is loaded

### DIFF
--- a/examples/erc20_gas/src/handler.rs
+++ b/examples/erc20_gas/src/handler.rs
@@ -83,6 +83,7 @@ where
             .expect("effective balance is always smaller than max balance so it can't overflow");
 
         let account_balance_slot = erc_address_storage(tx.caller());
+        context.journal_mut().load_account(TOKEN)?;
         let account_balance = context
             .journal_mut()
             .sload(TOKEN, account_balance_slot)


### PR DESCRIPTION
this did panic because the token acc wasnt loaded

however this still prints

>Balance slot: 104280266076026851163620420727283721313063029652538475668650354374510891684603
Balance before: 200000000000000000
Balance after: 200000000000000000


I couldnt figure out why the caller gets reimbursed for the entire gas limit even tho this tx consumes 21k gas