### PR TITLE
feat: add `set_nonce` on `JournalState`

### DIFF
--- a/crates/context/interface/src/journaled_state/account.rs
+++ b/crates/context/interface/src/journaled_state/account.rs
@@ -137,6 +137,17 @@ impl<'a, ENTRY: JournalEntryTr> JournaledAccount<'a, ENTRY> {
         true
     }
 
+    /// Sets the nonce of the account.
+    ///
+    /// Touches the account in all cases.
+    #[inline]
+    pub fn set_nonce(&mut self, nonce: u64) {
+        self.touch();
+        self.account.info.set_nonce(nonce);
+        self.journal_entries
+            .push(ENTRY::nonce_changed(self.address));
+    }
+
     /// Sets the code of the account.
     ///
     /// Touches the account in all cases.


### PR DESCRIPTION
Foundry requires this in https://github.com/foundry-rs/foundry/blob/806792b21fd5ae9b9d2480b37a8a616ad09b544e/crates/evm/core/src/backend/mod.rs#L1457