### PR TITLE
bump: tag v100 revm v33.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
 
+# v100
+date: 12.11.2025
+
+Bumping major version for `revm-context-interface` sa it is breaking change.
+Host selfdestruct function got changed in v99
+
+* `revm-context-interface`: 12.1.0 -> 13.0.0 (⚠ API breaking changes)
+* `revm-context`: 11.1.0 -> 12.0.0 (✓ API compatible changes)
+* `revm-interpreter`: 30.0.0 -> 31.0.0 (✓ API compatible changes)
+* `revm-precompile`: 30.0.0 -> 31.0.0 (✓ API compatible changes)
+* `revm-handler`: 13.0.0 -> 14.0.0 (✓ API compatible changes)
+* `revm-inspector`: 13.0.0 -> 14.0.0 (✓ API compatible changes)
+* `op-revm`: 13.0.0 -> 14.0.0 (✓ API compatible changes)
+* `revm-ee-tests`: 0.1.0
+* `revm`: 32.0.0 -> 33.0.0
+* `revm-statetest-types`: 12.0.0 -> 13.0.0
+* `revme`: 9.1.0 -> 10.0.0
+
+revm-context-interface@13.0.0 revm-context@12.0.0 revm-interpreter@31.0.0 revm-precompile@31.0.0 revm-handler@14.0.0 revm-inspector@14.0.0
+op-revm@14.0.0 revm@33.0.0 revm-statetest-types@13.0.0 revme@10.0.0
+
 # v99
 date 10.11.2025
 
@@ -16,6 +37,8 @@ Maintainance release.
 * `revm`: 31.0.2 -> 32.0.0
 * `revm-statetest-types`: 11.0.2 -> 12.0.0
 * `revme`: 9.0.2 -> 9.1.0
+
+
 
 # v98
 date: 10.11.2025

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,7 +2922,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-revm"
-version = "13.0.0"
+version = "14.0.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -3533,7 +3533,7 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "32.0.0"
+version = "33.0.0"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "11.1.0"
+version = "12.0.0"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "12.1.0"
+version = "13.0.0"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3636,7 +3636,7 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "13.0.0"
+version = "14.0.0"
 dependencies = [
  "alloy-provider",
  "alloy-signer",
@@ -3657,7 +3657,7 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "13.0.0"
+version = "14.0.0"
 dependencies = [
  "auto_impl",
  "either",
@@ -3674,7 +3674,7 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3686,7 +3686,7 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3734,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "revm-statetest-types"
-version = "12.0.0"
+version = "13.0.0"
 dependencies = [
  "alloy-eips",
  "k256",
@@ -3746,7 +3746,7 @@ dependencies = [
 
 [[package]]
 name = "revme"
-version = "9.1.0"
+version = "10.0.0"
 dependencies = [
  "alloy-rlp",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,20 +41,20 @@ default-members = ["crates/revm"]
 
 [workspace.dependencies]
 # revm
-revm = { path = "crates/revm", version = "32.0.0", default-features = false }
+revm = { path = "crates/revm", version = "33.0.0", default-features = false }
 primitives = { path = "crates/primitives", package = "revm-primitives", version = "21.0.2", default-features = false }
 bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "7.1.1", default-features = false }
 database = { path = "crates/database", package = "revm-database", version = "9.0.5", default-features = false }
 database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "8.0.5", default-features = false }
 state = { path = "crates/state", package = "revm-state", version = "8.1.1", default-features = false }
-interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "30.0.0", default-features = false }
-inspector = { path = "crates/inspector", package = "revm-inspector", version = "13.0.0", default-features = false }
-precompile = { path = "crates/precompile", package = "revm-precompile", version = "30.0.0", default-features = false }
-statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "12.0.0", default-features = false }
-context = { path = "crates/context", package = "revm-context", version = "11.1.0", default-features = false }
-context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "12.1.0", default-features = false }
-handler = { path = "crates/handler", package = "revm-handler", version = "13.0.0", default-features = false }
-op-revm = { path = "crates/op-revm", package = "op-revm", version = "13.0.0", default-features = false }
+interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "31.0.0", default-features = false }
+inspector = { path = "crates/inspector", package = "revm-inspector", version = "14.0.0", default-features = false }
+precompile = { path = "crates/precompile", package = "revm-precompile", version = "31.0.0", default-features = false }
+statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "13.0.0", default-features = false }
+context = { path = "crates/context", package = "revm-context", version = "12.0.0", default-features = false }
+context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "13.0.0", default-features = false }
+handler = { path = "crates/handler", package = "revm-handler", version = "14.0.0", default-features = false }
+op-revm = { path = "crates/op-revm", package = "op-revm", version = "14.0.0", default-features = false }
 ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "0.1.0", default-features = false }
 
 # alloy

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,5 +1,12 @@
 
+# v100 tag (revm v33.0.0)
+
+* Additionally to v99 version:
+  * `Host::selfdestruct` function got changed to support oog on cold load for target account. 
+
 # v99 tag ( revm v32.0.0 )
+
+(yanked version)
 
 * Added support for transmitting Logs set from precompiles.
    * `Inspector::log` function got renamed to `log` and `log_full`

