### PR TITLE
Add an option to disable "fee-charge" on `op-revm`

### DIFF
--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -67,6 +67,7 @@ dev = [
 	"optional_eip3607",
 	"optional_no_base_fee",
 	"optional_priority_fee_check",
+	"optional_fee_charge",
 ]
 memory_limit = []
 optional_balance_check = []
@@ -75,3 +76,4 @@ optional_eip3541 = []
 optional_eip3607 = []
 optional_no_base_fee = []
 optional_priority_fee_check = []
+optional_fee_charge = []

--- a/crates/context/interface/src/cfg.rs
+++ b/crates/context/interface/src/cfg.rs
@@ -58,6 +58,9 @@ pub trait Cfg {
 
     /// Returns whether the priority fee check is disabled.
     fn is_priority_fee_check_disabled(&self) -> bool;
+
+    /// Returns whether the fee charge is disabled.
+    fn is_fee_charge_disabled(&self) -> bool;
 }
 
 /// What bytecode analysis to perform

--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -104,6 +104,12 @@ pub struct CfgEnv<SPEC = SpecId> {
     /// By default, it is set to `false`.
     #[cfg(feature = "optional_priority_fee_check")]
     pub disable_priority_fee_check: bool,
+    /// Disables fee charging for transactions.
+    /// This is useful when executing `eth_call` for example, on OP-chains where setting the base fee
+    /// to 0 isn't sufficient.
+    /// By default, it is set to `false`.
+    #[cfg(feature = "optional_fee_charge")]
+    pub disable_fee_charge: bool,
 }
 
 impl CfgEnv {
@@ -159,6 +165,8 @@ impl<SPEC> CfgEnv<SPEC> {
             disable_base_fee: false,
             #[cfg(feature = "optional_priority_fee_check")]
             disable_priority_fee_check: false,
+            #[cfg(feature = "optional_fee_charge")]
+            disable_fee_charge: false,
         }
     }
 
@@ -206,6 +214,8 @@ impl<SPEC> CfgEnv<SPEC> {
             disable_base_fee: self.disable_base_fee,
             #[cfg(feature = "optional_priority_fee_check")]
             disable_priority_fee_check: self.disable_priority_fee_check,
+            #[cfg(feature = "optional_fee_charge")]
+            disable_fee_charge: self.disable_fee_charge,
         }
     }
 
@@ -229,6 +239,13 @@ impl<SPEC> CfgEnv<SPEC> {
     #[cfg(feature = "optional_priority_fee_check")]
     pub fn with_disable_priority_fee_check(mut self, disable: bool) -> Self {
         self.disable_priority_fee_check = disable;
+        self
+    }
+
+    /// Sets the disable fee charge flag.
+    #[cfg(feature = "optional_fee_charge")]
+    pub fn with_disable_fee_charge(mut self, disable: bool) -> Self {
+        self.disable_fee_charge = disable;
         self
     }
 }
@@ -339,6 +356,16 @@ impl<SPEC: Into<SpecId> + Copy> Cfg for CfgEnv<SPEC> {
         cfg_if::cfg_if! {
             if #[cfg(feature = "optional_priority_fee_check")] {
                 self.disable_priority_fee_check
+            } else {
+                false
+            }
+        }
+    }
+
+    fn is_fee_charge_disabled(&self) -> bool {
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "optional_fee_charge")] {
+                self.disable_fee_charge
             } else {
                 false
             }

--- a/crates/op-revm/src/handler.rs
+++ b/crates/op-revm/src/handler.rs
@@ -115,7 +115,7 @@ where
         let mut additional_cost = U256::ZERO;
 
         // The L1-cost fee is only computed for Optimism non-deposit transactions.
-        if !is_deposit {
+        if !is_deposit && !ctx.cfg().is_fee_charge_disabled() {
             // L1 block info is stored in the context for later use.
             // and it will be reloaded from the database if it is not for the current block.
             if ctx.chain().l2_block != block_number {


### PR DESCRIPTION
An option to disable fee charges, only meaningful on `op-revm` is added, which doesn't charge additional fees, in addition from the default fee from the gas limit and gas price.

This is useful for `eth_call`s which should disable all fees.

See https://github.com/paradigmxyz/reth/issues/18470