### PR TITLE
Make CallInput::bytes accept immutable ContextTr

### DIFF
--- a/crates/interpreter/src/interpreter_action/call_inputs.rs
+++ b/crates/interpreter/src/interpreter_action/call_inputs.rs
@@ -43,7 +43,7 @@ impl CallInput {
     ///
     /// If this `CallInput` is a `SharedBuffer`, the slice will be copied
     /// into a fresh `Bytes` buffer, which can pose a performance penalty.
-    pub fn bytes<CTX>(&self, ctx: &mut CTX) -> Bytes
+    pub fn bytes<CTX>(&self, ctx: &CTX) -> Bytes
     where
         CTX: ContextTr,
     {


### PR DESCRIPTION
- Change CallInput::bytes to take &CTX instead of &mut CTX.
- The method only reads from context via local() and shared_memory_buffer_slice(), both of which are immutable.
- Removes unnecessary mutable borrow