### PR TITLE
docs: fix typos and grammar in database crate

### DIFF
--- a/crates/database/interface/src/async_db.rs
+++ b/crates/database/interface/src/async_db.rs
@@ -171,7 +171,7 @@ impl<T: DatabaseAsync> Database for WrapDatabaseAsync<T> {
 
     /// Gets storage value of account by its id.
     ///
-    /// Default implementation is to call [`DatabaseRef::storage_ref`] method.
+    /// Wraps [`DatabaseAsync::storage_by_account_id_async`] in a blocking call.
     #[inline]
     fn storage_by_account_id(
         &mut self,

--- a/crates/database/src/states/bundle_state.rs
+++ b/crates/database/src/states/bundle_state.rs
@@ -397,7 +397,7 @@ impl BundleRetention {
 ///
 /// This is needed to decide if there were any changes to the account.
 ///
-/// Reverts and created when TransitionState is applied to BundleState.
+/// Changes are applied and reverts are created when TransitionState is applied to BundleState.
 ///
 /// And can be used to revert BundleState to the state before transition.
 #[derive(Default, Clone, Debug, PartialEq, Eq)]

--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -50,13 +50,13 @@ pub struct State<DB> {
     ///
     /// Build reverts and state that gets applied to the state.
     pub transition_state: Option<TransitionState>,
-    /// After block is finishes we merge those changes inside bundle
+    /// After block finishes we merge those changes inside bundle
     ///
     /// Bundle is used to update database and create changesets.
     ///
     /// Bundle state can be set on initialization if we want to use preloaded bundle.
     pub bundle_state: BundleState,
-    /// Addition layer that is going to be used to fetched values before fetching values
+    /// Additional layer that is going to be used to fetch values before fetching values
     /// from database
     ///
     /// Bundle is the main output of the state execution and this allows setting previous bundle
@@ -192,7 +192,7 @@ impl<DB: Database> State<DB> {
     }
 
     // TODO : Make cache aware of transitions dropping by having global transition counter.
-    /// Takess the [`BundleState`] changeset from the [`State`], replacing it
+    /// Takes the [`BundleState`] changeset from the [`State`], replacing it
     /// with an empty one.
     ///
     /// This will not apply any pending [`TransitionState`].


### PR DESCRIPTION
- state.rs: Fix 'After block is finishes' -> 'After block finishes'
- state.rs: Fix 'Addition layer' -> 'Additional layer', 'fetched' -> 'fetch'
- state.rs: Fix 'Takess' -> 'Takes'
- bundle_state.rs: Fix incomplete sentence to match function docs
- async_db.rs: Fix incorrect doc reference to actual method called