### PR TITLE
chore: update `EthFrame::invalid` visibility

### DIFF
--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -68,7 +68,7 @@ impl Default for EthFrame<EthInterpreter> {
 }
 
 impl EthFrame<EthInterpreter> {
-    fn invalid() -> Self {
+    pub fn invalid() -> Self {
         Self::do_default(Interpreter::invalid())
     }
 


### PR DESCRIPTION
This PR updates `EthFrame::invalid` visibility to `pub` to enable consumers of the lib to utilize this function.