### PR TITLE
docs: Clarify that legacy bytecode padding is variable, not fixed

### DIFF
--- a/crates/bytecode/src/legacy/analyzed.rs
+++ b/crates/bytecode/src/legacy/analyzed.rs
@@ -85,7 +85,7 @@ impl LegacyAnalyzedBytecode {
 
     /// Returns a reference to the bytecode.
     ///
-    /// The bytecode is padded with 32 zero bytes.
+    /// The bytecode is padded with up to 33 zero bytes.
     pub fn bytecode(&self) -> &Bytes {
         &self.bytecode
     }


### PR DESCRIPTION
The comment for the `bytecode()` method was misleading, claiming the padding was always 32 bytes. The actual padding is variable (up to 33 bytes).

This change corrects the comment to be more accurate.