### PR TITLE
fix: remove unused Jumps import from CountInspector

### DIFF
--- a/crates/inspector/src/count_inspector.rs
+++ b/crates/inspector/src/count_inspector.rs
@@ -1,6 +1,6 @@
 //! CountInspector - Inspector that counts all opcodes that were called.
 use crate::inspector::Inspector;
-use interpreter::{interpreter_types::Jumps, InterpreterTypes};
+use interpreter::InterpreterTypes;
 use primitives::HashMap;
 
 /// Inspector that counts all opcodes that were called during execution.


### PR DESCRIPTION
The trait was imported but never used in the implementation, as CountInspector only accesses opcode information through interp.bytecode.opcode() which doesn't require the Jumps trait directly.