### PR TITLE
chore: changelog update for v87

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
 
+# v87
+date: 23.09.2025
+
+Small change release.
+
+* `revm-context-interface`: 10.1.0 -> 10.2.0 (✓ API compatible changes)
+* `revm-context`: 9.0.2 -> 9.1.0 (✓ API compatible changes)
+* `op-revm`: 10.0.0 -> 10.1.0 (✓ API compatible changes)
+* `revm-ee-tests`: 0.1.0
+* `revm-interpreter`: 25.0.2 -> 25.0.3
+* `revm-handler`: 10.0.0 -> 10.0.1
+* `revm-inspector`: 10.0.0 -> 10.0.1
+* `revm`: 29.0.0 -> 29.0.1
+* `revm-statetest-types`: 9.0.2 -> 9.0.3
+* `revme`: 7.2.2 -> 7.2.3
+
+
 # v86
 date: 24.08.2025
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2942,7 +2942,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-revm"
-version = "10.0.0"
+version = "10.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -3553,7 +3553,7 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "9.0.2"
+version = "9.1.0"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3600,7 +3600,7 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "10.1.0"
+version = "10.2.0"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3656,7 +3656,7 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "10.0.0"
+version = "10.0.1"
 dependencies = [
  "alloy-eip7702",
  "alloy-provider",
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "10.0.0"
+version = "10.0.1"
 dependencies = [
  "auto_impl",
  "either",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "bincode 2.0.1",
  "revm-bytecode",
@@ -3755,7 +3755,7 @@ dependencies = [
 
 [[package]]
 name = "revm-statetest-types"
-version = "9.0.2"
+version = "9.0.3"
 dependencies = [
  "alloy-eips",
  "k256",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "revme"
-version = "7.2.2"
+version = "7.2.3"
 dependencies = [
  "alloy-rlp",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,20 +41,20 @@ default-members = ["crates/revm"]
 
 [workspace.dependencies]
 # revm
-revm = { path = "crates/revm", version = "29.0.0", default-features = false }
+revm = { path = "crates/revm", version = "29.0.1", default-features = false }
 primitives = { path = "crates/primitives", package = "revm-primitives", version = "20.2.1", default-features = false }
 bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "6.2.2", default-features = false }
 database = { path = "crates/database", package = "revm-database", version = "7.0.5", default-features = false }
 database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "7.0.5", default-features = false }
 state = { path = "crates/state", package = "revm-state", version = "7.0.5", default-features = false }
-interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "25.0.2", default-features = false }
-inspector = { path = "crates/inspector", package = "revm-inspector", version = "10.0.0", default-features = false }
+interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "25.0.3", default-features = false }
+inspector = { path = "crates/inspector", package = "revm-inspector", version = "10.0.1", default-features = false }
 precompile = { path = "crates/precompile", package = "revm-precompile", version = "27.0.0", default-features = false }
-statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "9.0.2", default-features = false }
-context = { path = "crates/context", package = "revm-context", version = "9.0.2", default-features = false }
-context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "10.1.0", default-features = false }
-handler = { path = "crates/handler", package = "revm-handler", version = "10.0.0", default-features = false }
-op-revm = { path = "crates/op-revm", package = "op-revm", version = "10.0.0", default-features = false }
+statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "9.0.3", default-features = false }
+context = { path = "crates/context", package = "revm-context", version = "9.1.0", default-features = false }
+context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "10.2.0", default-features = false }
+handler = { path = "crates/handler", package = "revm-handler", version = "10.0.1", default-features = false }
+op-revm = { path = "crates/op-revm", package = "op-revm", version = "10.1.0", default-features = false }
 ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "0.1.0", default-features = false }
 
 # alloy

