### PR TITLE
fix(inspector): remove redundant pc()/opcode() calls in step_end

### DIFF
--- a/crates/inspector/src/gas.rs
+++ b/crates/inspector/src/gas.rs
@@ -109,8 +109,6 @@ mod tests {
         }
 
         fn step_end(&mut self, interp: &mut Interpreter<INTR>, _context: &mut CTX) {
-            interp.bytecode.pc();
-            interp.bytecode.opcode();
             self.gas_inspector.step_end(&mut interp.gas);
             self.gas_remaining_steps
                 .push((self.pc, self.gas_inspector.gas_remaining()));


### PR DESCRIPTION
Remove two no-op calls to interp.bytecode.pc() and interp.bytecode.opcode() in StackInspector::step_end test.
These getters are side-effect free; values are already captured in step(). Keeping them was misleading and unnecessary.