### PR TITLE
docs: clarify timestamp default in BlockEnv

### DIFF
--- a/crates/context/src/block.rs
+++ b/crates/context/src/block.rs
@@ -104,6 +104,7 @@ impl Default for BlockEnv {
         Self {
             number: U256::ZERO,
             beneficiary: Address::ZERO,
+            // Set to 1 instead of 0 to avoid zero timestamp. Users should set the actual value.
             timestamp: U256::ONE,
             gas_limit: u64::MAX,
             basefee: 0,


### PR DESCRIPTION
Was reading through the block env code and noticed timestamp is set to ONE while everything else is ZERO. Took me some time to figure out if there's a technical reason for this.

Added a quick comment to save future readers the confusion. If there's actually a specific reason it needs to be 1 (like some validation I missed or edge case), let me know and I can update the comment to be more specific.