### PR TITLE
refactor: optimize vector initialization using size hints

### DIFF
--- a/crates/handler/src/api.rs
+++ b/crates/handler/src/api.rs
@@ -90,7 +90,8 @@ pub trait ExecuteEvm {
         &mut self,
         txs: impl Iterator<Item = Self::Tx>,
     ) -> Result<Vec<Self::ExecutionResult>, TransactionIndexedError<Self::Error>> {
-        let mut outputs = Vec::new();
+        let (lower, _) = txs.size_hint();
+        let mut outputs = Vec::with_capacity(lower);
         for (index, tx) in txs.enumerate() {
             outputs.push(
                 self.transact_one(tx)

--- a/crates/precompile/src/bls12_381/arkworks.rs
+++ b/crates/precompile/src/bls12_381/arkworks.rs
@@ -460,8 +460,9 @@ pub(crate) fn map_fp2_to_g2_bytes(
 pub(crate) fn p1_msm_bytes(
     point_scalar_pairs: impl Iterator<Item = Result<(G1Point, [u8; SCALAR_LENGTH]), PrecompileError>>,
 ) -> Result<[u8; G1_LENGTH], PrecompileError> {
-    let mut g1_points = Vec::new();
-    let mut scalars = Vec::new();
+    let (lower, _) = point_scalar_pairs.size_hint();
+    let mut g1_points = Vec::with_capacity(lower);
+    let mut scalars = Vec::with_capacity(lower);
 
     // Parse all points and scalars
     for pair_result in point_scalar_pairs {
@@ -497,8 +498,9 @@ pub(crate) fn p1_msm_bytes(
 pub(crate) fn p2_msm_bytes(
     point_scalar_pairs: impl Iterator<Item = Result<(G2Point, [u8; SCALAR_LENGTH]), PrecompileError>>,
 ) -> Result<[u8; G2_LENGTH], PrecompileError> {
-    let mut g2_points = Vec::new();
-    let mut scalars = Vec::new();
+    let (lower, _) = point_scalar_pairs.size_hint();
+    let mut g2_points = Vec::with_capacity(lower);
+    let mut scalars = Vec::with_capacity(lower);
 
     // Parse all points and scalars
     for pair_result in point_scalar_pairs {


### PR DESCRIPTION
Pre-allocate memory for vectors using `size_hint()` in `transact_many` and arkworks precompiles. This improves performance by avoiding unnecessary reallocations when the iteration count is known.