### PR TITLE
chore: add `SECURITY.md` 

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+For any security questions or findings, please reach out to me directly via email at [dragan0rakita@gmail.com](mailto:dragan0rakita@gmail.com) or contact me on Keybase under the username @draganrakita.

--- a/README.md
+++ b/README.md
@@ -78,4 +78,4 @@ If `gmp` feature flag is used, GPL code gets compiled, if enabled please make su
 
 ### Security
 
-For any security questions or findings, please reach out to me directly via email at dragan0rakita@gmail.com or contact me on Keybase under the username @draganrakita.
+For any security questions or findings, please reach out to me directly via email at [dragan0rakita@gmail.com](mailto:dragan0rakita@gmail.com) or contact me on Keybase under the username @draganrakita.


### PR DESCRIPTION
This makes it easier to find for users as it shows up as a `Security` tab

<img width="110" height="52" alt="Screenshot from 2025-09-10 12-02-17" src="https://github.com/user-attachments/assets/eb664db1-0048-489f-8f90-400a358288dc" />

If you would prefer to include / change it to `security@ithaca.xyz` this is of course also a possibility