### PR TITLE
feat: propagate precompile error

### DIFF
--- a/crates/handler/src/precompile_provider.rs
+++ b/crates/handler/src/precompile_provider.rs
@@ -133,6 +133,7 @@ impl<CTX: ContextTr> PrecompileProvider<CTX> for EthPrecompiles {
                 result.output = output.bytes;
             }
             Err(PrecompileError::Fatal(e)) => return Err(e),
+            Err(PrecompileError::Other(e)) => return Err(e),
             Err(e) => {
                 result.result = if e.is_oog() {
                     InstructionResult::PrecompileOOG


### PR DESCRIPTION
This PR updates `PrecompileProvider::run()` to propagate precompile error messages when `PrecompileError::Other` is returned. 