### PR TITLE
refactor(revme): optimize error vector allocation in test runner

### DIFF
--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -610,7 +610,7 @@ pub fn run(
     }
 
     // Collect results from all threads
-    let mut thread_errors = Vec::new();
+    let mut thread_errors = Vec::with_capacity(num_threads);
     for (i, handle) in handles.into_iter().enumerate() {
         match handle.join() {
             Ok(Ok(())) => {}


### PR DESCRIPTION
Changed `thread_errors` vector initialization to pre-allocate memory using `num_threads` in `statetest/runner.rs` to prevent unnecessary memory reallocations when collecting errors from parallel test execution.