### PR TITLE
feat: add `new_oog` helpers to InterpreterResult, CallOutcome, CreateOutcome, and FrameResult

### DIFF
--- a/crates/handler/src/frame_data.rs
+++ b/crates/handler/src/frame_data.rs
@@ -42,6 +42,18 @@ pub enum FrameResult {
 }
 
 impl FrameResult {
+    /// Creates a new call frame result for an out-of-gas error.
+    #[inline]
+    pub fn new_call_oog(gas_limit: u64, memory_offset: core::ops::Range<usize>) -> Self {
+        Self::Call(CallOutcome::new_oog(gas_limit, memory_offset))
+    }
+
+    /// Creates a new create frame result for an out-of-gas error.
+    #[inline]
+    pub fn new_create_oog(gas_limit: u64) -> Self {
+        Self::Create(CreateOutcome::new_oog(gas_limit))
+    }
+
     /// Casts frame result to interpreter result.
     #[inline]
     pub fn into_interpreter_result(self) -> InterpreterResult {

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -370,6 +370,15 @@ impl InterpreterResult {
         }
     }
 
+    /// Returns a new `InterpreterResult` for an out-of-gas error with the given gas limit.
+    pub fn new_oog(gas_limit: u64) -> Self {
+        Self {
+            result: InstructionResult::OutOfGas,
+            output: Bytes::default(),
+            gas: Gas::new_spent(gas_limit),
+        }
+    }
+
     /// Returns whether the instruction result is a success.
     #[inline]
     pub const fn is_ok(&self) -> bool {

--- a/crates/interpreter/src/interpreter_action/call_outcome.rs
+++ b/crates/interpreter/src/interpreter_action/call_outcome.rs
@@ -45,6 +45,16 @@ impl CallOutcome {
         }
     }
 
+    /// Constructs a new [`CallOutcome`] for an out-of-gas error.
+    ///
+    /// # Arguments
+    ///
+    /// * `gas_limit` - The gas limit that was exceeded.
+    /// * `memory_offset` - The range in memory indicating where the output data is stored.
+    pub fn new_oog(gas_limit: u64, memory_offset: Range<usize>) -> Self {
+        Self::new(InterpreterResult::new_oog(gas_limit), memory_offset)
+    }
+
     /// Returns a reference to the instruction result.
     ///
     /// Provides access to the result of the executed instruction.

--- a/crates/interpreter/src/interpreter_action/create_outcome.rs
+++ b/crates/interpreter/src/interpreter_action/create_outcome.rs
@@ -30,6 +30,19 @@ impl CreateOutcome {
         Self { result, address }
     }
 
+    /// Constructs a new [`CreateOutcome`] for an out-of-gas error.
+    ///
+    /// # Arguments
+    ///
+    /// * `gas_limit` - The gas limit that was exceeded.
+    ///
+    /// # Returns
+    ///
+    /// A new [`CreateOutcome`] instance with no address.
+    pub fn new_oog(gas_limit: u64) -> Self {
+        Self::new(InterpreterResult::new_oog(gas_limit), None)
+    }
+
     /// Retrieves a reference to the [`InstructionResult`] from the [`InterpreterResult`].
     ///
     /// This method provides access to the [`InstructionResult`] which represents the


### PR DESCRIPTION
## Summary
- Add `InterpreterResult::new_oog(gas_limit)` - creates OOG result with empty output and all gas consumed
- Add `CallOutcome::new_oog(gas_limit, memory_offset)` - creates call outcome for OOG error
- Add `CreateOutcome::new_oog(gas_limit)` - creates create outcome for OOG error with no address
- Add `FrameResult::new_call_oog(gas_limit, memory_offset)` - creates call frame result for OOG
- Add `FrameResult::new_create_oog(gas_limit)` - creates create frame result for OOG

## Test plan
- [x] Code compiles successfully with `cargo check -p revm-interpreter -p revm-handler`