### PR TITLE
fix: return MemoryLimitOOG when memory_limit is enabled

### DIFF
--- a/crates/interpreter/src/instructions/macros.rs
+++ b/crates/interpreter/src/instructions/macros.rs
@@ -132,6 +132,11 @@ macro_rules! resize_memory {
         $crate::resize_memory!($interpreter, $offset, $len, ())
     };
     ($interpreter:expr, $offset:expr, $len:expr, $ret:expr) => {
+        #[cfg(feature = "memory_limit")]
+        if $interpreter.memory.limit_reached($offset, $len) {
+            $interpreter.halt_memory_limit_oog();
+            return $ret;
+        }
         if !$crate::interpreter::resize_memory(
             &mut $interpreter.gas,
             &mut $interpreter.memory,

--- a/crates/interpreter/src/interpreter_types.rs
+++ b/crates/interpreter/src/interpreter_types.rs
@@ -144,8 +144,13 @@ pub trait MemoryTr {
     ///
     /// # Note
     ///
-    /// It checks memory limits.
+    /// It checks if the memory allocation fits under gas cap.
     fn resize(&mut self, new_size: usize) -> bool;
+
+    /// Returns `true` if the `new_size` for the current context memory will
+    /// make the shared buffer length exceed the `memory_limit`.
+    #[cfg(feature = "memory_limit")]
+    fn limit_reached(&self, offset: usize, len: usize) -> bool;
 }
 
 /// Functions needed for Interpreter Stack operations.


### PR DESCRIPTION
### Summary
This PR reintroduces memory memory limit enforcement when `memory_limit` feature is used.

Currently, EVM configuration allows specifying `memory_limit` [here](https://github.com/bluealloy/revm/blob/9613d612763de70ebe54cb5c72b6a88db8d5f80f/crates/context/src/cfg.rs#L58-L66), but the limit is not actually enforced anywhere. It appears that enforcement logic was unintentionally dropped in [this major refactor](https://github.com/bluealloy/revm/pull/1865/files#diff-af2c02a4a0741ed447a4fe1416b389204e482794c95741483843210e43c48b00L99-L102). On top of that, in [another refactor](https://github.com/bluealloy/revm/commit/fd52a1fb531f4627ea7e69780aab56536533269d#diff-af2c02a4a0741ed447a4fe1416b389204e482794c95741483843210e43c48b00L104-R104), `MemoryOOG` was replaced with `MemoryLimitOOG`. This PR restores the original semantics of these two instruction results.

### Context
We run Reth with gas cap set to `uint64::MAX` to allow for complex EVM computation. Without memory limit enforcement, this configuration risks out-of-memory crashes if a buggy contract triggers invalid allocations (e.g., `MSTORE` with an invalid offset). The included unit test demonstrates this scenario.