### PR TITLE
feat: expose `balance_decr` on `Journal`

### DIFF
--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -144,6 +144,13 @@ pub trait JournalTr {
         balance: U256,
     ) -> Result<(), <Self::Database as Database>::Error>;
 
+    /// Decrements the balance of the account.
+    fn balance_decr(
+        &mut self,
+        address: Address,
+        balance: U256,
+    ) -> Result<(), <Self::Database as Database>::Error>;
+
     /// Increments the nonce of the account.
     fn nonce_bump_journal_entry(&mut self, address: Address);
 

--- a/crates/context/src/journal.rs
+++ b/crates/context/src/journal.rs
@@ -231,6 +231,17 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
             .balance_incr(&mut self.database, address, balance)
     }
 
+    /// Decrements the balance of the account.
+    #[inline]
+    fn balance_decr(
+        &mut self,
+        address: Address,
+        balance: U256,
+    ) -> Result<(), <Self::Database as Database>::Error> {
+        self.inner
+            .balance_decr(&mut self.database, address, balance)
+    }
+
     /// Increments the nonce of the account.
     #[inline]
     fn nonce_bump_journal_entry(&mut self, address: Address) {

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -300,6 +300,21 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         Ok(())
     }
 
+    /// Decrements the balance of the account.
+    ///
+    /// Mark account as touched.
+    #[inline]
+    pub fn balance_decr<DB: Database>(
+        &mut self,
+        db: &mut DB,
+        address: Address,
+        balance: U256,
+    ) -> Result<(), DB::Error> {
+        let mut account = self.load_account_mut(db, address)?.data;
+        account.decr_balance(balance);
+        Ok(())
+    }
+
     /// Increments the nonce of the account.
     #[inline]
     pub fn nonce_bump_journal_entry(&mut self, address: Address) {

--- a/examples/cheatcode_inspector/src/main.rs
+++ b/examples/cheatcode_inspector/src/main.rs
@@ -249,6 +249,14 @@ impl JournalTr for Backend {
         self.journaled_state.balance_incr(address, balance)
     }
 
+    fn balance_decr(
+        &mut self,
+        address: Address,
+        balance: U256,
+    ) -> Result<(), <Self::Database as Database>::Error> {
+        self.journaled_state.balance_decr(address, balance)
+    }
+
     fn nonce_bump_journal_entry(&mut self, address: Address) {
         self.journaled_state.nonce_bump_journal_entry(address)
     }

--- a/examples/custom_precompile_journal/README.md
+++ b/examples/custom_precompile_journal/README.md
@@ -79,6 +79,12 @@ context
     .journal_mut()
     .balance_incr(address, amount)
     .map_err(|e| PrecompileError::Other(format!("Balance increment failed: {:?}", e)))?;
+
+/// Decrementing balance
+context
+    .journal_mut()
+    .balance_decr(address, amount)
+    .map_err(|e| PrecompileError::Other(format!("Balance decrement failed: {:?}", e)))?;
 ```
 
 ## Usage


### PR DESCRIPTION
Mirroring `balance_incr`, Foundry requires this as we deduct from a balance in this Celo precompile: https://github.com/foundry-rs/foundry/blob/806792b21fd5ae9b9d2480b37a8a616ad09b544e/crates/evm/networks/src/celo/transfer.rs#L82

I did not find tests to extend for this particular piece of code