### PR TITLE
fix: remove redundant balance check in self-transfer

### DIFF
--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -322,11 +322,6 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         balance: U256,
     ) -> Option<TransferError> {
         if from == to {
-            let from_balance = self.state.get_mut(&to).unwrap().info.balance;
-            // Check if from balance is enough to transfer the balance.
-            if balance > from_balance {
-                return Some(TransferError::OutOfFunds);
-            }
             return None;
         }
 


### PR DESCRIPTION
When `from == to` in `transfer_loaded()`, the balance check was pointless. Self-transfer doesn't change anything - subtract and add cancel out. Removed the unnecessary `get_mut` call and balance comparison.