### PR TITLE
fix: interpreter_result_mut should return mutable reference

### DIFF
--- a/crates/handler/src/frame_data.rs
+++ b/crates/handler/src/frame_data.rs
@@ -91,7 +91,7 @@ impl FrameResult {
 
     /// Returns mutable reference to interpreter result.
     #[inline]
-    pub fn interpreter_result_mut(&mut self) -> &InterpreterResult {
+    pub fn interpreter_result_mut(&mut self) -> &mut InterpreterResult {
         match self {
             FrameResult::Call(outcome) => &mut outcome.result,
             FrameResult::Create(outcome) => &mut outcome.result,


### PR DESCRIPTION
I found the `interpreter_result_mut` function of `FrameResult` isdoes not return a mutable reference. Is that an expected implementation? This PR modifies the method to return a mutable reference. 
https://github.com/bluealloy/revm/blob/0ca6564f02004976f533cacf8821fed09d801e0a/crates/handler/src/frame_data.rs#L94