### PR TITLE
fix(interpreter): remove redundant stack underflow check in LOG instruction

### DIFF
--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -367,10 +367,6 @@ pub fn log<const N: usize, H: Host + ?Sized>(
         resize_memory!(context.interpreter, offset, len);
         Bytes::copy_from_slice(context.interpreter.memory.slice_len(offset, len).as_ref())
     };
-    if context.interpreter.stack.len() < N {
-        context.interpreter.halt(InstructionResult::StackUnderflow);
-        return;
-    }
     let Some(topics) = context.interpreter.stack.popn::<N>() else {
         context.interpreter.halt_underflow();
         return;

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -372,7 +372,7 @@ pub fn log<const N: usize, H: Host + ?Sized>(
         return;
     }
     let Some(topics) = context.interpreter.stack.popn::<N>() else {
-        context.interpreter.halt(InstructionResult::StackUnderflow);
+        context.interpreter.halt_underflow();
         return;
     };
 


### PR DESCRIPTION
This change removes a duplicate stack length check before calling popn::<N>() in the LOG instruction and uses halt_underflow() in the None arm for consistency. The explicit len() < N guard is unnecessary because popn::<N>() already performs an underflow-safe check and returns None when insufficient items are present. Keeping both checks adds duplication without improving safety and can confuse future maintenance.