### PR TITLE
chore: helper caller_touch_and_change added

### DIFF
--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -152,7 +152,7 @@ pub fn validate_against_state_and_deduct_caller<
         new_balance = new_balance.max(tx.value());
     }
 
-    let old_balance = caller_account.caller_touch_and_change(new_balance, tx.kind().is_call());
+    let old_balance = caller_account.caller_initial_modification(new_balance, tx.kind().is_call());
 
     journal.caller_accounting_journal_entry(tx.caller(), old_balance, tx.kind().is_call());
     Ok(())

--- a/crates/op-revm/src/handler.rs
+++ b/crates/op-revm/src/handler.rs
@@ -199,7 +199,8 @@ where
             new_balance = new_balance.max(tx.value());
         }
 
-        let old_balance = caller_account.caller_touch_and_change(new_balance, tx.kind().is_call());
+        let old_balance =
+            caller_account.caller_initial_modification(new_balance, tx.kind().is_call());
 
         // NOTE: all changes to the caller account should journaled so in case of error
         // we can revert the changes.

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -42,21 +42,20 @@ impl Account {
 
     /// Make changes to the caller account.
     ///
-    /// It marks the account as touched, changes the balance and bumps the nonce if `bump_nonce` is true.
+    /// It marks the account as touched, changes the balance and bumps the nonce if `is_call` is true.
     ///
     /// Returns the old balance.
     #[inline]
-    pub fn caller_touch_and_change(&mut self, new_balance: U256, bump_nonce: bool) -> U256 {
+    pub fn caller_initial_modification(&mut self, new_balance: U256, is_call: bool) -> U256 {
         // Touch account so we know it is changed.
         self.mark_touch();
 
-        let old_balance = core::mem::replace(&mut self.info.balance, new_balance);
-
-        if bump_nonce {
+        if is_call {
             // Nonce is already checked
             self.info.nonce = self.info.nonce.saturating_add(1);
         }
-        old_balance
+
+        core::mem::replace(&mut self.info.balance, new_balance)
     }
 
     /// Checks if account is empty and check if empty state before spurious dragon hardfork.

--- a/examples/erc20_gas/src/handler.rs
+++ b/examples/erc20_gas/src/handler.rs
@@ -68,7 +68,8 @@ where
         )?;
 
         // make changes to the account. Account balance stays the same
-        caller_account.caller_touch_and_change(caller_account.info.balance, tx.kind().is_call());
+        caller_account
+            .caller_initial_modification(caller_account.info.balance, tx.kind().is_call());
 
         let effective_balance_spending = tx
             .effective_balance_spending(basefee, blob_price)


### PR DESCRIPTION
Refactor account changed from `validate_against_state_and_deduct_caller` into one function. Split from PR https://github.com/bluealloy/revm/pull/2991