### PR TITLE
perf: elide some jumps in jump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,9 +169,7 @@ strip = false
 
 # Make sure debug symbols are in the bench profile
 [profile.bench]
-debug = 2
-inherits = "release"
-strip = false
+inherits = "profiling"
 
 [profile.ethtests]
 inherits = "test"

--- a/crates/interpreter/src/instructions/control.rs
+++ b/crates/interpreter/src/instructions/control.rs
@@ -31,7 +31,7 @@ pub fn jumpi<WIRE: InterpreterTypes, H: ?Sized>(context: InstructionContext<'_, 
 /// Validates jump target and performs the actual jump.
 #[inline(always)]
 fn jump_inner<WIRE: InterpreterTypes>(interpreter: &mut Interpreter<WIRE>, target: U256) {
-    let target = as_usize_or_fail!(interpreter, target, InstructionResult::InvalidJump);
+    let target = as_usize_saturated!(target);
     if !interpreter.bytecode.is_valid_legacy_jump(target) {
         interpreter.halt(InstructionResult::InvalidJump);
         return;

--- a/crates/interpreter/src/instructions/macros.rs
+++ b/crates/interpreter/src/instructions/macros.rs
@@ -156,15 +156,7 @@ macro_rules! push {
 #[collapse_debuginfo(yes)]
 macro_rules! as_u64_saturated {
     ($v:expr) => {
-        match $v.as_limbs() {
-            x => {
-                if (x[1] == 0) & (x[2] == 0) & (x[3] == 0) {
-                    x[0]
-                } else {
-                    u64::MAX
-                }
-            }
-        }
+        u64::try_from($v).unwrap_or(u64::MAX)
     };
 }
 
@@ -173,7 +165,7 @@ macro_rules! as_u64_saturated {
 #[collapse_debuginfo(yes)]
 macro_rules! as_usize_saturated {
     ($v:expr) => {
-        usize::try_from($crate::as_u64_saturated!($v)).unwrap_or(usize::MAX)
+        usize::try_from($v).unwrap_or(usize::MAX)
     };
 }
 
@@ -182,9 +174,7 @@ macro_rules! as_usize_saturated {
 #[collapse_debuginfo(yes)]
 macro_rules! as_isize_saturated {
     ($v:expr) => {
-        // `isize_try_from(u64::MAX)`` will fail and return isize::MAX
-        // This is expected behavior as we are saturating the value.
-        isize::try_from($crate::as_u64_saturated!($v)).unwrap_or(isize::MAX)
+        isize::try_from($v).unwrap_or(isize::MAX)
     };
 }
 

--- a/crates/interpreter/src/instructions/system.rs
+++ b/crates/interpreter/src/instructions/system.rs
@@ -106,7 +106,7 @@ pub fn codecopy<WIRE: InterpreterTypes, H: Host + ?Sized>(
 pub fn calldataload<WIRE: InterpreterTypes, H: ?Sized>(context: InstructionContext<'_, H, WIRE>) {
     popn_top!([], offset_ptr, context.interpreter);
     let mut word = B256::ZERO;
-    let offset = as_usize_saturated!(offset_ptr);
+    let offset = as_usize_saturated!(*offset_ptr);
     let input = context.interpreter.input.input();
     let input_len = input.len();
     if offset < input_len {

--- a/crates/interpreter/src/instructions/tx_info.rs
+++ b/crates/interpreter/src/instructions/tx_info.rs
@@ -32,6 +32,6 @@ pub fn blob_hash<WIRE: InterpreterTypes, H: Host + ?Sized>(
 ) {
     check!(context.interpreter, CANCUN);
     popn_top!([], index, context.interpreter);
-    let i = as_usize_saturated!(index);
+    let i = as_usize_saturated!(*index);
     *index = context.host.blob_hash(i).unwrap_or_default();
 }

--- a/crates/interpreter/src/interpreter/ext_bytecode.rs
+++ b/crates/interpreter/src/interpreter/ext_bytecode.rs
@@ -140,15 +140,14 @@ impl Jumps for ExtBytecode {
 
     #[inline]
     fn is_valid_legacy_jump(&mut self, offset: usize) -> bool {
-        self.base
-            .legacy_jump_table()
-            .expect("Panic if not legacy")
-            .is_valid(offset)
+        let jt = self.base.legacy_jump_table();
+        // SAFETY: Only called by legacy bytecode. Panics in debug mode.
+        unsafe { jt.unwrap_unchecked() }.is_valid(offset)
     }
 
     #[inline]
     fn opcode(&self) -> u8 {
-        // SAFETY: `instruction_pointer` always point to bytecode.
+        // SAFETY: `instruction_pointer` always points to bytecode.
         unsafe { *self.instruction_pointer }
     }
 


### PR DESCRIPTION
1. legacy bytecode check (nullptr check); replace `expect` with `unwrap_unchecked` (still panics in debug mode)
2. saturate instead of early fail in jump_inner, since usize::MAX is always an invalid jump regardless
3. cleanups (use TryFrom impl in ruint since I optimized it, same code gen)

`JUMPI` diff:

```diff
diff --git a/a.s b/d.s
index 379024bb..49d5f819 100644
--- a/a.s
+++ b/d.s
@@ -8,10 +8,9 @@ revm_interpreter::instructions::control::jumpi::<revm_interpreter::interpreter::
 	.cfi_offset rbp, -16
 	mov rbp, rsp
 	.cfi_def_cfa_register rbp
-	sub rsp, 32
 	mov r8, qword ptr [rdi + 192]
 	cmp r8, 2
-	jb .LBB148_8
+	jb .LBB148_6
 	mov r9, qword ptr [rdi + 184]
 	mov rsi, r8
 	add r8, -2
@@ -30,49 +29,38 @@ revm_interpreter::instructions::control::jumpi::<revm_interpreter::interpreter::
 	or r9, qword ptr [rbp - 8]
 	or r8, qword ptr [rbp - 16]
 	or r8, r9
-	je .LBB148_7
+	je .LBB148_5
 	or rcx, rdx
 	or rcx, rsi
-	jne .LBB148_10
-	cmp dword ptr [rdi], 1
-	jne .LBB148_9
-	mov rcx, qword ptr [rdi + 8]
-	cmp rax, qword ptr [rcx + 64]
-	jae .LBB148_10
-	mov rdx, qword ptr [rcx + 56]
-	mov rsi, rax
+	mov rcx, -1
+	cmove rcx, rax
+	mov rax, qword ptr [rdi + 8]
+	cmp rcx, qword ptr [rax + 64]
+	jae .LBB148_7
+	mov rdx, qword ptr [rax + 56]
+	mov rsi, rcx
 	shr rsi, 3
 	movzx edx, byte ptr [rdx + rsi]
-	mov esi, eax
+	mov esi, ecx
 	and esi, 7
 	bt edx, esi
-	jae .LBB148_10
-	add rax, qword ptr [rcx + 24]
-	mov qword ptr [rdi + 96], rax
-.LBB148_7:
-	add rsp, 32
+	jae .LBB148_7
+	add rcx, qword ptr [rax + 24]
+	mov qword ptr [rdi + 96], rcx
+.LBB148_5:
 	pop rbp
 	.cfi_def_cfa rsp, 8
 	vzeroupper
 	ret
-.LBB148_8:
+.LBB148_6:
 	.cfi_def_cfa rbp, 16
-	add rsp, 32
 	pop rbp
 	.cfi_def_cfa rsp, 8
 	jmp qword ptr [rip + <revm_interpreter::interpreter::Interpreter>::halt_underflow@GOTPCREL]
-.LBB148_10:
+.LBB148_7:
 	.cfi_def_cfa rbp, 16
 	mov esi, 42
-	add rsp, 32
 	pop rbp
 	.cfi_def_cfa rsp, 8
 	vzeroupper
 	jmp qword ptr [rip + <revm_interpreter::interpreter::Interpreter>::halt@GOTPCREL]
-.LBB148_9:
-	.cfi_def_cfa rbp, 16
-	lea rdi, [rip + .Lanon.393361ac5c29a9e6e6e4d251883b8a2b.38]
-	lea rdx, [rip + .Lanon.393361ac5c29a9e6e6e4d251883b8a2b.40]
-	mov esi, 19
-	vzeroupper
-	call qword ptr [rip + core::option::expect_failed@GOTPCREL]
```