### PR TITLE
Rename misleading calc_linear_cost_u32 function

### DIFF
--- a/crates/precompile/src/hash.rs
+++ b/crates/precompile/src/hash.rs
@@ -1,6 +1,6 @@
 //! Hash precompiles, it contains SHA-256 and RIPEMD-160 hash precompiles
 //! More details in [`sha256_run`] and [`ripemd160_run`]
-use super::calc_linear_cost_u32;
+use super::calc_linear_cost;
 use crate::{
     crypto, Precompile, PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult,
 };
@@ -23,7 +23,7 @@ pub const RIPEMD160: Precompile = Precompile::new(
 /// - [Solidity Documentation on Mathematical and Cryptographic Functions](https://docs.soliditylang.org/en/develop/units-and-global-variables.html#mathematical-and-cryptographic-functions)
 /// - [Address 0x02](https://etherscan.io/address/0000000000000000000000000000000000000002)
 pub fn sha256_run(input: &[u8], gas_limit: u64) -> PrecompileResult {
-    let cost = calc_linear_cost_u32(input.len(), 60, 12);
+    let cost = calc_linear_cost(input.len(), 60, 12);
     if cost > gas_limit {
         Err(PrecompileError::OutOfGas)
     } else {
@@ -39,7 +39,7 @@ pub fn sha256_run(input: &[u8], gas_limit: u64) -> PrecompileResult {
 /// - [Solidity Documentation on Mathematical and Cryptographic Functions](https://docs.soliditylang.org/en/develop/units-and-global-variables.html#mathematical-and-cryptographic-functions)
 /// - [Address 03](https://etherscan.io/address/0000000000000000000000000000000000000003)
 pub fn ripemd160_run(input: &[u8], gas_limit: u64) -> PrecompileResult {
-    let gas_used = calc_linear_cost_u32(input.len(), 600, 120);
+    let gas_used = calc_linear_cost(input.len(), 600, 120);
     if gas_used > gas_limit {
         Err(PrecompileError::OutOfGas)
     } else {

--- a/crates/precompile/src/identity.rs
+++ b/crates/precompile/src/identity.rs
@@ -1,5 +1,5 @@
 //! Identity precompile returns
-use super::calc_linear_cost_u32;
+use super::calc_linear_cost;
 use crate::{Precompile, PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult};
 use primitives::Bytes;
 
@@ -21,7 +21,7 @@ pub const IDENTITY_PER_WORD: u64 = 3;
 ///
 /// See: <https://etherscan.io/address/0000000000000000000000000000000000000004>
 pub fn identity_run(input: &[u8], gas_limit: u64) -> PrecompileResult {
-    let gas_used = calc_linear_cost_u32(input.len(), IDENTITY_BASE, IDENTITY_PER_WORD);
+    let gas_used = calc_linear_cost(input.len(), IDENTITY_BASE, IDENTITY_PER_WORD);
     if gas_used > gas_limit {
         return Err(PrecompileError::OutOfGas);
     }

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -59,8 +59,15 @@ use primitives::{
 use std::vec::Vec;
 
 /// Calculate the linear cost of a precompile.
-pub fn calc_linear_cost_u32(len: usize, base: u64, word: u64) -> u64 {
+#[inline]
+pub fn calc_linear_cost(len: usize, base: u64, word: u64) -> u64 {
     (len as u64).div_ceil(32) * word + base
+}
+
+/// Calculate the linear cost of a precompile.
+#[deprecated(note = "please use `calc_linear_cost` instead")]
+pub fn calc_linear_cost_u32(len: usize, base: u64, word: u64) -> u64 {
+    calc_linear_cost(len, base, word)
 }
 
 /// Precompiles contain map of precompile addresses to functions and HashSet of precompile addresses.


### PR DESCRIPTION
Rename `calc_linear_cost_u32` to `calc_linear_cost` as inputs are u64/usize, and keep the old name as a deprecated alias.