### PR TITLE
fix(handler): write CALL output to memory only on success

### DIFF
--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -486,9 +486,12 @@ impl EthFrame<EthInterpreter> {
                 // Safe to push without stack limit check
                 let _ = interpreter.stack.push(item);
 
-                // Return unspend gas.
+                // Return unspend gas (both success and revert),
+                // but write to memory only on success per EVM semantics.
                 if ins_result.is_ok_or_revert() {
                     interpreter.gas.erase_cost(out_gas.remaining());
+                }
+                if ins_result.is_ok() {
                     interpreter
                         .memory
                         .set(mem_start, &interpreter.return_data.buffer()[..target_len]);


### PR DESCRIPTION
Prevent copying CALL return data into the caller’s output buffer on REVERT. EVM semantics require that the output buffer is written only on successful calls; on failure (including REVERT) the buffer must remain unchanged and return data should be accessed via RETURNDATACOPY. We still erase remaining gas for both success and revert and keep refunds only on success. This aligns with EIP-140/EIP-211 and avoids incorrect memory mutations on reverted subcalls.