### PR TITLE
feat: selfdestruct oog on cold load

### DIFF
--- a/crates/context/interface/src/host.rs
+++ b/crates/context/interface/src/host.rs
@@ -72,7 +72,8 @@ pub trait Host {
         &mut self,
         address: Address,
         target: Address,
-    ) -> Option<StateLoad<SelfDestructResult>>;
+        skip_cold_load: bool,
+    ) -> Result<StateLoad<SelfDestructResult>, LoadError>;
 
     /// Log, calls `ContextTr::journal_mut().log(log)`
     fn log(&mut self, log: Log);
@@ -263,8 +264,9 @@ impl Host for DummyHost {
         &mut self,
         _address: Address,
         _target: Address,
-    ) -> Option<StateLoad<SelfDestructResult>> {
-        None
+        _skip_cold_load: bool,
+    ) -> Result<StateLoad<SelfDestructResult>, LoadError> {
+        Err(LoadError::ColdLoadSkipped)
     }
 
     fn log(&mut self, _log: Log) {}

--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -92,7 +92,8 @@ pub trait JournalTr {
         &mut self,
         address: Address,
         target: Address,
-    ) -> Result<StateLoad<SelfDestructResult>, <Self::Database as Database>::Error>;
+        skip_cold_load: bool,
+    ) -> Result<StateLoad<SelfDestructResult>, JournalLoadError<<Self::Database as Database>::Error>>;
 
     /// Sets access list inside journal.
     fn warm_access_list(&mut self, access_list: HashMap<Address, HashSet<StorageKey>>);

--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -526,13 +526,17 @@ impl<
         &mut self,
         address: Address,
         target: Address,
-    ) -> Option<StateLoad<SelfDestructResult>> {
+        skip_cold_load: bool,
+    ) -> Result<StateLoad<SelfDestructResult>, LoadError> {
         self.journal_mut()
-            .selfdestruct(address, target)
+            .selfdestruct(address, target, skip_cold_load)
             .map_err(|e| {
-                *self.error() = Err(e.into());
+                let (ret, err) = e.into_parts();
+                if let Some(err) = err {
+                    *self.error() = Err(err.into());
+                }
+                ret
             })
-            .ok()
     }
 
     #[inline]

--- a/crates/context/src/journal.rs
+++ b/crates/context/src/journal.rs
@@ -146,8 +146,11 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
         &mut self,
         address: Address,
         target: Address,
-    ) -> Result<StateLoad<SelfDestructResult>, DB::Error> {
-        self.inner.selfdestruct(&mut self.database, address, target)
+        skip_cold_load: bool,
+    ) -> Result<StateLoad<SelfDestructResult>, JournalLoadError<<Self::Database as Database>::Error>>
+    {
+        self.inner
+            .selfdestruct(&mut self.database, address, target, skip_cold_load)
     }
 
     #[inline]

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -497,9 +497,10 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         db: &mut DB,
         address: Address,
         target: Address,
-    ) -> Result<StateLoad<SelfDestructResult>, DB::Error> {
+        skip_cold_load: bool,
+    ) -> Result<StateLoad<SelfDestructResult>, JournalLoadError<<DB as Database>::Error>> {
         let spec = self.spec;
-        let account_load = self.load_account(db, target)?;
+        let account_load = self.load_account_optional(db, target, false, skip_cold_load)?;
         let is_cold = account_load.is_cold;
         let is_empty = account_load.state_clear_aware_is_empty(spec);
 

--- a/examples/cheatcode_inspector/src/main.rs
+++ b/examples/cheatcode_inspector/src/main.rs
@@ -107,8 +107,10 @@ impl JournalTr for Backend {
         &mut self,
         address: Address,
         target: Address,
-    ) -> Result<StateLoad<SelfDestructResult>, Infallible> {
-        self.journaled_state.selfdestruct(address, target)
+        skip_cold_load: bool,
+    ) -> Result<StateLoad<SelfDestructResult>, JournalLoadError<Infallible>> {
+        self.journaled_state
+            .selfdestruct(address, target, skip_cold_load)
     }
 
     fn warm_access_list(


### PR DESCRIPTION
Fix for BAL, selfdestruct should not cold load the target account if there is not enought gas to do such operation. 