### PR TITLE
test: reusing state / state cache across blocks

### DIFF
--- a/crates/database/src/states/account_status.rs
+++ b/crates/database/src/states/account_status.rs
@@ -58,9 +58,7 @@ impl AccountStatus {
     pub fn is_storage_known(&self) -> bool {
         matches!(
             self,
-            Self::LoadedNotExisting
-                | Self::Destroyed
-                | Self::DestroyedAgain
+            Self::LoadedNotExisting | Self::Destroyed | Self::DestroyedAgain
         )
     }
 

--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -1029,7 +1029,8 @@ mod tests {
 
         // Block 1: Deploy the contract with an initial slot.
         let first_block_slot_key = U256::from(1);
-        let first_block_slot_value = state::EvmStorageSlot::new_changed(U256::ZERO, U256::from(1), 0);
+        let first_block_slot_value =
+            state::EvmStorageSlot::new_changed(U256::ZERO, U256::from(1), 0);
         let contract_account = Account {
             info: contract_info.clone(),
             storage: state::EvmStorage::from_iter([(
@@ -1056,7 +1057,8 @@ mod tests {
 
         // Block 2: Write a new slot to the contract
         let second_block_slot_key = U256::from(2);
-        let second_block_slot_value = state::EvmStorageSlot::new_changed(U256::ZERO, U256::from(2), 1);
+        let second_block_slot_value =
+            state::EvmStorageSlot::new_changed(U256::ZERO, U256::from(2), 1);
         let contract_account = Account {
             info: contract_info,
             storage: state::EvmStorage::from_iter([(


### PR DESCRIPTION
Hi, thanks a lot for `revm` - great work 🙏

I have two short, related questions about **reusing `State` / state cache across blocks**.

#### 1. Storage fallback when reusing cache

In my use case, I want to **reuse the state cache across blocks** for performance.

I noticed that when a storage slot is not found in cache, but the cached account has status
`InMemoryChange` or `DestroyedChanged`, storage reads may return incorrect values if the cache is reused for a new block.

I made a small PR so that in this case, `revm` **falls back to the underlying DB** when the value is missing from cache.

Does this behavior align with the intended cache semantics, or does it break any assumptions in `revm`?

Refer Test: https://github.com/bluealloy/revm/pull/2196/files

#### 2. Safety of reusing State across blocks

More generally, is it **safe to reuse `State` across blocks** if the bundle and transitions are reset?

If not, is it at least safe to reuse **only the state cache** across blocks?

My assumption is that as long as missing data can correctly fall back to the DB, correctness should be preserved - but I’d appreciate your confirmation.

Thanks a lot for your guidance!
