### PR TITLE
docs(handler): correct internal reference in system_call_with_caller doc comment

### DIFF
--- a/crates/handler/src/system_call.rs
+++ b/crates/handler/src/system_call.rs
@@ -114,7 +114,7 @@ pub trait SystemCallEvm: ExecuteEvm {
         self.system_call_with_caller(SYSTEM_ADDRESS, system_contract_address, data)
     }
 
-    /// Internally calls [`SystemCallEvm::system_call_one`] and [`ExecuteEvm::finalize`] functions to obtain the changed state.
+    /// Internally calls [`SystemCallEvm::system_call_one_with_caller`] and [`ExecuteEvm::finalize`] functions to obtain the changed state.
     fn system_call_with_caller(
         &mut self,
         caller: Address,


### PR DESCRIPTION

- **Summary**: Update the doc comment in `crates/handler/src/system_call.rs` to reference `SystemCallEvm::system_call_one_with_caller` instead of `system_call_one`.
- **Why**: The implementation calls `system_call_one_with_caller`; the previous comment was misleading. Aligning docs with behavior improves clarity of `cargo doc`.

