### PR TITLE
fix: Align no_std OnceLock semantics with std

### DIFF
--- a/crates/primitives/src/once_lock.rs
+++ b/crates/primitives/src/once_lock.rs
@@ -31,9 +31,8 @@ mod no_std_impl {
         pub fn get_or_init<F>(&self, f: F) -> &T
         where
             F: FnOnce() -> T,
-            T: Into<Box<T>>,
         {
-            self.inner.get_or_init(|| f().into())
+            self.inner.get_or_init(|| Box::new(f()))
         }
 
         /// Gets the contents of the OnceLock, returning None if it is not initialized.


### PR DESCRIPTION
Ensured the no_std OnceLock::get_or_init now boxes values internally so it no longer requires T: Into<Box<T>>.
This brings the API in line with std::sync::OnceLock and restores compatibility for all consumer types.
