### PR TITLE
Fix: potential panic in State::storage fallback

### DIFF
--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -284,7 +284,7 @@ impl<DB: Database> Database for State<DB> {
                 .unwrap_or_default())
         } else {
             // Fallback: if the account is unexpectedly not in cache, read directly from the database
-            self.database.storage(address, index);
+            return self.database.storage(address, index);
         }
     }
 


### PR DESCRIPTION


### Description

**Problem**: The `State::storage` method uses `unreachable!()` when an account is unexpectedly not found in cache, which could cause a panic in edge cases.

**Solution**: Replace the panic with a safe fallback to direct database access.

