### PR TITLE
feat: Add set nonce journal entry and fn

### DIFF
--- a/crates/context/interface/src/journaled_state/account.rs
+++ b/crates/context/interface/src/journaled_state/account.rs
@@ -79,7 +79,7 @@ impl<'a, ENTRY: JournalEntryTr> JournaledAccount<'a, ENTRY> {
 
     /// Marks the account as cold without making a journal entry.
     ///
-    /// Changing account without journal entry can be a footgun as reverting of the journal
+    /// Changing account without journal entry can be a footgun as reverting of the state change
     /// would not happen without entry. It is the reason why this function has an `unsafe` prefix.
     ///
     /// If account is in access list, it would still be marked as warm if account get accessed again.
@@ -143,9 +143,29 @@ impl<'a, ENTRY: JournalEntryTr> JournaledAccount<'a, ENTRY> {
             return false;
         };
         self.account.info.set_nonce(nonce);
-        self.journal_entries
-            .push(ENTRY::nonce_changed(self.address));
+        self.journal_entries.push(ENTRY::nonce_bumped(self.address));
         true
+    }
+
+    /// Set the nonce of the account and create a journal entry.
+    ///
+    /// Touches the account in all cases.
+    #[inline]
+    pub fn set_nonce(&mut self, nonce: u64) {
+        self.touch();
+        let previous_nonce = self.account.info.nonce;
+        self.account.info.set_nonce(nonce);
+        self.journal_entries
+            .push(ENTRY::nonce_changed(self.address, previous_nonce));
+    }
+
+    /// Set the nonce of the account without creating a journal entry.
+    ///
+    /// Changing account without journal entry can be a footgun as reverting of the state change
+    /// would not happen without entry. It is the reason why this function has an `unsafe` prefix.
+    #[inline]
+    pub fn unsafe_set_nonce(&mut self, nonce: u64) {
+        self.account.info.set_nonce(nonce);
     }
 
     /// Sets the code of the account.

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -281,7 +281,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
 
         if bump_nonce {
             // nonce changed.
-            self.journal.push(ENTRY::nonce_changed(address));
+            self.journal.push(ENTRY::nonce_bumped(address));
         }
     }
 
@@ -303,7 +303,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
     /// Increments the nonce of the account.
     #[inline]
     pub fn nonce_bump_journal_entry(&mut self, address: Address) {
-        self.journal.push(ENTRY::nonce_changed(address));
+        self.journal.push(ENTRY::nonce_bumped(address));
     }
 
     /// Transfers balance from two accounts. Returns error if sender balance is not enough.


### PR DESCRIPTION
Foundry requires this in https://github.com/foundry-rs/foundry/blob/806792b21fd5ae9b9d2480b37a8a616ad09b544e/crates/evm/core/src/backend/mod.rs#L1457

Have added both `set_nonce` and `unsafe_set_nonce`, set_nonce would create entry an touch the account,

while unsafe_set_nonce would skip those steps and would just change the nonce number.