### PR TITLE
refactor(gas_params): add dedicated GasIds for sstore_refund

### DIFF
--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -220,6 +220,12 @@ impl GasParams {
             gas::SSTORE_SET - gas::SSTORE_RESET;
         // SSTORE RESET Is covered in SSTORE_STATIC.
         table[GasId::sstore_reset_without_cold_load_cost().as_usize()] = 0;
+        // SSTORE SET REFUND (same as sstore_set_without_load_cost but used only in sstore_refund)
+        table[GasId::sstore_set_refund().as_usize()] =
+            table[GasId::sstore_set_without_load_cost().as_usize()];
+        // SSTORE RESET REFUND (same as sstore_reset_without_cold_load_cost but used only in sstore_refund)
+        table[GasId::sstore_reset_refund().as_usize()] =
+            table[GasId::sstore_reset_without_cold_load_cost().as_usize()];
         // SSTORE CLEARING SLOT REFUND
         table[GasId::sstore_clearing_slot_refund().as_usize()] = 15000;
         table[GasId::selfdestruct_refund().as_usize()] = 24000;
@@ -251,6 +257,10 @@ impl GasParams {
                 gas::SSTORE_SET - gas::ISTANBUL_SLOAD_GAS;
             table[GasId::sstore_reset_without_cold_load_cost().as_usize()] =
                 gas::SSTORE_RESET - gas::ISTANBUL_SLOAD_GAS;
+            table[GasId::sstore_set_refund().as_usize()] =
+                table[GasId::sstore_set_without_load_cost().as_usize()];
+            table[GasId::sstore_reset_refund().as_usize()] =
+                table[GasId::sstore_reset_without_cold_load_cost().as_usize()];
             table[GasId::tx_token_non_zero_byte_multiplier().as_usize()] =
                 gas::NON_ZERO_BYTE_MULTIPLIER_ISTANBUL;
         }
@@ -268,6 +278,10 @@ impl GasParams {
                 gas::WARM_SSTORE_RESET - gas::WARM_STORAGE_READ_COST;
             table[GasId::sstore_set_without_load_cost().as_usize()] =
                 gas::SSTORE_SET - gas::WARM_STORAGE_READ_COST;
+            table[GasId::sstore_set_refund().as_usize()] =
+                table[GasId::sstore_set_without_load_cost().as_usize()];
+            table[GasId::sstore_reset_refund().as_usize()] =
+                table[GasId::sstore_reset_without_cold_load_cost().as_usize()];
 
             table[GasId::tx_access_list_address_cost().as_usize()] = gas::ACCESS_LIST_ADDRESS;
             table[GasId::tx_access_list_storage_key_cost().as_usize()] =
@@ -389,6 +403,18 @@ impl GasParams {
         self.get(GasId::sstore_clearing_slot_refund())
     }
 
+    /// SSTORE set refund. Used in sstore_refund for SSTORE_SET_GAS - SLOAD_GAS.
+    #[inline]
+    pub fn sstore_set_refund(&self) -> u64 {
+        self.get(GasId::sstore_set_refund())
+    }
+
+    /// SSTORE reset refund. Used in sstore_refund for SSTORE_RESET_GAS - SLOAD_GAS.
+    #[inline]
+    pub fn sstore_reset_refund(&self) -> u64 {
+        self.get(GasId::sstore_reset_refund())
+    }
+
     /// Dynamic gas cost for SSTORE opcode.
     ///
     /// Dynamic gas cost is gas that needs input from SSTORE operation to be calculated.
@@ -469,11 +495,11 @@ impl GasParams {
             // If original value is 0
             if vals.is_original_zero() {
                 // add SSTORE_SET_GAS - SLOAD_GAS to refund counter.
-                refund += self.sstore_set_without_load_cost() as i64;
+                refund += self.sstore_set_refund() as i64;
             // Otherwise
             } else {
                 // add SSTORE_RESET_GAS - SLOAD_GAS gas to refund counter.
-                refund += self.sstore_reset_without_cold_load_cost() as i64;
+                refund += self.sstore_reset_refund() as i64;
             }
         }
         refund
@@ -827,6 +853,8 @@ impl GasId {
             x if x == Self::tx_base_stipend().as_u8() => "tx_base_stipend",
             x if x == Self::tx_create_cost().as_u8() => "tx_create_cost",
             x if x == Self::tx_initcode_cost().as_u8() => "tx_initcode_cost",
+            x if x == Self::sstore_set_refund().as_u8() => "sstore_set_refund",
+            x if x == Self::sstore_reset_refund().as_u8() => "sstore_reset_refund",
             _ => "unknown",
         }
     }
@@ -884,6 +912,8 @@ impl GasId {
             "tx_base_stipend" => Some(Self::tx_base_stipend()),
             "tx_create_cost" => Some(Self::tx_create_cost()),
             "tx_initcode_cost" => Some(Self::tx_initcode_cost()),
+            "sstore_set_refund" => Some(Self::sstore_set_refund()),
+            "sstore_reset_refund" => Some(Self::sstore_reset_refund()),
             _ => None,
         }
     }
@@ -1070,6 +1100,16 @@ impl GasId {
     pub const fn tx_initcode_cost() -> GasId {
         Self::new(36)
     }
+
+    /// SSTORE set refund. Used in sstore_refund for SSTORE_SET_GAS - SLOAD_GAS refund calculation.
+    pub const fn sstore_set_refund() -> GasId {
+        Self::new(37)
+    }
+
+    /// SSTORE reset refund. Used in sstore_refund for SSTORE_RESET_GAS - SLOAD_GAS refund calculation.
+    pub const fn sstore_reset_refund() -> GasId {
+        Self::new(38)
+    }
 }
 
 #[cfg(test)]
@@ -1112,11 +1152,11 @@ mod tests {
             "Not all unique names are resolvable via from_str"
         );
 
-        // We should have exactly 36 known GasIds (based on the indices 1-36 used)
+        // We should have exactly 38 known GasIds (based on the indices 1-38 used)
         assert_eq!(
             unique_names.len(),
-            36,
-            "Expected 36 unique GasIds, found {}",
+            38,
+            "Expected 38 unique GasIds, found {}",
             unique_names.len()
         );
     }


### PR DESCRIPTION
## Summary
- Add `sstore_set_refund` and `sstore_reset_refund` GasIds (indices 37-38)
- Update `sstore_refund` to use these new dedicated parameters instead of `sstore_set_without_load_cost` and `sstore_reset_without_cold_load_cost`
- This decouples `sstore_refund` from `sstore_dynamic_gas` allowing independent parameter configuration while maintaining the same values

## Test plan
- [x] Existing `test_gas_id_name_and_from_str_coverage` test updated and passing
- [x] Clippy passes with no warnings