### PR TITLE
feat(precompiles/jovian): add jovian precompiles to revm

### DIFF
--- a/crates/op-revm/src/precompiles.rs
+++ b/crates/op-revm/src/precompiles.rs
@@ -34,7 +34,8 @@ impl OpPrecompiles {
             | OpSpecId::ECOTONE) => Precompiles::new(spec.into_eth_spec().into()),
             OpSpecId::FJORD => fjord(),
             OpSpecId::GRANITE | OpSpecId::HOLOCENE => granite(),
-            OpSpecId::ISTHMUS | OpSpecId::INTEROP | OpSpecId::OSAKA | OpSpecId::JOVIAN => isthmus(),
+            OpSpecId::ISTHMUS => isthmus(),
+            OpSpecId::INTEROP | OpSpecId::OSAKA | OpSpecId::JOVIAN => jovian(),
         };
 
         Self {
@@ -92,6 +93,34 @@ pub fn isthmus() -> &'static Precompiles {
     })
 }
 
+/// Returns precompiles for jovian spec.
+pub fn jovian() -> &'static Precompiles {
+    static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
+    INSTANCE.get_or_init(|| {
+        let mut precompiles = isthmus().clone();
+
+        let mut to_remove = Precompiles::default();
+        to_remove.extend([
+            bn254::pair::ISTANBUL,
+            bls12_381::ISTHMUS_G1_MSM,
+            bls12_381::ISTHMUS_G2_MSM,
+            bls12_381::ISTHMUS_PAIRING,
+        ]);
+
+        // Replace the 4 variable-input precompiles with Jovian versions (reduced limits)
+        precompiles.difference(&to_remove);
+
+        precompiles.extend([
+            bn254_pair::JOVIAN,
+            bls12_381::JOVIAN_G1_MSM,
+            bls12_381::JOVIAN_G2_MSM,
+            bls12_381::JOVIAN_PAIRING,
+        ]);
+
+        precompiles
+    })
+}
+
 impl<CTX> PrecompileProvider<CTX> for OpPrecompiles
 where
     CTX: ContextTr<Cfg: Cfg<Spec = OpSpecId>>,
@@ -129,7 +158,7 @@ where
 
 impl Default for OpPrecompiles {
     fn default() -> Self {
-        Self::new_with_spec(OpSpecId::ISTHMUS)
+        Self::new_with_spec(OpSpecId::JOVIAN)
     }
 }
 
