### PR TITLE
perf: avoid loading bytecode in extcodehash

### DIFF
--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -84,11 +84,11 @@ pub fn extcodehash<WIRE: InterpreterTypes, H: Host + ?Sized>(
 
     let spec_id = context.interpreter.runtime_flag.spec_id();
     let account = if spec_id.is_enabled_in(BERLIN) {
-        berlin_load_account!(context, address, true)
+        berlin_load_account!(context, address, false)
     } else {
         let Ok(account) = context
             .host
-            .load_account_info_skip_cold_load(address, true, false)
+            .load_account_info_skip_cold_load(address, false, false)
         else {
             return context.interpreter.halt_fatal();
         };


### PR DESCRIPTION
`EXTCODEHASH` only needs the account’s emptiness status and code_hash, not the full bytecode. Previously we were calling 
load_account_info_skip_cold_load and `berlin_load_account!` with load_code = true, which forced bytecode loading from the database even though extcodehash only reads is_empty() and code_hash. This change switches both branches to use load_code = false, so we no longer pull code blobs into memory. The cold/warm account accounting and gas behaviour are unchanged, and the implementation remains consistent with EIP-1052/EIP-161 semantics while reducing unnecessary IO and allocations.