### PR TITLE
feat(database): add storage getter to BundleState

### DIFF
--- a/crates/database/src/states/bundle_state.rs
+++ b/crates/database/src/states/bundle_state.rs
@@ -536,6 +536,14 @@ impl BundleState {
         self.contracts.get(hash).cloned()
     }
 
+    /// Gets storage value from state.
+    ///
+    /// Returns `None` if the account is not present in the bundle state or the slot is not known.
+    pub fn storage(&self, address: &Address, storage_key: StorageKey) -> Option<StorageValue> {
+        self.account(address)
+            .and_then(|account| account.storage_slot(storage_key))
+    }
+
     /// Consumes [`TransitionState`] by applying the changes and creating the
     /// reverts.
     ///


### PR DESCRIPTION
Adds a `storage()` convenience method to `BundleState` that retrieves a storage value by address and key.

This mirrors the pattern in reth's `ExecutionOutcome` where `account()`, `storage()`, and `bytecode()` methods exist for convenient state access.

```rust
pub fn storage(&self, address: &Address, storage_key: StorageKey) -> Option<StorageValue> {
    self.account(address)
        .and_then(|account| account.storage_slot(storage_key))
}
```