### PR TITLE
fix(devnet2): add slot_num to tests, transfer log fixes

### DIFF
--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -327,6 +327,9 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
             if balance > from_balance {
                 return Some(TransferError::OutOfFunds);
             }
+
+            // EIP-7708: emit ETH transfer log
+            self.eip7708_transfer_log(from, to, balance);
             return None;
         }
 
@@ -570,8 +573,11 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         } else {
             // State is not changed:
             // * if we are after Cancun upgrade and
-            // * Selfdestruct account that is created in the same transaction and
+            // * Pre-existing account (not created in this transaction) and
             // * Specify the target is same as selfdestructed account. The balance stays unchanged.
+            // EIP-7708: emit selfdestruct-to-self log even when balance doesn't move
+            self.eip7708_selfdestruct_to_self_log(address, balance);
+
             None
         };
 

--- a/crates/statetest-types/src/blockchain.rs
+++ b/crates/statetest-types/src/blockchain.rs
@@ -89,6 +89,8 @@ pub struct BlockHeader {
     pub requests_hash: Option<B256>,
     /// Target blobs per block (EIP-4844 related)
     pub target_blobs_per_block: Option<U256>,
+    /// Slot number (EIP-7843)
+    pub slot_number: Option<U256>,
 }
 
 /// Block structure containing header and transactions
@@ -346,7 +348,7 @@ impl BlockHeader {
                 None
             },
             blob_excess_gas_and_price,
-            slot_num: 0,
+            slot_num: self.slot_number.unwrap_or_default().try_into().unwrap_or(u64::MAX),
         }
     }
 }

--- a/crates/statetest-types/src/env.rs
+++ b/crates/statetest-types/src/env.rs
@@ -33,4 +33,7 @@ pub struct Env {
 
     /// Current block excess blob gas (EIP-4844)
     pub current_excess_blob_gas: Option<U256>,
+
+    /// Current slot number (EIP-7843)
+    pub slot_number: Option<U256>,
 }

--- a/crates/statetest-types/src/test_unit.rs
+++ b/crates/statetest-types/src/test_unit.rs
@@ -107,6 +107,12 @@ impl TestUnit {
                 .unwrap_or(u64::MAX),
             difficulty: self.env.current_difficulty,
             prevrandao: self.env.current_random,
+            slot_num: self
+                .env
+                .slot_number
+                .unwrap_or_default()
+                .try_into()
+                .unwrap_or(u64::MAX),
             ..BlockEnv::default()
         };
 
@@ -154,6 +160,7 @@ mod tests {
                 current_beacon_root: None,
                 current_withdrawals_root: None,
                 current_excess_blob_gas: Some(U256::from(excess_blob_gas)),
+                slot_number: Some(U256::from(1u64)),
             },
             pre: HashMap::default(),
             post: BTreeMap::default(),


### PR DESCRIPTION
Some things are pending and are here to just pass devnet-2 v5.0.0 tests