### PR TITLE
chore: add ensure_enough_balance helper

### DIFF
--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -16,7 +16,6 @@ use core::cmp::Ordering;
 use primitives::StorageKey;
 use primitives::{eip7702, hardfork::SpecId, KECCAK_EMPTY, U256};
 use state::AccountInfo;
-use std::boxed::Box;
 
 /// Loads and warms accounts for execution, including precompiles and access list.
 pub fn load_accounts<
@@ -132,16 +131,8 @@ pub fn validate_against_state_and_deduct_caller<
         is_nonce_check_disabled,
     )?;
 
-    let max_balance_spending = tx.max_balance_spending()?;
-
-    // Check if account has enough balance for `gas_limit * max_fee`` and value transfer.
-    // Transfer will be done inside `*_inner` functions.
-    if max_balance_spending > caller_account.info.balance && !is_balance_check_disabled {
-        return Err(InvalidTransaction::LackOfFundForMaxFee {
-            fee: Box::new(max_balance_spending),
-            balance: Box::new(caller_account.info.balance),
-        }
-        .into());
+    if !is_balance_check_disabled {
+        tx.ensure_enough_balance(caller_account.info.balance)?;
     }
 
     let effective_balance_spending = tx

--- a/examples/erc20_gas/src/handler.rs
+++ b/examples/erc20_gas/src/handler.rs
@@ -1,9 +1,6 @@
 use revm::{
     context::Cfg,
-    context_interface::{
-        result::{HaltReason, InvalidTransaction},
-        Block, ContextTr, JournalTr, Transaction,
-    },
+    context_interface::{result::HaltReason, Block, ContextTr, JournalTr, Transaction},
     handler::{
         pre_execution::validate_account_nonce_and_code, EvmTr, EvmTrError, FrameResult, FrameTr,
         Handler,
@@ -77,38 +74,26 @@ where
         // Touch account so we know it is changed.
         caller_account.mark_touch();
 
-        let max_balance_spending = tx.max_balance_spending()?;
         let effective_balance_spending = tx
             .effective_balance_spending(basefee, blob_price)
             .expect("effective balance is always smaller than max balance so it can't overflow");
 
         let account_balance_slot = erc_address_storage(tx.caller());
-        context.journal_mut().load_account(TOKEN)?.data.mark_touch();
+        journal.load_account(TOKEN)?.data.mark_touch();
 
-        let account_balance = context
-            .journal_mut()
+        let account_balance = journal
             .sload(TOKEN, account_balance_slot)
             .map(|v| v.data)
             .unwrap_or_default();
 
-        if account_balance < max_balance_spending && !is_balance_check_disabled {
-            return Err(InvalidTransaction::LackOfFundForMaxFee {
-                fee: Box::new(max_balance_spending),
-                balance: Box::new(account_balance),
-            }
-            .into());
-        };
+        if !is_balance_check_disabled {
+            tx.ensure_enough_balance(account_balance)?;
+        }
 
         // Check if account has enough balance for `gas_limit * max_fee`` and value transfer.
         // Transfer will be done inside `*_inner` functions.
         if is_balance_check_disabled {
             // ignore balance check.
-        } else if max_balance_spending > account_balance {
-            return Err(InvalidTransaction::LackOfFundForMaxFee {
-                fee: Box::new(max_balance_spending),
-                balance: Box::new(account_balance),
-            }
-            .into());
         } else {
             // subtracting max balance spending with value that is going to be deducted later in the call.
             let gas_balance_spending = effective_balance_spending - value;


### PR DESCRIPTION
Helper function for `ensure_enough_balance` for Transaction that compares balance with max amount that tx could spend.

Extracted from https://github.com/bluealloy/revm/pull/2991