### PR TITLE
perf:write directly to mem rather than use copy_non_overlapping

### DIFF
--- a/crates/interpreter/src/interpreter/stack.rs
+++ b/crates/interpreter/src/interpreter/stack.rs
@@ -1,5 +1,5 @@
 use crate::InstructionResult;
-use core::{fmt, ptr};
+use core::fmt;
 use primitives::U256;
 use std::vec::Vec;
 


### PR DESCRIPTION
https://godbolt.org/z/badnnzEaT

write directly to mem rather than use copy_non_overlapping

we know the layout 

took this from swap_non_overlapping