### PR TITLE
Prevent panic in operator fee calculation when unset; default to zero

### DIFF
--- a/crates/op-revm/src/l1block.rs
+++ b/crates/op-revm/src/l1block.rs
@@ -163,12 +163,12 @@ impl L1BlockInfo {
 
     /// Calculate the operator fee for the given `gas`.
     fn operator_fee_charge_inner(&self, gas: U256) -> U256 {
-        let operator_fee_scalar = self
-            .operator_fee_scalar
-            .expect("Missing operator fee scalar for isthmus L1 Block");
-        let operator_fee_constant = self
-            .operator_fee_constant
-            .expect("Missing operator fee constant for isthmus L1 Block");
+        let Some(operator_fee_scalar) = self.operator_fee_scalar else {
+            return U256::ZERO;
+        };
+        let Some(operator_fee_constant) = self.operator_fee_constant else {
+            return U256::ZERO;
+        };
 
         let product =
             gas.saturating_mul(operator_fee_scalar) / (U256::from(OPERATOR_FEE_SCALAR_DECIMAL));


### PR DESCRIPTION

### Summary
Safely handle missing `operator_fee_scalar` and `operator_fee_constant` by returning zero instead of panicking.

### Rationale
Before Isthmus, operator fees should be zero. Using `expect(...)` could cause unexpected panics in valid configurations where those fields are unset.

### Changes
- `crates/op-revm/src/l1block.rs`: Replace `expect(...)` with safe `Option` handling in `operator_fee_charge_inner`, returning `U256::ZERO` if values are missing.

