### PR TITLE
chore(handler): return NonceOverflow on CREATE nonce overflow

### DIFF
--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -268,7 +268,7 @@ impl EthFrame<EthInterpreter> {
         // Increase nonce of caller and check if it overflows
         let old_nonce = caller_info.nonce;
         let Some(new_nonce) = old_nonce.checked_add(1) else {
-            return return_error(InstructionResult::Return);
+            return return_error(InstructionResult::NonceOverflow);
         };
         caller_info.nonce = new_nonce;
         context


### PR DESCRIPTION
Previously, CREATE returned InstructionResult::Return when the caller nonce increment overflowed, which incorrectly signaled success. This change returns InstructionResult::NonceOverflow instead, aligning with internal semantics and downstream mappings to HaltReason::NonceOverflow. This ensures consumers correctly detect and handle nonce overflow as a halt, not a successful return.