### PR TITLE
chore: update default hardfork to Osaka (Ethereum) and Jovian (Optimism)

### DIFF
--- a/bins/revme/src/cmd/bench/burntpix.rs
+++ b/bins/revme/src/cmd/bench/burntpix.rs
@@ -37,7 +37,10 @@ pub fn run(criterion: &mut Criterion) {
 
     let mut evm = Context::mainnet()
         .with_db(db)
-        .modify_cfg_chained(|c| c.disable_nonce_check = true)
+        .modify_cfg_chained(|c| {
+            c.disable_nonce_check = true;
+            c.tx_gas_limit_cap = Some(u64::MAX);
+        })
         .build_mainnet();
 
     let tx = TxEnv::builder()

--- a/bins/revme/src/cmd/bench/gas_cost_estimator.rs
+++ b/bins/revme/src/cmd/bench/gas_cost_estimator.rs
@@ -23,7 +23,10 @@ pub fn run(criterion: &mut Criterion) {
 
         let mut evm = Context::mainnet()
             .with_db(BenchmarkDB::new_bytecode(bytecode.clone()))
-            .modify_cfg_chained(|c| c.disable_nonce_check = true)
+            .modify_cfg_chained(|c| {
+                c.disable_nonce_check = true;
+                c.tx_gas_limit_cap = Some(u64::MAX);
+            })
             .build_mainnet();
 
         let tx = TxEnv::builder()

--- a/bins/revme/src/cmd/bench/snailtracer.rs
+++ b/bins/revme/src/cmd/bench/snailtracer.rs
@@ -14,7 +14,10 @@ pub fn run(criterion: &mut Criterion) {
 
     let mut evm = Context::mainnet()
         .with_db(BenchmarkDB::new_bytecode(bytecode))
-        .modify_cfg_chained(|c| c.disable_nonce_check = true)
+        .modify_cfg_chained(|c| {
+            c.disable_nonce_check = true;
+            c.tx_gas_limit_cap = Some(u64::MAX);
+        })
         .build_mainnet()
         .with_inspector(NoOpInspector {});
 

--- a/crates/inspector/src/gas.rs
+++ b/crates/inspector/src/gas.rs
@@ -79,14 +79,14 @@ impl GasInspector {
 mod tests {
     use super::*;
     use crate::{InspectEvm, Inspector};
-    use context::{Context, TxEnv};
+    use context::{CfgEnv, Context, TxEnv};
     use database::{BenchmarkDB, BENCH_CALLER, BENCH_TARGET};
     use handler::{MainBuilder, MainContext};
     use interpreter::{
         interpreter_types::{Jumps, ReturnData},
         CallInputs, CreateInputs, Interpreter, InterpreterResult, InterpreterTypes,
     };
-    use primitives::{Address, Bytes, TxKind};
+    use primitives::{hardfork::SpecId, Address, Bytes, TxKind};
     use state::bytecode::{opcode, Bytecode};
 
     #[derive(Default, Debug)]
@@ -250,8 +250,12 @@ mod tests {
 
         let bytecode = Bytecode::new_raw(contract_data);
 
+        let mut cfg = CfgEnv::<SpecId>::default();
+        cfg.tx_gas_limit_cap = Some(u64::MAX);
+
         let mut evm = Context::mainnet()
             .with_db(BenchmarkDB::new_bytecode(bytecode.clone()))
+            .with_cfg(cfg)
             .build_mainnet_with_inspector(inspector);
 
         let _ = evm

--- a/crates/op-revm/src/spec.rs
+++ b/crates/op-revm/src/spec.rs
@@ -23,9 +23,9 @@ pub enum OpSpecId {
     /// Holocene spec id.
     HOLOCENE,
     /// Isthmus spec id.
-    #[default]
     ISTHMUS,
     /// Jovian spec id.
+    #[default]
     JOVIAN,
     /// Interop spec id.
     INTEROP,
@@ -243,6 +243,6 @@ mod tests {
 
     #[test]
     fn default_op_spec_id() {
-        assert_eq!(OpSpecId::default(), OpSpecId::ISTHMUS);
+        assert_eq!(OpSpecId::default(), OpSpecId::JOVIAN);
     }
 }

--- a/crates/primitives/src/hardfork.rs
+++ b/crates/primitives/src/hardfork.rs
@@ -70,10 +70,10 @@ pub enum SpecId {
     CANCUN,
     /// Prague hard fork
     /// Activated at block 22431084 (Timestamp: 1746612311)
-    #[default]
     PRAGUE,
     /// Osaka hard fork
-    /// Activated at block TBD
+    /// Activated at slot 13164544 (Timestamp: 1764798551)
+    #[default]
     OSAKA,
     /// Amsterdam hard fork
     /// Activated at block TBD


### PR DESCRIPTION
## Summary

Updates the default EVM specification to the latest mainnet hardforks:

- **Ethereum**: `SpecId::OSAKA` (previously `PRAGUE`)
- **Optimism**: `OpSpecId::JOVIAN` (previously `ISTHMUS`)

## Changes

### Ethereum (`revm-primitives`)
- Move `#[default]` attribute from `PRAGUE` to `OSAKA`
- Add activation details: slot 13164544, timestamp 1764798551 (Dec 3, 2025 21:49:11 UTC)

### Optimism (`op-revm`)
- Move `#[default]` attribute from `ISTHMUS` to `JOVIAN`
- Update `default_op_spec_id` test assertion

## Verification

- Osaka activation confirmed on-chain via [beaconcha.in/slot/13164544](https://beaconcha.in/slot/13164544)
- Build passes
- Tests pass