### PR TITLE
chore: EvmTr and InspectorEvmTr receive all/all_mut fn

### DIFF
--- a/crates/inspector/src/mainnet_inspect.rs
+++ b/crates/inspector/src/mainnet_inspect.rs
@@ -2,7 +2,7 @@ use crate::{
     inspect::{InspectCommitEvm, InspectEvm, InspectSystemCallEvm},
     Inspector, InspectorEvmTr, InspectorHandler, JournalExt,
 };
-use context::{ContextSetters, ContextTr, Evm, JournalTr};
+use context::{ContextSetters, ContextTr, Evm, FrameStack, JournalTr};
 use database_interface::DatabaseCommit;
 use handler::{
     instructions::InstructionProvider, system_call::SystemCallTx, EthFrame, EvmTr, EvmTrError,
@@ -95,33 +95,36 @@ where
 {
     type Inspector = INSP;
 
-    fn inspector(&mut self) -> &mut Self::Inspector {
-        &mut self.inspector
+    fn all_inspector(
+        &self,
+    ) -> (
+        &Self::Context,
+        &Self::Instructions,
+        &Self::Precompiles,
+        &FrameStack<Self::Frame>,
+        &Self::Inspector,
+    ) {
+        let ctx = &self.ctx;
+        let frame = &self.frame_stack;
+        let instructions = &self.instruction;
+        let precompiles = &self.precompiles;
+        let inspector = &self.inspector;
+        (ctx, instructions, precompiles, frame, inspector)
     }
-
-    fn ctx_inspector(&mut self) -> (&mut Self::Context, &mut Self::Inspector) {
-        (&mut self.ctx, &mut self.inspector)
-    }
-
-    fn ctx_inspector_frame(
-        &mut self,
-    ) -> (&mut Self::Context, &mut Self::Inspector, &mut Self::Frame) {
-        (&mut self.ctx, &mut self.inspector, self.frame_stack.get())
-    }
-
-    fn ctx_inspector_frame_instructions(
+    fn all_mut_inspector(
         &mut self,
     ) -> (
         &mut Self::Context,
-        &mut Self::Inspector,
-        &mut Self::Frame,
         &mut Self::Instructions,
+        &mut Self::Precompiles,
+        &mut FrameStack<Self::Frame>,
+        &mut Self::Inspector,
     ) {
-        (
-            &mut self.ctx,
-            &mut self.inspector,
-            self.frame_stack.get(),
-            &mut self.instruction,
-        )
+        let ctx = &mut self.ctx;
+        let frame = &mut self.frame_stack;
+        let instructions = &mut self.instruction;
+        let precompiles = &mut self.precompiles;
+        let inspector = &mut self.inspector;
+        (ctx, instructions, precompiles, frame, inspector)
     }
 }

--- a/crates/op-revm/src/evm.rs
+++ b/crates/op-revm/src/evm.rs
@@ -65,38 +65,30 @@ where
 {
     type Inspector = INSP;
 
-    fn inspector(&mut self) -> &mut Self::Inspector {
-        &mut self.0.inspector
+    #[inline]
+    fn all_inspector(
+        &self,
+    ) -> (
+        &Self::Context,
+        &Self::Instructions,
+        &Self::Precompiles,
+        &FrameStack<Self::Frame>,
+        &Self::Inspector,
+    ) {
+        self.0.all_inspector()
     }
 
-    fn ctx_inspector(&mut self) -> (&mut Self::Context, &mut Self::Inspector) {
-        (&mut self.0.ctx, &mut self.0.inspector)
-    }
-
-    fn ctx_inspector_frame(
-        &mut self,
-    ) -> (&mut Self::Context, &mut Self::Inspector, &mut Self::Frame) {
-        (
-            &mut self.0.ctx,
-            &mut self.0.inspector,
-            self.0.frame_stack.get(),
-        )
-    }
-
-    fn ctx_inspector_frame_instructions(
+    #[inline]
+    fn all_mut_inspector(
         &mut self,
     ) -> (
         &mut Self::Context,
-        &mut Self::Inspector,
-        &mut Self::Frame,
         &mut Self::Instructions,
+        &mut Self::Precompiles,
+        &mut FrameStack<Self::Frame>,
+        &mut Self::Inspector,
     ) {
-        (
-            &mut self.0.ctx,
-            &mut self.0.inspector,
-            self.0.frame_stack.get(),
-            &mut self.0.instruction,
-        )
+        self.0.all_mut_inspector()
     }
 }
 
@@ -111,24 +103,28 @@ where
     type Precompiles = P;
     type Frame = EthFrame<EthInterpreter>;
 
-    fn ctx(&mut self) -> &mut Self::Context {
-        &mut self.0.ctx
+    #[inline]
+    fn all(
+        &self,
+    ) -> (
+        &Self::Context,
+        &Self::Instructions,
+        &Self::Precompiles,
+        &FrameStack<Self::Frame>,
+    ) {
+        self.0.all()
     }
 
-    fn ctx_ref(&self) -> &Self::Context {
-        &self.0.ctx
-    }
-
-    fn ctx_instructions(&mut self) -> (&mut Self::Context, &mut Self::Instructions) {
-        (&mut self.0.ctx, &mut self.0.instruction)
-    }
-
-    fn ctx_precompiles(&mut self) -> (&mut Self::Context, &mut Self::Precompiles) {
-        (&mut self.0.ctx, &mut self.0.precompiles)
-    }
-
-    fn frame_stack(&mut self) -> &mut FrameStack<Self::Frame> {
-        &mut self.0.frame_stack
+    #[inline]
+    fn all_mut(
+        &mut self,
+    ) -> (
+        &mut Self::Context,
+        &mut Self::Instructions,
+        &mut Self::Precompiles,
+        &mut FrameStack<Self::Frame>,
+    ) {
+        self.0.all_mut()
     }
 
     fn frame_init(

--- a/examples/custom_precompile_journal/src/custom_evm.rs
+++ b/examples/custom_precompile_journal/src/custom_evm.rs
@@ -67,24 +67,26 @@ where
     type Precompiles = CustomPrecompileProvider;
     type Frame = EthFrame<EthInterpreter>;
 
-    fn ctx(&mut self) -> &mut Self::Context {
-        &mut self.0.ctx
+    fn all(
+        &self,
+    ) -> (
+        &Self::Context,
+        &Self::Instructions,
+        &Self::Precompiles,
+        &FrameStack<Self::Frame>,
+    ) {
+        self.0.all()
     }
 
-    fn ctx_ref(&self) -> &Self::Context {
-        self.0.ctx_ref()
-    }
-
-    fn ctx_instructions(&mut self) -> (&mut Self::Context, &mut Self::Instructions) {
-        self.0.ctx_instructions()
-    }
-
-    fn ctx_precompiles(&mut self) -> (&mut Self::Context, &mut Self::Precompiles) {
-        self.0.ctx_precompiles()
-    }
-
-    fn frame_stack(&mut self) -> &mut FrameStack<Self::Frame> {
-        self.0.frame_stack()
+    fn all_mut(
+        &mut self,
+    ) -> (
+        &mut Self::Context,
+        &mut Self::Instructions,
+        &mut Self::Precompiles,
+        &mut FrameStack<Self::Frame>,
+    ) {
+        self.0.all_mut()
     }
 
     fn frame_init(
@@ -124,28 +126,27 @@ where
 {
     type Inspector = INSP;
 
-    fn inspector(&mut self) -> &mut Self::Inspector {
-        self.0.inspector()
+    fn all_inspector(
+        &self,
+    ) -> (
+        &Self::Context,
+        &Self::Instructions,
+        &Self::Precompiles,
+        &FrameStack<Self::Frame>,
+        &Self::Inspector,
+    ) {
+        self.0.all_inspector()
     }
 
-    fn ctx_inspector(&mut self) -> (&mut Self::Context, &mut Self::Inspector) {
-        self.0.ctx_inspector()
-    }
-
-    fn ctx_inspector_frame(
-        &mut self,
-    ) -> (&mut Self::Context, &mut Self::Inspector, &mut Self::Frame) {
-        self.0.ctx_inspector_frame()
-    }
-
-    fn ctx_inspector_frame_instructions(
+    fn all_mut_inspector(
         &mut self,
     ) -> (
         &mut Self::Context,
-        &mut Self::Inspector,
-        &mut Self::Frame,
         &mut Self::Instructions,
+        &mut Self::Precompiles,
+        &mut FrameStack<Self::Frame>,
+        &mut Self::Inspector,
     ) {
-        self.0.ctx_inspector_frame_instructions()
+        self.0.all_mut_inspector()
     }
 }

--- a/examples/my_evm/src/evm.rs
+++ b/examples/my_evm/src/evm.rs
@@ -62,26 +62,32 @@ where
     type Instructions = EthInstructions<EthInterpreter, CTX>;
     type Precompiles = EthPrecompiles;
     type Frame = EthFrame<EthInterpreter>;
-    fn ctx(&mut self) -> &mut Self::Context {
-        &mut self.0.ctx
+
+    #[inline]
+    fn all(
+        &self,
+    ) -> (
+        &Self::Context,
+        &Self::Instructions,
+        &Self::Precompiles,
+        &FrameStack<Self::Frame>,
+    ) {
+        self.0.all()
     }
 
-    fn ctx_ref(&self) -> &Self::Context {
-        self.0.ctx_ref()
+    #[inline]
+    fn all_mut(
+        &mut self,
+    ) -> (
+        &mut Self::Context,
+        &mut Self::Instructions,
+        &mut Self::Precompiles,
+        &mut FrameStack<Self::Frame>,
+    ) {
+        self.0.all_mut()
     }
 
-    fn ctx_instructions(&mut self) -> (&mut Self::Context, &mut Self::Instructions) {
-        self.0.ctx_instructions()
-    }
-
-    fn ctx_precompiles(&mut self) -> (&mut Self::Context, &mut Self::Precompiles) {
-        self.0.ctx_precompiles()
-    }
-
-    fn frame_stack(&mut self) -> &mut FrameStack<Self::Frame> {
-        self.0.frame_stack()
-    }
-
+    #[inline]
     fn frame_init(
         &mut self,
         frame_input: <Self::Frame as FrameTr>::FrameInit,
@@ -92,6 +98,7 @@ where
         self.0.frame_init(frame_input)
     }
 
+    #[inline]
     fn frame_run(
         &mut self,
     ) -> Result<
@@ -101,6 +108,7 @@ where
         self.0.frame_run()
     }
 
+    #[inline]
     fn frame_return_result(
         &mut self,
         frame_result: <Self::Frame as FrameTr>::FrameResult,
@@ -119,28 +127,27 @@ where
 {
     type Inspector = INSP;
 
-    fn inspector(&mut self) -> &mut Self::Inspector {
-        self.0.inspector()
+    fn all_inspector(
+        &self,
+    ) -> (
+        &Self::Context,
+        &Self::Instructions,
+        &Self::Precompiles,
+        &FrameStack<Self::Frame>,
+        &Self::Inspector,
+    ) {
+        self.0.all_inspector()
     }
 
-    fn ctx_inspector(&mut self) -> (&mut Self::Context, &mut Self::Inspector) {
-        self.0.ctx_inspector()
-    }
-
-    fn ctx_inspector_frame(
-        &mut self,
-    ) -> (&mut Self::Context, &mut Self::Inspector, &mut Self::Frame) {
-        self.0.ctx_inspector_frame()
-    }
-
-    fn ctx_inspector_frame_instructions(
+    fn all_mut_inspector(
         &mut self,
     ) -> (
         &mut Self::Context,
-        &mut Self::Inspector,
-        &mut Self::Frame,
         &mut Self::Instructions,
+        &mut Self::Precompiles,
+        &mut FrameStack<Self::Frame>,
+        &mut Self::Inspector,
     ) {
-        self.0.ctx_inspector_frame_instructions()
+        self.0.all_mut_inspector()
     }
 }


### PR DESCRIPTION
Helper functions all and all_mut allow access to all items of trait, reducing the need for the user to implement a specific function that fetches just part of the fields.