### PR TITLE
opt: optimize eq of u256

### DIFF
--- a/crates/interpreter/src/instructions/bitwise.rs
+++ b/crates/interpreter/src/instructions/bitwise.rs
@@ -42,12 +42,20 @@ pub fn sgt<WIRE: InterpreterTypes, H: ?Sized>(context: InstructionContext<'_, H,
     *op2 = U256::from(i256_cmp(&op1, op2) == Ordering::Greater);
 }
 
+/// eq inline function
+#[inline]
+pub fn eq_inline(op1: &U256, op2: &U256) -> bool {
+    let a = op1.as_limbs();
+    let b = op2.as_limbs();
+    ((a[0] ^ b[0]) | (a[1] ^ b[1]) | (a[2] ^ b[2]) | (a[3] ^ b[3])) == 0
+}
+
 /// Implements the EQ instruction.
 ///
 /// Equality comparison of two values from stack.
 pub fn eq<WIRE: InterpreterTypes, H: ?Sized>(context: InstructionContext<'_, H, WIRE>) {
     popn_top!([op1], op2, context.interpreter);
-    *op2 = U256::from(op1 == *op2);
+    *op2 = U256::from(eq_inline(&op1, &*op2));
 }
 
 /// Implements the ISZERO instruction.


### PR DESCRIPTION
before:
```
#[inline]
pub fn eq_inline(a: &U256, b: &U256) -> bool {
      a == b
}

```

after opt:
```
#[inline]
pub fn eq_inline(a: &U256, b: &U256) -> bool {
    let a = a.as_limbs();
    let b = b.as_limbs();
    ((a[0] ^ b[0]) | (a[1] ^ b[1]) | (a[2] ^ b[2]) | (a[3] ^ b[3])) == 0
}

```

