### PR TITLE
chore(database): remove redundant ToString import from EmptyDB

### DIFF
--- a/crates/database/interface/src/empty_db.rs
+++ b/crates/database/interface/src/empty_db.rs
@@ -4,7 +4,6 @@ use core::error::Error;
 use core::{convert::Infallible, fmt, marker::PhantomData};
 use primitives::{keccak256, Address, StorageKey, StorageValue, B256};
 use state::{AccountInfo, Bytecode};
-use std::string::ToString;
 
 /// An empty database that always returns default values when queried
 pub type EmptyDB = EmptyDBTyped<Infallible>;


### PR DESCRIPTION
The ToString trait is available via the standard prelude under the crate’s default std feature, so importing std::string::ToString is unnecessary. Other modules already call .to_string() without explicit imports. Removing this import avoids redundancy and improves consistency, while also preventing an unconditional std path that could hinder potential no_std portability.