### PR TITLE
fix: return G2NotInSubgroup for G2 subgroup check failure

### DIFF
--- a/crates/precompile/src/bls12_381/arkworks.rs
+++ b/crates/precompile/src/bls12_381/arkworks.rs
@@ -179,7 +179,7 @@ fn read_g2(
 ) -> Result<G2Affine, PrecompileError> {
     let point = read_g2_no_subgroup_check(a_x_0, a_x_1, a_y_0, a_y_1)?;
     if !point.is_in_correct_subgroup_assuming_on_curve() {
-        return Err(PrecompileError::Bls12381G1NotInSubgroup);
+        return Err(PrecompileError::Bls12381G2NotInSubgroup);
     }
     Ok(point)
 }


### PR DESCRIPTION
The arkworks backend returned Bls12381G1NotInSubgroup from read_g2() when the G2 subgroup check failed. This was inconsistent with both the logical context (G2 subgroup validation) and the blst backend, which correctly returns Bls12381G2NotInSubgroup. Aligning the error variant ensures consistent behavior across backends, corrects diagnostics for callers that rely on precise error reporting, and matches EIP-2537 expectations where MSM and pairing must enforce subgroup checks for their respective groups.