### PR TITLE
feat(statetest-types): add BPO2ToAmsterdamAtTime15k fork spec

### DIFF
--- a/crates/statetest-types/src/blockchain.rs
+++ b/crates/statetest-types/src/blockchain.rs
@@ -315,6 +315,8 @@ pub enum ForkSpec {
     Osaka,
     /// BPO1 to BPO2 transition
     BPO1ToBPO2AtTime15k,
+    /// BPO2 to Amsterdam transition
+    BPO2ToAmsterdamAtTime15k,
     /// Amsterdam
     Amsterdam,
 }


### PR DESCRIPTION
## Summary
- Add new `BPO2ToAmsterdamAtTime15k` variant to the `ForkSpec` enum for handling the BPO2 to Amsterdam transition at time 15k

## Test plan
- [ ] Verify the code compiles successfully
- [ ] Confirm the new variant is properly positioned in the enum ordering