### PR TITLE
chore: expose stack data

### DIFF
--- a/crates/interpreter/src/interpreter/stack.rs
+++ b/crates/interpreter/src/interpreter/stack.rs
@@ -54,6 +54,11 @@ impl StackTr for Stack {
     }
 
     #[inline]
+    fn data(&self) -> &[U256] {
+        &self.data
+    }
+
+    #[inline]
     fn clear(&mut self) {
         self.data.clear();
     }

--- a/crates/interpreter/src/interpreter_types.rs
+++ b/crates/interpreter/src/interpreter_types.rs
@@ -153,6 +153,9 @@ pub trait StackTr {
     /// Returns stack length.
     fn len(&self) -> usize;
 
+    /// Returns stack content.
+    fn data(&self) -> &[U256];
+
     /// Returns `true` if stack is empty.
     fn is_empty(&self) -> bool {
         self.len() == 0


### PR DESCRIPTION
`StackTr` allows all kinds of operations on `Stack` but actually getting the stack data.
I need this data to make a full after-step snapshot of the EVM state: https://github.com/sergey-melnychuk/solenoid/blob/6faf25a94763d237424c406d248fdb9f50829b43/evm-tracer/src/lib.rs#L272