### PR TITLE
Remove artificial balance inflation in disabled balance check mode

### DIFF
--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -146,14 +146,7 @@ pub fn calculate_caller_fee(
     let gas_balance_spending = effective_balance_spending - tx.value();
 
     // new balance
-    let mut new_balance = balance.saturating_sub(gas_balance_spending);
-
-    if is_balance_check_disabled {
-        // Make sure the caller's balance is at least the value of the transaction.
-        new_balance = new_balance.max(tx.value());
-    }
-
-    Ok(new_balance)
+    Ok(balance.saturating_sub(gas_balance_spending))
 }
 
 /// Validates caller state and deducts transaction costs from the caller's balance.


### PR DESCRIPTION
When `is_balance_check_disabled` is enabled, the code was forcing the caller's balance to be at least `tx.value()`, effectively creating ETH out of thin air. This violates balance invariants and can cause incorrect behavior in test scenarios.
Removed the conditional logic that artificially inflated the balance. The function now correctly calculates the new balance as `balance.saturating_sub(gas_balance_spending)` regardless of the balance check setting.
