### PR TITLE
op-revm: treat empty input as zero operator fee in operator_fee_charge

### DIFF
--- a/crates/op-revm/src/l1block.rs
+++ b/crates/op-revm/src/l1block.rs
@@ -154,7 +154,7 @@ impl L1BlockInfo {
     /// Introduced in isthmus. Prior to isthmus, the operator fee is always zero.
     pub fn operator_fee_charge(&self, input: &[u8], gas_limit: U256) -> U256 {
         // If the input is a deposit transaction or empty, the default value is zero.
-        if input.first() == Some(&0x7E) {
+        if input.is_empty() || input.first() == Some(&0x7E) {
             return U256::ZERO;
         }
 


### PR DESCRIPTION


### Description
- **Summary**: Align `operator_fee_charge` with its doc comment by returning zero for empty inputs.
- **Rationale**: The function’s comment states that deposit or empty inputs should yield zero fee; previously, only the deposit prefix (0x7E) was handled.
- **Change**: Added `input.is_empty()` to the early-return condition in `l1block.rs`.
- **Impact**: Prevents overcharging operator fees for empty inputs; behavior now matches documentation.

