### PR TITLE
fix: expose optional_priority_fee_check feature from context crate

### DIFF
--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -98,6 +98,7 @@ optional_eip3607 = ["context/optional_eip3607"]
 optional_eip7623 = ["context/optional_eip7623"]
 optional_no_base_fee = ["context/optional_no_base_fee"]
 optional_fee_charge = ["context/optional_fee_charge"]
+optional_priority_fee_check = ["context/optional_priority_fee_check"]
 
 # Precompiles features: Please look at the comments in `precompile` crate for more information.
 


### PR DESCRIPTION
Add missing `optional_priority_fee_check` feature (introduced at #2588) forwarding from `context` crate to allow disabling priority fee validation checks.