### PR TITLE
perf(interpreter): add #[inline] to full_len()

### DIFF
--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -263,6 +263,7 @@ impl SharedMemory {
         self.full_len() - self.my_checkpoint
     }
 
+    #[inline]
     fn full_len(&self) -> usize {
         self.buffer_ref().len()
     }


### PR DESCRIPTION
Add missing #[inline] attribute to full_len() for consistency with other private helper methods (buffer, buffer_ref, buffer_ref_mut) in SharedMemory. This function is called from the public inline len() method used in hot paths.