### PR TITLE
chore: deprecate InterpreterAction::new_stop

### DIFF
--- a/crates/interpreter/src/interpreter_action.rs
+++ b/crates/interpreter/src/interpreter_action.rs
@@ -121,6 +121,7 @@ impl InterpreterAction {
     }
 
     /// Create new stop action.
+    #[deprecated(note = "Use new_halt(InstructionResult::Stop, gas).")]
     #[inline]
     pub fn new_stop() -> Self {
         Self::Return(InterpreterResult::new(


### PR DESCRIPTION
Deprecate InterpreterAction::new_stop because it constructs a STOP result with zero gas, which contradicts EVM semantics where STOP preserves the remaining gas. Consumers should use new_halt(InstructionResult::Stop, gas) or interpreter.halt(InstructionResult::Stop) to preserve gas.