### PR TITLE
fix(op): Ensure L1Block account is always loaded (#3150)

### DIFF
--- a/crates/ee-tests/tests/op_revm_testdata/test_l1block_load_for_regolit.json
+++ b/crates/ee-tests/tests/op_revm_testdata/test_l1block_load_for_regolit.json
@@ -1,0 +1,165 @@
+{
+  "result": {
+    "Success": {
+      "gas_refunded": 0,
+      "gas_used": 21000,
+      "logs": [],
+      "output": {
+        "Call": "0x"
+      },
+      "reason": "Stop"
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x0000000000000000000000000000000000100000": {
+      "info": {
+        "balance": "0x1",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee": {
+      "info": {
+        "balance": "0x2386f26fc0ffff",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "status": "Touched",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/crates/op-revm/src/l1block.rs
+++ b/crates/op-revm/src/l1block.rs
@@ -16,7 +16,7 @@ use revm::{
         gas::{get_tokens_in_calldata, NON_ZERO_BYTE_MULTIPLIER_ISTANBUL, STANDARD_TOKEN_COST},
         Gas,
     },
-    primitives::{hardfork::SpecId, U256},
+    primitives::U256,
 };
 
 /// L1 block info
@@ -138,11 +138,8 @@ impl L1BlockInfo {
         l2_block: U256,
         spec_id: OpSpecId,
     ) -> Result<L1BlockInfo, DB::Error> {
-        // Ensure the L1 Block account is loaded into the cache after Ecotone. With EIP-4788, it is no longer the case
-        // that the L1 block account is loaded into the cache prior to the first inquiry for the L1 block info.
-        if spec_id.into_eth_spec().is_enabled_in(SpecId::CANCUN) {
-            let _ = db.basic(L1_BLOCK_CONTRACT)?;
-        }
+        // Ensure the L1 Block account is loaded into the cache.
+        let _ = db.basic(L1_BLOCK_CONTRACT)?;
 
         let mut out = L1BlockInfo {
             l2_block: Some(l2_block),


### PR DESCRIPTION
Backport from op-revm 12.0.2 release: #3150 