### PR TITLE
fix: deduplicate post-state validation error handling

### DIFF
--- a/bins/revme/src/cmd/blockchaintest.rs
+++ b/bins/revme/src/cmd/blockchaintest.rs
@@ -326,6 +326,7 @@ fn validate_post_state(
     debug_info: &DebugInfo,
     print_env_on_error: bool,
 ) -> Result<(), TestExecutionError> {
+    #[allow(clippy::too_many_arguments)]
     fn make_failure(
         state: &mut State<EmptyDB>,
         debug_info: &DebugInfo,


### PR DESCRIPTION
Refactored `validate_post_state` in `blockchaintest` to remove duplicated error-handling code while preserving existing behavior.

