### PR TITLE
refactor(revme): consolidate find_all_json_tests in dir_utils

### DIFF
--- a/bins/revme/src/cmd/blockchaintest.rs
+++ b/bins/revme/src/cmd/blockchaintest.rs
@@ -1,6 +1,7 @@
 pub mod post_block;
 pub mod pre_block;
 
+use crate::dir_utils::find_all_json_tests;
 use clap::Parser;
 
 use revm::statetest_types::blockchain::{
@@ -26,7 +27,6 @@ use std::{
     time::Instant,
 };
 use thiserror::Error;
-use walkdir::{DirEntry, WalkDir};
 
 /// Panics if the value cannot be serialized to JSON.
 fn print_json<T: serde::Serialize>(value: &T) {
@@ -83,22 +83,6 @@ impl Cmd {
             )?;
         }
         Ok(())
-    }
-}
-
-/// Find all JSON test files in the given path
-/// If path is a file, returns it in a vector
-/// If path is a directory, recursively finds all .json files
-pub fn find_all_json_tests(path: &Path) -> Vec<PathBuf> {
-    if path.is_file() {
-        vec![path.to_path_buf()]
-    } else {
-        WalkDir::new(path)
-            .into_iter()
-            .filter_map(Result::ok)
-            .filter(|e| e.path().extension() == Some("json".as_ref()))
-            .map(DirEntry::into_path)
-            .collect()
     }
 }
 

--- a/bins/revme/src/cmd/statetest.rs
+++ b/bins/revme/src/cmd/statetest.rs
@@ -4,8 +4,9 @@ pub mod utils;
 
 pub use runner::{TestError as Error, TestErrorKind};
 
+use crate::dir_utils::find_all_json_tests;
 use clap::Parser;
-use runner::{find_all_json_tests, run, TestError};
+use runner::{run, TestError};
 use std::path::PathBuf;
 
 /// `statetest` subcommand

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -26,7 +26,6 @@ use std::{
     time::{Duration, Instant},
 };
 use thiserror::Error;
-use walkdir::{DirEntry, WalkDir};
 
 /// Error that occurs during test execution
 #[derive(Debug, Error)]
@@ -64,22 +63,6 @@ pub enum TestErrorKind {
     InvalidPath,
     #[error("no JSON test files found in path")]
     NoJsonFiles,
-}
-
-/// Find all JSON test files in the given path
-/// If path is a file, returns it in a vector
-/// If path is a directory, recursively finds all .json files
-pub fn find_all_json_tests(path: &Path) -> Vec<PathBuf> {
-    if path.is_file() {
-        vec![path.to_path_buf()]
-    } else {
-        WalkDir::new(path)
-            .into_iter()
-            .filter_map(Result::ok)
-            .filter(|e| e.path().extension() == Some("json".as_ref()))
-            .map(DirEntry::into_path)
-            .collect()
-    }
 }
 
 /// Check if a test should be skipped based on its filename

--- a/bins/revme/src/dir_utils.rs
+++ b/bins/revme/src/dir_utils.rs
@@ -1,16 +1,18 @@
 use std::path::{Path, PathBuf};
 use walkdir::{DirEntry, WalkDir};
 
+/// Find all JSON test files in the given path.
+/// If path is a file, returns it in a vector.
+/// If path is a directory, recursively finds all .json files.
 pub fn find_all_json_tests(path: &Path) -> Vec<PathBuf> {
-    WalkDir::new(path)
-        .into_iter()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.path()
-                .extension()
-                .map(|ext| ext == "json")
-                .unwrap_or(false)
-        })
-        .map(DirEntry::into_path)
-        .collect::<Vec<PathBuf>>()
+    if path.is_file() {
+        vec![path.to_path_buf()]
+    } else {
+        WalkDir::new(path)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|e| e.path().extension() == Some("json".as_ref()))
+            .map(DirEntry::into_path)
+            .collect()
+    }
 }


### PR DESCRIPTION
Eliminates code duplication by consolidating three implementations of `find_all_json_tests` into a single, complete implementation in the shared `dir_utils` module.