### PR TITLE
refactor: delegate CountInspector::new() to Self::default()

### DIFF
--- a/crates/inspector/src/count_inspector.rs
+++ b/crates/inspector/src/count_inspector.rs
@@ -31,18 +31,7 @@ pub struct CountInspector {
 impl CountInspector {
     /// Create a new CountInspector.
     pub fn new() -> Self {
-        Self {
-            opcode_counts: HashMap::default(),
-            initialize_interp_count: 0,
-            step_count: 0,
-            step_end_count: 0,
-            log_count: 0,
-            call_count: 0,
-            call_end_count: 0,
-            create_count: 0,
-            create_end_count: 0,
-            selfdestruct_count: 0,
-        }
+        Self::default()
     }
 
     /// Get the count for a specific opcode.


### PR DESCRIPTION
Remove code duplication in CountInspector constructor by delegating to Default implementation.