### PR TITLE
Set l2_block in try_fetch for pre-Isthmus forks; add reload tests

### DIFF
--- a/crates/op-revm/src/l1block.rs
+++ b/crates/op-revm/src/l1block.rs
@@ -74,6 +74,7 @@ impl L1BlockInfo {
             let l1_fee_scalar = db.storage(L1_BLOCK_CONTRACT, L1_SCALAR_SLOT)?;
 
             Ok(L1BlockInfo {
+                l2_block,
                 l1_base_fee,
                 l1_fee_overhead: Some(l1_fee_overhead),
                 l1_base_fee_scalar: l1_fee_scalar,
@@ -137,6 +138,7 @@ impl L1BlockInfo {
             } else {
                 // Pre-isthmus L1 block info
                 Ok(L1BlockInfo {
+                    l2_block,
                     l1_base_fee,
                     l1_base_fee_scalar,
                     l1_blob_base_fee: Some(l1_blob_base_fee),


### PR DESCRIPTION
Set l2_block in L1BlockInfo::try_fetch for Bedrock/Regolith and Ecotone (pre-Isthmus) branches to align caching/reload semantics with Isthmus.
Reason: OpHandler checks ctx.chain().l2_block != block_number to decide whether to reload. When l2_block was left at U256::ZERO pre-Isthmus, the handler reloaded on every non-deposit tx within the same block, defeating the intended cache and causing redundant DB fetches.
This change ensures consistent behavior across forks, reduces unnecessary DB reads, and matches the documented intent (“reloaded if not current block”).
Add tests mirroring the Isthmus case to verify reload behavior for Regolith and Ecotone pre-Isthmus: 
- test_reload_l1_block_info_regolith
- test_reload_l1_block_info_ecotone_pre_isthmus