### PR TITLE
feat: Implement EIP-7843 SLOTNUM opcode for Amsterdam

### DIFF
--- a/crates/bytecode/src/opcode.rs
+++ b/crates/bytecode/src/opcode.rs
@@ -473,7 +473,7 @@ opcodes! {
     0x48 => BASEFEE      => stack_io(0, 1);
     0x49 => BLOBHASH     => stack_io(1, 1);
     0x4A => BLOBBASEFEE  => stack_io(0, 1);
-    // 0x4B
+    0x4B => SLOTNUM      => stack_io(0, 1);
     // 0x4C
     // 0x4D
     // 0x4E
@@ -731,7 +731,7 @@ mod tests {
         for _ in OPCODE_INFO.into_iter().flatten() {
             opcode_num += 1;
         }
-        assert_eq!(opcode_num, 153);
+        assert_eq!(opcode_num, 154);
     }
 
     #[test]

--- a/crates/context/interface/src/block.rs
+++ b/crates/context/interface/src/block.rs
@@ -68,4 +68,13 @@ pub trait Block {
     fn blob_excess_gas(&self) -> Option<u64> {
         self.blob_excess_gas_and_price().map(|a| a.excess_blob_gas)
     }
+
+    /// Return the slot number of the block. See [EIP-7843].
+    ///
+    /// Defaults to zero if not set.
+    ///
+    /// [EIP-7843]: https://eips.ethereum.org/EIPS/eip-7843
+    fn slot_num(&self) -> u64 {
+        0
+    }
 }

--- a/crates/context/interface/src/host.rs
+++ b/crates/context/interface/src/host.rs
@@ -44,6 +44,8 @@ pub trait Host {
     fn timestamp(&self) -> U256;
     /// Block beneficiary, calls ContextTr::block().beneficiary()
     fn beneficiary(&self) -> Address;
+    /// Block slot number, calls ContextTr::block().slot_num()
+    fn slot_num(&self) -> U256;
     /// Chain id, calls ContextTr::cfg().chain_id()
     fn chain_id(&self) -> U256;
 
@@ -253,6 +255,10 @@ impl Host for DummyHost {
 
     fn beneficiary(&self) -> Address {
         Address::ZERO
+    }
+
+    fn slot_num(&self) -> U256 {
+        U256::ZERO
     }
 
     fn chain_id(&self) -> U256 {

--- a/crates/context/src/block.rs
+++ b/crates/context/src/block.rs
@@ -40,6 +40,12 @@ pub struct BlockEnv {
     ///
     /// [EIP-4844]: https://eips.ethereum.org/EIPS/eip-4844
     pub blob_excess_gas_and_price: Option<BlobExcessGasAndPrice>,
+    /// The slot number of the block.
+    ///
+    /// Incorporated as part of the Amsterdam upgrade via [EIP-7843].
+    ///
+    /// [EIP-7843]: https://eips.ethereum.org/EIPS/eip-7843
+    pub slot_num: u64,
 }
 
 impl BlockEnv {
@@ -97,6 +103,11 @@ impl Block for BlockEnv {
     fn blob_excess_gas_and_price(&self) -> Option<BlobExcessGasAndPrice> {
         self.blob_excess_gas_and_price
     }
+
+    #[inline]
+    fn slot_num(&self) -> u64 {
+        self.slot_num
+    }
 }
 
 impl Default for BlockEnv {
@@ -113,6 +124,7 @@ impl Default for BlockEnv {
                 0,
                 BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE,
             )),
+            slot_num: 0,
         }
     }
 }

--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -467,6 +467,10 @@ impl<
         self.block().beneficiary()
     }
 
+    fn slot_num(&self) -> U256 {
+        U256::from(self.block().slot_num())
+    }
+
     fn chain_id(&self) -> U256 {
         U256::from(self.cfg().chain_id())
     }

--- a/crates/interpreter/src/instructions.rs
+++ b/crates/interpreter/src/instructions.rs
@@ -192,6 +192,7 @@ const fn instruction_table_impl<WIRE: InterpreterTypes, H: Host>() -> [Instructi
     table[BASEFEE as usize] = Instruction::new(block_info::basefee, 2);
     table[BLOBHASH as usize] = Instruction::new(tx_info::blob_hash, 3);
     table[BLOBBASEFEE as usize] = Instruction::new(block_info::blob_basefee, 2);
+    table[SLOTNUM as usize] = Instruction::new(block_info::slot_num, 2);
 
     table[POP as usize] = Instruction::new(stack::pop, 2);
     table[MLOAD as usize] = Instruction::new(memory::mload, 3);

--- a/crates/interpreter/src/instructions/block_info.rs
+++ b/crates/interpreter/src/instructions/block_info.rs
@@ -83,3 +83,11 @@ pub fn blob_basefee<WIRE: InterpreterTypes, H: Host + ?Sized>(
     check!(context.interpreter, CANCUN);
     push!(context.interpreter, context.host.blob_gasprice());
 }
+
+/// EIP-7843: SLOTNUM opcode
+pub fn slot_num<WIRE: InterpreterTypes, H: Host + ?Sized>(
+    context: InstructionContext<'_, H, WIRE>,
+) {
+    check!(context.interpreter, AMSTERDAM);
+    push!(context.interpreter, context.host.slot_num());
+}

--- a/crates/statetest-types/src/blockchain.rs
+++ b/crates/statetest-types/src/blockchain.rs
@@ -346,6 +346,7 @@ impl BlockHeader {
                 None
             },
             blob_excess_gas_and_price,
+            slot_num: 0,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Implement EIP-7843 SLOTNUM opcode (0x4B) that returns the slot number for the current block
- The opcode is gated behind the AMSTERDAM hardfork
- Gas cost: 2 (aligned with similar base-level opcodes like BASEFEE and BLOBBASEFEE)

## Changes
- Add `SLOTNUM` opcode constant at `0x4B` in bytecode
- Add `slot_num: u64` field to `BlockEnv` struct
- Add `slot_num()` method to `Block` trait with default returning `0`
- Add `slot_num()` method to `Host` trait returning `U256`
- Implement `slot_num` instruction in `block_info.rs`
- Add instruction to dispatch table with gas cost of 2

## EIP Reference
https://eips.ethereum.org/EIPS/eip-7843

## Test plan
- [x] All existing tests pass (362 tests)
- [x] Clippy passes
- [x] Code formatted