@@ -140,12 +169,37 @@ pub mod bn254_pair {
     /// Max input size for the bn254 pair precompile.
     pub const GRANITE_MAX_INPUT_SIZE: usize = 112687;
     /// Bn254 pair precompile.
-    pub const GRANITE: Precompile =
-        Precompile::new(PrecompileId::Bn254Pairing, bn254::pair::ADDRESS, run_pair);
+    pub const GRANITE: Precompile = Precompile::new(
+        PrecompileId::Bn254Pairing,
+        bn254::pair::ADDRESS,
+        run_pair_granite,
+    );
 
     /// Run the bn254 pair precompile with Optimism input limit.
-    pub fn run_pair(input: &[u8], gas_limit: u64) -> PrecompileResult {
+    pub fn run_pair_granite(input: &[u8], gas_limit: u64) -> PrecompileResult {
         if input.len() > GRANITE_MAX_INPUT_SIZE {
+            return Err(PrecompileError::Bn254PairLength);
+        }
+        bn254::run_pair(
+            input,
+            bn254::pair::ISTANBUL_PAIR_PER_POINT,
+            bn254::pair::ISTANBUL_PAIR_BASE,
+            gas_limit,
+        )
+    }
+
+    /// Max input size for the bn254 pair precompile.
+    pub const JOVIAN_MAX_INPUT_SIZE: usize = 81_984;
+    /// Bn254 pair precompile.
+    pub const JOVIAN: Precompile = Precompile::new(
+        PrecompileId::Bn254Pairing,
+        bn254::pair::ADDRESS,
+        run_pair_jovian,
+    );
+
+    /// Run the bn254 pair precompile with Optimism input limit.
+    pub fn run_pair_jovian(input: &[u8], gas_limit: u64) -> PrecompileResult {
+        if input.len() > JOVIAN_MAX_INPUT_SIZE {
             return Err(PrecompileError::Bn254PairLength);
         }
         bn254::run_pair(
@@ -167,33 +221,67 @@ pub mod bls12_381 {
 
     /// Max input size for the g1 msm precompile.
     pub const ISTHMUS_G1_MSM_MAX_INPUT_SIZE: usize = 513760;
+
+    /// The maximum input size for the BLS12-381 g1 msm operation after the Jovian Hardfork.
+    pub const JOVIAN_G1_MSM_MAX_INPUT_SIZE: usize = 288_960;
+
     /// Max input size for the g2 msm precompile.
     pub const ISTHMUS_G2_MSM_MAX_INPUT_SIZE: usize = 488448;
+
+    /// Max input size for the g2 msm precompile after the Jovian Hardfork.
+    pub const JOVIAN_G2_MSM_MAX_INPUT_SIZE: usize = 278_784;
+
     /// Max input size for the pairing precompile.
     pub const ISTHMUS_PAIRING_MAX_INPUT_SIZE: usize = 235008;
 
+    /// Max input size for the pairing precompile after the Jovian Hardfork.
+    pub const JOVIAN_PAIRING_MAX_INPUT_SIZE: usize = 156_672;
+
     /// G1 msm precompile.
     pub const ISTHMUS_G1_MSM: Precompile =
-        Precompile::new(PrecompileId::Bls12G1Msm, G1_MSM_ADDRESS, run_g1_msm);
+        Precompile::new(PrecompileId::Bls12G1Msm, G1_MSM_ADDRESS, run_g1_msm_isthmus);
     /// G2 msm precompile.
     pub const ISTHMUS_G2_MSM: Precompile =
-        Precompile::new(PrecompileId::Bls12G2Msm, G2_MSM_ADDRESS, run_g2_msm);
+        Precompile::new(PrecompileId::Bls12G2Msm, G2_MSM_ADDRESS, run_g2_msm_isthmus);
     /// Pairing precompile.
-    pub const ISTHMUS_PAIRING: Precompile =
-        Precompile::new(PrecompileId::Bls12Pairing, PAIRING_ADDRESS, run_pair);
+    pub const ISTHMUS_PAIRING: Precompile = Precompile::new(
+        PrecompileId::Bls12Pairing,
+        PAIRING_ADDRESS,
+        run_pair_isthmus,
+    );
+
+    /// G1 msm precompile after the Jovian Hardfork.
+    pub const JOVIAN_G1_MSM: Precompile =
+        Precompile::new(PrecompileId::Bls12G1Msm, G1_MSM_ADDRESS, run_g1_msm_jovian);
+    /// G2 msm precompile after the Jovian Hardfork.
+    pub const JOVIAN_G2_MSM: Precompile =
+        Precompile::new(PrecompileId::Bls12G2Msm, G2_MSM_ADDRESS, run_g2_msm_jovian);
+    /// Pairing precompile after the Jovian Hardfork.
+    pub const JOVIAN_PAIRING: Precompile =
+        Precompile::new(PrecompileId::Bls12Pairing, PAIRING_ADDRESS, run_pair_jovian);
 
     /// Run the g1 msm precompile with Optimism input limit.
-    pub fn run_g1_msm(input: &[u8], gas_limit: u64) -> PrecompileResult {
+    pub fn run_g1_msm_isthmus(input: &[u8], gas_limit: u64) -> PrecompileResult {
         if input.len() > ISTHMUS_G1_MSM_MAX_INPUT_SIZE {
             return Err(PrecompileError::Other(
-                "G1MSM input length too long for OP Stack input size limitation".to_string(),
+                "G1MSM input length too long for OP Stack input size limitation after the Isthmus Hardfork".to_string(),
+            ));
+        }
+        precompile::bls12_381::g1_msm::g1_msm(input, gas_limit)
+    }
+
+    /// Run the g1 msm precompile with Optimism input limit.
+    pub fn run_g1_msm_jovian(input: &[u8], gas_limit: u64) -> PrecompileResult {
+        if input.len() > JOVIAN_G1_MSM_MAX_INPUT_SIZE {
+            return Err(PrecompileError::Other(
+                "G1MSM input length too long for OP Stack input size limitation after the Jovian Hardfork".to_string(),
             ));
         }
         precompile::bls12_381::g1_msm::g1_msm(input, gas_limit)
     }
 
     /// Run the g2 msm precompile with Optimism input limit.
-    pub fn run_g2_msm(input: &[u8], gas_limit: u64) -> PrecompileResult {
+    pub fn run_g2_msm_isthmus(input: &[u8], gas_limit: u64) -> PrecompileResult {
         if input.len() > ISTHMUS_G2_MSM_MAX_INPUT_SIZE {
             return Err(PrecompileError::Other(
                 "G2MSM input length too long for OP Stack input size limitation".to_string(),
@@ -202,11 +290,31 @@ pub mod bls12_381 {
         precompile::bls12_381::g2_msm::g2_msm(input, gas_limit)
     }
 
+    /// Run the g2 msm precompile with Optimism input limit after the Jovian Hardfork.
+    pub fn run_g2_msm_jovian(input: &[u8], gas_limit: u64) -> PrecompileResult {
+        if input.len() > JOVIAN_G2_MSM_MAX_INPUT_SIZE {
+            return Err(PrecompileError::Other(
+                "G2MSM input length too long for OP Stack input size limitation after the Jovian Hardfork".to_string(),
+            ));
+        }
+        precompile::bls12_381::g2_msm::g2_msm(input, gas_limit)
+    }
+
     /// Run the pairing precompile with Optimism input limit.
-    pub fn run_pair(input: &[u8], gas_limit: u64) -> PrecompileResult {
+    pub fn run_pair_isthmus(input: &[u8], gas_limit: u64) -> PrecompileResult {
         if input.len() > ISTHMUS_PAIRING_MAX_INPUT_SIZE {
             return Err(PrecompileError::Other(
                 "Pairing input length too long for OP Stack input size limitation".to_string(),
+            ));
+        }
+        precompile::bls12_381::pairing::pairing(input, gas_limit)
+    }
+
+    /// Run the pairing precompile with Optimism input limit after the Jovian Hardfork.
+    pub fn run_pair_jovian(input: &[u8], gas_limit: u64) -> PrecompileResult {
+        if input.len() > JOVIAN_PAIRING_MAX_INPUT_SIZE {
+            return Err(PrecompileError::Other(
+                "Pairing input length too long for OP Stack input size limitation after the Jovian Hardfork".to_string(),
             ));
         }
         precompile::bls12_381::pairing::pairing(input, gas_limit)
@@ -216,13 +324,15 @@ pub mod bls12_381 {
 #[cfg(test)]
 mod tests {
     use crate::precompiles::bls12_381::{
-        run_g1_msm, run_g2_msm, ISTHMUS_G1_MSM_MAX_INPUT_SIZE, ISTHMUS_G2_MSM_MAX_INPUT_SIZE,
-        ISTHMUS_PAIRING_MAX_INPUT_SIZE,
+        run_g1_msm_isthmus, run_g1_msm_jovian, run_g2_msm_isthmus, run_g2_msm_jovian,
+        ISTHMUS_G1_MSM_MAX_INPUT_SIZE, ISTHMUS_G2_MSM_MAX_INPUT_SIZE,
+        ISTHMUS_PAIRING_MAX_INPUT_SIZE, JOVIAN_G1_MSM_MAX_INPUT_SIZE, JOVIAN_G2_MSM_MAX_INPUT_SIZE,
+        JOVIAN_PAIRING_MAX_INPUT_SIZE,
     };
 
     use super::*;
     use revm::{
-        precompile::PrecompileError,
+        precompile::{bls12_381_const, PrecompileError},
         primitives::{hex, Bytes},
     };
     use std::vec;
@@ -248,7 +358,7 @@ mod tests {
         let expected =
             hex::decode("0000000000000000000000000000000000000000000000000000000000000001")
                 .unwrap();
-        let outcome = bn254_pair::run_pair(&input, 260_000).unwrap();
+        let outcome = bn254_pair::run_pair_granite(&input, 260_000).unwrap();
         assert_eq!(outcome.bytes, expected);
 
         // Invalid input length
@@ -261,18 +371,89 @@ mod tests {
         )
         .unwrap();
 
-        let res = bn254_pair::run_pair(&input, 260_000);
+        let res = bn254_pair::run_pair_granite(&input, 260_000);
         assert!(matches!(res, Err(PrecompileError::Bn254PairLength)));
 
         // Valid input length shorter than 112687
         let input = vec![1u8; 586 * bn254::PAIR_ELEMENT_LEN];
-        let res = bn254_pair::run_pair(&input, 260_000);
+        let res = bn254_pair::run_pair_granite(&input, 260_000);
         assert!(matches!(res, Err(PrecompileError::OutOfGas)));
 
         // Input length longer than 112687
         let input = vec![1u8; 587 * bn254::PAIR_ELEMENT_LEN];
-        let res = bn254_pair::run_pair(&input, 260_000);
+        let res = bn254_pair::run_pair_granite(&input, 260_000);
         assert!(matches!(res, Err(PrecompileError::Bn254PairLength)));
+    }
+
+    #[test]
+    fn test_accelerated_bn254_pairing_jovian() {
+        const TEST_INPUT: [u8; 384] = hex!(
+            "2cf44499d5d27bb186308b7af7af02ac5bc9eeb6a3d147c186b21fb1b76e18da2c0f001f52110ccfe69108924926e45f0b0c868df0e7bde1fe16d3242dc715f61fb19bb476f6b9e44e2a32234da8212f61cd63919354bc06aef31e3cfaff3ebc22606845ff186793914e03e21df544c34ffe2f2f3504de8a79d9159eca2d98d92bd368e28381e8eccb5fa81fc26cf3f048eea9abfdd85d7ed3ab3698d63e4f902fe02e47887507adf0ff1743cbac6ba291e66f59be6bd763950bb16041a0a85e000000000000000000000000000000000000000000000000000000000000000130644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd451971ff0471b09fa93caaf13cbf443c1aede09cc4328f5a62aad45f40ec133eb4091058a3141822985733cbdddfed0fd8d6c104e9e9eff40bf5abfef9ab163bc72a23af9a5ce2ba2796c1f4e453a370eb0af8c212d9dc9acd8fc02c2e907baea223a8eb0b0996252cb548a4487da97b02422ebc0e834613f954de6c7e0afdc1fc"
+        );
+        const EXPECTED_OUTPUT: [u8; 32] =
+            hex!("0000000000000000000000000000000000000000000000000000000000000001");
+
+        let res = bn254_pair::run_pair_jovian(TEST_INPUT.as_ref(), u64::MAX);
+        assert!(matches!(res, Ok(outcome) if **outcome.bytes == EXPECTED_OUTPUT));
+    }
+
+    #[test]
+    fn test_accelerated_bn254_pairing_bad_input_len_jovian() {
+        let input = [0u8; bn254_pair::JOVIAN_MAX_INPUT_SIZE + 1];
+        let res = bn254_pair::run_pair_jovian(&input, u64::MAX);
+        assert!(matches!(res, Err(PrecompileError::Bn254PairLength)));
+    }
+
+    #[test]
+    fn test_get_jovian_precompile_with_bad_input_len() {
+        let precompiles = OpPrecompiles::new_with_spec(OpSpecId::JOVIAN);
+        let bn254_pair_precompile = precompiles
+            .precompiles()
+            .get(&bn254::pair::ADDRESS)
+            .unwrap();
+
+        let mut bad_input_len = bn254_pair::JOVIAN_MAX_INPUT_SIZE + 1;
+        assert!(bad_input_len < bn254_pair::GRANITE_MAX_INPUT_SIZE);
+        let input = vec![0u8; bad_input_len];
+
+        let res = bn254_pair_precompile.execute(&input, u64::MAX);
+        assert!(matches!(res, Err(PrecompileError::Bn254PairLength)));
+
+        let bls12_381_g1_msm_precompile = precompiles
+            .precompiles()
+            .get(&bls12_381_const::G1_MSM_ADDRESS)
+            .unwrap();
+        bad_input_len = bls12_381::JOVIAN_G1_MSM_MAX_INPUT_SIZE + 1;
+        assert!(bad_input_len < bls12_381::ISTHMUS_G1_MSM_MAX_INPUT_SIZE);
+        let input = vec![0u8; bad_input_len];
+        let res = bls12_381_g1_msm_precompile.execute(&input, u64::MAX);
+        assert!(
+            matches!(res, Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
+        );
+
+        let bls12_381_g2_msm_precompile = precompiles
+            .precompiles()
+            .get(&bls12_381_const::G2_MSM_ADDRESS)
+            .unwrap();
+        bad_input_len = bls12_381::JOVIAN_G2_MSM_MAX_INPUT_SIZE + 1;
+        assert!(bad_input_len < bls12_381::ISTHMUS_G2_MSM_MAX_INPUT_SIZE);
+        let input = vec![0u8; bad_input_len];
+        let res = bls12_381_g2_msm_precompile.execute(&input, u64::MAX);
+        assert!(
+            matches!(res, Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
+        );
+
+        let bls12_381_pairing_precompile = precompiles
+            .precompiles()
+            .get(&bls12_381_const::PAIRING_ADDRESS)
+            .unwrap();
+        bad_input_len = bls12_381::JOVIAN_PAIRING_MAX_INPUT_SIZE + 1;
+        assert!(bad_input_len < bls12_381::ISTHMUS_PAIRING_MAX_INPUT_SIZE);
+        let input = vec![0u8; bad_input_len];
+        let res = bls12_381_pairing_precompile.execute(&input, u64::MAX);
+        assert!(
+            matches!(res, Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
+        );
     }
 
     #[test]
@@ -297,6 +478,23 @@ mod tests {
     }
 
     #[test]
+    fn test_prague_precompiles_in_jovian() {
+        let new_prague_precompiles = Precompiles::prague().difference(Precompiles::cancun());
+
+        // jovian contains all precompiles that were new in prague, without modifications
+        assert!(new_prague_precompiles.difference(jovian()).is_empty())
+    }
+
+    /// All the addresses of the precompiles in isthmus should be in jovian
+    #[test]
+    fn test_isthmus_precompiles_in_jovian() {
+        let new_isthmus_precompiles = isthmus().difference(Precompiles::cancun());
+
+        // jovian contains all precompiles that were new in isthmus, without modifications
+        assert!(new_isthmus_precompiles.difference(jovian()).is_empty())
+    }
+
+    #[test]
     fn test_default_precompiles_is_latest() {
         let latest = OpPrecompiles::new_with_spec(OpSpecId::default())
             .inner
@@ -313,7 +511,19 @@ mod tests {
         let oversized_input = vec![0u8; ISTHMUS_G1_MSM_MAX_INPUT_SIZE + 1];
         let input = Bytes::from(oversized_input);
 
-        let res = run_g1_msm(&input, 260_000);
+        let res = run_g1_msm_isthmus(&input, 260_000);
+
+        assert!(
+            matches!(res, Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
+        );
+    }
+
+    #[test]
+    fn test_g1_jovian_max_size() {
+        let oversized_input = vec![0u8; JOVIAN_G1_MSM_MAX_INPUT_SIZE + 1];
+        let input = Bytes::from(oversized_input);
+
+        let res = run_g1_msm_jovian(&input, u64::MAX);
 
         assert!(
             matches!(res, Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
@@ -324,7 +534,18 @@ mod tests {
         let oversized_input = vec![0u8; ISTHMUS_G2_MSM_MAX_INPUT_SIZE + 1];
         let input = Bytes::from(oversized_input);
 
-        let res = run_g2_msm(&input, 260_000);
+        let res = run_g2_msm_isthmus(&input, 260_000);
+
+        assert!(
+            matches!(res, Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
+        );
+    }
+    #[test]
+    fn test_g2_jovian_max_size() {
+        let oversized_input = vec![0u8; JOVIAN_G2_MSM_MAX_INPUT_SIZE + 1];
+        let input = Bytes::from(oversized_input);
+
+        let res = run_g2_msm_jovian(&input, u64::MAX);
 
         assert!(
             matches!(res, Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
@@ -335,7 +556,18 @@ mod tests {
         let oversized_input = vec![0u8; ISTHMUS_PAIRING_MAX_INPUT_SIZE + 1];
         let input = Bytes::from(oversized_input);
 
-        let res = bls12_381::run_pair(&input, 260_000);
+        let res = bls12_381::run_pair_isthmus(&input, 260_000);
+
+        assert!(
+            matches!(res, Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
+        );
+    }
+    #[test]
+    fn test_pair_jovian_max_size() {
+        let oversized_input = vec![0u8; JOVIAN_PAIRING_MAX_INPUT_SIZE + 1];
+        let input = Bytes::from(oversized_input);
+
+        let res = bls12_381::run_pair_jovian(&input, u64::MAX);
 
         assert!(
             matches!(res, Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))


### PR DESCRIPTION
## Description

Updates the precompiles for the Jovian hardfork.

Relevant `op-geth` PR: https://github.com/ethereum-optimism/op-geth/pull/709

@pauldowman