### PR TITLE
refactor: reuse bound tx and remove redundant context.tx() calls

### DIFF
--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -107,8 +107,8 @@ pub fn validate_tx_env<CTX: ContextTr>(
     spec_id: SpecId,
 ) -> Result<(), InvalidTransaction> {
     // Check if the transaction's chain id is correct
-    let tx_type = context.tx().tx_type();
     let tx = context.tx();
+    let tx_type = tx.tx_type();
 
     let base_fee = if context.cfg().is_base_fee_check_disabled() {
         None
@@ -216,7 +216,7 @@ pub fn validate_tx_env<CTX: ContextTr>(
     // EIP-3860: Limit and meter initcode. Still valid with EIP-7907 and increase of initcode size.
     if spec_id.is_enabled_in(SpecId::SHANGHAI)
         && tx.kind().is_create()
-        && context.tx().input().len() > context.cfg().max_initcode_size()
+        && tx.input().len() > context.cfg().max_initcode_size()
     {
         return Err(InvalidTransaction::CreateInitCodeSizeLimit);
     }


### PR DESCRIPTION
his refactor binds the transaction once in validate_tx_env() and derives tx_type from the bound reference, eliminating redundant calls to context.tx(). It also reuses the bound tx for the EIP-3860 initcode size check instead of calling context.tx() again. The change improves clarity and marginally reduces method calls without changing semantics or borrow behavior. Repeated immutable borrows from ContextTr::tx() are cheap, but centralizing on a single borrow makes intent clearer and avoids unnecessary lookups via all().