### PR TITLE
refactor: remove redundant clone calls

### DIFF
--- a/bins/revme/src/cmd/bench/burntpix.rs
+++ b/bins/revme/src/cmd/bench/burntpix.rs
@@ -43,7 +43,7 @@ pub fn run(criterion: &mut Criterion) {
     let tx = TxEnv::builder()
         .caller(BENCH_CALLER)
         .kind(TxKind::Call(BURNTPIX_MAIN_ADDRESS))
-        .data(run_call_data.clone().into())
+        .data(run_call_data.into())
         .gas_limit(u64::MAX)
         .build()
         .unwrap();

--- a/bins/revme/src/cmd/bench/snailtracer.rs
+++ b/bins/revme/src/cmd/bench/snailtracer.rs
@@ -13,7 +13,7 @@ pub fn run(criterion: &mut Criterion) {
     let bytecode = Bytecode::new_raw(Bytes::from(hex::decode(BYTES).unwrap()));
 
     let mut evm = Context::mainnet()
-        .with_db(BenchmarkDB::new_bytecode(bytecode.clone()))
+        .with_db(BenchmarkDB::new_bytecode(bytecode))
         .modify_cfg_chained(|c| c.disable_nonce_check = true)
         .build_mainnet()
         .with_inspector(NoOpInspector {});

--- a/bins/revme/src/cmd/blockchaintest.rs
+++ b/bins/revme/src/cmd/blockchaintest.rs
@@ -268,7 +268,7 @@ fn run_test_file(
                     println!("{}", serde_json::to_string(&output).unwrap());
                 }
                 return Err(Error::TestExecution {
-                    test_name: test_name.clone(),
+                    test_name,
                     test_path: file_path.to_path_buf(),
                     error: e.to_string(),
                 });

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -361,8 +361,8 @@ pub fn execute_test_suite(
                     Err(_) if test.expect_exception.is_some() => continue,
                     Err(_) => {
                         return Err(TestError {
-                            name: name.clone(),
-                            path: path.clone(),
+                            name,
+                            path,
                             kind: TestErrorKind::UnknownPrivateKey(unit.transaction.secret_key),
                         });
                     }
@@ -387,8 +387,8 @@ pub fn execute_test_suite(
                     static FAILED: AtomicBool = AtomicBool::new(false);
                     if print_json_outcome || FAILED.swap(true, Ordering::SeqCst) {
                         return Err(TestError {
-                            name: name.clone(),
-                            path: path.clone(),
+                            name,
+                            path,
                             kind: e,
                         });
                     }
@@ -407,8 +407,8 @@ pub fn execute_test_suite(
                     });
 
                     return Err(TestError {
-                        path: path.clone(),
-                        name: name.clone(),
+                        path,
+                        name,
                         kind: e,
                     });
                 }

--- a/examples/contract_deployment/src/main.rs
+++ b/examples/contract_deployment/src/main.rs
@@ -55,7 +55,7 @@ fn main() -> anyhow::Result<()> {
     let ref_tx = evm.transact_commit(
         TxEnv::builder()
             .kind(TxKind::Create)
-            .data(bytecode.clone())
+            .data(bytecode)
             .build()
             .unwrap(),
     )?;


### PR DESCRIPTION
- Remove unnecessary `.clone()` calls where variables are not used after the clone
- Allows direct ownership transfer instead of copying, improving performance