### PR TITLE
refactor(handler): eliminate code duplication in transaction validation

### DIFF
--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -63,7 +63,7 @@ pub fn validate_priority_fee_tx(
 
 /// Validate priority fee for transactions that support EIP-1559 (Eip1559, Eip4844, Eip7702).
 #[inline]
-fn validate_priority_fee_for_tx<TX: ContextTr>(
+fn validate_priority_fee_for_tx<TX: Transaction>(
     tx: TX,
     base_fee: Option<u128>,
     disable_priority_fee_check: bool,


### PR DESCRIPTION
Created a helper function `validate_priority_fee_for_tx` to reduce code duplication. The function is used for Eip1559, Eip4844, and Eip7702 transaction types, eliminating three identical calls with the same parameters.