### PR TITLE
Feature: Support bubbling up Precompile error messages 

### DIFF
--- a/crates/context/interface/src/local.rs
+++ b/crates/context/interface/src/local.rs
@@ -3,7 +3,7 @@ use core::{
     cell::{Ref, RefCell},
     ops::Range,
 };
-use std::{rc::Rc, vec::Vec};
+use std::{rc::Rc, string::String, vec::Vec};
 
 /// Non-empty, item-pooling Vec.
 #[derive(Debug, Clone)]
@@ -202,6 +202,19 @@ pub trait LocalContextTr {
 
     /// Clear the local context.
     fn clear(&mut self);
+
+    /// Set the error message for a precompile error, if any.
+    ///
+    /// This is used to bubble up precompile error messages when the
+    /// transaction directly targets a precompile (depth == 1).
+    fn set_precompile_error_context(&mut self, _output: String) {}
+
+    /// Take and clear the precompile error context, if present.
+    ///
+    /// Returns `Some(String)` if a precompile error message was recorded.
+    fn take_precompile_error_context(&mut self) -> Option<String> {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/crates/context/interface/src/local.rs
+++ b/crates/context/interface/src/local.rs
@@ -207,14 +207,12 @@ pub trait LocalContextTr {
     ///
     /// This is used to bubble up precompile error messages when the
     /// transaction directly targets a precompile (depth == 1).
-    fn set_precompile_error_context(&mut self, _output: String) {}
+    fn set_precompile_error_context(&mut self, _output: String);
 
     /// Take and clear the precompile error context, if present.
     ///
     /// Returns `Some(String)` if a precompile error message was recorded.
-    fn take_precompile_error_context(&mut self) -> Option<String> {
-        None
-    }
+    fn take_precompile_error_context(&mut self) -> Option<String>;
 }
 
 #[cfg(test)]

--- a/crates/context/interface/src/result.rs
+++ b/crates/context/interface/src/result.rs
@@ -568,7 +568,7 @@ pub enum SuccessReason {
 /// Indicates that the EVM has experienced an exceptional halt.
 ///
 /// This causes execution to immediately end with all gas being consumed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum HaltReason {
     /// Out of gas error.
@@ -591,6 +591,8 @@ pub enum HaltReason {
     CreateCollision,
     /// Precompile error.
     PrecompileError,
+    /// Precompile error with message from context.
+    PrecompileErrorWithContext(String),
     /// Nonce overflow.
     NonceOverflow,
     /// Create init code size exceeds limit (runtime).

--- a/crates/context/src/local.rs
+++ b/crates/context/src/local.rs
@@ -1,19 +1,22 @@
 //! Local context that is filled by execution.
 use context_interface::LocalContextTr;
 use core::cell::RefCell;
-use std::{rc::Rc, vec::Vec};
+use std::{rc::Rc, string::String, vec::Vec};
 
 /// Local context that is filled by execution.
 #[derive(Clone, Debug)]
 pub struct LocalContext {
     /// Interpreter shared memory buffer. A reused memory buffer for calls.
     pub shared_memory_buffer: Rc<RefCell<Vec<u8>>>,
+    /// Optional precompile error message to bubble up.
+    precompile_error_message: Option<String>,
 }
 
 impl Default for LocalContext {
     fn default() -> Self {
         Self {
             shared_memory_buffer: Rc::new(RefCell::new(Vec::with_capacity(1024 * 4))),
+            precompile_error_message: None,
         }
     }
 }
@@ -22,10 +25,19 @@ impl LocalContextTr for LocalContext {
     fn clear(&mut self) {
         // Sets len to 0 but it will not shrink to drop the capacity.
         unsafe { self.shared_memory_buffer.borrow_mut().set_len(0) };
+        self.precompile_error_message = None;
     }
 
     fn shared_memory_buffer(&self) -> &Rc<RefCell<Vec<u8>>> {
         &self.shared_memory_buffer
+    }
+
+    fn set_precompile_error_context(&mut self, output: String) {
+        self.precompile_error_message = Some(output);
+    }
+
+    fn take_precompile_error_context(&mut self) -> Option<String> {
+        self.precompile_error_message.take()
     }
 }
 

--- a/crates/ee-tests/src/op_revm_tests.rs
+++ b/crates/ee-tests/src/op_revm_tests.rs
@@ -230,9 +230,9 @@ fn test_halted_tx_call_bn254_pair_granite() {
     assert!(matches!(
         output.result,
         ExecutionResult::Halt {
-            reason: OpHaltReason::Base(HaltReason::PrecompileError),
+            reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
             ..
-        }
+        } if msg == "bn254 invalid pair length"
     ));
 
     compare_or_save_op_testdata("test_halted_tx_call_bn254_pair_granite.json", &output);
@@ -300,9 +300,9 @@ fn test_halted_tx_call_bls12_381_g1_add_input_wrong_size() {
     assert!(matches!(
         output.result,
         ExecutionResult::Halt {
-            reason: OpHaltReason::Base(HaltReason::PrecompileError),
+            reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
             ..
-        }
+        } if msg == "bls12-381 g1 add input length error"
     ));
 
     compare_or_save_op_testdata(
@@ -379,9 +379,9 @@ fn test_halted_tx_call_bls12_381_g1_msm_input_wrong_size() {
     assert!(matches!(
         output.result,
         ExecutionResult::Halt {
-            reason: OpHaltReason::Base(HaltReason::PrecompileError),
+            reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
             ..
-        }
+        } if msg == "bls12-381 g1 msm input length error"
     ));
 
     compare_or_save_op_testdata(
@@ -448,9 +448,9 @@ fn test_halted_tx_call_bls12_381_g1_msm_wrong_input_layout() {
     assert!(matches!(
         output.result,
         ExecutionResult::Halt {
-            reason: OpHaltReason::Base(HaltReason::PrecompileError),
+            reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
             ..
-        }
+        } if msg == "bls12-381 fp 64 top bytes of input are not zero"
     ));
 
     compare_or_save_op_testdata(
@@ -522,9 +522,9 @@ fn test_halted_tx_call_bls12_381_g2_add_input_wrong_size() {
     assert!(matches!(
         output.result,
         ExecutionResult::Halt {
-            reason: OpHaltReason::Base(HaltReason::PrecompileError),
+            reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
             ..
-        }
+        } if msg == "bls12-381 g2 add input length error"
     ));
 
     compare_or_save_op_testdata(
@@ -601,9 +601,9 @@ fn test_halted_tx_call_bls12_381_g2_msm_input_wrong_size() {
     assert!(matches!(
         output.result,
         ExecutionResult::Halt {
-            reason: OpHaltReason::Base(HaltReason::PrecompileError),
+            reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
             ..
-        }
+        } if msg == "bls12-381 g2 msm input length error"
     ));
 
     compare_or_save_op_testdata(
@@ -670,9 +670,9 @@ fn test_halted_tx_call_bls12_381_g2_msm_wrong_input_layout() {
     assert!(matches!(
         output.result,
         ExecutionResult::Halt {
-            reason: OpHaltReason::Base(HaltReason::PrecompileError),
+            reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
             ..
-        }
+        } if msg == "bls12-381 fp 64 top bytes of input are not zero"
     ));
 
     compare_or_save_op_testdata(
@@ -744,9 +744,9 @@ fn test_halted_tx_call_bls12_381_pairing_input_wrong_size() {
     assert!(matches!(
         output.result,
         ExecutionResult::Halt {
-            reason: OpHaltReason::Base(HaltReason::PrecompileError),
+            reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
             ..
-        }
+        } if msg == "bls12-381 pairing input length error"
     ));
 
     compare_or_save_op_testdata(
@@ -810,9 +810,9 @@ fn test_tx_call_bls12_381_pairing_wrong_input_layout() {
     assert!(matches!(
         output.result,
         ExecutionResult::Halt {
-            reason: OpHaltReason::Base(HaltReason::PrecompileError),
+            reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
             ..
-        }
+        } if msg == "bls12-381 fp 64 top bytes of input are not zero"
     ));
 
     compare_or_save_op_testdata(
@@ -894,9 +894,9 @@ fn test_halted_tx_call_bls12_381_map_fp_to_g1_input_wrong_size() {
     assert!(matches!(
         output.result,
         ExecutionResult::Halt {
-            reason: OpHaltReason::Base(HaltReason::PrecompileError),
+            reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
             ..
-        }
+        } if msg == "bls12-381 map fp to g1 input length error"
     ));
 
     compare_or_save_op_testdata(
@@ -978,9 +978,9 @@ fn test_halted_tx_call_bls12_381_map_fp2_to_g2_input_wrong_size() {
     assert!(matches!(
         output.result,
         ExecutionResult::Halt {
-            reason: OpHaltReason::Base(HaltReason::PrecompileError),
+            reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
             ..
-        }
+        } if msg == "bls12-381 map fp2 to g2 input length error"
     ));
 
     compare_or_save_op_testdata(

--- a/crates/ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g1_add_input_wrong_size.json
+++ b/crates/ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g1_add_input_wrong_size.json
@@ -3,7 +3,9 @@
     "Halt": {
       "gas_used": 21375,
       "reason": {
-        "Base": "PrecompileError"
+        "Base": {
+          "PrecompileErrorWithContext": "bls12-381 g1 add input length error"
+        }
       }
     }
   },

--- a/crates/ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g1_msm_input_wrong_size.json
+++ b/crates/ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g1_msm_input_wrong_size.json
@@ -3,7 +3,9 @@
     "Halt": {
       "gas_used": 35560,
       "reason": {
-        "Base": "PrecompileError"
+        "Base": {
+          "PrecompileErrorWithContext": "bls12-381 g1 msm input length error"
+        }
       }
     }
   },

--- a/crates/ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g1_msm_wrong_input_layout.json
+++ b/crates/ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g1_msm_wrong_input_layout.json
@@ -3,7 +3,9 @@
     "Halt": {
       "gas_used": 35560,
       "reason": {
-        "Base": "PrecompileError"
+        "Base": {
+          "PrecompileErrorWithContext": "bls12-381 fp 64 top bytes of input are not zero"
+        }
       }
     }
   },

--- a/crates/ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g2_add_input_wrong_size.json
+++ b/crates/ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g2_add_input_wrong_size.json
@@ -3,7 +3,9 @@
     "Halt": {
       "gas_used": 21600,
       "reason": {
-        "Base": "PrecompileError"
+        "Base": {
+          "PrecompileErrorWithContext": "bls12-381 g2 add input length error"
+        }
       }
     }
   },

--- a/crates/ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g2_msm_input_wrong_size.json
+++ b/crates/ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g2_msm_input_wrong_size.json
@@ -3,7 +3,9 @@
     "Halt": {
       "gas_used": 48108,
       "reason": {
-        "Base": "PrecompileError"
+        "Base": {
+          "PrecompileErrorWithContext": "bls12-381 g2 msm input length error"
+        }
       }
     }
   },

--- a/crates/ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g2_msm_wrong_input_layout.json
+++ b/crates/ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g2_msm_wrong_input_layout.json
@@ -3,7 +3,9 @@
     "Halt": {
       "gas_used": 48108,
       "reason": {
-        "Base": "PrecompileError"
+        "Base": {
+          "PrecompileErrorWithContext": "bls12-381 fp 64 top bytes of input are not zero"
+        }
       }
     }
   },

--- a/crates/ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_map_fp2_to_g2_input_wrong_size.json
+++ b/crates/ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_map_fp2_to_g2_input_wrong_size.json
@@ -3,7 +3,9 @@
     "Halt": {
       "gas_used": 46848,
       "reason": {
-        "Base": "PrecompileError"
+        "Base": {
+          "PrecompileErrorWithContext": "bls12-381 map fp2 to g2 input length error"
+        }
       }
     }
   },

--- a/crates/ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_map_fp_to_g1_input_wrong_size.json
+++ b/crates/ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_map_fp_to_g1_input_wrong_size.json
@@ -3,7 +3,9 @@
     "Halt": {
       "gas_used": 27524,
       "reason": {
-        "Base": "PrecompileError"
+        "Base": {
+          "PrecompileErrorWithContext": "bls12-381 map fp to g1 input length error"
+        }
       }
     }
   },

--- a/crates/ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_pairing_input_wrong_size.json
+++ b/crates/ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_pairing_input_wrong_size.json
@@ -3,7 +3,9 @@
     "Halt": {
       "gas_used": 97444,
       "reason": {
-        "Base": "PrecompileError"
+        "Base": {
+          "PrecompileErrorWithContext": "bls12-381 pairing input length error"
+        }
       }
     }
   },

--- a/crates/ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_pairing_wrong_input_layout.json
+++ b/crates/ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_pairing_wrong_input_layout.json
@@ -3,7 +3,9 @@
     "Halt": {
       "gas_used": 97444,
       "reason": {
-        "Base": "PrecompileError"
+        "Base": {
+          "PrecompileErrorWithContext": "bls12-381 fp 64 top bytes of input are not zero"
+        }
       }
     }
   },

--- a/crates/ee-tests/tests/op_revm_testdata/test_halted_tx_call_bn254_pair_granite.json
+++ b/crates/ee-tests/tests/op_revm_testdata/test_halted_tx_call_bn254_pair_granite.json
@@ -3,7 +3,9 @@
     "Halt": {
       "gas_used": 1824024,
       "reason": {
-        "Base": "PrecompileError"
+        "Base": {
+          "PrecompileErrorWithContext": "bn254 invalid pair length"
+        }
       }
     }
   },

--- a/crates/inspector/src/eip3155.rs
+++ b/crates/inspector/src/eip3155.rs
@@ -283,7 +283,7 @@ where
     fn call_end(&mut self, context: &mut CTX, _: &CallInputs, outcome: &mut CallOutcome) {
         self.gas_inspector.call_end(outcome);
 
-        if context.journal_mut().depth() == 1 {
+        if context.journal_mut().depth() == 0 {
             self.print_summary(&outcome.result, context);
             let _ = self.output.flush();
             // Clear the state if we are at the top level.
@@ -294,7 +294,7 @@ where
     fn create_end(&mut self, context: &mut CTX, _: &CreateInputs, outcome: &mut CreateOutcome) {
         self.gas_inspector.create_end(outcome);
 
-        if context.journal_mut().depth() == 1 {
+        if context.journal_mut().depth() == 0 {
             self.print_summary(&outcome.result, context);
             let _ = self.output.flush();
             // Clear the state if we are at the top level.

--- a/crates/inspector/src/eip3155.rs
+++ b/crates/inspector/src/eip3155.rs
@@ -283,7 +283,7 @@ where
     fn call_end(&mut self, context: &mut CTX, _: &CallInputs, outcome: &mut CallOutcome) {
         self.gas_inspector.call_end(outcome);
 
-        if context.journal_mut().depth() == 0 {
+        if context.journal_mut().depth() == 1 {
             self.print_summary(&outcome.result, context);
             let _ = self.output.flush();
             // Clear the state if we are at the top level.
@@ -294,7 +294,7 @@ where
     fn create_end(&mut self, context: &mut CTX, _: &CreateInputs, outcome: &mut CreateOutcome) {
         self.gas_inspector.create_end(outcome);
 
-        if context.journal_mut().depth() == 0 {
+        if context.journal_mut().depth() == 1 {
             self.print_summary(&outcome.result, context);
             let _ = self.output.flush();
             // Clear the state if we are at the top level.

--- a/crates/interpreter/src/instruction_result.rs
+++ b/crates/interpreter/src/instruction_result.rs
@@ -123,6 +123,7 @@ impl From<HaltReason> for InstructionResult {
             HaltReason::OutOfOffset => Self::OutOfOffset,
             HaltReason::CreateCollision => Self::CreateCollision,
             HaltReason::PrecompileError => Self::PrecompileError,
+            HaltReason::PrecompileErrorWithContext(_) => Self::PrecompileError,
             HaltReason::NonceOverflow => Self::NonceOverflow,
             HaltReason::CreateContractSizeLimit => Self::CreateContractSizeLimit,
             HaltReason::CreateContractStartingWithEF => Self::CreateContractStartingWithEF,


### PR DESCRIPTION
## Motivation
This PR enhances precompile error reporting and closes #2898.

## Solution
Attempt to implement a mechanism that records potential precompile error in context if depth == 0, in order to bubble it up in output as Bytes. Idea proposed by Rakita https://github.com/bluealloy/revm/pull/2905#pullrequestreview-3155479883.

## TODO
- [x] make tests
- [x] doc