### PR TITLE
Fix typos and standardize comments

### DIFF
--- a/crates/bytecode/src/bytecode.rs
+++ b/crates/bytecode/src/bytecode.rs
@@ -180,7 +180,7 @@ impl Bytecode {
         self.original_byte_slice().len()
     }
 
-    /// Returns whether the bytecode is empty.
+    /// Returns `true` if the bytecode is empty.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.len() == 0

--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -435,7 +435,7 @@ impl SharedMemory {
     }
 
     /// Set memory from data. Our memory offset+len is expected to be correct but we
-    /// are doing bound checks on data/data_offeset/len and zeroing parts that is not copied.
+    /// are doing bound checks on data/data_offset/len and zeroing parts that is not copied.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
Correct a typo in `SharedMemory` doc and standardize `Bytecode::is_empty` comment.