### PR TITLE
feat(revme): add map-foldhash feature

### DIFF
--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -43,6 +43,7 @@ csv = "1.1.6"
 [features]
 # Optionally enable gmp because it doesn't work on i686 github actions runners
 gmp = ["revm/gmp"]
+map-foldhash = ["revm/map-foldhash"]
 
 [[bench]]
 name = "evm"


### PR DESCRIPTION
Adds `map-foldhash` feature to revme that enables foldhash-based hash maps from alloy-primitives. This allows users to opt-in to faster hash implementation when using revme.