### PR TITLE
feat(context): add mark_cold method to JournaledAccount

### DIFF
--- a/crates/context/interface/src/journaled_state/account.rs
+++ b/crates/context/interface/src/journaled_state/account.rs
@@ -77,9 +77,14 @@ impl<'a, ENTRY: JournalEntryTr> JournaledAccount<'a, ENTRY> {
         }
     }
 
-    /// Marks the account as cold.
+    /// Marks the account as cold without making a journal entry.
+    ///
+    /// Changing account without journal entry can be a footgun as reverting of the journal
+    /// would not happen without entry. It is the reason why this function has an `unsafe` prefix.
+    ///
+    /// If account is in access list, it would still be marked as warm if account get accessed again.
     #[inline]
-    pub fn mark_cold(&mut self) {
+    pub fn unsafe_mark_cold(&mut self) {
         self.account.mark_cold();
     }
 


### PR DESCRIPTION
Add a public `mark_cold()` method to `JournaledAccount` that delegates to the underlying `Account::mark_cold()`. This is analogous to the other methods and provides a way to mark accounts as cold that was available in previous revm versions.

This is used by celo-revm to provide backwards compatibility for the `transfer` precompile, which does not warm addresses in its initial implementation.
See https://github.com/celo-org/celo-kona/blob/f466c56a909513dbdc4b2fbfa4445121aaaea82d/crates/celo-revm/src/precompiles/transfer.rs#L134-L141 and https://github.com/celo-org/celo-kona/blob/f466c56a909513dbdc4b2fbfa4445121aaaea82d/crates/celo-revm/src/precompiles/transfer.rs#L107-L109