### PR TITLE
chore: rename SELFDESTRUCT to SELFDESTRUCT_REFUND

### DIFF
--- a/crates/interpreter/src/gas/constants.rs
+++ b/crates/interpreter/src/gas/constants.rs
@@ -24,7 +24,7 @@ pub const HIGH: u64 = 10;
 /// Gas cost for JUMPDEST instruction.
 pub const JUMPDEST: u64 = 1;
 /// Gas cost for REFUND SELFDESTRUCT instruction.
-pub const REFUND_SELFDESTRUCT: i64 = 24000;
+pub const SELFDESTRUCT_REFUND: i64 = 24000;
 /// Gas cost for CREATE instruction.
 pub const CREATE: u64 = 32000;
 /// Additional gas cost when a call transfers value.

--- a/crates/interpreter/src/gas/constants.rs
+++ b/crates/interpreter/src/gas/constants.rs
@@ -23,8 +23,8 @@ pub const MID: u64 = 8;
 pub const HIGH: u64 = 10;
 /// Gas cost for JUMPDEST instruction.
 pub const JUMPDEST: u64 = 1;
-/// Gas cost for SELFDESTRUCT instruction.
-pub const SELFDESTRUCT: i64 = 24000;
+/// Gas cost for REFUND SELFDESTRUCT instruction.
+pub const REFUND_SELFDESTRUCT: i64 = 24000;
 /// Gas cost for CREATE instruction.
 pub const CREATE: u64 = 32000;
 /// Additional gas cost when a call transfers value.

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -419,7 +419,10 @@ pub fn selfdestruct<WIRE: InterpreterTypes, H: Host + ?Sized>(
         .is_enabled_in(LONDON)
         && !res.previously_destroyed
     {
-        context.interpreter.gas.record_refund(gas::SELFDESTRUCT)
+        context
+            .interpreter
+            .gas
+            .record_refund(gas::REFUND_SELFDESTRUCT);
     }
 
     context.interpreter.halt(InstructionResult::SelfDestruct);

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -422,7 +422,7 @@ pub fn selfdestruct<WIRE: InterpreterTypes, H: Host + ?Sized>(
         context
             .interpreter
             .gas
-            .record_refund(gas::REFUND_SELFDESTRUCT);
+            .record_refund(gas::SELFDESTRUCT_REFUND);
     }
 
     context.interpreter.halt(InstructionResult::SelfDestruct);


### PR DESCRIPTION
In `go-ethereum`, the name `SelfdestructRefundGas` is used (https://github.com/ethereum/go-ethereum/blob/f3c696fa1db75d0f78ea47dd0975f6f0de6fdd84/params/protocol_params.go#L90). 
A more suitable name might be REFUND_SELFDESTRUCT. Feel free to close this.