### PR TITLE
fix: remove redundant U256::from on Host getters in instructions

### DIFF
--- a/crates/interpreter/src/instructions/block_info.rs
+++ b/crates/interpreter/src/instructions/block_info.rs
@@ -43,7 +43,7 @@ pub fn block_number<WIRE: InterpreterTypes, H: Host + ?Sized>(
     context: InstructionContext<'_, H, WIRE>,
 ) {
     //gas!(context.interpreter, gas::BASE);
-    push!(context.interpreter, U256::from(context.host.block_number()));
+    push!(context.interpreter, context.host.block_number());
 }
 
 /// Implements the DIFFICULTY/PREVRANDAO instruction.

--- a/crates/interpreter/src/instructions/block_info.rs
+++ b/crates/interpreter/src/instructions/block_info.rs
@@ -2,7 +2,7 @@ use crate::{
     interpreter_types::{InterpreterTypes, RuntimeFlag, StackTr},
     Host,
 };
-use primitives::{hardfork::SpecId::*, U256};
+use primitives::hardfork::SpecId::*;
 
 use crate::InstructionContext;
 

--- a/crates/interpreter/src/instructions/tx_info.rs
+++ b/crates/interpreter/src/instructions/tx_info.rs
@@ -2,7 +2,6 @@ use crate::{
     interpreter_types::{InterpreterTypes, RuntimeFlag, StackTr},
     Host,
 };
-use primitives::U256;
 
 use crate::InstructionContext;
 
@@ -13,10 +12,7 @@ pub fn gasprice<WIRE: InterpreterTypes, H: Host + ?Sized>(
     context: InstructionContext<'_, H, WIRE>,
 ) {
     //gas!(context.interpreter, gas::BASE);
-    push!(
-        context.interpreter,
-        context.host.effective_gas_price()
-    );
+    push!(context.interpreter, context.host.effective_gas_price());
 }
 
 /// Implements the ORIGIN instruction.

--- a/crates/interpreter/src/instructions/tx_info.rs
+++ b/crates/interpreter/src/instructions/tx_info.rs
@@ -15,7 +15,7 @@ pub fn gasprice<WIRE: InterpreterTypes, H: Host + ?Sized>(
     //gas!(context.interpreter, gas::BASE);
     push!(
         context.interpreter,
-        U256::from(context.host.effective_gas_price())
+        context.host.effective_gas_price()
     );
 }
 


### PR DESCRIPTION
- Replace U256::from(context.host.block_number()) with context.host.block_number() in block_info.rs.
- Replace U256::from(context.host.effective_gas_price()) with context.host.effective_gas_price() in tx_info.rs.
- Aligns with Host methods already returning U256 and matches style of adjacent instructions.