### PR TITLE
chore: remove tx type check

### DIFF
--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -3,7 +3,7 @@ use crate::{block::BlockEnv, cfg::CfgEnv, journal::Journal, tx::TxEnv, LocalCont
 use context_interface::{
     context::{ContextError, ContextSetters, SStoreResult, SelfDestructResult, StateLoad},
     journaled_state::AccountLoad,
-    Block, Cfg, ContextTr, Host, JournalTr, LocalContextTr, Transaction, TransactionType,
+    Block, Cfg, ContextTr, Host, JournalTr, LocalContextTr, Transaction,
 };
 use database_interface::{Database, DatabaseRef, EmptyDB, WrapDatabaseRef};
 use derive_where::derive_where;


### PR DESCRIPTION
I believe this is reasonable because a non 4844 tx shouldnt have blobhashes, so there's no need to check txtype, which is inconvenient for forge testing for example

ref https://github.com/foundry-rs/foundry/pull/11355

