### PR TITLE
chore: remove unused generic from validate_tx_env and fix call site

### DIFF
--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -20,7 +20,7 @@ pub fn validate_env<CTX: ContextTr, ERROR: From<InvalidHeader> + From<InvalidTra
     if spec.is_enabled_in(SpecId::CANCUN) && context.block().blob_excess_gas_and_price().is_none() {
         return Err(InvalidHeader::ExcessBlobGasNotSet.into());
     }
-    validate_tx_env::<CTX, InvalidTransaction>(context, spec).map_err(Into::into)
+    validate_tx_env::<CTX>(context, spec).map_err(Into::into)
 }
 
 /// Validate transaction that has EIP-1559 priority fee
@@ -84,7 +84,7 @@ pub fn validate_eip4844_tx(
 }
 
 /// Validate transaction against block and configuration for mainnet.
-pub fn validate_tx_env<CTX: ContextTr, Error>(
+pub fn validate_tx_env<CTX: ContextTr>(
     context: CTX,
     spec_id: SpecId,
 ) -> Result<(), InvalidTransaction> {


### PR DESCRIPTION
The validate_tx_env function declared a second generic parameter (Error) that was never used and the function always returned Result<(), InvalidTransaction>. This created the false impression that the error type was configurable, while the implementation was fixed. The unused generic caused confusion and added no value. This commit removes the extraneous generic and updates the sole call in validate_env to use only ::<CTX>, aligning with the module’s error-handling design where inner validators return InvalidTransaction and the outer layer maps to the handler’s error type.