### PR TITLE
fix(bytecode): remove duplicate implementation in bytes_ref method

### DIFF
--- a/crates/bytecode/src/bytecode.rs
+++ b/crates/bytecode/src/bytecode.rs
@@ -147,10 +147,7 @@ impl Bytecode {
     /// Returns raw bytes reference.
     #[inline]
     pub fn bytes_ref(&self) -> &Bytes {
-        match self {
-            Self::LegacyAnalyzed(analyzed) => analyzed.bytecode(),
-            Self::Eip7702(code) => code.raw(),
-        }
+        self.bytecode()
     }
 
     /// Returns raw bytes slice.


### PR DESCRIPTION
Remove code duplication in `Bytecode::bytes_ref()` method which was identical to `Bytecode::bytecode()`. Now `bytes_ref()` delegates to `bytecode()` instead of duplicating the match logic.