### PR TITLE
fix: use provided code hash when setting account code

### DIFF
--- a/crates/context/interface/src/journaled_state/account.rs
+++ b/crates/context/interface/src/journaled_state/account.rs
@@ -426,8 +426,7 @@ impl<'a, DB: Database, ENTRY: JournalEntryTr> JournaledAccountTr
     #[inline]
     fn set_code(&mut self, code_hash: B256, code: Bytecode) {
         self.touch();
-        self.account.info.set_code_hash(code_hash);
-        self.account.info.set_code(code);
+        self.account.info.set_code_and_hash(code, code_hash);
         self.journal_entries.push(ENTRY::code_changed(self.address));
     }
 


### PR DESCRIPTION
 Use the provided code hash when setting account code in JournaledAccount to avoid redundant hashing and preserve the caller’s hash, aligning behavior with the intended API and the set_code_with_hash flow.