### PR TITLE
docs: clarify gmp uses dynamic linking (no GPL implications)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ Revm is licensed under MIT License.
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in these crates by you, shall be licensed as above, without any additional terms or conditions.
 
-If `gmp` feature flag is used, GPL code gets compiled, if enabled please make sure to follow this license.
-
 ### Security
 
 For any security questions or findings, please reach out to me directly via email at [dragan0rakita@gmail.com](mailto:dragan0rakita@gmail.com) or contact me on Keybase under the username @draganrakita.

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -115,9 +115,7 @@ blst = ["dep:blst"]
 # Enables the substrate implementation of eip1962
 bn = ["dep:bn"]
 
-# Use GMP (LGPL) for modexp precompile via gmp-mpfr-sys.
-# If you want to use a system libs and dynamic linking of GMP, include `gmp-mpfr-sys` in your project
-# with a `features = ["use-system-libs"]` enabled.
+# Use GMP for accelerated modexp precompile. Dynamically links to libgmp at runtime.
 gmp = ["dep:gmp-mpfr-sys"]
 
 [[bench]]

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -115,7 +115,7 @@ asm-sha2 = ["precompile/asm-sha2"]
 # Binary can be executed on all systems.
 portable = ["precompile/portable"]
 
-# Use GMP for modexp precompile (LGPL; dynamically linked via system libs).
+# Use GMP for accelerated modexp precompile. Dynamically links to libgmp at runtime.
 gmp = ["precompile/gmp"]
 
 # Statetest types for running ethereum tests


### PR DESCRIPTION
The README incorrectly states that using the `gmp` feature compiles GPL code. Since [PR #3250](https://github.com/bluealloy/revm/pull/3250), gmp is dynamically linked at runtime, so there are no GPL license implications for binaries using this feature.

## Changes

- Updated LICENSE section in README to clarify dynamic linking behavior