### PR TITLE
feat: add generic state to ResultAndState

### DIFF
--- a/crates/context/interface/src/result.rs
+++ b/crates/context/interface/src/result.rs
@@ -30,7 +30,7 @@ pub struct ExecResultAndState<R, S = EvmState> {
 }
 
 /// Type alias for backwards compatibility.
-pub type ResultAndState<H = HaltReason> = ExecResultAndState<ExecutionResult<H>>;
+pub type ResultAndState<H = HaltReason, S = EvmState> = ExecResultAndState<ExecutionResult<H>, S>;
 
 /// Tuple containing multiple execution results and state.
 pub type ResultVecAndState<R, S> = ExecResultAndState<Vec<R>, S>;


### PR DESCRIPTION
This small PR lets a third party inject a custom state to the `ResultAndState` type. The `ExecResultAndState` already supports for a generic state so it's really a small PR.

The `alloy_evm::Evm` trait relies on this `ResultAndState` type for the `transact_raw` method, so it's impossible to use a different state than the `EvmState` without this modification.