### PR TITLE
fix: EIP-7702 target check to return correct error

### DIFF
--- a/crates/context/src/tx.rs
+++ b/crates/context/src/tx.rs
@@ -541,7 +541,7 @@ impl TxEnvBuilder {
 
                     // target is required
                     if !self.kind.is_call() {
-                        return Err(DeriveTxTypeError::MissingTargetForEip4844.into());
+                        return Err(DeriveTxTypeError::MissingTargetForEip7702.into());
                     }
                 }
                 TransactionType::Custom => {


### PR DESCRIPTION
In crates/context/src/tx.rs, corrected the EIP-7702 branch in TxEnvBuilder::build to return MissingTargetForEip7702 instead of MissingTargetForEip4844 when the transaction kind is not Call. This aligns the error with the intended EIP and improves diagnosability without changing runtime logic or tests.