### PR TITLE
refactor: re-export statetest-types from revm crate behind test-types feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3646,6 +3646,7 @@ dependencies = [
  "revm-precompile",
  "revm-primitives",
  "revm-state",
+ "revm-statetest-types",
  "serde",
  "serde_json",
 ]
@@ -3840,9 +3841,13 @@ name = "revm-statetest-types"
 version = "13.1.0"
 dependencies = [
  "alloy-eip7928",
- "alloy-eips",
  "k256",
- "revm",
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database",
+ "revm-primitives",
+ "revm-state",
  "serde",
  "serde_json",
  "thiserror",
@@ -3862,7 +3867,6 @@ dependencies = [
  "k256",
  "plain_hasher",
  "revm",
- "revm-statetest-types",
  "serde",
  "serde_json",
  "thiserror",

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -17,8 +17,8 @@ revm = { workspace = true, features = [
     "blst",
     "tracer",
     "parse",
+    "test-types",
 ] }
-statetest-types.workspace = true
 
 # criterion
 criterion.workspace = true

--- a/bins/revme/src/cmd/blockchaintest.rs
+++ b/bins/revme/src/cmd/blockchaintest.rs
@@ -3,6 +3,9 @@ pub mod pre_block;
 
 use clap::Parser;
 
+use revm::statetest_types::blockchain::{
+    Account, BlockchainTest, BlockchainTestCase, ForkSpec, Withdrawal,
+};
 use revm::{
     bytecode::Bytecode,
     context::{cfg::CfgEnv, ContextTr},
@@ -15,9 +18,6 @@ use revm::{
     Context, Database, ExecuteCommitEvm, ExecuteEvm, InspectEvm, MainBuilder, MainContext,
 };
 use serde_json::json;
-use statetest_types::blockchain::{
-    Account, BlockchainTest, BlockchainTestCase, ForkSpec, Withdrawal,
-};
 use std::{
     collections::BTreeMap,
     fs,

--- a/bins/revme/src/cmd/blockchaintest/post_block.rs
+++ b/bins/revme/src/cmd/blockchaintest/post_block.rs
@@ -2,9 +2,9 @@ use revm::{
     context::{Block, ContextTr, JournalTr},
     handler::EvmTr,
     primitives::{address, hardfork::SpecId, Address, Bytes, ONE_ETHER, ONE_GWEI, U256},
+    statetest_types::blockchain::Withdrawal,
     Database, DatabaseCommit, SystemCallCommitEvm,
 };
-use statetest_types::blockchain::Withdrawal;
 
 /// Post block transition that includes:
 ///   * Block and uncle rewards before the Merge/Paris hardfork.

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -10,10 +10,10 @@ use revm::{
     database_interface::EmptyDB,
     inspector::{inspectors::TracerEip3155, InspectCommitEvm},
     primitives::{hardfork::SpecId, Bytes, B256, U256},
+    statetest_types::{SpecName, Test, TestSuite, TestUnit},
     Context, ExecuteCommitEvm, MainBuilder, MainContext,
 };
 use serde_json::json;
-use statetest_types::{SpecName, Test, TestSuite, TestUnit};
 use std::{
     convert::Infallible,
     fmt::Debug,

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -30,6 +30,7 @@ interpreter.workspace = true
 precompile.workspace = true
 primitives.workspace = true
 state.workspace = true
+statetest-types = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json = { workspace = true, features = ["alloc", "preserve_order"] }
@@ -117,3 +118,6 @@ portable = ["precompile/portable"]
 # use gmp for modexp precompile.
 # It is faster library but licenced as GPL code, if enabled please make sure to follow the license.
 gmp = ["precompile/gmp"]
+
+# Statetest types for running ethereum tests
+test-types = ["dep:statetest-types"]

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -26,6 +26,10 @@ pub use primitives;
 #[doc(inline)]
 pub use state;
 
+#[cfg(feature = "test-types")]
+#[doc(inline)]
+pub use statetest_types;
+
 // Export items.
 
 pub use context::{

--- a/crates/statetest-types/Cargo.toml
+++ b/crates/statetest-types/Cargo.toml
@@ -18,13 +18,18 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-# revm
-revm = { workspace = true, features = ["std", "serde"] }
+# revm crates
+primitives = { workspace = true, features = ["std", "serde"] }
+bytecode = { workspace = true, features = ["std", "serde"] }
+state = { workspace = true, features = ["std", "serde"] }
+context = { workspace = true, features = ["std", "serde"] }
+context-interface = { workspace = true, features = ["std", "serde"] }
+database = { workspace = true, features = ["std", "serde"] }
+
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 k256 = { workspace = true }
 thiserror = { workspace = true }
-alloy-eips = { workspace = true }
 
 # alloy
 alloy-eip7928 = { workspace = true, features = ["std", "serde", "rlp"] }

--- a/crates/statetest-types/src/account_info.rs
+++ b/crates/statetest-types/src/account_info.rs
@@ -1,4 +1,4 @@
-use revm::primitives::{Bytes, HashMap, StorageKey, StorageValue, U256};
+use primitives::{Bytes, HashMap, StorageKey, StorageValue, U256};
 use serde::Deserialize;
 
 use crate::deserializer::deserialize_str_as_u64;

--- a/crates/statetest-types/src/blockchain.rs
+++ b/crates/statetest-types/src/blockchain.rs
@@ -5,11 +5,9 @@
 
 use crate::{deserialize_maybe_empty, AccountInfo, TestAuthorization};
 use alloy_eip7928::BlockAccessList;
-use revm::{
-    context::{transaction::AccessList, BlockEnv, TxEnv},
-    context_interface::block::BlobExcessGasAndPrice,
-    primitives::{Address, Bytes, FixedBytes, TxKind, B256, U256},
-};
+use context::{transaction::AccessList, BlockEnv, TxEnv};
+use context_interface::block::BlobExcessGasAndPrice;
+use primitives::{Address, Bytes, FixedBytes, TxKind, B256, U256};
 use serde::Deserialize;
 use std::collections::BTreeMap;
 
@@ -444,7 +442,7 @@ impl BlockchainTestCase {
 
 #[cfg(test)]
 mod test {
-    use revm::primitives::address;
+    use primitives::address;
 
     use super::*;
 
@@ -519,7 +517,7 @@ mod test {
     #[test]
     fn test_transaction_conversion() {
         use crate::blockchain::Transaction;
-        use revm::primitives::{Bytes, U256};
+        use primitives::{Bytes, U256};
 
         let tx = Transaction {
             transaction_type: Some(U256::from(0)),

--- a/crates/statetest-types/src/deserializer.rs
+++ b/crates/statetest-types/src/deserializer.rs
@@ -1,4 +1,4 @@
-use revm::primitives::Address;
+use primitives::Address;
 use serde::{de, Deserialize};
 
 /// Deserializes a [string][String] as a [u64].

--- a/crates/statetest-types/src/env.rs
+++ b/crates/statetest-types/src/env.rs
@@ -1,4 +1,4 @@
-use revm::primitives::{Address, B256, U256};
+use primitives::{Address, B256, U256};
 use serde::Deserialize;
 
 /// Environment variables

--- a/crates/statetest-types/src/error.rs
+++ b/crates/statetest-types/src/error.rs
@@ -1,4 +1,4 @@
-use revm::primitives::B256;
+use primitives::B256;
 use thiserror::Error;
 
 /// Errors that can occur during test setup and execution

--- a/crates/statetest-types/src/spec.rs
+++ b/crates/statetest-types/src/spec.rs
@@ -1,4 +1,4 @@
-use revm::primitives::hardfork::SpecId;
+use primitives::hardfork::SpecId;
 use serde::Deserialize;
 
 /// Ethereum specification names

--- a/crates/statetest-types/src/test.rs
+++ b/crates/statetest-types/src/test.rs
@@ -1,7 +1,5 @@
-use revm::{
-    context::tx::TxEnv,
-    primitives::{Address, Bytes, HashMap, TxKind, B256},
-};
+use context::tx::TxEnv;
+use primitives::{Address, Bytes, HashMap, TxKind, B256};
 use serde::Deserialize;
 
 use crate::{
@@ -119,7 +117,7 @@ impl Test {
                 .map(|auth_list| {
                     auth_list
                         .into_iter()
-                        .map(|i| revm::context::either::Either::Left(i.into()))
+                        .map(|i| context::either::Either::Left(i.into()))
                         .collect::<Vec<_>>()
                 })
                 .unwrap_or_default(),

--- a/crates/statetest-types/src/test_authorization.rs
+++ b/crates/statetest-types/src/test_authorization.rs
@@ -1,4 +1,4 @@
-use revm::context_interface::transaction::SignedAuthorization;
+use context_interface::transaction::SignedAuthorization;
 use serde::{de::Error, Deserialize, Deserializer, Serialize};
 
 /// Struct for test authorization

--- a/crates/statetest-types/src/test_unit.rs
+++ b/crates/statetest-types/src/test_unit.rs
@@ -1,11 +1,9 @@
 use crate::{AccountInfo, Env, SpecName, Test, TransactionParts};
-use revm::{
-    context::{block::BlockEnv, cfg::CfgEnv},
-    database::CacheState,
-    primitives::{hardfork::SpecId, keccak256, Address, Bytes, HashMap, B256},
-    state::Bytecode,
-};
+use context::{block::BlockEnv, cfg::CfgEnv};
+use database::CacheState;
+use primitives::{hardfork::SpecId, keccak256, Address, Bytes, HashMap, B256};
 use serde::Deserialize;
+use state::Bytecode;
 use std::collections::BTreeMap;
 
 /// Single test unit struct
@@ -71,7 +69,7 @@ impl TestUnit {
             let code_hash = keccak256(&info.code);
             let bytecode = Bytecode::new_raw_checked(info.code.clone())
                 .unwrap_or(Bytecode::new_legacy(info.code.clone()));
-            let acc_info = revm::state::AccountInfo {
+            let acc_info = state::AccountInfo {
                 balance: info.balance,
                 code_hash,
                 code: Some(bytecode),
@@ -133,12 +131,10 @@ impl TestUnit {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use revm::{
-        context_interface::block::calc_blob_gasprice,
-        primitives::{
-            eip4844::{BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN, BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE},
-            U256,
-        },
+    use context_interface::block::calc_blob_gasprice;
+    use primitives::{
+        eip4844::{BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN, BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE},
+        U256,
     };
 
     /// Creates a minimal TestUnit with excess blob gas set for testing blob fee calculation

--- a/crates/statetest-types/src/transaction.rs
+++ b/crates/statetest-types/src/transaction.rs
@@ -1,9 +1,7 @@
 use crate::{deserializer::deserialize_maybe_empty, TestAuthorization};
-use revm::{
-    context::TransactionType,
-    context_interface::transaction::AccessList,
-    primitives::{Address, Bytes, B256, U256},
-};
+use context::TransactionType;
+use context_interface::transaction::AccessList;
+use primitives::{Address, Bytes, B256, U256};
 use serde::{Deserialize, Serialize};
 
 /// Transaction parts.

--- a/crates/statetest-types/src/utils.rs
+++ b/crates/statetest-types/src/utils.rs
@@ -1,5 +1,5 @@
 use k256::ecdsa::SigningKey;
-use revm::primitives::Address;
+use primitives::Address;
 
 /// Recover the address from a private key ([SigningKey]).
 pub fn recover_address(private_key: &[u8]) -> Option<Address> {
@@ -11,7 +11,7 @@ pub fn recover_address(private_key: &[u8]) -> Option<Address> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use revm::primitives::{address, hex};
+    use primitives::{address, hex};
 
     #[test]
     fn sanity_test() {


### PR DESCRIPTION
## Summary
- Update `statetest-types` to depend on individual revm crates (`primitives`, `bytecode`, `state`, `context`, `context-interface`, `database`) instead of `revm` to avoid circular dependency
- Add `statetest-types` as an optional dependency to the `revm` crate
- Add `test-types` feature flag to `revm` that enables `statetest-types` re-export
- Update `revme` to import `statetest_types` from `revm` instead of directly from `revm-statetest-types`

## Test plan
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace --all-targets --all-features` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)