### PR TITLE
Fix incorrect debug log message in blockchain test runner

### DIFF
--- a/bins/revme/src/cmd/blockchaintest.rs
+++ b/bins/revme/src/cmd/blockchaintest.rs
@@ -856,7 +856,7 @@ fn execute_blockchain_test(
                             println!("{}", serde_json::to_string(&output).unwrap());
                         } else {
                             eprintln!(
-                                "⚠️  Skipping block {block_idx} due to expected failure: {exception}"
+                                "⚠️  Skipping block {block_idx}: transaction unexpectedly succeeded (expected failure: {exception})"
                             );
                         }
                         break; // Skip to next block


### PR DESCRIPTION

The error message incorrectly stated that a block was skipped "due to expected failure" when the actual issue was that a transaction unexpectedly succeeded (when failure was expected).

