### PR TITLE
feat(interpreter): add `new_oog` helper to `InterpreterResult`

### DIFF
--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -370,6 +370,15 @@ impl InterpreterResult {
         }
     }
 
+    /// Returns a new `InterpreterResult` for an out-of-gas error with the given gas limit.
+    pub fn new_oog(gas_limit: u64) -> Self {
+        Self {
+            result: InstructionResult::OutOfGas,
+            output: Bytes::default(),
+            gas: Gas::new_spent(gas_limit),
+        }
+    }
+
     /// Returns whether the instruction result is a success.
     #[inline]
     pub const fn is_ok(&self) -> bool {


### PR DESCRIPTION
## Summary
- Add `new_oog(gas_limit: u64)` convenience constructor to `InterpreterResult`
- Creates an out-of-gas result with empty output and all gas consumed

## Test plan
- [x] Code compiles successfully with `cargo check -p revm-interpreter`