### PR TITLE
fix(db): use self.storage() in storage_by_account_id to avoid cache bypass

### DIFF
--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -347,8 +347,7 @@ impl<DB: Database> Database for State<DB> {
             return Ok(storage);
         }
 
-        self.database
-            .storage(address, key)
+        self.storage(address, key)
             .map_err(EvmDatabaseError::Database)
     }
 


### PR DESCRIPTION
When **storage_by_account_id** misses the BAL layer, it previously called `self.database.storage()` directly, bypassing the Cache and Bundle layers. This could return stale data when storage values have been modified in Cache or Bundle but not yet synced to BAL.                            
                                                                                                                                                                                                                                                                                             The fix changes this to call self.storage(), which correctly traverses the full lookup chain: Cache → Bundle → Database. This is consistent with the storage() method implementation and matches the expected behavior documented in the Database trait's default implementation (lines 67-80). 