### PR TITLE
fix call stack depth limit check

### DIFF
--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -160,7 +160,7 @@ impl EthFrame<EthInterpreter> {
         };
 
         // Check depth
-        if depth > CALL_STACK_LIMIT as usize {
+        if depth >= CALL_STACK_LIMIT as usize {
             return return_result(InstructionResult::CallTooDeep);
         }
 
@@ -272,7 +272,7 @@ impl EthFrame<EthInterpreter> {
         };
 
         // Check depth
-        if depth > CALL_STACK_LIMIT as usize {
+        if depth >= CALL_STACK_LIMIT as usize {
             return return_error(InstructionResult::CallTooDeep);
         }
 


### PR DESCRIPTION


Fixes an off-by-one error in the call stack depth validation that allowed frames to be created at depth 1024, exceeding the EVM consensus limit of 1024 active frames.

