### PR TITLE
fix(bal): ensure sorted writes in Alloy type conversions

### DIFF
--- a/crates/state/src/bal/alloy.rs
+++ b/crates/state/src/bal/alloy.rs
@@ -29,34 +29,34 @@ impl TryFrom<AlloyBal> for Bal {
 
 impl From<Vec<AlloyBalanceChange>> for BalWrites<U256> {
     fn from(value: Vec<AlloyBalanceChange>) -> Self {
-        Self {
-            writes: value
+        Self::new(
+            value
                 .into_iter()
                 .map(|change| (change.block_access_index, change.post_balance))
                 .collect(),
-        }
+        )
     }
 }
 
 impl From<Vec<AlloyNonceChange>> for BalWrites<u64> {
     fn from(value: Vec<AlloyNonceChange>) -> Self {
-        Self {
-            writes: value
+        Self::new(
+            value
                 .into_iter()
                 .map(|change| (change.block_access_index, change.new_nonce))
                 .collect(),
-        }
+        )
     }
 }
 
 impl From<Vec<AlloyStorageChange>> for BalWrites<U256> {
     fn from(value: Vec<AlloyStorageChange>) -> Self {
-        Self {
-            writes: value
+        Self::new(
+            value
                 .into_iter()
                 .map(|change| (change.block_access_index, change.new_value))
                 .collect(),
-        }
+        )
     }
 }
 
@@ -64,8 +64,8 @@ impl TryFrom<Vec<AlloyCodeChange>> for BalWrites<(B256, Bytecode)> {
     type Error = BytecodeDecodeError;
 
     fn try_from(value: Vec<AlloyCodeChange>) -> Result<Self, Self::Error> {
-        Ok(Self {
-            writes: value
+        Ok(Self::new(
+            value
                 .into_iter()
                 .map(|change| {
                     // convert bytes to bytecode.
@@ -75,6 +75,6 @@ impl TryFrom<Vec<AlloyCodeChange>> for BalWrites<(B256, Bytecode)> {
                     })
                 })
                 .collect::<Result<Vec<_>, Self::Error>>()?,
-        })
+        ))
     }
 }


### PR DESCRIPTION
## Summary
`From`/`TryFrom` implementations for Alloy EIP-7928 types now use `Self::new()` 
to ensure writes are sorted by `block_access_index`.

## Problem
`BalWrites::get()` relies on sorted data for correct binary/linear search.
However, Alloy types (`Vec<BalanceChange>`, etc.) do not guarantee ordering.
Using direct struct initialization (`Self { writes: ... }`) bypassed sorting,
potentially causing incorrect lookups.

## Solution
Replace `Self { writes: ... }` with `Self::new(...)` which sorts the data.

## Changes
- `alloy.rs`: 4 conversions updated (`BalanceChange`, `NonceChange`, `StorageChange`, `CodeChange`)