### PR TITLE
fix(op-revm): return error instead of panic when enveloped_tx is missing

### DIFF
--- a/crates/op-revm/src/handler.rs
+++ b/crates/op-revm/src/handler.rs
@@ -124,11 +124,14 @@ where
 
             if !ctx.cfg().is_fee_charge_disabled() {
                 // account for additional cost of l1 fee and operator fee
-                let enveloped_tx = ctx
-                    .tx()
-                    .enveloped_tx()
-                    .expect("all not deposit tx have enveloped tx")
-                    .clone();
+                let enveloped_tx = match ctx.tx().enveloped_tx() {
+                    Some(bytes) => bytes.clone(),
+                    None => {
+                        return Err(ERROR::from_string(
+                            "[OPTIMISM] Failed to load enveloped transaction.".into(),
+                        ));
+                    }
+                };
 
                 // compute L1 cost
                 additional_cost = ctx.chain_mut().calculate_tx_l1_cost(&enveloped_tx, spec);

--- a/crates/op-revm/src/handler.rs
+++ b/crates/op-revm/src/handler.rs
@@ -125,9 +125,9 @@ where
             if !ctx.cfg().is_fee_charge_disabled() {
                 // account for additional cost of l1 fee and operator fee
                 let Some(enveloped_tx) = ctx.tx().enveloped_tx().cloned() else {
-                        return Err(ERROR::from_string(
-                            "[OPTIMISM] Failed to load enveloped transaction.".into(),
-                        ));
+                    return Err(ERROR::from_string(
+                        "[OPTIMISM] Failed to load enveloped transaction.".into(),
+                    ));
                 };
 
                 // compute L1 cost

--- a/crates/op-revm/src/handler.rs
+++ b/crates/op-revm/src/handler.rs
@@ -124,13 +124,10 @@ where
 
             if !ctx.cfg().is_fee_charge_disabled() {
                 // account for additional cost of l1 fee and operator fee
-                let enveloped_tx = match ctx.tx().enveloped_tx() {
-                    Some(bytes) => bytes.clone(),
-                    None => {
+                let Some(enveloped_tx) = ctx.tx().enveloped_tx().cloned() else {
                         return Err(ERROR::from_string(
                             "[OPTIMISM] Failed to load enveloped transaction.".into(),
                         ));
-                    }
                 };
 
                 // compute L1 cost


### PR DESCRIPTION
Replace expect() with a graceful error in validate_against_state_and_deduct_caller for non-deposit transactions when enveloped_tx is missing. This unifies behavior with reward_beneficiary, avoids process panics on malformed/external inputs (OpTxTr trait boundary), and aligns with the builder’s contract where missing enveloped bytes are a validation error, not an unreachable state.