### PR TITLE
fix(database): return correct bytecode in BenchmarkDB::code_by_hash

### DIFF
--- a/crates/database/src/in_memory_db.rs
+++ b/crates/database/src/in_memory_db.rs
@@ -482,8 +482,12 @@ impl Database for BenchmarkDB {
     }
 
     /// Get account code by its hash
-    fn code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
-        Ok(Bytecode::default())
+    fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        if code_hash == self.1 {
+            Ok(self.0.clone())
+        } else {
+            Ok(Bytecode::default())
+        }
     }
 
     /// Get storage value of address at index.


### PR DESCRIPTION


The `BenchmarkDB::code_by_hash` method always returned empty bytecode, ignoring the stored bytecode hash that was set during initialization. This broke the contract between `basic()` (which returns account info with code hash) and `code_by_hash()` (which should return the corresponding bytecode).

