### PR TITLE
fix: remove dead difference call in `jovian()`

### DIFF
--- a/crates/op-revm/src/precompiles.rs
+++ b/crates/op-revm/src/precompiles.rs
@@ -97,18 +97,7 @@ pub fn jovian() -> &'static Precompiles {
     static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
     INSTANCE.get_or_init(|| {
         let mut precompiles = isthmus().clone();
-
-        let mut to_remove = Precompiles::default();
-        to_remove.extend([
-            bn254::pair::ISTANBUL,
-            bls12_381::ISTHMUS_G1_MSM,
-            bls12_381::ISTHMUS_G2_MSM,
-            bls12_381::ISTHMUS_PAIRING,
-        ]);
-
         // Replace the 4 variable-input precompiles with Jovian versions (reduced limits)
-        precompiles.difference(&to_remove);
-
         precompiles.extend([
             bn254_pair::JOVIAN,
             bls12_381::JOVIAN_G1_MSM,


### PR DESCRIPTION
Previously jovian() built a temporary Precompiles set and called `precompiles.difference(&to_remove)` without using the result. This left dead code, extra allocations and a misleading comment suggesting that the old precompiles were removed via difference, while the actual replacement was done only by extend() overwriting entries by address.
Removed the unused `to_remove` set and the no-op `difference()` call, relying solely on `extend()` to override the four variable-input precompiles with the Jovian variants while keeping the intent comment aligned with the real behavior.