### PR TITLE
refactor(database): remove unnecessary Send+Sync bounds from TryDatabaseCommit for Arc

### DIFF
--- a/crates/database/interface/src/try_commit.rs
+++ b/crates/database/interface/src/try_commit.rs
@@ -46,7 +46,7 @@ impl Error for ArcUpgradeError {}
 
 impl<Db> TryDatabaseCommit for Arc<Db>
 where
-    Db: DatabaseCommit + Send + Sync,
+    Db: DatabaseCommit,
 {
     type Error = ArcUpgradeError;
 


### PR DESCRIPTION
Relax trait bounds on the Arc<Db> implementation of TryDatabaseCommit by removing Send + Sync. Arc::get_mut does not require these bounds, and dropping them broadens applicability in single-threaded contexts without changing behavior.