### PR TITLE
refactor(revme): use unwrap_or_default for non-UTF8 path safety

### DIFF
--- a/bins/revme/src/cmd/blockchaintest.rs
+++ b/bins/revme/src/cmd/blockchaintest.rs
@@ -1059,7 +1059,7 @@ fn skip_test(path: &Path) -> bool {
         return true;
     }
 
-    let name = path.file_name().unwrap().to_str().unwrap();
+    let name = path.file_name().unwrap().to_str().unwrap_or_default();
     // Add any problematic tests here that should be skipped
     matches!(
         name,


### PR DESCRIPTION
Improves safety in `blockchaintest.rs` by using `unwrap_or_default()` instead of double `unwrap()` when converting file paths to strings.

`runner.rs:95` uses the same safer approach.