### PR TITLE
fix(bytecode): exclude MLOAD from modifies_memory and update test

### DIFF
--- a/crates/bytecode/src/opcode.rs
+++ b/crates/bytecode/src/opcode.rs
@@ -182,7 +182,6 @@ impl OpCode {
         matches!(
             *self,
             OpCode::EXTCODECOPY
-                | OpCode::MLOAD
                 | OpCode::MSTORE
                 | OpCode::MSTORE8
                 | OpCode::MCOPY
@@ -769,7 +768,7 @@ mod tests {
 
     #[test]
     fn test_modifies_memory() {
-        assert!(OpCode::new(MLOAD).unwrap().modifies_memory());
+        assert!(!OpCode::new(MLOAD).unwrap().modifies_memory());
         assert!(OpCode::new(MSTORE).unwrap().modifies_memory());
         assert!(!OpCode::new(ADD).unwrap().modifies_memory());
     }


### PR DESCRIPTION
- MLOAD only reads from memory; it does not write to it. Including it in OpCode::modifies_memory misclassifies read-only behavior as memory-modifying.
- Memory expansion (zero-filling) during reads is an allocation side effect, not a semantic write by the opcode itself. This aligns with interpreter implementations and EVM references.
- Updated the test to expect false for MLOAD, kept MSTORE as modifying, and ADD as non-modifying.
- This improves correctness for analyzers/inspectors relying on opcode classification and keeps consistency with other read-only ops (e.g., KECCAK256, RETURN) that also expand memory but aren’t flagged as modifying.