### PR TITLE
perf: remove redundant clones in gas params defaults

### DIFF
--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -91,7 +91,7 @@ mod serde {
 
 impl Default for GasParams {
     fn default() -> Self {
-        Self::new_spec(SpecId::default()).clone()
+        Self::new_spec(SpecId::default())
     }
 }
 

--- a/crates/context/interface/src/host.rs
+++ b/crates/context/interface/src/host.rs
@@ -213,7 +213,7 @@ impl DummyHost {
     /// Create a new dummy host with the given spec.
     pub fn new(spec: SpecId) -> Self {
         Self {
-            gas_params: GasParams::new_spec(spec).clone(),
+            gas_params: GasParams::new_spec(spec),
         }
     }
 }


### PR DESCRIPTION
Drop the unnecessary clone() in gas params default impl and DummyHost ctor to quiet clippy::redundant_clone. Behavior stays the same