### PR TITLE
Use context_interface::either::Either in mainnet_builder test

### DIFF
--- a/crates/handler/src/mainnet_builder.rs
+++ b/crates/handler/src/mainnet_builder.rs
@@ -75,7 +75,8 @@ impl MainContext for Context<BlockEnv, TxEnv, CfgEnv, EmptyDB, Journal<EmptyDB>,
 mod test {
     use crate::ExecuteEvm;
     use crate::{MainBuilder, MainContext};
-    use alloy_signer::{Either, SignerSync};
+    use context_interface::either::Either;
+    use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
     use bytecode::{
         opcode::{PUSH1, SSTORE},


### PR DESCRIPTION
The test in mainnet_builder.rs incorrectly imported Either from alloy_signer, but TxEnvBuilder and related traits expect either::Either re-exported via context_interface. This change aligns the test with the expected Either type, preventing type mismatches and ensuring compatibility with authorization_list and Transaction trait implementations.