### PR TITLE
fix: remove redundant trace file creation in block_traces example

### DIFF
--- a/examples/block_traces/src/main.rs
+++ b/examples/block_traces/src/main.rs
@@ -91,16 +91,7 @@ async fn main() -> anyhow::Result<()> {
             c.chain_id = chain_id;
         });
 
-    let write = OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .open("traces/0.json");
-    let inner = Arc::new(Mutex::new(BufWriter::new(
-        write.expect("Failed to open file"),
-    )));
-    let writer = FlushWriter::new(Arc::clone(&inner));
-    let mut evm = ctx.build_mainnet_with_inspector(TracerEip3155::new(Box::new(writer)));
+    let mut evm = ctx.build_mainnet_with_inspector(TracerEip3155::new(Box::new(std::io::sink())));
 
     let txs = block.transactions.len();
     println!("Found {txs} transactions.");


### PR DESCRIPTION


Remove unnecessary creation of `traces/0.json` file that was immediately overwritten in the loop. Initialize the tracer with a sink writer before the loop, as trace files are properly created inside the loop for each transaction.
