### PR TITLE
refactor(database): extract duplicate test balance constants

### DIFF
--- a/crates/database/interface/src/lib.rs
+++ b/crates/database/interface/src/lib.rs
@@ -26,7 +26,7 @@ pub const EEADDRESS: Address = address!("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
 /// BENCH_CALLER address
 pub const BENCH_CALLER: Address = EEADDRESS;
 /// BENCH_CALLER_BALANCE balance
-pub const BENCH_CALLER_BALANCE: U256 = COMMON_TEST_BALANCE;
+pub const BENCH_CALLER_BALANCE: U256 = TEST_BALANCE;
 
 #[cfg(feature = "asyncdb")]
 pub mod async_db;

--- a/crates/database/interface/src/lib.rs
+++ b/crates/database/interface/src/lib.rs
@@ -20,7 +20,7 @@ pub const BENCH_TARGET: Address = FFADDRESS;
 /// Common test balance used for benchmark addresses
 pub const TEST_BALANCE: U256 = U256::from_limbs([10_000_000_000_000_000, 0, 0, 0]);
 /// BENCH_TARGET_BALANCE balance
-pub const BENCH_TARGET_BALANCE: U256 = COMMON_TEST_BALANCE;
+pub const BENCH_TARGET_BALANCE: U256 = TEST_BALANCE;
 /// Address with all `0xee..ee` in it. Used for testing.
 pub const EEADDRESS: Address = address!("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
 /// BENCH_CALLER address

--- a/crates/database/interface/src/lib.rs
+++ b/crates/database/interface/src/lib.rs
@@ -18,7 +18,7 @@ pub const FFADDRESS: Address = address!("0xfffffffffffffffffffffffffffffffffffff
 /// BENCH_TARGET address
 pub const BENCH_TARGET: Address = FFADDRESS;
 /// Common test balance used for benchmark addresses
-pub const COMMON_TEST_BALANCE: U256 = U256::from_limbs([10_000_000_000_000_000, 0, 0, 0]);
+pub const TEST_BALANCE: U256 = U256::from_limbs([10_000_000_000_000_000, 0, 0, 0]);
 /// BENCH_TARGET_BALANCE balance
 pub const BENCH_TARGET_BALANCE: U256 = COMMON_TEST_BALANCE;
 /// Address with all `0xee..ee` in it. Used for testing.

--- a/crates/database/interface/src/lib.rs
+++ b/crates/database/interface/src/lib.rs
@@ -17,14 +17,16 @@ use std::string::String;
 pub const FFADDRESS: Address = address!("0xffffffffffffffffffffffffffffffffffffffff");
 /// BENCH_TARGET address
 pub const BENCH_TARGET: Address = FFADDRESS;
+/// Common test balance used for benchmark addresses
+pub const COMMON_TEST_BALANCE: U256 = U256::from_limbs([10_000_000_000_000_000, 0, 0, 0]);
 /// BENCH_TARGET_BALANCE balance
-pub const BENCH_TARGET_BALANCE: U256 = U256::from_limbs([10_000_000_000_000_000, 0, 0, 0]);
+pub const BENCH_TARGET_BALANCE: U256 = COMMON_TEST_BALANCE;
 /// Address with all `0xee..ee` in it. Used for testing.
 pub const EEADDRESS: Address = address!("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
 /// BENCH_CALLER address
 pub const BENCH_CALLER: Address = EEADDRESS;
 /// BENCH_CALLER_BALANCE balance
-pub const BENCH_CALLER_BALANCE: U256 = U256::from_limbs([10_000_000_000_000_000, 0, 0, 0]);
+pub const BENCH_CALLER_BALANCE: U256 = COMMON_TEST_BALANCE;
 
 #[cfg(feature = "asyncdb")]
 pub mod async_db;


### PR DESCRIPTION
Replace duplicate BENCH_TARGET_BALANCE and BENCH_CALLER_BALANCE constants with a shared COMMON_TEST_BALANCE constant to improve maintainability.

Both constants had identical values: U256::from_limbs([10_000_000_000_000_000, 0, 0, 0])

This change:
- Eliminates code duplication
- Makes balance changes easier to maintain 
- Preserves all existing functionality
- Only affects test/benchmark constants