### PR TITLE
feat: update mainnet builder to respect memory_limit

### DIFF
--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -70,7 +70,7 @@ dev = [
 	"optional_priority_fee_check",
 	"optional_fee_charge",
 ]
-memory_limit = []
+memory_limit = ["context-interface/memory_limit"]
 optional_balance_check = []
 optional_block_gas_limit = []
 optional_eip3541 = []

--- a/crates/context/interface/Cargo.toml
+++ b/crates/context/interface/Cargo.toml
@@ -43,6 +43,7 @@ std = [
 	"state/std",
 	"either/std",
 ]
+memory_limit = []
 serde = [
 	"dep:serde",
 	"primitives/serde",

--- a/crates/context/interface/src/cfg.rs
+++ b/crates/context/interface/src/cfg.rs
@@ -64,6 +64,10 @@ pub trait Cfg {
 
     /// Returns whether the fee charge is disabled.
     fn is_fee_charge_disabled(&self) -> bool;
+
+    /// Returns the memory limit for contract execution.
+    #[cfg(feature = "memory_limit")]
+    fn memory_limit(&self) -> u64;
 }
 
 /// What bytecode analysis to perform

--- a/crates/context/interface/src/local.rs
+++ b/crates/context/interface/src/local.rs
@@ -31,6 +31,18 @@ impl<T: Default> FrameStack<T> {
 }
 
 impl<T> FrameStack<T> {
+    /// Creates a new stack with preallocated items by calling the provided closure `len` times.
+    /// Index will still be `None` until `end_init` is called.
+    pub fn new_prealloc_with<F>(len: usize, mut f: F) -> Self
+    where
+        F: FnMut() -> T,
+    {
+        let mut stack = Vec::with_capacity(len);
+        for _ in 0..len {
+            stack.push(f());
+        }
+        Self { stack, index: None }
+    }
     /// Creates a new, empty stack. It must be initialized with init before use.
     pub fn new() -> Self {
         // Init N amount of frames to allocate the stack.

--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -400,6 +400,11 @@ impl<SPEC: Into<SpecId> + Copy> Cfg for CfgEnv<SPEC> {
             }
         }
     }
+
+    #[cfg(feature = "memory_limit")]
+    fn memory_limit(&self) -> u64 {
+        self.memory_limit
+    }
 }
 
 impl<SPEC: Default> Default for CfgEnv<SPEC> {

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -72,3 +72,4 @@ serde = [
 
 # Deprecated, please use `serde` feature instead.
 serde-json = ["serde"]
+memory_limit = ["context/memory_limit", "interpreter/memory_limit"]

--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -298,6 +298,12 @@ pub trait Handler {
         gas_limit: u64,
     ) -> Result<FrameInit, Self::Error> {
         let ctx = evm.ctx_mut();
+        #[cfg(feature = "memory_limit")]
+        let memory = SharedMemory::new_with_buffer_and_memory_limit(
+            ctx.local().shared_memory_buffer().clone(),
+            ctx.cfg().memory_limit(),
+        );
+        #[cfg(not(feature = "memory_limit"))]
         let memory = SharedMemory::new_with_buffer(ctx.local().shared_memory_buffer().clone());
 
         let (tx, journal) = ctx.tx_journal_mut();

--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -184,14 +184,28 @@ impl SharedMemory {
 
     /// Creates a new memory instance that can be shared between calls,
     /// with `memory_limit` as upper bound for allocation size.
-    ///
-    /// The default initial capacity is 4KiB.
     #[cfg(feature = "memory_limit")]
     #[inline]
     pub fn new_with_memory_limit(memory_limit: u64) -> Self {
         Self {
             memory_limit,
             ..Self::new()
+        }
+    }
+
+    /// Creates a new memory instance that can be shared between calls,
+    /// with `memory_limit` as upper bound for allocation size.
+    #[cfg(feature = "memory_limit")]
+    #[inline]
+    pub fn new_with_buffer_and_memory_limit(
+        buffer: Rc<RefCell<Vec<u8>>>,
+        memory_limit: u64,
+    ) -> Self {
+        Self {
+            buffer: Some(buffer),
+            my_checkpoint: 0,
+            child_checkpoint: None,
+            memory_limit,
         }
     }
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -87,7 +87,7 @@ dev = [
 	"optional_eip7623",
 	"optional_no_base_fee",
 ]
-memory_limit = ["context/memory_limit", "interpreter/memory_limit"]
+memory_limit = ["context/memory_limit", "interpreter/memory_limit", "handler/memory_limit"]
 optional_balance_check = ["context/optional_balance_check"]
 optional_block_gas_limit = ["context/optional_block_gas_limit"]
 optional_eip3541 = ["context/optional_eip3541"]


### PR DESCRIPTION
`memory_limit` feature allows specifying maximum memory limit for EVM execution, but this setting is currently ignored when constructing EVM in `mainnet_builder.rs`. This change will unblock https://github.com/paradigmxyz/reth/issues/19107 in Reth, draft PR: https://github.com/paradigmxyz/reth/pull/19279.