### PR TITLE
chore: merge context_interface import

### DIFF
--- a/crates/handler/src/precompile_provider.rs
+++ b/crates/handler/src/precompile_provider.rs
@@ -5,8 +5,10 @@ use interpreter::{CallInput, CallInputs, Gas, InstructionResult, InterpreterResu
 use precompile::PrecompileError;
 use precompile::{PrecompileSpecId, Precompiles};
 use primitives::{hardfork::SpecId, Address, Bytes};
-use std::boxed::Box;
-use std::string::{String, ToString};
+use std::{
+    boxed::Box,
+    string::{String, ToString},
+};
 
 /// Provider for precompiled contracts in the EVM.
 #[auto_impl(&mut, Box)]

--- a/crates/interpreter/src/lib.rs
+++ b/crates/interpreter/src/lib.rs
@@ -28,7 +28,7 @@ pub mod interpreter_types;
 // Reexport primary types.
 pub use context_interface::{
     context::{SStoreResult, SelfDestructResult, StateLoad},
-    host, Host, CreateScheme,
+    host, CreateScheme, Host,
 };
 pub use gas::{Gas, InitialAndFloorGas};
 pub use instruction_context::InstructionContext;


### PR DESCRIPTION
Is there a reason to import `context_interface` separately? Should we merge them?