### PR TITLE
fix: the MLOAD opcode can modify memory

### DIFF
--- a/crates/bytecode/src/opcode.rs
+++ b/crates/bytecode/src/opcode.rs
@@ -182,6 +182,7 @@ impl OpCode {
         matches!(
             *self,
             OpCode::EXTCODECOPY
+                | OpCode::MLOAD
                 | OpCode::MSTORE
                 | OpCode::MSTORE8
                 | OpCode::MCOPY
@@ -768,7 +769,7 @@ mod tests {
 
     #[test]
     fn test_modifies_memory() {
-        assert!(!OpCode::new(MLOAD).unwrap().modifies_memory());
+        assert!(OpCode::new(MLOAD).unwrap().modifies_memory());
         assert!(OpCode::new(MSTORE).unwrap().modifies_memory());
         assert!(!OpCode::new(ADD).unwrap().modifies_memory());
     }


### PR DESCRIPTION
This occurs if the `MLOAD` opcode needs to be resize the memory to read from the requested memory offset.

```rs
pub fn mload<WIRE: InterpreterTypes, H: ?Sized>(context: InstructionContext<'_, H, WIRE>) {
    popn_top!([], top, context.interpreter);
    let offset = as_usize_or_fail!(context.interpreter, top);
    resize_memory!(context.interpreter, offset, 32); // <-- This can modify the memory!!
    *top =
        U256::try_from_be_slice(context.interpreter.memory.slice_len(offset, 32).as_ref()).unwrap()
}
```