### PR TITLE
refactor(handler): validate_initial_tx_gas takes &mut Evm

### DIFF
--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -265,14 +265,8 @@ pub trait Handler {
     ///
     /// Verifies the initial cost does not exceed the transaction gas limit.
     #[inline]
-    fn validate_initial_tx_gas(&self, evm: &Self::Evm) -> Result<InitialAndFloorGas, Self::Error> {
-        let ctx = evm.ctx_ref();
-        validation::validate_initial_tx_gas(
-            ctx.tx(),
-            ctx.cfg().spec().into(),
-            ctx.cfg().is_eip7623_disabled(),
-        )
-        .map_err(From::from)
+    fn validate_initial_tx_gas(&self, evm: &mut Self::Evm) -> Result<InitialAndFloorGas, Self::Error> {
+        validation::validate_initial_tx_gas(evm).map_err(From::from)
     }
 
     /* PRE EXECUTION */

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -1,3 +1,4 @@
+use crate::EvmTr;
 use context_interface::{
     result::{InvalidHeader, InvalidTransaction},
     transaction::{Transaction, TransactionType},
@@ -225,12 +226,15 @@ pub fn validate_tx_env<CTX: ContextTr>(
 }
 
 /// Validate initial transaction gas.
-pub fn validate_initial_tx_gas(
-    tx: impl Transaction,
-    spec: SpecId,
-    is_eip7623_disabled: bool,
+pub fn validate_initial_tx_gas<EVM: EvmTr>(
+    evm: &mut EVM,
 ) -> Result<InitialAndFloorGas, InvalidTransaction> {
-    let mut gas = gas::calculate_initial_tx_gas_for_tx(&tx, spec);
+    let ctx = evm.ctx_ref();
+    let tx = ctx.tx();
+    let spec: SpecId = ctx.cfg().spec().into();
+    let is_eip7623_disabled = ctx.cfg().is_eip7623_disabled();
+
+    let mut gas = gas::calculate_initial_tx_gas_for_tx(tx, spec);
 
     if is_eip7623_disabled {
         gas.floor_gas = 0


### PR DESCRIPTION
## Summary
- Change `validate_initial_tx_gas` function signature to take `&mut EVM` instead of individual parameters
- Update the Handler trait method to use the new signature
- Makes the API more consistent with other handler functions

## Test plan
- [x] `cargo check --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)