### PR TITLE
chore(context): remove TODO in local context tests

### DIFF
--- a/crates/context/interface/src/local.rs
+++ b/crates/context/interface/src/local.rs
@@ -262,8 +262,7 @@ mod tests {
         let mut b = stack.get_next();
         assert!(!b.init);
         assert_eq!(b.get(|| 2), &mut 2);
-        let token = b.consume(); // TODO: remove
-        unsafe { stack.push(token) };
+        unsafe { stack.push(b.consume()) };
 
         assert_eq!(stack.index(), Some(1));
         assert_eq!(stack.stack.len(), 2);


### PR DESCRIPTION
Inline `b.consume()` call in `frame_stack` test to remove the TODO comment, simplifying the test code logic.