### PR TITLE
interpreter: deduplicate Gas “spent minus refunded” calculation

### DIFF
--- a/crates/interpreter/src/gas.rs
+++ b/crates/interpreter/src/gas.rs
@@ -78,7 +78,7 @@ impl Gas {
     /// Returns the total amount of gas spent, minus the refunded gas.
     #[inline]
     pub const fn spent_sub_refunded(&self) -> u64 {
-        self.spent().saturating_sub(self.refunded as u64)
+        self.used()
     }
 
     /// Returns the amount of gas remaining.


### PR DESCRIPTION

This removes duplicated gas accounting logic by making `Gas::spent_sub_refunded()` delegate to `Gas::used()`.

`used()` and `spent_sub_refunded()` represent the same metric (spent gas minus refund). Keeping two separate implementations risks them diverging over time, especially since `spent_sub_refunded()` is used in EIP-7623 gas-floor enforcement.

