### PR TITLE
refactor(state): remove unnecessary core::hash::Hash import from lib.rs

### DIFF
--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -12,7 +12,6 @@ pub use primitives;
 pub use types::{EvmState, EvmStorage, TransientStorage};
 
 use bitflags::bitflags;
-use core::hash::Hash;
 use primitives::hardfork::SpecId;
 use primitives::{HashMap, StorageKey, StorageValue};
 


### PR DESCRIPTION
Removed unused use core::hash::Hash; from crates/state/src/lib.rs.
#[derive(Hash)] does not require an explicit import, so this cleans up an unnecessary dependency.