### PR TITLE
refactor: clarify gas accounting check in custom precompile

### DIFF
--- a/examples/custom_precompile_journal/src/precompile_provider.rs
+++ b/examples/custom_precompile_journal/src/precompile_provider.rs
@@ -119,8 +119,9 @@ fn run_custom_precompile<CTX: ContextTr>(
                 gas: Gas::new(inputs.gas_limit),
                 output: output.bytes,
             };
-            let underflow = interpreter_result.gas.record_cost(output.gas_used);
-            if !underflow {
+            // Record cost; returns false if not enough gas
+            let cost_recorded = interpreter_result.gas.record_cost(output.gas_used);
+            if !cost_recorded {
                 interpreter_result.result = InstructionResult::PrecompileOOG;
             }
             Ok(interpreter_result)


### PR DESCRIPTION


## Description
Renamed misleading variable `underflow` to `cost_recorded` and add a clarifying comment about `record_cost` semantics. Improves readability and reduces risk of future logic mistakes around OOG handling.

