### PR TITLE
chore(inspector): remove redundant EthInterpreter import in either.rs

### DIFF
--- a/crates/inspector/src/either.rs
+++ b/crates/inspector/src/either.rs
@@ -101,7 +101,6 @@ mod tests {
 
     #[test]
     fn test_either_inspector_type_check() {
-
         // This test verifies that Either<NoOpInspector, NoOpInspector>
         // implements the Inspector trait as required by the issue
         fn _requires_inspector<T: Inspector<(), EthInterpreter>>(inspector: T) -> T {


### PR DESCRIPTION
Remove inner use of EthInterpreter inside test_either_inspector_type_check; module-level import remains.