### PR TITLE
fix(op-revm): add missing enveloped_tx validation in validate_env

### DIFF
--- a/crates/op-revm/src/handler.rs
+++ b/crates/op-revm/src/handler.rs
@@ -1510,15 +1510,13 @@ mod tests {
     #[test]
     fn test_validate_missing_enveloped_tx() {
         use crate::transaction::deposit::DepositTransactionParts;
-        
+
         // Create a non-deposit transaction without enveloped_tx
-        let ctx = Context::op().with_tx(
-            OpTransaction {
-                base: TxEnv::builder().build_fill(),
-                enveloped_tx: None, // Missing enveloped_tx for non-deposit transaction
-                deposit: DepositTransactionParts::default(), // No source_hash means non-deposit
-            },
-        );
+        let ctx = Context::op().with_tx(OpTransaction {
+            base: TxEnv::builder().build_fill(),
+            enveloped_tx: None, // Missing enveloped_tx for non-deposit transaction
+            deposit: DepositTransactionParts::default(), // No source_hash means non-deposit
+        });
 
         let mut evm = ctx.build_op();
         let handler =

--- a/crates/op-revm/src/transaction/error.rs
+++ b/crates/op-revm/src/transaction/error.rs
@@ -67,7 +67,10 @@ impl Display for OpTransactionError {
                 )
             }
             Self::MissingEnvelopedTx => {
-                write!(f, "missing enveloped transaction bytes for non-deposit transaction")
+                write!(
+                    f,
+                    "missing enveloped transaction bytes for non-deposit transaction"
+                )
             }
         }
     }


### PR DESCRIPTION
Fixes #3092

Non-deposit transactions need `enveloped_tx` set to calculate L1 costs properly. 

Added validation in `validate_env` to catch this early instead of failing later during execution. Returns a clear
`MissingEnvelopedTx` error when the field is missing.
