### PR TITLE
chore(interpreter): deprecate public otry! macro

### DIFF
--- a/crates/interpreter/src/instructions/macros.rs
+++ b/crates/interpreter/src/instructions/macros.rs
@@ -28,6 +28,10 @@ macro_rules! require_non_staticcall {
 /// Similar to the `?` operator but for use in instruction implementations.
 #[macro_export]
 #[collapse_debuginfo(yes)]
+#[deprecated(
+    since = "29.0.0",
+    note = "Prefer `let Some(x) = expr else { return; };` for early return in instruction functions"
+)]
 macro_rules! otry {
     ($expression: expr) => {{
         let Some(value) = $expression else {


### PR DESCRIPTION
Deprecated revm_interpreter::otry! The macro is unused internally across the workspace but is part of the public API and documented on docs.rs. Guides users toward the idiomatic let Some(x) = expr else { return; }; pattern for early return in instruction functions.