### PR TITLE
feat(database): add clear() to CacheState and TransitionState

### DIFF
--- a/crates/database/src/states/cache.rs
+++ b/crates/database/src/states/cache.rs
@@ -45,6 +45,12 @@ impl CacheState {
         self.has_state_clear = has_state_clear;
     }
 
+    /// Clear the cache state.
+    pub fn clear(&mut self) {
+        self.accounts.clear();
+        self.contracts.clear();
+    }
+
     /// Helper function that returns all accounts.
     ///
     /// Used inside tests to generate merkle tree.

--- a/crates/database/src/states/transition_state.rs
+++ b/crates/database/src/states/transition_state.rs
@@ -24,6 +24,11 @@ impl TransitionState {
         core::mem::take(self)
     }
 
+    /// Clear the transition state.
+    pub fn clear(&mut self) {
+        self.transitions.clear();
+    }
+
     /// Add transitions to the transition state.
     ///
     /// This will insert new [`TransitionAccount`]s, or update existing ones via


### PR DESCRIPTION
Adds `clear()` methods to `CacheState` and `TransitionState` to allow reusing allocations.