### PR TITLE
Gate OP-specific payouts in reward_beneficiary when fee charging disabled

### DIFF
--- a/crates/op-revm/src/handler.rs
+++ b/crates/op-revm/src/handler.rs
@@ -341,6 +341,10 @@ where
         }
 
         self.mainnet.reward_beneficiary(evm, frame_result)?;
+        // If fee charging is disabled (e.g., eth_call simulations), skip OP-specific payouts.
+        if evm.ctx().cfg().is_fee_charge_disabled() {
+            return Ok(());
+        }
         let basefee = evm.ctx().block().basefee() as u128;
 
         // If the transaction is not a deposit transaction, fees are paid out


### PR DESCRIPTION
- This change adds a cfg.is_fee_charge_disabled() check inside reward_beneficiary to skip Optimism-specific payouts (L1 fee vault, base fee vault, operator fee) when fee charging is disabled, e.g., during eth_call simulations on OP chains.
- The base (mainnet) beneficiary reward remains intact, preserving standard EVM tip behavior.
- This aligns with existing gating in pre-execution deduction and operator fee refund, preventing unintended minting to OP fee recipients when no OP fees are being charged.