### PR TITLE
fix: Remove redundant `LocalContext::new` constructor

### DIFF
--- a/crates/context/src/local.rs
+++ b/crates/context/src/local.rs
@@ -42,8 +42,4 @@ impl LocalContextTr for LocalContext {
 }
 
 impl LocalContext {
-    /// Creates a new local context, initcodes are hashes and added to the mapping.
-    pub fn new() -> Self {
-        Self::default()
-    }
 }


### PR DESCRIPTION


**Description:**
- Drop the unused `LocalContext::new` helper that only wrapped `Default`.
- Reduce API noise and avoid maintaining duplicate initialization paths.