### PR TITLE
Deprecate `nonce_bump_journal_entry` and `caller_accounting_journal_entry` functions

### DIFF
--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -139,6 +139,7 @@ pub trait JournalTr {
     ) -> Option<TransferError>;
 
     /// Increments the balance of the account.
+    #[deprecated]
     fn caller_accounting_journal_entry(
         &mut self,
         address: Address,
@@ -154,6 +155,7 @@ pub trait JournalTr {
     ) -> Result<(), <Self::Database as Database>::Error>;
 
     /// Increments the nonce of the account.
+    #[deprecated]
     fn nonce_bump_journal_entry(&mut self, address: Address);
 
     /// Loads the account.

--- a/crates/context/src/journal.rs
+++ b/crates/context/src/journal.rs
@@ -225,6 +225,7 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
     }
 
     #[inline]
+    #[allow(deprecated)]
     fn caller_accounting_journal_entry(
         &mut self,
         address: Address,
@@ -248,6 +249,7 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
 
     /// Increments the nonce of the account.
     #[inline]
+    #[allow(deprecated)]
     fn nonce_bump_journal_entry(&mut self, address: Address) {
         self.inner.nonce_bump_journal_entry(address)
     }

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -270,6 +270,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
 
     /// Add journal entry for caller accounting.
     #[inline]
+    #[deprecated]
     pub fn caller_accounting_journal_entry(
         &mut self,
         address: Address,
@@ -305,6 +306,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
 
     /// Increments the nonce of the account.
     #[inline]
+    #[deprecated]
     pub fn nonce_bump_journal_entry(&mut self, address: Address) {
         self.journal.push(ENTRY::nonce_bumped(address));
     }

--- a/examples/cheatcode_inspector/src/main.rs
+++ b/examples/cheatcode_inspector/src/main.rs
@@ -235,12 +235,14 @@ impl JournalTr for Backend {
         self.journaled_state.finalize()
     }
 
+    #[allow(deprecated)]
     fn caller_accounting_journal_entry(
         &mut self,
         address: Address,
         old_balance: U256,
         bump_nonce: bool,
     ) {
+        #[allow(deprecated)]
         self.journaled_state
             .caller_accounting_journal_entry(address, old_balance, bump_nonce)
     }
@@ -253,7 +255,9 @@ impl JournalTr for Backend {
         self.journaled_state.balance_incr(address, balance)
     }
 
+    #[allow(deprecated)]
     fn nonce_bump_journal_entry(&mut self, address: Address) {
+        #[allow(deprecated)]
         self.journaled_state.nonce_bump_journal_entry(address)
     }
 


### PR DESCRIPTION
## Summary
- Deprecate `nonce_bump_journal_entry` and `caller_accounting_journal_entry` functions in `JournalTr` trait
- Add `#[deprecated]` attributes to trait definitions and implementations
- Add `#[allow(deprecated)]` to example implementations to suppress warnings

## Test plan
- [x] Build passes
- [x] Clippy passes

Closes #3365