### PR TITLE
fix(context): remove unreachable zero-denominator check in fake_exponential

### DIFF
--- a/crates/context/interface/src/block/blob.rs
+++ b/crates/context/interface/src/block/blob.rs
@@ -86,10 +86,6 @@ pub fn fake_exponential(factor: u64, numerator: u64, denominator: u64) -> u128 {
     let numerator = numerator as u128;
     let denominator = denominator as u128;
 
-    if denominator == 0 {
-        return 0;
-    }
-
     let mut i = 1;
     let mut output = 0;
     let mut numerator_accum = factor * denominator;


### PR DESCRIPTION
- Remove the redundant if denominator == 0 { return 0; } in fake_exponential.
- The function already asserts denominator != 0, so the branch is never executed.
- The denominator originates from protocol constants (BLOB_BASE_FEE_UPDATE_FRACTION_*) and config fallback, both guaranteed non-zero.
- Keeping the check was contradictory (assert panics vs returning 0) and introduced dead code