### PR TITLE
test(op-revm): add serialize DepositTransactionParts test

### DIFF
--- a/crates/op-revm/src/transaction/deposit.rs
+++ b/crates/op-revm/src/transaction/deposit.rs
@@ -33,17 +33,20 @@ mod tests {
     use revm::primitives::b256;
 
     #[test]
-    fn serialize_json_deposit_tx_parts() {
+    fn serialize_deserialize_json_deposit_tx_parts() {
+        let parts = DepositTransactionParts::new(
+            b256!("0xe927a1448525fb5d32cb50ee1408461a945ba6c39bd5cf5621407d500ecc8de9"),
+            Some(0x34),
+            false,
+        );
         let response = r#"{"source_hash":"0xe927a1448525fb5d32cb50ee1408461a945ba6c39bd5cf5621407d500ecc8de9","mint":52,"is_system_transaction":false}"#;
 
+        // serialize
+        let json = serde_json::to_string(&parts).unwrap();
+        assert_eq!(json.as_str(), response);
+
+        // deserialize
         let deposit_tx_parts: DepositTransactionParts = serde_json::from_str(response).unwrap();
-        assert_eq!(
-            deposit_tx_parts,
-            DepositTransactionParts::new(
-                b256!("0xe927a1448525fb5d32cb50ee1408461a945ba6c39bd5cf5621407d500ecc8de9"),
-                Some(0x34),
-                false,
-            )
-        );
+        assert_eq!(deposit_tx_parts, parts);
     }
 }


### PR DESCRIPTION
The test is named `serialize_json_deposit_tx_parts`, but it actually tests deserialization. Add a serialization test.