### PR TITLE
fix(database): make DatabaseCommit dyn-compatible

### DIFF
--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -392,7 +392,7 @@ impl<DB: Database> DatabaseCommit for State<DB> {
         }
     }
 
-    fn commit_iter(&mut self, changes: impl IntoIterator<Item = (Address, Account)>) {
+    fn commit_iter(&mut self, changes: &mut dyn Iterator<Item = (Address, Account)>) {
         let transitions = self
             .cache
             .apply_evm_state_iter(changes, |address, account| {


### PR DESCRIPTION
# Summary

This PR fixes dyn-compatibility of DatabaseCommit for downstream users like Foundry that use dyn DatabaseExt (which extends DatabaseCommit).

# Problem

While integrating recent revm codebase with Foundry, I discovered that DatabaseCommit is not dyn-compatible due to how #[auto_impl] generates implementations.

Foundry defines DatabaseExt which extends DatabaseCommit:

```rust
pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit + Debug { ... }
```

And uses it as a trait object throughout the codebase:

```rust
  pub struct FoundryEvm<'db, I: InspectorExt> {
      db: &'db mut dyn DatabaseExt,
      // ...
  }
```

The issue is that `#[auto_impl(&mut, Box)]` generates implementations like:

```rust
  impl<T: DatabaseCommit + ?Sized> DatabaseCommit for &mut T {
      fn commit_iter(&mut self, changes: impl IntoIterator<Item = (Address, Account)>) {
          T::commit_iter(*self, changes) 
      }
  }
```

This fails because `commit_iter` uses `impl` Trait in argument position (which requires Self: Sized). When T is ?Sized (like dyn DatabaseCommit), the generated code tries to call a method that requires Sized on a ?Sized type.

# Solution

1. commit_iter now uses `&mut dyn Iterator`: this keeps the method in the vtable and callable on trait objects
2. impl dyn DatabaseCommit provides ergonomic commit_from_iter(impl IntoIterator) wrapper
3. Add tests for dyn-compatibility including a compile-time check mirroring Foundry's approach