### PR TITLE
fix: support 0x prefix in evmrunner hex input

### DIFF
--- a/bins/revme/src/cmd/evmrunner.rs
+++ b/bins/revme/src/cmd/evmrunner.rs
@@ -75,7 +75,8 @@ impl Cmd {
             unreachable!()
         };
 
-        let bytecode = hex::decode(bytecode_str.trim().trim_start_matches("0x")).map_err(|_| Errors::InvalidBytecode)?;
+        let bytecode = hex::decode(bytecode_str.trim().trim_start_matches("0x"))
+            .map_err(|_| Errors::InvalidBytecode)?;
         let input = hex::decode(self.input.trim().trim_start_matches("0x"))
             .map_err(|_| Errors::InvalidInput)?
             .into();

--- a/bins/revme/src/cmd/evmrunner.rs
+++ b/bins/revme/src/cmd/evmrunner.rs
@@ -75,8 +75,8 @@ impl Cmd {
             unreachable!()
         };
 
-        let bytecode = hex::decode(bytecode_str.trim()).map_err(|_| Errors::InvalidBytecode)?;
-        let input = hex::decode(self.input.trim())
+        let bytecode = hex::decode(bytecode_str.trim().trim_start_matches("0x")).map_err(|_| Errors::InvalidBytecode)?;
+        let input = hex::decode(self.input.trim().trim_start_matches("0x"))
             .map_err(|_| Errors::InvalidInput)?
             .into();
 


### PR DESCRIPTION


```markdown
## Fix

Support `0x` prefix in hex input for `evmrunner` command to improve user experience.

## Changes

- Strip `0x` prefix from `bytecode` and `input` parameters before hex decoding
- Aligns behavior with `bytecode` subcommand which already handles `0x` prefix correctly

## Impact

- **Before:** `revme evmrunner 0x6080604052...` would fail with "Invalid bytecode"
- **After:** Both `6080604052...` and `0x6080604052...` formats work seamlessly

