### PR TITLE
chore: apply_auth_list helper fn

### DIFF
--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -1,6 +1,8 @@
 use crate::{
-    evm::FrameTr, execution, post_execution, pre_execution, validation, EvmTr, FrameResult,
-    ItemOrResult,
+    evm::FrameTr,
+    execution, post_execution,
+    pre_execution::{self, apply_eip7702_auth_list},
+    validation, EvmTr, FrameResult, ItemOrResult,
 };
 use context::{
     result::{ExecutionResult, FromStringError},
@@ -274,7 +276,7 @@ pub trait Handler {
     /// Returns the gas refund amount specified by EIP-7702.
     #[inline]
     fn apply_eip7702_auth_list(&self, evm: &mut Self::Evm) -> Result<u64, Self::Error> {
-        pre_execution::apply_eip7702_auth_list(evm.ctx())
+        apply_eip7702_auth_list(evm.ctx_mut())
     }
 
     /// Deducts maximum possible fee and transfer value from caller's balance.


### PR DESCRIPTION
Helper function that would allow to apply EIP-7702 type authorization with just journal and chain id.