### PR TITLE
docs(Cargo.toml): fix typos in comment

### DIFF
--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -98,10 +98,10 @@ optional_no_base_fee = ["context/optional_no_base_fee"]
 secp256k1 = ["precompile/secp256k1"] # See comments in `precompile`
 c-kzg = [
 	"precompile/c-kzg",
-] # `kzg-rs` is not audited but useful for `no_std` environment, use it with causing and default to `c-kzg` if possible.
+] # `kzg-rs` is not audited but useful for `no_std` environment, use it with caution and default to `c-kzg` if possible.
 kzg-rs = ["precompile/kzg-rs"]
 
-# blst will enabled both for bls precompiles and for kzg precompile.
+# blst will be enabled both for bls precompiles and for kzg precompile.
 blst = ["precompile/blst"]
 bn = ["precompile/bn"]
 asm-sha2 = ["precompile/asm-sha2"]
@@ -111,5 +111,5 @@ asm-sha2 = ["precompile/asm-sha2"]
 portable = ["precompile/portable"]
 
 # use gmp for modexp precompile.
-# It is faster library but licences as GPL code, if enabled please make sure to follow the license.
+# It is faster library but licenced as GPL code, if enabled please make sure to follow the license.
 gmp = ["precompile/gmp"]


### PR DESCRIPTION
## Description:

Fix typos in crates/revm/Cargo.toml comments:
 - causing → caution
 - will enabled → will be enabled
 - licences → licenced

No functional changes.