--- a/bins/revme/CHANGELOG.md
+++ b/bins/revme/CHANGELOG.md
@@ -40,6 +40,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.2.3](https://github.com/bluealloy/revm/compare/revme-v7.2.2...revme-v7.2.3) - 2025-09-23
+
+### Other
+
+- updated the following local packages: revm-context-interface, revm-context, revm-inspector, revm, revm-statetest-types
+
 ## [7.1.0](https://github.com/bluealloy/revm/compare/revme-v7.0.4...revme-v7.1.0) - 2025-07-23
 
 ### Added

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revme"
 description = "Rust Ethereum Virtual Machine Executable"
-version = "7.2.2"
+version = "7.2.3"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/context/CHANGELOG.md
+++ b/crates/context/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.1.0](https://github.com/bluealloy/revm/compare/revm-context-v9.0.2...revm-context-v9.1.0) - 2025-09-23
+
+### Added
+
+- *(op-revm)* Add an option to disable "fee-charge" on `op-revm` ([#2980](https://github.com/bluealloy/revm/pull/2980))
+
 ## [9.0.2](https://github.com/bluealloy/revm/compare/revm-context-v9.0.1...revm-context-v9.0.2) - 2025-08-23
 
 ### Fixed

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-context"
 description = "Revm context crates"
-version = "9.0.2"
+version = "9.1.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/context/interface/CHANGELOG.md
+++ b/crates/context/interface/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.2.0](https://github.com/bluealloy/revm/compare/revm-context-interface-v10.1.0...revm-context-interface-v10.2.0) - 2025-09-23
+
+### Added
+
+- *(op-revm)* Add an option to disable "fee-charge" on `op-revm` ([#2980](https://github.com/bluealloy/revm/pull/2980))
+
 ## [10.1.0](https://github.com/bluealloy/revm/compare/revm-context-interface-v10.0.1...revm-context-interface-v10.1.0) - 2025-08-23
 
 ### Added

--- a/crates/context/interface/Cargo.toml
+++ b/crates/context/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-context-interface"
 description = "Revm context interface crates"
-version = "10.1.0"
+version = "10.2.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/handler/CHANGELOG.md
+++ b/crates/handler/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.1](https://github.com/bluealloy/revm/compare/revm-handler-v10.0.0...revm-handler-v10.0.1) - 2025-09-23
+
+### Other
+
+- updated the following local packages: revm-context-interface, revm-context, revm-interpreter
+
 ## [10.0.0](https://github.com/bluealloy/revm/compare/revm-handler-v9.0.1...revm-handler-v10.0.0) - 2025-08-23
 
 ### Added

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-handler"
 description = "Revm handler crates"
-version = "10.0.0"
+version = "10.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/inspector/CHANGELOG.md
+++ b/crates/inspector/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.1](https://github.com/bluealloy/revm/compare/revm-inspector-v10.0.0...revm-inspector-v10.0.1) - 2025-09-23
+
+### Other
+
+- updated the following local packages: revm-context, revm-interpreter, revm-handler
+
 ## [10.0.0](https://github.com/bluealloy/revm/compare/revm-inspector-v9.1.0...revm-inspector-v10.0.0) - 2025-08-23
 
 ### Other

--- a/crates/inspector/Cargo.toml
+++ b/crates/inspector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-inspector"
 description = "Revm inspector interface"
-version = "10.0.0"
+version = "10.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -51,6 +51,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [25.0.3](https://github.com/bluealloy/revm/compare/revm-interpreter-v25.0.2...revm-interpreter-v25.0.3) - 2025-09-23
+
+### Other
+
+- updated the following local packages: revm-context-interface
+
 ## [24.0.0](https://github.com/bluealloy/revm/compare/revm-interpreter-v23.0.2...revm-interpreter-v24.0.0) - 2025-07-23
 
 ### Added

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-interpreter"
 description = "Revm Interpreter that executes bytecode."
-version = "25.0.2"
+version = "25.0.3"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/op-revm/CHANGELOG.md
+++ b/crates/op-revm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.1.0](https://github.com/bluealloy/revm/compare/op-revm-v10.0.0...op-revm-v10.1.0) - 2025-09-23
+
+### Added
+
+- *(op-revm)* Add an option to disable "fee-charge" on `op-revm` ([#2980](https://github.com/bluealloy/revm/pull/2980))
+
 ## [10.0.0](https://github.com/bluealloy/revm/compare/op-revm-v9.0.1...op-revm-v10.0.0) - 2025-08-23
 
 ### Added

--- a/crates/op-revm/Cargo.toml
+++ b/crates/op-revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "op-revm"
 description = "Optimism variant of Revm"
-version = "10.0.0"
+version = "10.1.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/revm/CHANGELOG.md
+++ b/crates/revm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [29.0.1](https://github.com/bluealloy/revm/compare/revm-v29.0.0...revm-v29.0.1) - 2025-09-23
+
+### Other
+
+- updated the following local packages: revm-context-interface, revm-context, revm-interpreter, revm-handler, revm-inspector
+
 ## [29.0.0](https://github.com/bluealloy/revm/compare/revm-v28.0.1...revm-v29.0.0) - 2025-08-23
 
 ### Other

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm"
 description = "Revm - Rust Ethereum Virtual Machine"
-version = "29.0.0"
+version = "29.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/statetest-types/CHANGELOG.md
+++ b/crates/statetest-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.0.3](https://github.com/bluealloy/revm/compare/revm-statetest-types-v9.0.2...revm-statetest-types-v9.0.3) - 2025-09-23
+
+### Other
+
+- updated the following local packages: revm
+
 ## [9.0.2](https://github.com/bluealloy/revm/compare/revm-statetest-types-v9.0.1...revm-statetest-types-v9.0.2) - 2025-08-23
 
 ### Other

--- a/crates/statetest-types/Cargo.toml
+++ b/crates/statetest-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-statetest-types"
 description = "Statetest types for revme"
-version = "9.0.2"
+version = "9.0.3"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
This PR aligns crates.io versions.

Code for v87 release can be found in `release/v87` branch