### PR TITLE
Remove duplicate traces directory creation in block_traces example`

### DIFF
--- a/examples/block_traces/src/main.rs
+++ b/examples/block_traces/src/main.rs
@@ -108,9 +108,6 @@ async fn main() -> anyhow::Result<()> {
     let console_bar = Arc::new(ProgressBar::new(txs as u64));
     let start = Instant::now();
 
-    // Create the traces directory if it doesn't exist
-    std::fs::create_dir_all("traces").expect("Failed to create traces directory");
-
     // Fill in CfgEnv
     let BlockTransactions::Full(transactions) = block.transactions else {
         panic!("Wrong transaction type")


### PR DESCRIPTION


This PR removes a duplicated `traces` directory creation in the `block_traces` example, keeping a single, early `create_dir_all("traces")?` call.

