### PR TITLE
Interpreter: make debug_unreachable safe by default; gate unreachable_unchecked behind feature

### DIFF
--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -51,3 +51,5 @@ serde = [
 arbitrary = ["std", "primitives/arbitrary"]
 # TODO : Should be set from Context or from crate that consumes this PR.
 memory_limit = []
+# Enable UB-unsafe unreachable in release only when explicitly requested.
+unchecked_unreachable = []

--- a/crates/interpreter/src/macros.rs
+++ b/crates/interpreter/src/macros.rs
@@ -4,10 +4,13 @@
 #[collapse_debuginfo(yes)]
 macro_rules! debug_unreachable {
     ($($t:tt)*) => {
-        if cfg!(debug_assertions) {
-            unreachable!($($t)*);
-        } else {
+        #[cfg(all(not(debug_assertions), feature = "unchecked_unreachable"))]
+        {
             unsafe { core::hint::unreachable_unchecked() };
+        }
+        #[cfg(any(debug_assertions, not(feature = "unchecked_unreachable")))]
+        {
+            unreachable!($($t)*);
         }
     };
 }


### PR DESCRIPTION

- Replaces UB-prone unreachable_unchecked in release builds with safe unreachable!() by default.
- Introduces optional feature flag unchecked_unreachable to re-enable unreachable_unchecked for peak performance.

- Avoids undefined behavior in production if assumptions are violated, which is critical for an interpreter executing untrusted bytecode.
