### PR TITLE
fix: CTX bound in InspectorEvmTr

### DIFF
--- a/examples/my_evm/src/evm.rs
+++ b/examples/my_evm/src/evm.rs
@@ -112,9 +112,10 @@ where
     }
 }
 
-impl<CTX: ContextTr, INSP> InspectorEvmTr for MyEvm<CTX, INSP>
+impl<CTX, INSP> InspectorEvmTr for MyEvm<CTX, INSP>
 where
-    CTX: ContextSetters<Journal: JournalExt>,
+    CTX: ContextSetters,
+    <CTX as ContextSetters>::Journal: JournalExt,
     INSP: Inspector<CTX, EthInterpreter>,
 {
     type Inspector = INSP;


### PR DESCRIPTION
adjusted `CTX` so the associated `Journal` type properly implements `JournalExt`.