### PR TITLE
chore: the KECCAK256 opcode can resize memory

### DIFF
--- a/crates/bytecode/src/opcode.rs
+++ b/crates/bytecode/src/opcode.rs
@@ -186,6 +186,7 @@ impl OpCode {
                 | OpCode::MSTORE
                 | OpCode::MSTORE8
                 | OpCode::MCOPY
+                | OpCode::KECCAK256
                 | OpCode::CODECOPY
                 | OpCode::CALLDATACOPY
                 | OpCode::RETURNDATACOPY
@@ -771,6 +772,7 @@ mod tests {
     fn test_modifies_memory() {
         assert!(OpCode::new(MLOAD).unwrap().modifies_memory());
         assert!(OpCode::new(MSTORE).unwrap().modifies_memory());
+        assert!(OpCode::new(KECCAK256).unwrap().modifies_memory());
         assert!(!OpCode::new(ADD).unwrap().modifies_memory());
     }
 }


### PR DESCRIPTION
KECCAK256 calls resize_memory! when len > 0.