### PR TITLE
chore(op-revm): remove unused std::vec import in abstraction.rs

### DIFF
--- a/crates/op-revm/src/transaction/abstraction.rs
+++ b/crates/op-revm/src/transaction/abstraction.rs
@@ -10,7 +10,6 @@ use revm::{
     handler::SystemCallTx,
     primitives::{Address, Bytes, TxKind, B256, U256},
 };
-use std::vec;
 
 /// Optimism Transaction trait.
 #[auto_impl(&, &mut, Box, Arc)]


### PR DESCRIPTION
Remove redundant use std::vec; from crates/op-revm/src/transaction/abstraction.rs.
The vec! macro is available without importing std::vec; the module itself wasn’t referenced.