### PR TITLE
feat(statetest-types): add slot_number support (EIP-7843)

### DIFF
--- a/crates/statetest-types/src/blockchain.rs
+++ b/crates/statetest-types/src/blockchain.rs
@@ -89,6 +89,8 @@ pub struct BlockHeader {
     pub requests_hash: Option<B256>,
     /// Target blobs per block (EIP-4844 related)
     pub target_blobs_per_block: Option<U256>,
+    /// Slot number (EIP-7843)
+    pub slot_number: Option<U256>,
 }
 
 /// Block structure containing header and transactions
@@ -346,7 +348,11 @@ impl BlockHeader {
                 None
             },
             blob_excess_gas_and_price,
-            slot_num: 0,
+            slot_num: self
+                .slot_number
+                .unwrap_or_default()
+                .try_into()
+                .unwrap_or(u64::MAX),
         }
     }
 }

--- a/crates/statetest-types/src/env.rs
+++ b/crates/statetest-types/src/env.rs
@@ -33,4 +33,7 @@ pub struct Env {
 
     /// Current block excess blob gas (EIP-4844)
     pub current_excess_blob_gas: Option<U256>,
+
+    /// Current slot number (EIP-7843)
+    pub slot_number: Option<U256>,
 }

--- a/crates/statetest-types/src/test.rs
+++ b/crates/statetest-types/src/test.rs
@@ -8,7 +8,7 @@ use crate::{
 
 /// State test indexed state result deserialization.
 #[derive(Debug, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub struct Test {
     /// Expected exception for this test case, if any.
     ///

--- a/crates/statetest-types/src/test_unit.rs
+++ b/crates/statetest-types/src/test_unit.rs
@@ -107,6 +107,12 @@ impl TestUnit {
                 .unwrap_or(u64::MAX),
             difficulty: self.env.current_difficulty,
             prevrandao: self.env.current_random,
+            slot_num: self
+                .env
+                .slot_number
+                .unwrap_or_default()
+                .try_into()
+                .unwrap_or(u64::MAX),
             ..BlockEnv::default()
         };
 
@@ -154,6 +160,7 @@ mod tests {
                 current_beacon_root: None,
                 current_withdrawals_root: None,
                 current_excess_blob_gas: Some(U256::from(excess_blob_gas)),
+                slot_number: Some(U256::from(1u64)),
             },
             pre: AddressMap::default(),
             post: BTreeMap::default(),


### PR DESCRIPTION
## Summary
- Add `slot_number` field to `BlockHeader` and `Env` structs to support EIP-7843
- Map `slot_number` to `slot_num` in `BlockEnv` for both blockchain and state tests
- Temporarily disable serde strict parsing in `Test` struct to allow unknown fields

## Test plan
- [ ] Run state tests with new test vectors containing `slot_number` field
- [ ] Verify backward compatibility with existing test fixtures