### PR TITLE
fix: silent walkdir error handling in test discovery

### DIFF
--- a/bins/revme/src/dir_utils.rs
+++ b/bins/revme/src/dir_utils.rs
@@ -4,7 +4,14 @@ use walkdir::{DirEntry, WalkDir};
 pub fn find_all_json_tests(path: &Path) -> Vec<PathBuf> {
     WalkDir::new(path)
         .into_iter()
-        .filter_map(|e| e.ok())
+        // Log and skip entries that failed to be read instead of silently dropping errors
+        .filter_map(|res| match res {
+            Ok(e) => Some(e),
+            Err(err) => {
+                eprintln!("walkdir error at {}: {}", path.display(), err);
+                None
+            }
+        })
         .filter(|e| {
             e.path()
                 .extension()


### PR DESCRIPTION


## Description

Replace silent `.ok()` error swallowing with explicit error logging in `find_all_json_tests()` to improve debugging visibility when filesystem traversal fails.

**Changes:**
- Log walkdir errors to stderr instead of silently ignoring them
- Maintain existing behavior for test file collection

**Impact:**
- Better debugging experience when directory access issues occur

Fixes potential silent failures that could make test runs appear to "lose" test files without explanation.
