### PR TITLE
feat: Persistent warm cache for accounts and storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "revme"
-version = "8.1.0"
+version = "8.2.0"
 dependencies = [
  "alloy-rlp",
  "alloy-sol-types",

--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -249,6 +249,17 @@ pub trait JournalTr {
     /// Clear current journal resetting it to initial state and return changes state.
     fn finalize(&mut self) -> Self::State;
 
+    /// Enable persistent warming. Warming persists across transactions for the EVM instance lifetime.
+    fn enable_persistent_warming(&mut self) {}
+
+    /// Disable persistent warming.
+    fn disable_persistent_warming(&mut self) {}
+
+    /// Check if persistent warming is enabled.
+    fn is_persistent_warming_enabled(&self) -> bool {
+        false
+    }
+
     /// Loads the account info from Journal state.
     fn load_account_info_skip_cold_load(
         &mut self,

--- a/crates/context/src/journal.rs
+++ b/crates/context/src/journal.rs
@@ -4,6 +4,8 @@
 //! and inner submodule contains [`JournalInner`] struct that contains state.
 pub mod entry;
 pub mod inner;
+/// Persistent warming cache for addresses and storage slots.
+pub mod persistent_warm_cache;
 pub mod warm_addresses;
 
 pub use entry::{JournalEntry, JournalEntryTr};
@@ -312,6 +314,21 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
     #[inline]
     fn finalize(&mut self) -> Self::State {
         self.inner.finalize()
+    }
+
+    #[inline]
+    fn enable_persistent_warming(&mut self) {
+        self.inner.enable_persistent_warming();
+    }
+
+    #[inline]
+    fn disable_persistent_warming(&mut self) {
+        self.inner.disable_persistent_warming();
+    }
+
+    #[inline]
+    fn is_persistent_warming_enabled(&self) -> bool {
+        self.inner.is_persistent_warming_enabled()
     }
 
     #[inline]

--- a/crates/context/src/journal/PERSISTENT_WARMING_USAGE.md
+++ b/crates/context/src/journal/PERSISTENT_WARMING_USAGE.md
@@ -1,0 +1,180 @@
+# Persistent Warming Usage Guide
+
+## Overview
+
+Persistent warming allows EVM state access patterns (account loads, storage reads) to persist across multiple transactions for the lifetime of the EVM instance. This means the first access is COLD (expensive) and subsequent accesses are WARM (cheap).
+
+## Key Design
+
+- **Single HashMap**: Tracks `Address -> HashSet<StorageKey>`
+- **Address warming**: Implicit - if address exists as key in map, it's warm
+- **Storage warming**: Explicit - if storage key exists in the set for that address, it's warm
+- **Empty set**: An address with an empty `HashSet` means the address is warm but no storage slots are warmed
+- **Lifetime**: Cache lives for the lifetime of the EVM instance (never explicitly cleared)
+- **Block boundaries**: In practice, a fresh EVM instance is created per block (e.g., in Reth), so the cache is naturally cleared between blocks
+
+## Usage
+
+### Basic Block Execution
+
+```rust
+use revm::*;
+
+fn execute_block(transactions: Vec<Transaction>) -> EvmState {
+    let ctx = Context::mainnet().with_db(your_database);
+    let mut evm = ctx.build_mainnet();
+
+    // Enable persistent warming before first transaction
+    evm.journal_mut().enable_persistent_warming();
+
+    for tx in transactions {
+        let result = evm.transact(tx)?;
+        // Note: transact() calls finalize() internally but the warming cache persists!
+        // Commit the state changes to the database
+        your_database.commit(result.state);
+    }
+
+    // At the end of the block, the EVM instance is dropped and the warming cache
+    // is automatically cleaned up. For the next block, create a fresh EVM instance.
+
+    your_database.finalize_block()
+}
+```
+
+### Multi-Block Execution
+
+```rust
+fn execute_blocks(blocks: Vec<Block>) {
+    for block in blocks {
+        // Create a fresh EVM instance per block
+        let ctx = Context::mainnet().with_db(your_database.clone());
+        let mut evm = ctx.build_mainnet();
+
+        // Enable persistent warming
+        evm.journal_mut().enable_persistent_warming();
+
+        for tx in block.transactions {
+            let result = evm.transact(tx)?;
+            your_database.commit(result.state);
+        }
+
+        // EVM instance (and warming cache) dropped here automatically
+    }
+}
+```
+
+### Mixing Per-Transaction and Persistent Modes
+
+```rust
+// Per-transaction warming (default) - each tx starts cold
+evm.transact(tx1)?;  // Cold
+evm.transact(tx2)?;  // Cold again
+
+// Enable persistent warming
+evm.journal_mut().enable_persistent_warming();
+evm.transact(tx3)?;  // Cold (first access)
+evm.transact(tx4)?;  // Warm! (already accessed in tx3)
+
+// Disable if needed (rarely useful in practice)
+evm.journal_mut().disable_persistent_warming();
+evm.transact(tx5)?;  // Cold (per-tx warming mode)
+```
+
+## Gas Cost Behavior
+
+### Without Persistent Warming (Default)
+```
+3 transactions accessing address 0xABCD:
+
+Tx 1: Load 0xABCD → 2600 gas (COLD)
+Tx 2: Load 0xABCD → 2600 gas (COLD) ❌
+Tx 3: Load 0xABCD → 2600 gas (COLD) ❌
+
+Total: 7800 gas
+```
+
+### With Persistent Warming
+```
+3 transactions accessing address 0xABCD:
+
+Tx 1: Load 0xABCD → 2600 gas (COLD)
+Tx 2: Load 0xABCD → 100 gas (WARM) ✅
+Tx 3: Load 0xABCD → 100 gas (WARM) ✅
+
+Total: 2800 gas (saves 5000 gas!)
+```
+
+## Implementation Details
+
+### What Gets Warmed
+- **Account loads**: Any call to `load_account`, `load_account_code`
+- **Storage reads**: Any `SLOAD` operation
+- **Storage writes**: Any `SSTORE` operation (warms the slot)
+
+### What Doesn't Get Warmed
+- **Precompiles**: Always warm (tracked separately in `WarmAddresses`)
+- **Coinbase**: Warm only within transaction (cleared on `commit_tx`)
+
+### Interaction with transaction_id
+- `transaction_id` still increments on `commit_tx()` ✅
+- EIP-6780 selfdestruct logic works correctly ✅
+- Account cleanup (selfdestructed accounts) works correctly ✅
+- Persistent warm cache is checked **before** per-transaction warming
+
+## Performance
+
+### Memory Usage
+- **Per warmed address**: ~56 bytes (HashMap entry + empty HashSet)
+- **Per warmed slot**: ~32 bytes (StorageKey in HashSet)
+- **Typical block**: ~1000 addresses, ~5000 slots = ~300 KB
+
+### CPU Cost
+- **HashSet lookup**: ~20-30ns
+- **Negligible** compared to gas savings
+
+## Example: Testing Persistent Warming
+
+```rust
+#[test]
+fn test_persistent_warming() {
+    let mut evm = /* setup */;
+    let addr = address!("0x1234...");
+
+    evm.journal_mut().enable_persistent_warming();
+
+    // Tx 1: First access is COLD
+    let result1 = evm.transact(tx_accessing_addr)?;
+    assert_eq!(result1.gas_used, base_cost + 2600);
+
+    // Tx 2: Second access is WARM (warming persists)
+    let result2 = evm.transact(tx_accessing_addr)?;
+    assert_eq!(result2.gas_used, base_cost + 100);
+
+    // finalize() does NOT clear warming cache
+    evm.finalize();
+
+    // Tx 3: Still WARM (cache persists for lifetime of EVM)
+    let result3 = evm.transact(tx_accessing_addr)?;
+    assert_eq!(result3.gas_used, base_cost + 100);
+}
+```
+
+## When to Use
+
+✅ **Use persistent warming when:**
+- Building/validating blocks in an L2 environment
+- Creating an EVM where warming persists across transactions
+- Implementing custom gas accounting
+- Each block gets a fresh EVM instance (natural cache cleanup)
+
+❌ **Don't use when:**
+- Executing single isolated transactions
+- Simulating Ethereum mainnet behavior (EIP-2929 is per-transaction)
+- Memory is constrained (the cache adds ~300KB per block)
+
+## Important Notes
+
+- **Not Ethereum Mainnet**: Persistent warming is NOT part of Ethereum mainnet consensus (EIP-2929 is per-transaction)
+- **L2-specific feature**: This is an optimization/feature for L2s or custom EVM implementations
+- **Cache lifetime**: The cache lives for the lifetime of the EVM instance and is never explicitly cleared
+- **Reth integration**: Reth creates a fresh EVM instance per block, so the cache is naturally cleaned up between blocks

--- a/crates/context/src/journal/persistent_warm_cache.rs
+++ b/crates/context/src/journal/persistent_warm_cache.rs
@@ -1,0 +1,144 @@
+use primitives::{Address, HashMap, HashSet, StorageKey};
+
+/// Tracks addresses and storage slots that have been accessed.
+/// Persists across transactions for the lifetime of the EVM instance.
+///
+/// The cache is never cleared - it lives for the lifetime of the EVM instance,
+/// which in practice is one block (e.g., in Reth, a fresh EVM is created per block).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct PersistentWarmCache {
+    warm_storage: HashMap<Address, HashSet<StorageKey>>,
+}
+
+impl PersistentWarmCache {
+    /// Creates a new empty persistent warm cache.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Marks an account and its storage keys as warm.
+    ///
+    /// If the account is already warm, the storage keys are added to the existing set.
+    /// Pass an empty iterator to warm only the account without any storage slots.
+    pub fn warm_account_and_storage(
+        &mut self,
+        address: Address,
+        storage_keys: impl IntoIterator<Item = StorageKey>,
+    ) {
+        let set = self.warm_storage.entry(address).or_default();
+        for key in storage_keys {
+            set.insert(key);
+        }
+    }
+
+    /// Check if an address is warm.
+    pub fn is_address_warm(&self, address: &Address) -> bool {
+        self.warm_storage.contains_key(address)
+    }
+
+    /// Check if a storage slot is warm for the given address.
+    pub fn is_storage_warm(&self, address: &Address, key: &StorageKey) -> bool {
+        self.warm_storage
+            .get(address)
+            .map(|keys| keys.contains(key))
+            .unwrap_or(false)
+    }
+
+    /// Mark an address as warm without any storage slots. (test only)
+    #[cfg(test)]
+    pub fn warm_address(&mut self, address: Address) {
+        self.warm_storage.entry(address).or_default();
+    }
+
+    /// Mark a storage slot as warm. (test only)
+    #[cfg(test)]
+    pub fn warm_storage(&mut self, address: Address, key: StorageKey) {
+        self.warm_storage.entry(address).or_default().insert(key);
+    }
+
+    /// Count of warm addresses. (test only)
+    #[cfg(test)]
+    pub fn warm_address_count(&self) -> usize {
+        self.warm_storage.len()
+    }
+
+    /// Count of warm storage slots across all addresses. (test only)
+    #[cfg(test)]
+    pub fn warm_storage_count(&self) -> usize {
+        self.warm_storage.values().map(|set| set.len()).sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use primitives::{address, U256};
+
+    #[test]
+    fn test_address_warming() {
+        let mut cache = PersistentWarmCache::new();
+        let addr = address!("0x1234567890123456789012345678901234567890");
+
+        assert!(!cache.is_address_warm(&addr));
+
+        cache.warm_account_and_storage(addr, []);
+        assert!(cache.is_address_warm(&addr));
+    }
+
+    #[test]
+    fn test_storage_warming() {
+        let mut cache = PersistentWarmCache::new();
+        let addr = address!("0x1234567890123456789012345678901234567890");
+        let key = U256::from(42);
+
+        assert!(!cache.is_storage_warm(&addr, &key));
+
+        cache.warm_account_and_storage(addr, [key]);
+        assert!(cache.is_storage_warm(&addr, &key));
+
+        let other_key = U256::from(99);
+        assert!(!cache.is_storage_warm(&addr, &other_key));
+    }
+
+    #[test]
+    fn test_multiple_slots() {
+        let mut cache = PersistentWarmCache::new();
+        let addr = address!("0x1234567890123456789012345678901234567890");
+
+        cache.warm_account_and_storage(addr, [U256::from(1), U256::from(2), U256::from(3)]);
+
+        assert_eq!(cache.warm_storage_count(), 3);
+        assert!(cache.is_storage_warm(&addr, &U256::from(1)));
+        assert!(cache.is_storage_warm(&addr, &U256::from(2)));
+        assert!(cache.is_storage_warm(&addr, &U256::from(3)));
+        assert!(!cache.is_storage_warm(&addr, &U256::from(4)));
+    }
+
+    #[test]
+    fn test_multiple_addresses() {
+        let mut cache = PersistentWarmCache::new();
+        let addr1 = address!("0x1111111111111111111111111111111111111111");
+        let addr2 = address!("0x2222222222222222222222222222222222222222");
+
+        cache.warm_address(addr1);
+        cache.warm_address(addr2);
+
+        assert_eq!(cache.warm_address_count(), 2);
+        assert!(cache.is_address_warm(&addr1));
+        assert!(cache.is_address_warm(&addr2));
+    }
+
+    #[test]
+    fn test_storage_isolation_between_addresses() {
+        let mut cache = PersistentWarmCache::new();
+        let addr1 = address!("0x1111111111111111111111111111111111111111");
+        let addr2 = address!("0x2222222222222222222222222222222222222222");
+        let key = U256::from(42);
+
+        cache.warm_account_and_storage(addr1, [key]);
+
+        assert!(cache.is_storage_warm(&addr1, &key));
+        assert!(!cache.is_storage_warm(&addr2, &key));
+    }
+}

--- a/crates/ee-tests/src/lib.rs
+++ b/crates/ee-tests/src/lib.rs
@@ -132,3 +132,6 @@ mod op_revm_tests;
 
 #[cfg(test)]
 mod revm_tests;
+
+#[cfg(test)]
+mod persistent_warming_gas_test;

--- a/crates/ee-tests/src/persistent_warming_gas_test.rs
+++ b/crates/ee-tests/src/persistent_warming_gas_test.rs
@@ -1,0 +1,241 @@
+//! Integration test for persistent warming cache gas calculation.
+//!
+//! This test verifies that the interpreter correctly calculates gas costs
+//! based on the `is_cold` flag provided by the journal's persistent warming cache.
+
+use revm::{
+    bytecode::{opcode, Bytecode},
+    context::{ContextTr, TxEnv},
+    database::BenchmarkDB,
+    interpreter::gas::{COLD_ACCOUNT_ACCESS_COST_ADDITIONAL, COLD_SLOAD_COST_ADDITIONAL},
+    primitives::{address, Address, Bytes},
+    Context, ExecuteEvm, MainBuilder, MainContext,
+};
+
+/// Creates bytecode that performs BALANCE opcode on a target address
+/// PUSH20 <address> BALANCE STOP
+fn create_balance_bytecode(target: Address) -> Bytecode {
+    let mut bytes = vec![opcode::PUSH20];
+    bytes.extend_from_slice(target.as_slice());
+    bytes.push(opcode::BALANCE);
+    bytes.push(opcode::STOP);
+    Bytecode::new_legacy(Bytes::from(bytes))
+}
+
+/// Creates bytecode that performs SLOAD on storage key
+/// PUSH1 <key> SLOAD STOP
+fn create_sload_bytecode(key: u8) -> Bytecode {
+    Bytecode::new_legacy(Bytes::from(vec![
+        opcode::PUSH1,
+        key,
+        opcode::SLOAD,
+        opcode::STOP,
+    ]))
+}
+
+#[test]
+fn test_persistent_warming_account_access_gas() {
+    // Target address to check balance of
+    let target_addr = address!("0x1000000000000000000000000000000000000000");
+    let bytecode = create_balance_bytecode(target_addr);
+
+    // Test WITHOUT persistent warming (default behavior)
+    {
+        let mut evm = Context::mainnet()
+            .with_db(BenchmarkDB::new_bytecode(bytecode.clone()))
+            .build_mainnet();
+
+        // Transaction 1
+        let result1 = evm
+            .transact_one(TxEnv::builder_for_bench().build_fill())
+            .unwrap();
+        let gas1 = result1.gas_used();
+
+        // Transaction 2 - should also be COLD
+        let result2 = evm
+            .transact_one(TxEnv::builder_for_bench().nonce(1).build_fill())
+            .unwrap();
+        let gas2 = result2.gas_used();
+
+        // Gas should be the same (both cold)
+        assert_eq!(
+            gas1, gas2,
+            "Without persistent warming, both txs should use same gas (both COLD)"
+        );
+    }
+
+    // Test WITH persistent warming
+    {
+        let mut evm = Context::mainnet()
+            .with_db(BenchmarkDB::new_bytecode(bytecode.clone()))
+            .build_mainnet();
+
+        // Enable persistent warming
+        evm.ctx.journal_mut().enable_persistent_warming();
+
+        // Transaction 1 - COLD
+        let result1 = evm
+            .transact_one(TxEnv::builder_for_bench().build_fill())
+            .unwrap();
+        let gas1 = result1.gas_used();
+
+        // Transaction 2 - WARM (persistent warming!)
+        let result2 = evm
+            .transact_one(TxEnv::builder_for_bench().nonce(1).build_fill())
+            .unwrap();
+        let gas2 = result2.gas_used();
+
+        // Calculate savings
+        let gas_saved = gas1 - gas2;
+        let expected_savings = COLD_ACCOUNT_ACCESS_COST_ADDITIONAL;
+
+        println!("\n=== Account Access Gas Test ===");
+        println!("Tx1 (COLD): {} gas", gas1);
+        println!("Tx2 (WARM): {} gas", gas2);
+        println!("Saved:      {} gas", gas_saved);
+        println!(
+            "Expected:   {} gas (COLD_ACCOUNT_ACCESS_COST_ADDITIONAL)",
+            expected_savings
+        );
+
+        // Verify gas savings with tolerance for base transaction costs
+        assert!(
+            gas_saved == expected_savings,
+            "Expected {} gas savings (COLD_ACCOUNT_ACCESS_COST_ADDITIONAL), got {}",
+            expected_savings,
+            gas_saved
+        );
+    }
+}
+
+#[test]
+fn test_persistent_warming_storage_access_gas() {
+    let bytecode = create_sload_bytecode(1);
+
+    // Test WITHOUT persistent warming
+    {
+        let mut evm = Context::mainnet()
+            .with_db(BenchmarkDB::new_bytecode(bytecode.clone()))
+            .build_mainnet();
+
+        let result1 = evm
+            .transact_one(TxEnv::builder_for_bench().build_fill())
+            .unwrap();
+        let gas1 = result1.gas_used();
+
+        let result2 = evm
+            .transact_one(TxEnv::builder_for_bench().nonce(1).build_fill())
+            .unwrap();
+        let gas2 = result2.gas_used();
+
+        // Gas should be the same (both cold)
+        assert_eq!(
+            gas1, gas2,
+            "Without persistent warming, both txs should use same gas (both COLD)"
+        );
+    }
+
+    // Test WITH persistent warming
+    {
+        let mut evm = Context::mainnet()
+            .with_db(BenchmarkDB::new_bytecode(bytecode.clone()))
+            .build_mainnet();
+
+        evm.ctx.journal_mut().enable_persistent_warming();
+
+        // Transaction 1 - COLD
+        let result1 = evm
+            .transact_one(TxEnv::builder_for_bench().build_fill())
+            .unwrap();
+        let gas1 = result1.gas_used();
+
+        // Transaction 2 - WARM
+        let result2 = evm
+            .transact_one(TxEnv::builder_for_bench().nonce(1).build_fill())
+            .unwrap();
+        let gas2 = result2.gas_used();
+
+        let gas_saved = gas1 - gas2;
+        let expected_savings = COLD_SLOAD_COST_ADDITIONAL;
+
+        println!("\n=== Storage Access Gas Test ===");
+        println!("Tx1 (COLD): {} gas", gas1);
+        println!("Tx2 (WARM): {} gas", gas2);
+        println!("Saved:      {} gas", gas_saved);
+        println!(
+            "Expected:   {} gas (COLD_SLOAD_COST_ADDITIONAL)",
+            expected_savings
+        );
+
+        // Verify gas savings with tolerance for base transaction costs
+        assert!(
+            gas_saved == expected_savings,
+            "Expected {} gas savings (COLD_SLOAD_COST_ADDITIONAL), got {}",
+            expected_savings,
+            gas_saved
+        );
+    }
+}
+
+#[test]
+fn test_persistent_warming_combined_gas() {
+    // Bytecode that does both BALANCE and SLOAD
+    let target_addr = address!("0x2000000000000000000000000000000000000000");
+    let mut bytes = vec![opcode::PUSH20];
+    bytes.extend_from_slice(target_addr.as_slice());
+    bytes.extend_from_slice(&[
+        opcode::BALANCE,
+        opcode::POP,
+        opcode::PUSH1,
+        0x05, // storage key
+        opcode::SLOAD,
+        opcode::POP,
+        opcode::STOP,
+    ]);
+    let bytecode = Bytecode::new_legacy(Bytes::from(bytes));
+
+    let mut evm = Context::mainnet()
+        .with_db(BenchmarkDB::new_bytecode(bytecode))
+        .build_mainnet();
+
+    evm.ctx.journal_mut().enable_persistent_warming();
+
+    // Transaction 1 - Both COLD
+    let result1 = evm
+        .transact_one(TxEnv::builder_for_bench().build_fill())
+        .unwrap();
+    let gas1 = result1.gas_used();
+
+    // Transaction 2 - Both WARM
+    let result2 = evm
+        .transact_one(TxEnv::builder_for_bench().nonce(1).build_fill())
+        .unwrap();
+    let gas2 = result2.gas_used();
+
+    let gas_saved = gas1 - gas2;
+    let expected_savings = COLD_ACCOUNT_ACCESS_COST_ADDITIONAL + COLD_SLOAD_COST_ADDITIONAL;
+
+    println!("\n=== Combined Access Gas Test ===");
+    println!("Tx1 (COLD account + COLD storage): {} gas", gas1);
+    println!("Tx2 (WARM account + WARM storage): {} gas", gas2);
+    println!("Total saved:                        {} gas", gas_saved);
+    println!(
+        "Expected:                           {} gas (COLD_ACCOUNT_ACCESS_COST_ADDITIONAL + COLD_SLOAD_COST_ADDITIONAL)",
+        expected_savings
+    );
+
+    // Verify combined savings
+    assert!(
+        gas_saved == expected_savings,
+        "Expected {} gas savings (account {} + storage {}), got {}",
+        expected_savings,
+        COLD_ACCOUNT_ACCESS_COST_ADDITIONAL,
+        COLD_SLOAD_COST_ADDITIONAL,
+        gas_saved
+    );
+
+    println!(
+        "✓ Persistent warming verified: {} gas saved across transactions!\n",
+        gas_saved
+    );
+}


### PR DESCRIPTION
Persistent warm cache keeps track of accounts and storage slots that have been touched before, anytime during the lifetime of the REVM instance.

It is intended to be used by the `reth` client, where a new REVM instance is created for each block, effectively creating block-level account/storage warming (vs. traditional transaction-level warming).

See the PERSISTENT_WARMING_USAGE.md for more details.