--- a/bins/revme/CHANGELOG.md
+++ b/bins/revme/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [9.1.0](https://github.com/bluealloy/revm/compare/revme-v9.0.2...revme-v9.1.0) - 2025-11-10
+## [10.0.0](https://github.com/bluealloy/revm/compare/revme-v9.0.2...revme-v10.0.0) - 2025-11-10
 
 ### Other
 

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revme"
 description = "Rust Ethereum Virtual Machine Executable"
-version = "9.1.0"
+version = "10.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/context/CHANGELOG.md
+++ b/crates/context/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.1.0](https://github.com/bluealloy/revm/compare/revm-context-v11.0.2...revm-context-v11.1.0) - 2025-11-10
+## [12.0.0](https://github.com/bluealloy/revm/compare/revm-context-v11.0.2...revm-context-v12.0.0) - 2025-11-10
 
 ### Added
 

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-context"
 description = "Revm context crates"
-version = "11.1.0"
+version = "12.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/context/interface/CHANGELOG.md
+++ b/crates/context/interface/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [12.1.0](https://github.com/bluealloy/revm/compare/revm-context-interface-v12.0.1...revm-context-interface-v12.1.0) - 2025-11-10
+## [13.0.0](https://github.com/bluealloy/revm/compare/revm-context-interface-v12.0.1...revm-context-interface-v13.0.0) - 2025-11-10
 
 ### Added
 

--- a/crates/context/interface/Cargo.toml
+++ b/crates/context/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-context-interface"
 description = "Revm context interface crates"
-version = "12.1.0"
+version = "13.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/handler/CHANGELOG.md
+++ b/crates/handler/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [13.0.0](https://github.com/bluealloy/revm/compare/revm-handler-v12.0.2...revm-handler-v13.0.0) - 2025-11-10
+## [14.0.0](https://github.com/bluealloy/revm/compare/revm-handler-v12.0.2...revm-handler-v14.0.0) - 2025-11-10
 
 ### Added
 

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-handler"
 description = "Revm handler crates"
-version = "13.0.0"
+version = "14.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/inspector/CHANGELOG.md
+++ b/crates/inspector/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [13.0.0](https://github.com/bluealloy/revm/compare/revm-inspector-v12.0.2...revm-inspector-v13.0.0) - 2025-11-10
+## [14.0.0](https://github.com/bluealloy/revm/compare/revm-inspector-v12.0.2...revm-inspector-v14.0.0) - 2025-11-10
 
 ### Added
 

--- a/crates/inspector/Cargo.toml
+++ b/crates/inspector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-inspector"
 description = "Revm inspector interface"
-version = "13.0.0"
+version = "14.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [30.0.0](https://github.com/bluealloy/revm/compare/revm-interpreter-v29.0.1...revm-interpreter-v30.0.0) - 2025-11-10
+## [31.0.0](https://github.com/bluealloy/revm/compare/revm-interpreter-v29.0.1...revm-interpreter-v31.0.0) - 2025-11-10
 
 ### Added
 

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-interpreter"
 description = "Revm Interpreter that executes bytecode."
-version = "30.0.0"
+version = "31.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/op-revm/CHANGELOG.md
+++ b/crates/op-revm/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [13.0.0](https://github.com/bluealloy/revm/compare/op-revm-v12.0.2...op-revm-v13.0.0) - 2025-11-10
+## [14.0.0](https://github.com/bluealloy/revm/compare/op-revm-v12.0.2...op-revm-v14.0.0) - 2025-11-10
 
 ### Added
 

--- a/crates/op-revm/Cargo.toml
+++ b/crates/op-revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "op-revm"
 description = "Optimism variant of Revm"
-version = "13.0.0"
+version = "14.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/precompile/CHANGELOG.md
+++ b/crates/precompile/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [30.0.0](https://github.com/bluealloy/revm/compare/revm-precompile-v29.0.1...revm-precompile-v30.0.0) - 2025-11-10
+## [31.0.0](https://github.com/bluealloy/revm/compare/revm-precompile-v29.0.1...revm-precompile-v31.0.0) - 2025-11-10
 
 ### Added
 

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-precompile"
 description = "Revm Precompiles - Ethereum compatible precompiled contracts"
-version = "30.0.0"
+version = "31.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/revm/CHANGELOG.md
+++ b/crates/revm/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [32.0.0](https://github.com/bluealloy/revm/compare/revm-v31.0.2...revm-v32.0.0) - 2025-11-10
+## [33.0.0](https://github.com/bluealloy/revm/compare/revm-v31.0.2...revm-v33.0.0) - 2025-11-10
 
 ### Other
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm"
 description = "Revm - Rust Ethereum Virtual Machine"
-version = "32.0.0"
+version = "33.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/statetest-types/CHANGELOG.md
+++ b/crates/statetest-types/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [12.0.0](https://github.com/bluealloy/revm/compare/revm-statetest-types-v11.0.2...revm-statetest-types-v12.0.0) - 2025-11-10
+## [13.0.0](https://github.com/bluealloy/revm/compare/revm-statetest-types-v11.0.2...revm-statetest-types-v13.0.0) - 2025-11-10
 
 ### Other
 

--- a/crates/statetest-types/Cargo.toml
+++ b/crates/statetest-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-statetest-types"
 description = "Statetest types for revme"
-version = "12.0.0"
+version = "13.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
No change to code other than re publishing all crates with major bump. Closing https://github.com/bluealloy/revm/issues/3158