### PR TITLE
fix: correct debug log key/value for blob gas fields in blockchaintest

### DIFF
--- a/bins/revme/src/cmd/blockchaintest.rs
+++ b/bins/revme/src/cmd/blockchaintest.rs
@@ -501,10 +501,9 @@ fn print_error_with_state(
     eprintln!("  Difficulty: {}", debug_info.block_env.difficulty);
     eprintln!("  Prevrandao: {:?}", debug_info.block_env.prevrandao);
     eprintln!("  Beneficiary: {:?}", debug_info.block_env.beneficiary);
-    eprintln!(
-        "  Blob excess gas: {:?}",
-        debug_info.block_env.blob_excess_gas_and_price
-    );
+    let blob = debug_info.block_env.blob_excess_gas_and_price;
+    eprintln!("  Blob excess gas: {:?}", blob.map(|a| a.excess_blob_gas));
+    eprintln!("  Blob gas price: {:?}", blob.map(|a| a.blob_gasprice));
 
     // Print withdrawals
     if let Some(withdrawals) = &debug_info.withdrawals {


### PR DESCRIPTION
The debug output in blockchain test error messages incorrectly labeled the log key as `"Blob excess gas"` while printing the entire `BlobExcessGasAndPrice` struct, which contains both `excess_blob_gas` and `blob_gasprice` fields.

Split the log output into two separate lines with correct labels:
- `"Blob excess gas"` now correctly shows only `excess_blob_gas`
- `"Blob gas price"` now correctly shows only `blob_gasprice`

