### PR TITLE
chore: use offset_from_unsigned

### DIFF
--- a/crates/bytecode/src/legacy/analysis.rs
+++ b/crates/bytecode/src/legacy/analysis.rs
@@ -25,7 +25,7 @@ pub fn analyze_legacy(bytecode: Bytes) -> (JumpTable, Bytes) {
         opcode = unsafe { *iterator };
         if opcode == opcode::JUMPDEST {
             // SAFETY: Jumps are max length of the code
-            unsafe { jumps.set_unchecked(iterator.offset_from(start) as usize, true) }
+            unsafe { jumps.set_unchecked(iterator.offset_from_unsigned(start), true) }
             iterator = unsafe { iterator.add(1) };
         } else {
             let push_offset = opcode.wrapping_sub(opcode::PUSH1);

--- a/crates/interpreter/src/interpreter/ext_bytecode.rs
+++ b/crates/interpreter/src/interpreter/ext_bytecode.rs
@@ -166,7 +166,7 @@ impl Jumps for ExtBytecode {
         // In practice this is always true unless a caller modifies the `instruction_pointer` field manually.
         unsafe {
             self.instruction_pointer
-                .offset_from(self.base.bytes_ref().as_ptr()) as usize
+                .offset_from_unsigned(self.base.bytes_ref().as_ptr())
         }
     }
 }


### PR DESCRIPTION
Same as `offset_from` but with the extra condition that `self >= origin`, which is true in all cases.