### PR TITLE
chore: add ModExp precompile unit test

### DIFF
--- a/crates/precompile/src/id.rs
+++ b/crates/precompile/src/id.rs
@@ -161,6 +161,8 @@ impl fmt::Display for PrecompileId {
 
 #[cfg(test)]
 mod tests {
+    use std::ptr;
+
     use crate::{modexp, Precompile, PrecompileId, PrecompileSpecId};
 
     #[test]
@@ -176,7 +178,12 @@ mod tests {
         ];
 
         for (spec_id, expected) in EXPECTED_PRECOMPILES_BY_SPEC_ID {
-            assert_eq!(PrecompileId::ModExp.precompile(spec_id), Some(expected));
+            let precompile = PrecompileId::ModExp
+                .precompile(spec_id)
+                .expect("Precompile should be defined");
+            assert_eq!(precompile.id, expected.id);
+            assert_eq!(precompile.address, expected.address);
+            assert!(ptr::fn_addr_eq(precompile.fn_, expected.fn_));
         }
     }
 }

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -313,7 +313,7 @@ impl Precompiles {
 }
 
 /// Precompile.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct Precompile {
     /// Unique identifier.
     id: PrecompileId,


### PR DESCRIPTION
- Add unit test that validates that the right ModExp precompile is used for each spec_id