### PR TITLE
refactor(interpreter): deduplicate slice range logic

### DIFF
--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -225,9 +225,11 @@ impl SharedMemory {
     #[cfg_attr(debug_assertions, track_caller)]
     fn slice_range_with_base(&self, range: Range<usize>, base: usize) -> Ref<'_, [u8]> {
         let buffer = self.buffer_ref();
-        Ref::map(buffer, |b| match b.get(range.start + base..range.end + base) {
-            Some(slice) => slice,
-            None => debug_unreachable!("slice OOB: range; len: {}", self.len()),
+        Ref::map(buffer, |b| {
+            match b.get(range.start + base..range.end + base) {
+                Some(slice) => slice,
+                None => debug_unreachable!("slice OOB: range; len: {}", self.len()),
+            }
         })
     }
 


### PR DESCRIPTION
Refactor `SharedMemory` by extracting common logic into a single private helper function.