### PR TITLE
feat: early return if the l1 fee scalar is zero

### DIFF
--- a/crates/op-revm/src/l1block.rs
+++ b/crates/op-revm/src/l1block.rs
@@ -348,7 +348,7 @@ impl L1BlockInfo {
         if l1_fee_scaled.is_zero() {
             return U256::ZERO;
         }
-        
+
         let estimated_size = self.tx_estimated_size_fjord(input);
 
         estimated_size


### PR DESCRIPTION
On certain chains (ours included), the L1 fee scalar is set to zero to simplify the fee formula. It would be beneficial to return early during L1 fee calculation when the scalar is zero, thereby avoiding the expensive transaction-size estimation.

Thanks and I’d appreciate your review, and any comments or suggestions are very welcome.