benchmark code:
```
//! Benchmarks for U256 equality comparison function
//! 
//! This benchmark tests the performance of:
//! - `eq_origin`: Standard `==` operator

use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
use revm_interpreter::instructions::bitwise::eq_inline;
use primitives::{uint, U256};

/// Generate test data pairs for benchmarking
fn generate_test_data() -> Vec<(U256, U256, &'static str)> {
    uint! {
        vec![
            // Equal cases
            (0_U256, 0_U256, "equal_zero"),
            (1_U256, 1_U256, "equal_small"),
            (0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256, 
             0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256, 
             "equal_max"),
            (0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef_U256,
             0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef_U256,
             "equal_large"),
            
            // Not equal cases - different in first limb
            (1_U256, 2_U256, "not_equal_first_limb"),
            (0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
             0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe_U256,
             "not_equal_first_limb_max"),
            
            // Not equal cases - different in last limb
            (0x0000000000000000000000000000000000000000000000000000000000000001_U256,
             0x0000000000000000000000000000000000000000000000000000000000000002_U256,
             "not_equal_last_limb"),
            (0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_U256,
             0x8000000000000000000000000000000000000000000000000000000000000000_U256,
             "not_equal_last_limb_boundary"),
            
            // Not equal cases - different in middle limbs
            (0x0000000000000001ffffffffffffffffffffffffffffffffffffffffffffffff_U256,
             0x0000000000000002ffffffffffffffffffffffffffffffffffffffffffffffff_U256,
             "not_equal_second_limb"),
            (0xffffffffffffffff0000000000000001ffffffffffffffffffffffffffffffff_U256,
             0xffffffffffffffff0000000000000002ffffffffffffffffffffffffffffffff_U256,
             "not_equal_third_limb"),
        ]
    }
}

fn bench_eq_equal(c: &mut Criterion) {
    let test_data = generate_test_data()
        .into_iter()
        .filter(|(_, _, name)| name.starts_with("equal"))
        .collect::<Vec<_>>();
    
    let mut group = c.benchmark_group("eq_equal");
    
    for (a, b, name) in &test_data {
        group.bench_with_input(
            BenchmarkId::new("eq_origin", name),
            &(a, b),
            |bencher, (a, b)| {
                bencher.iter(|| {
                    criterion::black_box(eq_inline(criterion::black_box(a), criterion::black_box(b)));
                });
            },
        );
    }
    
    group.finish();
}

fn bench_eq_not_equal(c: &mut Criterion) {
    let test_data = generate_test_data()
        .into_iter()
        .filter(|(_, _, name)| name.starts_with("not_equal"))
        .collect::<Vec<_>>();
    
    let mut group = c.benchmark_group("eq_not_equal");
    
    for (a, b, name) in &test_data {
        group.bench_with_input(
            BenchmarkId::new("eq_origin", name),
            &(a, b),
            |bencher, (a, b)| {
                bencher.iter(|| {
                    criterion::black_box(eq_inline(criterion::black_box(a), criterion::black_box(b)));
                });
            },
        );
    }
    
    group.finish();
}

fn bench_eq_mixed(c: &mut Criterion) {
    let test_data = generate_test_data();
    
    c.bench_function("eq_origin mixed", |b| {
        b.iter(|| {
            for (a, b, _) in &test_data {
                criterion::black_box(eq_inline(criterion::black_box(a), criterion::black_box(b)));
            }
        });
    });
}

criterion_group! {
    name = benches;
    config = Criterion::default()
        .measurement_time(std::time::Duration::from_secs(30)) // 每个 benchmark 测量 30 秒（默认 5 秒）
        .sample_size(200)                                      // 样本数量 200（默认 100）
        .warm_up_time(std::time::Duration::from_secs(5))      // 预热时间 5 秒（默认 3 秒）
        .save_baseline("baseline".to_string());                // Save baseline for comparison
    targets = 
        bench_eq_equal,
        bench_eq_not_equal,
        bench_eq_mixed
}
criterion_main!(benches);

```
on mac m4 pro.
result in:
```
eq_equal/eq_origin/equal_zero
                        time:   [763.72 ps 766.27 ps 769.06 ps]
                        change: [-3.1259% -2.1130% -1.3311%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 200 measurements (6.00%)
  9 (4.50%) high mild
  3 (1.50%) high severe
eq_equal/eq_origin/equal_small
                        time:   [755.65 ps 764.28 ps 776.23 ps]
                        change: [-2.0339% -1.1917% -0.1838%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 21 outliers among 200 measurements (10.50%)
  9 (4.50%) high mild
  12 (6.00%) high severe
eq_equal/eq_origin/equal_max
                        time:   [751.26 ps 753.91 ps 756.89 ps]
                        change: [-5.9842% -5.4411% -4.9920%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 20 outliers among 200 measurements (10.00%)
  11 (5.50%) high mild
  9 (4.50%) high severe
eq_equal/eq_origin/equal_large
                        time:   [768.08 ps 773.15 ps 781.84 ps]
                        change: [+0.7711% +1.3336% +2.1569%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 200 measurements (5.50%)
  10 (5.00%) high mild
  1 (0.50%) high severe

eq_not_equal/eq_origin/not_equal_first_limb
                        time:   [748.25 ps 750.39 ps 753.15 ps]
                        change: [-3.1847% -1.8707% -0.2915%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 20 outliers among 200 measurements (10.00%)
  9 (4.50%) high mild
  11 (5.50%) high severe
eq_not_equal/eq_origin/not_equal_first_limb_max
                        time:   [749.88 ps 752.09 ps 754.77 ps]
                        change: [-2.3427% -1.6873% -1.1062%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 20 outliers among 200 measurements (10.00%)
  12 (6.00%) high mild
  8 (4.00%) high severe
eq_not_equal/eq_origin/not_equal_last_limb
                        time:   [748.49 ps 750.54 ps 752.84 ps]
                        change: [-2.6041% -1.7078% -0.5401%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 25 outliers among 200 measurements (12.50%)
  11 (5.50%) high mild
  14 (7.00%) high severe
eq_not_equal/eq_origin/not_equal_last_limb_boundary
                        time:   [748.01 ps 752.46 ps 760.27 ps]
                        change: [-7.3913% -6.7562% -5.8498%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 200 measurements (8.50%)
  1 (0.50%) low severe
  1 (0.50%) low mild
  10 (5.00%) high mild
  5 (2.50%) high severe
eq_not_equal/eq_origin/not_equal_second_limb
                        time:   [745.23 ps 746.64 ps 748.34 ps]
                        change: [-5.1277% -3.4627% -2.2458%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 28 outliers among 200 measurements (14.00%)
  1 (0.50%) low mild
  5 (2.50%) high mild
  22 (11.00%) high severe
eq_not_equal/eq_origin/not_equal_third_limb
                        time:   [747.61 ps 756.67 ps 769.68 ps]
                        change: [-2.5817% -1.8877% -1.0105%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 31 outliers among 200 measurements (15.50%)
  1 (0.50%) low severe
  1 (0.50%) low mild
  11 (5.50%) high mild
  18 (9.00%) high severe

eq_origin mixed         time:   [6.6902 ns 6.7102 ns 6.7345 ns]
                        change: [-6.9025% -4.9059% -3.6907%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 18 outliers among 200 measurements (9.00%)
  1 (0.50%) low mild
  6 (3.00%) high mild
  11 (5.50%) high severe

```
