### PR TITLE
chore: fix outdated doc comment

### DIFF
--- a/crates/context/src/local.rs
+++ b/crates/context/src/local.rs
@@ -42,7 +42,9 @@ impl LocalContextTr for LocalContext {
 }
 
 impl LocalContext {
-    /// Creates a new local context, initcodes are hashes and added to the mapping.
+    /// Creates a new local context with default values.
+    ///
+    /// Initializes a shared memory buffer with 4KB capacity and no precompile error message.
     pub fn new() -> Self {
         Self::default()
     }


### PR DESCRIPTION
Found this doc comment talking about "initcodes are hashes and added to the mapping" but LocalContext doesn't have anything related to initcodes or mappings anymore - just shared_memory_buffer and precompile_error_message. Looks like it was left over from an old version and never updated. Fixed it to reflect what the code actually does.