### PR TITLE
chore(database): avoid panic by conditionally using block_in_place

### DIFF
--- a/crates/database/interface/src/async_db.rs
+++ b/crates/database/interface/src/async_db.rs
@@ -190,7 +190,23 @@ impl HandleOrRuntime {
         F::Output: Send,
     {
         match self {
-            Self::Handle(handle) => tokio::task::block_in_place(move || handle.block_on(f)),
+            Self::Handle(handle) => {
+                // Use block_in_place only when we're currently inside a multi-threaded Tokio runtime.
+                // Otherwise, call handle.block_on directly to avoid panicking outside of a runtime.
+                let can_block_in_place = match Handle::try_current() {
+                    Ok(current) => match current.runtime_flavor() {
+                        tokio::runtime::RuntimeFlavor::CurrentThread => false,
+                        _ => true,
+                    },
+                    Err(_) => false,
+                };
+
+                if can_block_in_place {
+                    tokio::task::block_in_place(move || handle.block_on(f))
+                } else {
+                    handle.block_on(f)
+                }
+            }
             Self::Runtime(rt) => rt.block_on(f),
         }
     }


### PR DESCRIPTION
Use block_in_place only when currently inside a multi-thread Tokio runtime; fallback to handle.block_on outside a runtime or on current-thread runtime. Aligns behavior with WrapDatabaseAsync::with_handle docs and prevents panics when used from sync contexts.