### PR TITLE
perf: resize short addresses bitvec instead of reallocating

### DIFF
--- a/crates/context/src/journal/warm_addresses.rs
+++ b/crates/context/src/journal/warm_addresses.rs
@@ -2,7 +2,7 @@
 //!
 //! It is used to optimize access to precompile addresses.
 
-use bitvec::{bitvec, order::Lsb0, vec::BitVec};
+use bitvec::{bitvec, vec::BitVec};
 use primitives::{short_address, Address, HashSet, SHORT_ADDRESS_CAP};
 
 /// Stores addresses that are warm loaded. Contains precompiles and coinbase address.
@@ -32,7 +32,7 @@ impl WarmAddresses {
     pub fn new() -> Self {
         Self {
             precompile_set: HashSet::default(),
-            precompile_short_addresses: BitVec::new(),
+            precompile_short_addresses: bitvec![0; SHORT_ADDRESS_CAP],
             all_short_addresses: true,
             coinbase: None,
         }
@@ -53,8 +53,7 @@ impl WarmAddresses {
     /// Set the precompile addresses and short addresses.
     #[inline]
     pub fn set_precompile_addresses(&mut self, addresses: HashSet<Address>) {
-        // short address is always smaller than SHORT_ADDRESS_CAP
-        self.precompile_short_addresses = bitvec![usize, Lsb0; 0; SHORT_ADDRESS_CAP];
+        self.precompile_short_addresses.fill(false);
 
         let mut all_short_addresses = true;
         for address in addresses.iter() {
@@ -124,7 +123,11 @@ mod tests {
     fn test_initialization() {
         let warm_addresses = WarmAddresses::new();
         assert!(warm_addresses.precompile_set.is_empty());
-        assert!(warm_addresses.precompile_short_addresses.is_empty());
+        assert_eq!(
+            warm_addresses.precompile_short_addresses.len(),
+            SHORT_ADDRESS_CAP
+        );
+        assert!(!warm_addresses.precompile_short_addresses.any());
         assert!(warm_addresses.coinbase.is_none());
 
         // Test Default trait

--- a/crates/handler/src/precompile_provider.rs
+++ b/crates/handler/src/precompile_provider.rs
@@ -16,7 +16,7 @@ pub trait PrecompileProvider<CTX: ContextTr> {
 
     /// Sets the spec id and returns true if the spec id was changed. Initial call to set_spec will always return true.
     ///
-    /// Returned booling will determine if precompile addresses should be injected into the journal.
+    /// Returns `true` if precompile addresses should be injected into the journal.
     fn set_spec(&mut self, spec: <CTX::Cfg as Cfg>::Spec) -> bool;
 
     /// Run the precompile.

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -54,8 +54,8 @@ pub const SHORT_ADDRESS_CAP: usize = 300;
 /// and last two bytes are less than [`SHORT_ADDRESS_CAP`].
 #[inline]
 pub fn short_address(address: &Address) -> Option<usize> {
-    if address.0[..18].iter().all(|b| *b == 0) {
-        let short_address = u16::from_be_bytes([address.0[18], address.0[19]]) as usize;
+    if address[..18].iter().all(|b| *b == 0) {
+        let short_address = u16::from_be_bytes([address[18], address[19]]) as usize;
         if short_address < SHORT_ADDRESS_CAP {
             return Some(short_address);
         }


### PR DESCRIPTION
Allocate on construction, fill to false on reset instead of always allocating.