### PR TITLE
refactor: revamp tx build

### DIFF
--- a/crates/handler/src/mainnet_builder.rs
+++ b/crates/handler/src/mainnet_builder.rs
@@ -112,6 +112,7 @@ mod test {
                     .gas_limit(100_000)
                     .authorization_list(vec![Either::Left(auth)])
                     .caller(EEADDRESS)
+                    .gas_priority_fee(Some(0))
                     .kind(TxKind::Call(signer.address()))
                     .build()
                     .unwrap(),


### PR DESCRIPTION
I'm currently running some state transitions tests on my implementation of REVM's interface to run transactions.

One test is expecting a transaction to be rejected if the authorization list is empty in an EIP-7702 transaction. While reading the code of `tx.rs`, in particular `build`. I was thinking that reorganising the transaction building and the condition could make sense as it allows to catch error earlier at building phase instead of validation **IF** the tx type is missing.
In my implementation, I don’t have direct access to the transaction type, so if I first derive it from the fields and then apply the checks, it will allow me to reject invalid transactions earlier.
This is just a proposition I wanted to have your thoughts on that.

It also allowed me to spot a missing field in a sanity test for EIP-7702 transactions in an early stage at tx building, see 0ffad112cab0233584c3f684577e25ae87636db8.

A bit more context: the state transition tests I'm running are from [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests) which don't explicit the tx type in the generated fixtures. So I'd need to derive the tx type prior to the tx build to benefit from that early exit.