### PR TITLE
chore: skip drain if checkpoing is incosistent

### DIFF
--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -466,12 +466,14 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         self.logs.truncate(checkpoint.log_i);
 
         // iterate over last N journals sets and revert our global state
-        self.journal
-            .drain(checkpoint.journal_i..)
-            .rev()
-            .for_each(|entry| {
-                entry.revert(state, Some(transient_storage), is_spurious_dragon_enabled);
-            });
+        if checkpoint.journal_i < self.journal.len() {
+            self.journal
+                .drain(checkpoint.journal_i..)
+                .rev()
+                .for_each(|entry| {
+                    entry.revert(state, Some(transient_storage), is_spurious_dragon_enabled);
+                });
+        }
     }
 
     /// Performs selfdestruct action.


### PR DESCRIPTION
Fix for foundry `vm.createFork` that would make journal entries in an inconsistent state by dropping the journal entries.