### PR TITLE
fix(context): avoid double reference in `Context::all()`

### DIFF
--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -70,7 +70,7 @@ impl<
         let block = &self.block;
         let tx = &self.tx;
         let cfg = &self.cfg;
-        let db = &self.journaled_state.db();
+        let db = self.journaled_state.db();
         let journal = &self.journaled_state;
         let chain = &self.chain;
         let local = &self.local;


### PR DESCRIPTION
`Context::all()` was taking `&self.journaled_state.db()`, producing `&&DB` instead of `&DB`.
This removes the redundant borrow and returns a proper database reference.
No behavior changes — just borrow simplification and cleaner API usage.
