### PR TITLE
refactor: remove unused deprecated methods

### DIFF
--- a/crates/database/src/states/bundle_state.rs
+++ b/crates/database/src/states/bundle_state.rs
@@ -1339,4 +1339,3 @@ mod tests {
         assert!(builder.get_contracts_mut().contains_key(&B256::default()));
     }
 }
-

--- a/crates/database/src/states/bundle_state.rs
+++ b/crates/database/src/states/bundle_state.rs
@@ -659,12 +659,6 @@ impl BundleState {
         }
     }
 
-    /// Converts the bundle state into a [`StateChangeset`].
-    #[deprecated = "Use `to_plain_state` instead"]
-    pub fn into_plain_state(self, is_value_known: OriginalValuesKnown) -> StateChangeset {
-        self.to_plain_state(is_value_known)
-    }
-
     /// Generates a [`StateChangeset`] and [`PlainStateReverts`] from the bundle
     /// state.
     pub fn to_plain_state_and_reverts(
@@ -1345,3 +1339,4 @@ mod tests {
         assert!(builder.get_contracts_mut().contains_key(&B256::default()));
     }
 }
+

--- a/crates/interpreter/src/interpreter/ext_bytecode.rs
+++ b/crates/interpreter/src/interpreter/ext_bytecode.rs
@@ -214,4 +214,3 @@ mod tests {
         assert_eq!(ext_bytecode.bytecode_hash, Some(hash));
     }
 }
-

--- a/crates/interpreter/src/interpreter/ext_bytecode.rs
+++ b/crates/interpreter/src/interpreter/ext_bytecode.rs
@@ -68,14 +68,6 @@ impl ExtBytecode {
         }
     }
 
-    /// Regenerates the bytecode hash.
-    #[inline]
-    #[deprecated(note = "use `get_or_calculate_hash` or `calculate_hash` instead")]
-    #[doc(hidden)]
-    pub fn regenerate_hash(&mut self) -> B256 {
-        self.calculate_hash()
-    }
-
     /// Re-calculates the bytecode hash.
     ///
     /// Prefer [`get_or_calculate_hash`](Self::get_or_calculate_hash) if you just need to get the hash.
@@ -222,3 +214,4 @@ mod tests {
         assert_eq!(ext_bytecode.bytecode_hash, Some(hash));
     }
 }
+


### PR DESCRIPTION

## Summary

Removes two unused deprecated methods that were marked for removal but never actually used in the codebase.

## Changes

- **`crates/database/src/states/bundle_state.rs`**: Removed `into_plain_state()` method
  - Method was deprecated with message "Use `to_plain_state` instead"
  - Confirmed unused after searching entire codebase

- **`crates/interpreter/src/interpreter/ext_bytecode.rs`**: Removed `regenerate_hash()` method  
  - Method was deprecated with message "use `get_or_calculate_hash` or `calculate_hash` instead"
  - Confirmed unused after searching entire codebase

