### PR TITLE
refactor(interpreter): Instruction impl bounds

### DIFF
--- a/crates/interpreter/src/instructions.rs
+++ b/crates/interpreter/src/instructions.rs
@@ -68,8 +68,8 @@ impl<W: InterpreterTypes, H: Host + ?Sized> Instruction<W, H> {
     }
 }
 
-impl<W: InterpreterTypes, H: Host + ?Sized> Copy for Instruction<W, H> {}
-impl<W: InterpreterTypes, H: Host + ?Sized> Clone for Instruction<W, H> {
+impl<W: InterpreterTypes, H: ?Sized> Copy for Instruction<W, H> {}
+impl<W: InterpreterTypes, H: ?Sized> Clone for Instruction<W, H> {
     fn clone(&self) -> Self {
         *self
     }


### PR DESCRIPTION
Remove `Host` bound from Copy/Clone impls - not needed since the struct only holds a fn pointer and u64.