### PR TITLE
chore: remove unused InterpreterAction::new_stop helper

### DIFF
--- a/crates/interpreter/src/interpreter_action.rs
+++ b/crates/interpreter/src/interpreter_action.rs
@@ -119,14 +119,4 @@ impl InterpreterAction {
     pub fn new_return(result: InstructionResult, output: Bytes, gas: Gas) -> Self {
         Self::Return(InterpreterResult::new(result, output, gas))
     }
-
-    /// Create new stop action.
-    #[inline]
-    pub fn new_stop() -> Self {
-        Self::Return(InterpreterResult::new(
-            InstructionResult::Stop,
-            Bytes::new(),
-            Gas::new(0),
-        ))
-    }
 }


### PR DESCRIPTION
InterpreterAction::new_stop was never used and created an InterpreterResult::Stop with Gas::new(0), which is inconsistent with all other interpreter exit paths that preserve the actual gas state. This helper is not part of the documented public API and having it around is a footgun for external users