### PR TITLE
perf: wire shared stack arena into frame creation  

### DIFF
--- a/bins/revme/src/cmd/bench/gas_cost_estimator.rs
+++ b/bins/revme/src/cmd/bench/gas_cost_estimator.rs
@@ -3,8 +3,9 @@ use revm::{
     bytecode::Bytecode,
     context::TxEnv,
     database::{BenchmarkDB, BENCH_CALLER, BENCH_TARGET},
+    handler::{Handler, MainnetHandler},
     primitives::{hex, Bytes, TxKind},
-    Context, ExecuteEvm, MainBuilder, MainContext,
+    Context, MainBuilder, MainContext,
 };
 use std::io::Cursor;
 
@@ -35,13 +36,10 @@ pub fn run(criterion: &mut Criterion) {
             .gas_limit(1_000_000_000)
             .build()
             .unwrap();
+        evm.ctx.tx = tx;
 
         criterion.bench_function(name, |b| {
-            b.iter_batched(
-                || tx.clone(),
-                |input| evm.transact_one(input).unwrap(),
-                criterion::BatchSize::SmallInput,
-            );
+            b.iter(|| MainnetHandler::default().run(&mut evm).unwrap());
         });
     }
 }

--- a/bins/revme/src/cmd/bench/gas_cost_estimator.rs
+++ b/bins/revme/src/cmd/bench/gas_cost_estimator.rs
@@ -2,7 +2,9 @@ use criterion::Criterion;
 use revm::{
     bytecode::Bytecode,
     context::TxEnv,
+    context_interface::result::{EVMError, InvalidTransaction},
     database::{BenchmarkDB, BENCH_CALLER, BENCH_TARGET},
+    database_interface::Database,
     handler::{Handler, MainnetHandler},
     primitives::{hex, Bytes, TxKind},
     Context, MainBuilder, MainContext,
@@ -38,8 +40,11 @@ pub fn run(criterion: &mut Criterion) {
             .unwrap();
         evm.ctx.tx = tx;
 
+        type BenchError = EVMError<<BenchmarkDB as Database>::Error, InvalidTransaction>;
+        let mut handler: MainnetHandler<_, BenchError, _> = MainnetHandler::default();
+
         criterion.bench_function(name, |b| {
-            b.iter(|| MainnetHandler::default().run(&mut evm).unwrap());
+            b.iter(|| handler.run(&mut evm).unwrap());
         });
     }
 }

--- a/crates/bytecode/src/opcode.rs
+++ b/crates/bytecode/src/opcode.rs
@@ -96,7 +96,8 @@ impl OpCode {
         Self(opcode)
     }
 
-    /// Returns the opcode as a string. This is the inverse of [`parse`](Self::parse).
+    /// Returns the opcode as a string. This is the inverse of `OpCode::parse`
+    /// (when the `parse` feature is enabled).
     #[doc(alias = "name")]
     #[inline]
     pub const fn as_str(self) -> &'static str {

--- a/crates/context/interface/src/context.rs
+++ b/crates/context/interface/src/context.rs
@@ -50,7 +50,7 @@ pub trait ContextTr: Host {
         &mut self,
     ) -> (
         &Self::Block,
-        &Self::Tx,
+        &mut Self::Tx,
         &Self::Cfg,
         &mut Self::Journal,
         &mut Self::Chain,
@@ -133,7 +133,7 @@ pub trait ContextTr: Host {
 
     /// Get the transaction and journal. It is used to efficiently load access list
     /// into journal without copying them from transaction.
-    fn tx_journal_mut(&mut self) -> (&Self::Tx, &mut Self::Journal) {
+    fn tx_journal_mut(&mut self) -> (&mut Self::Tx, &mut Self::Journal) {
         let (_, tx, _, journal, _, _) = self.all_mut();
         (tx, journal)
     }

--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -86,14 +86,14 @@ impl<
         &mut self,
     ) -> (
         &Self::Block,
-        &Self::Tx,
+        &mut Self::Tx,
         &Self::Cfg,
         &mut Self::Journal,
         &mut Self::Chain,
         &mut Self::Local,
     ) {
         let block = &self.block;
-        let tx = &self.tx;
+        let tx = &mut self.tx;
         let cfg = &self.cfg;
         let journal = &mut self.journaled_state;
         let chain = &mut self.chain;

--- a/crates/context/src/tx.rs
+++ b/crates/context/src/tx.rs
@@ -219,6 +219,11 @@ impl Transaction for TxEnv {
         &self.data
     }
 
+    #[inline]
+    fn take_input(&mut self) -> Bytes {
+        core::mem::take(&mut self.data)
+    }
+
     fn blob_versioned_hashes(&self) -> &[B256] {
         &self.blob_hashes
     }

--- a/crates/handler/src/evm.rs
+++ b/crates/handler/src/evm.rs
@@ -189,8 +189,14 @@ where
 
         let ctx = &mut self.ctx;
         let precompiles = &mut self.precompiles;
-        let res =
-            Self::Frame::init_with_context(new_frame, ctx, precompiles, frame_input, arena, frame_index)?;
+        let res = Self::Frame::init_with_context(
+            new_frame,
+            ctx,
+            precompiles,
+            frame_input,
+            arena,
+            frame_index,
+        )?;
 
         Ok(res.map_item(|token| {
             if is_first_init {

--- a/crates/handler/src/evm.rs
+++ b/crates/handler/src/evm.rs
@@ -174,18 +174,12 @@ where
         &mut self,
         frame_input: <Self::Frame as FrameTr>::FrameInit,
     ) -> Result<FrameInitResult<'_, Self::Frame>, ContextDbError<CTX>> {
-        let is_first_init = self.frame_stack.index().is_none();
-        let frame_index = if is_first_init {
-            0
-        } else {
-            self.frame_stack.index().unwrap() + 1
+        let index = self.frame_stack.index();
+        let (is_first_init, frame_index, new_frame) = match index {
+            None => (true, 0, self.frame_stack.start_init()),
+            Some(i) => (false, i + 1, self.frame_stack.get_next()),
         };
         let arena = self.stack_arena.clone();
-        let new_frame = if is_first_init {
-            self.frame_stack.start_init()
-        } else {
-            self.frame_stack.get_next()
-        };
 
         let ctx = &mut self.ctx;
         let precompiles = &mut self.precompiles;

--- a/crates/handler/src/evm.rs
+++ b/crates/handler/src/evm.rs
@@ -6,10 +6,7 @@ use auto_impl::auto_impl;
 use context::{ContextTr, Database, Evm, FrameStack};
 use context_interface::context::ContextError;
 use interpreter::{
-    interpreter::EthInterpreter,
-    interpreter_action::FrameInit,
-    InterpreterResult,
-    MAX_ARENA_FRAMES,
+    interpreter::EthInterpreter, interpreter_action::FrameInit, InterpreterResult, MAX_ARENA_FRAMES,
 };
 
 /// Type alias for database error within a context

--- a/crates/handler/src/evm.rs
+++ b/crates/handler/src/evm.rs
@@ -174,12 +174,17 @@ where
         &mut self,
         frame_input: <Self::Frame as FrameTr>::FrameInit,
     ) -> Result<FrameInitResult<'_, Self::Frame>, ContextDbError<CTX>> {
-        let index = self.frame_stack.index();
-        let (is_first_init, frame_index, new_frame) = match index {
-            None => (true, 0, self.frame_stack.start_init()),
-            Some(i) => (false, i + 1, self.frame_stack.get_next()),
+        let is_first_init = self.frame_stack.index().is_none();
+        let frame_index = if is_first_init {
+            0
+        } else {
+            self.frame_stack.index().unwrap() + 1
         };
-        let arena = self.stack_arena.clone();
+        let new_frame = if is_first_init {
+            self.frame_stack.start_init()
+        } else {
+            self.frame_stack.get_next()
+        };
 
         let ctx = &mut self.ctx;
         let precompiles = &mut self.precompiles;
@@ -188,7 +193,7 @@ where
             ctx,
             precompiles,
             frame_input,
-            arena,
+            &self.stack_arena,
             frame_index,
         )?;
 

--- a/crates/handler/src/evm.rs
+++ b/crates/handler/src/evm.rs
@@ -8,8 +8,8 @@ use context_interface::context::ContextError;
 use interpreter::{
     interpreter::EthInterpreter,
     interpreter_action::FrameInit,
-    stack_arena::MAX_ARENA_FRAMES,
     InterpreterResult,
+    MAX_ARENA_FRAMES,
 };
 
 /// Type alias for database error within a context

--- a/crates/handler/src/evm.rs
+++ b/crates/handler/src/evm.rs
@@ -175,6 +175,12 @@ where
         frame_input: <Self::Frame as FrameTr>::FrameInit,
     ) -> Result<FrameInitResult<'_, Self::Frame>, ContextDbError<CTX>> {
         let is_first_init = self.frame_stack.index().is_none();
+        let frame_index = if is_first_init {
+            0
+        } else {
+            self.frame_stack.index().unwrap() + 1
+        };
+        let arena = self.stack_arena.clone();
         let new_frame = if is_first_init {
             self.frame_stack.start_init()
         } else {
@@ -183,7 +189,8 @@ where
 
         let ctx = &mut self.ctx;
         let precompiles = &mut self.precompiles;
-        let res = Self::Frame::init_with_context(new_frame, ctx, precompiles, frame_input)?;
+        let res =
+            Self::Frame::init_with_context(new_frame, ctx, precompiles, frame_input, arena, frame_index)?;
 
         Ok(res.map_item(|token| {
             if is_first_init {

--- a/crates/handler/src/execution.rs
+++ b/crates/handler/src/execution.rs
@@ -9,11 +9,11 @@ use std::boxed::Box;
 /// Creates the first [`FrameInput`] from the transaction, spec and gas limit.
 #[inline]
 pub fn create_init_frame(
-    tx: &impl Transaction,
+    tx: &mut impl Transaction,
     bytecode: Option<(Bytecode, B256)>,
     gas_limit: u64,
 ) -> FrameInput {
-    let input = tx.input().clone();
+    let input = tx.take_input();
 
     match tx.kind() {
         TxKind::Call(target_address) => {

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -128,12 +128,22 @@ impl EthFrame<EthInterpreter> {
         *input_ref = input;
         *depth_ref = depth;
         *is_finished_ref = false;
-        interpreter.clear(memory, bytecode, inputs, is_static, spec_id, gas_limit, arena, frame_index);
+        interpreter.clear(
+            memory,
+            bytecode,
+            inputs,
+            is_static,
+            spec_id,
+            gas_limit,
+            arena,
+            frame_index,
+        );
         *checkpoint_ref = checkpoint;
     }
 
     /// Make call frame
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     pub fn make_call_frame<
         CTX: ContextTr,
         PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
@@ -380,9 +390,16 @@ impl EthFrame<EthInterpreter> {
         } = frame_init;
 
         match frame_input {
-            FrameInput::Call(inputs) => {
-                Self::make_call_frame(this, ctx, precompiles, depth, memory, inputs, arena, frame_index)
-            }
+            FrameInput::Call(inputs) => Self::make_call_frame(
+                this,
+                ctx,
+                precompiles,
+                depth,
+                memory,
+                inputs,
+                arena,
+                frame_index,
+            ),
             FrameInput::Create(inputs) => {
                 Self::make_create_frame(this, ctx, depth, memory, inputs, arena, frame_index)
             }

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -113,7 +113,7 @@ impl EthFrame<EthInterpreter> {
         spec_id: SpecId,
         gas_limit: u64,
         checkpoint: JournalCheckpoint,
-        arena: Arc<Vec<U256>>,
+        arena: &Arc<Vec<U256>>,
         frame_index: usize,
     ) {
         let Self {
@@ -155,7 +155,7 @@ impl EthFrame<EthInterpreter> {
         depth: usize,
         memory: SharedMemory,
         inputs: Box<CallInputs>,
-        arena: Arc<Vec<U256>>,
+        arena: &Arc<Vec<U256>>,
         frame_index: usize,
     ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR> {
         let gas = Gas::new(inputs.gas_limit);
@@ -273,7 +273,7 @@ impl EthFrame<EthInterpreter> {
         depth: usize,
         memory: SharedMemory,
         inputs: Box<CreateInputs>,
-        arena: Arc<Vec<U256>>,
+        arena: &Arc<Vec<U256>>,
         frame_index: usize,
     ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR> {
         let spec = context.cfg().spec().into();
@@ -376,7 +376,7 @@ impl EthFrame<EthInterpreter> {
         ctx: &mut CTX,
         precompiles: &mut PRECOMPILES,
         frame_init: FrameInit,
-        arena: Arc<Vec<U256>>,
+        arena: &Arc<Vec<U256>>,
         frame_index: usize,
     ) -> Result<
         ItemOrResult<FrameToken, FrameResult>,

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -223,7 +223,7 @@ impl EthFrame<EthInterpreter> {
         }
 
         // Get bytecode and hash - either from known_bytecode or load from account
-        let (bytecode, bytecode_hash) = if let Some((hash, code)) = inputs.known_bytecode.clone() {
+        let (bytecode, bytecode_hash) = if let Some((hash, code)) = inputs.known_bytecode.take() {
             // Use provided bytecode and hash
             (code, hash)
         } else {

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -113,7 +113,7 @@ impl EthFrame<EthInterpreter> {
         spec_id: SpecId,
         gas_limit: u64,
         checkpoint: JournalCheckpoint,
-        arena: &Arc<Vec<U256>>,
+        arena: Option<&Arc<Vec<U256>>>,
         frame_index: usize,
     ) {
         let Self {
@@ -155,7 +155,7 @@ impl EthFrame<EthInterpreter> {
         depth: usize,
         memory: SharedMemory,
         mut inputs: Box<CallInputs>,
-        arena: &Arc<Vec<U256>>,
+        arena: Option<&Arc<Vec<U256>>>,
         frame_index: usize,
     ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR> {
         let gas = Gas::new(inputs.gas_limit);
@@ -274,7 +274,7 @@ impl EthFrame<EthInterpreter> {
         depth: usize,
         memory: SharedMemory,
         inputs: Box<CreateInputs>,
-        arena: &Arc<Vec<U256>>,
+        arena: Option<&Arc<Vec<U256>>>,
         frame_index: usize,
     ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR> {
         let spec = context.cfg().spec().into();
@@ -377,7 +377,7 @@ impl EthFrame<EthInterpreter> {
         ctx: &mut CTX,
         precompiles: &mut PRECOMPILES,
         frame_init: FrameInit,
-        arena: &Arc<Vec<U256>>,
+        arena: Option<&Arc<Vec<U256>>>,
         frame_index: usize,
     ) -> Result<
         ItemOrResult<FrameToken, FrameResult>,

--- a/crates/handler/src/mainnet_builder.rs
+++ b/crates/handler/src/mainnet_builder.rs
@@ -2,8 +2,8 @@ use crate::{frame::EthFrame, instructions::EthInstructions, EthPrecompiles};
 use context::{BlockEnv, Cfg, CfgEnv, Context, Evm, FrameStack, Journal, TxEnv};
 use context_interface::{Block, Database, JournalTr, Transaction};
 use database_interface::EmptyDB;
-use interpreter::interpreter::EthInterpreter;
-use primitives::hardfork::SpecId;
+use interpreter::interpreter::{EthInterpreter, MAX_ARENA_FRAMES, STACK_LIMIT};
+use primitives::{hardfork::SpecId, U256};
 
 /// Type alias for a mainnet EVM instance with standard Ethereum components.
 pub type MainnetEvm<CTX, INSP = ()> =
@@ -43,6 +43,7 @@ where
             instruction: EthInstructions::new_mainnet_with_spec(spec),
             precompiles: EthPrecompiles::new(spec),
             frame_stack: FrameStack::new_prealloc(8),
+            stack_arena: std::sync::Arc::new(std::vec![U256::ZERO; MAX_ARENA_FRAMES * STACK_LIMIT]),
         }
     }
 
@@ -57,6 +58,7 @@ where
             instruction: EthInstructions::new_mainnet_with_spec(spec),
             precompiles: EthPrecompiles::new(spec),
             frame_stack: FrameStack::new_prealloc(8),
+            stack_arena: std::sync::Arc::new(std::vec![U256::ZERO; MAX_ARENA_FRAMES * STACK_LIMIT]),
         }
     }
 }

--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -166,9 +166,9 @@ pub fn validate_against_state_and_deduct_caller<
     // Load caller's account.
     let mut caller = journal.load_account_with_code_mut(tx.caller())?.data;
 
-    validate_account_nonce_and_code_with_components(&caller.account().info, tx, cfg)?;
+    validate_account_nonce_and_code_with_components(&caller.account().info, &*tx, cfg)?;
 
-    let new_balance = calculate_caller_fee(*caller.balance(), tx, block, cfg)?;
+    let new_balance = calculate_caller_fee(*caller.balance(), &*tx, block, cfg)?;
 
     caller.set_balance(new_balance);
     if tx.kind().is_call() {

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -212,8 +212,7 @@ pub fn validate_tx_env<CTX: ContextTr>(
     };
 
     // Check if gas_limit is more than block_gas_limit
-    if !cfg.is_block_gas_limit_disabled() && tx.gas_limit() > block.gas_limit()
-    {
+    if !cfg.is_block_gas_limit_disabled() && tx.gas_limit() > block.gas_limit() {
         return Err(InvalidTransaction::CallerGasLimitMoreThanBlock);
     }
 

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -11,13 +11,15 @@ use primitives::{eip4844, hardfork::SpecId, B256};
 pub fn validate_env<CTX: ContextTr, ERROR: From<InvalidHeader> + From<InvalidTransaction>>(
     context: CTX,
 ) -> Result<(), ERROR> {
-    let spec = context.cfg().spec().into();
+    let cfg = context.cfg();
+    let block = context.block();
+    let spec = cfg.spec().into();
     // `prevrandao` is required for the merge
-    if spec.is_enabled_in(SpecId::MERGE) && context.block().prevrandao().is_none() {
+    if spec.is_enabled_in(SpecId::MERGE) && block.prevrandao().is_none() {
         return Err(InvalidHeader::PrevrandaoNotSet.into());
     }
     // `excess_blob_gas` is required for Cancun
-    if spec.is_enabled_in(SpecId::CANCUN) && context.block().blob_excess_gas_and_price().is_none() {
+    if spec.is_enabled_in(SpecId::CANCUN) && block.blob_excess_gas_and_price().is_none() {
         return Err(InvalidHeader::ExcessBlobGasNotSet.into());
     }
     validate_tx_env::<CTX>(context, spec).map_err(Into::into)
@@ -123,21 +125,23 @@ pub fn validate_tx_env<CTX: ContextTr>(
 ) -> Result<(), InvalidTransaction> {
     // Check if the transaction's chain id is correct
     let tx = context.tx();
+    let cfg = context.cfg();
+    let block = context.block();
     let tx_type = tx.tx_type();
 
-    let base_fee = if context.cfg().is_base_fee_check_disabled() {
+    let base_fee = if cfg.is_base_fee_check_disabled() {
         None
     } else {
-        Some(context.block().basefee() as u128)
+        Some(block.basefee() as u128)
     };
 
     let tx_type = TransactionType::from(tx_type);
 
     // Check chain_id if config is enabled.
     // EIP-155: Simple replay attack protection
-    if context.cfg().tx_chain_id_check() {
+    if cfg.tx_chain_id_check() {
         if let Some(chain_id) = tx.chain_id() {
-            if chain_id != context.cfg().chain_id() {
+            if chain_id != cfg.chain_id() {
                 return Err(InvalidTransaction::InvalidChainId);
             }
         } else if !tx_type.is_legacy() && !tx_type.is_custom() {
@@ -147,7 +151,7 @@ pub fn validate_tx_env<CTX: ContextTr>(
     }
 
     // EIP-7825: Transaction Gas Limit Cap
-    let cap = context.cfg().tx_gas_limit_cap();
+    let cap = cfg.tx_gas_limit_cap();
     if tx.gas_limit() > cap {
         return Err(InvalidTransaction::TxGasLimitGreaterThanCap {
             gas_limit: tx.gas_limit(),
@@ -155,7 +159,7 @@ pub fn validate_tx_env<CTX: ContextTr>(
         });
     }
 
-    let disable_priority_fee_check = context.cfg().is_priority_fee_check_disabled();
+    let disable_priority_fee_check = cfg.is_priority_fee_check_disabled();
 
     match tx_type {
         TransactionType::Legacy => {
@@ -184,8 +188,8 @@ pub fn validate_tx_env<CTX: ContextTr>(
             validate_eip4844_tx(
                 tx.blob_versioned_hashes(),
                 tx.max_fee_per_blob_gas(),
-                context.block().blob_gasprice().unwrap_or_default(),
-                context.cfg().max_blobs_per_tx(),
+                block.blob_gasprice().unwrap_or_default(),
+                cfg.max_blobs_per_tx(),
             )?;
         }
         TransactionType::Eip7702 => {
@@ -208,7 +212,7 @@ pub fn validate_tx_env<CTX: ContextTr>(
     };
 
     // Check if gas_limit is more than block_gas_limit
-    if !context.cfg().is_block_gas_limit_disabled() && tx.gas_limit() > context.block().gas_limit()
+    if !cfg.is_block_gas_limit_disabled() && tx.gas_limit() > block.gas_limit()
     {
         return Err(InvalidTransaction::CallerGasLimitMoreThanBlock);
     }
@@ -216,7 +220,7 @@ pub fn validate_tx_env<CTX: ContextTr>(
     // EIP-3860: Limit and meter initcode. Still valid with EIP-7907 and increase of initcode size.
     if spec_id.is_enabled_in(SpecId::SHANGHAI)
         && tx.kind().is_create()
-        && tx.input().len() > context.cfg().max_initcode_size()
+        && tx.input().len() > cfg.max_initcode_size()
     {
         return Err(InvalidTransaction::CreateInitCodeSizeLimit);
     }

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -19,7 +19,7 @@ pub use runtime_flags::RuntimeFlags;
 pub use shared_memory::{num_words, resize_memory, SharedMemory};
 pub use stack::{Stack, STACK_LIMIT};
 pub use stack_arena::{StackArena, MAX_ARENA_FRAMES};
-use std::vec;
+use std::vec::Vec;
 
 // imports
 use crate::{

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -144,7 +144,7 @@ impl<EXT: Default> Interpreter<EthInterpreter<EXT>> {
         *bytecode_ref = bytecode;
         *gas = Gas::new(gas_limit);
         if frame_index < MAX_ARENA_FRAMES {
-            *stack = Stack::new_with_arena(stack_arena, frame_index);
+            stack.reinit_with_arena(stack_arena, frame_index);
         } else if !stack.is_valid() {
             *stack = Stack::new();
         } else {

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -19,6 +19,7 @@ pub use runtime_flags::RuntimeFlags;
 pub use shared_memory::{num_words, resize_memory, SharedMemory};
 pub use stack::{Stack, STACK_LIMIT};
 pub use stack_arena::{StackArena, MAX_ARENA_FRAMES};
+use std::vec;
 
 // imports
 use crate::{

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -128,7 +128,7 @@ impl<EXT: Default> Interpreter<EthInterpreter<EXT>> {
         is_static: bool,
         spec_id: SpecId,
         gas_limit: u64,
-        stack_arena: Arc<Vec<U256>>,
+        stack_arena: &Arc<Vec<U256>>,
         frame_index: usize,
     ) {
         let Self {
@@ -144,7 +144,7 @@ impl<EXT: Default> Interpreter<EthInterpreter<EXT>> {
         *bytecode_ref = bytecode;
         *gas = Gas::new(gas_limit);
         if frame_index < MAX_ARENA_FRAMES {
-            stack.reinit_with_arena(stack_arena, frame_index);
+            stack.reinit_with_arena(Arc::clone(stack_arena), frame_index);
         } else if !stack.is_valid() {
             *stack = Stack::new();
         } else {

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -128,7 +128,7 @@ impl<EXT: Default> Interpreter<EthInterpreter<EXT>> {
         is_static: bool,
         spec_id: SpecId,
         gas_limit: u64,
-        stack_arena: &Arc<Vec<U256>>,
+        stack_arena: Option<&Arc<Vec<U256>>>,
         frame_index: usize,
     ) {
         let Self {
@@ -143,8 +143,8 @@ impl<EXT: Default> Interpreter<EthInterpreter<EXT>> {
         } = self;
         *bytecode_ref = bytecode;
         *gas = Gas::new(gas_limit);
-        if frame_index < MAX_ARENA_FRAMES {
-            stack.reinit_with_arena(Arc::clone(stack_arena), frame_index);
+        if let Some(arena) = stack_arena {
+            stack.reinit_with_arena(Arc::clone(arena), frame_index);
         } else if !stack.is_valid() {
             *stack = Stack::new();
         } else {

--- a/crates/interpreter/src/interpreter/stack.rs
+++ b/crates/interpreter/src/interpreter/stack.rs
@@ -5,7 +5,6 @@ use std::{sync::Arc, vec::Vec};
 
 use super::StackTr;
 
-
 /// EVM interpreter stack limit.
 pub const STACK_LIMIT: usize = 1024;
 

--- a/crates/interpreter/src/interpreter/stack.rs
+++ b/crates/interpreter/src/interpreter/stack.rs
@@ -413,12 +413,13 @@ impl Stack {
                 return true;
             }
 
-            // Write limbs of partial last word
+            // Write limbs of partial last word (process from end backwards)
             let num_full_limbs = partial_last_word.len() / 8;
-            let partial_limb_start = num_full_limbs * 8;
+            let partial_limb_len = partial_last_word.len() % 8;
 
-            for limb_idx in (0..num_full_limbs).rev() {
-                let limb_start = limb_idx * 8;
+            // Process full 8-byte limbs from the end of the slice backwards
+            for limb_offset in 0..num_full_limbs {
+                let limb_start = partial_last_word.len() - (limb_offset + 1) * 8;
                 let limb_bytes = [
                     partial_last_word[limb_start],
                     partial_last_word[limb_start + 1],
@@ -433,7 +434,7 @@ impl Stack {
                 i += 1;
             }
 
-            let partial_last_limb = &partial_last_word[partial_limb_start..];
+            let partial_last_limb = &partial_last_word[..partial_limb_len];
 
             // Write partial last limb by padding with zeros
             if !partial_last_limb.is_empty() {

--- a/crates/interpreter/src/interpreter/stack.rs
+++ b/crates/interpreter/src/interpreter/stack.rs
@@ -161,6 +161,19 @@ impl Stack {
         }
     }
 
+    /// Reinitialize this stack to use a different frame slot in the arena.
+    ///
+    /// This avoids dropping and reallocating - just updates the pointer and length.
+    /// The arena must have been pre-allocated with at least
+    /// `(frame_index + 1) * STACK_LIMIT` elements.
+    #[inline]
+    pub fn reinit_with_arena(&mut self, arena: Arc<Vec<U256>>, frame_index: usize) {
+        debug_assert!(arena.len() >= (frame_index + 1) * STACK_LIMIT);
+        self.ptr = unsafe { arena.as_ptr().cast_mut().add(frame_index * STACK_LIMIT) };
+        self.len = 0;
+        self._backing = arena;
+    }
+
     /// Instantiate a new invalid Stack.
     #[inline]
     pub fn invalid() -> Self {

--- a/crates/interpreter/src/interpreter/stack.rs
+++ b/crates/interpreter/src/interpreter/stack.rs
@@ -137,7 +137,7 @@ impl Stack {
     /// Instantiate a new stack with the [default stack limit][STACK_LIMIT].
     #[inline]
     pub fn new() -> Self {
-        let backing = Arc::new(vec![U256::ZERO; STACK_LIMIT]);
+        let backing = Arc::new(std::vec![U256::ZERO; STACK_LIMIT]);
         let ptr = backing.as_ptr().cast_mut();
         Self {
             ptr,

--- a/crates/interpreter/src/interpreter/stack.rs
+++ b/crates/interpreter/src/interpreter/stack.rs
@@ -5,6 +5,7 @@ use std::{sync::Arc, vec::Vec};
 
 use super::StackTr;
 
+
 /// EVM interpreter stack limit.
 pub const STACK_LIMIT: usize = 1024;
 
@@ -13,7 +14,7 @@ pub const STACK_LIMIT: usize = 1024;
 /// The stack uses a cached raw pointer (`ptr`) to the start of its region
 /// for fast access on the hot path, backed by an `Arc<Vec<U256>>` that keeps
 /// the memory alive. Multiple stacks can share the same backing `Vec` when
-/// created via a [`StackArena`].
+/// created via a [`StackArena`](crate::interpreter::StackArena).
 #[derive(Debug)]
 pub struct Stack {
     /// Cached pointer to the first slot of this stack's region.

--- a/crates/interpreter/src/interpreter/stack.rs
+++ b/crates/interpreter/src/interpreter/stack.rs
@@ -1,7 +1,7 @@
 use crate::InstructionResult;
 use core::{fmt, ptr};
 use primitives::U256;
-use std::vec::Vec;
+use std::{sync::Arc, vec::Vec};
 
 use super::StackTr;
 
@@ -9,17 +9,34 @@ use super::StackTr;
 pub const STACK_LIMIT: usize = 1024;
 
 /// EVM stack with [STACK_LIMIT] capacity of words.
-#[derive(Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+///
+/// The stack uses a cached raw pointer (`ptr`) to the start of its region
+/// for fast access on the hot path, backed by an `Arc<Vec<U256>>` that keeps
+/// the memory alive. Multiple stacks can share the same backing `Vec` when
+/// created via a [`StackArena`].
+#[derive(Debug)]
 pub struct Stack {
-    /// The underlying data of the stack.
-    data: Vec<U256>,
+    /// Cached pointer to the first slot of this stack's region.
+    /// SAFETY: Valid as long as `_backing` is alive; the Vec is never reallocated.
+    ptr: *mut U256,
+    /// Current number of items on the stack.
+    len: usize,
+    /// Shared ownership of the backing buffer.
+    _backing: Arc<Vec<U256>>,
 }
+
+// SAFETY: Stack is Send + Sync because:
+// - `ptr` always points into the Vec inside `_backing` (an Arc<Vec<U256>>).
+// - The Vec is never reallocated (pre-allocated to capacity).
+// - Non-overlapping regions are guaranteed when arena is shared.
+unsafe impl Send for Stack {}
+unsafe impl Sync for Stack {}
 
 impl fmt::Display for Stack {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("[")?;
-        for (i, x) in self.data.iter().enumerate() {
+        let data = self.data();
+        for (i, x) in data.iter().enumerate() {
             if i > 0 {
                 f.write_str(", ")?;
             }
@@ -38,34 +55,48 @@ impl Default for Stack {
 
 impl Clone for Stack {
     fn clone(&self) -> Self {
-        // Use `Self::new()` to ensure the cloned Stack is constructed with at least
-        // STACK_LIMIT capacity, and then copy the data. This preserves the invariant
-        // that Stack has sufficient capacity for operations that rely on it.
         let mut new_stack = Self::new();
-        new_stack.data.extend_from_slice(&self.data);
+        unsafe {
+            ptr::copy_nonoverlapping(self.ptr, new_stack.ptr, self.len);
+            new_stack.len = self.len;
+        }
         new_stack
+    }
+}
+
+impl PartialEq for Stack {
+    fn eq(&self, other: &Self) -> bool {
+        self.data() == other.data()
+    }
+}
+
+impl Eq for Stack {}
+
+impl core::hash::Hash for Stack {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.data().hash(state);
     }
 }
 
 impl StackTr for Stack {
     #[inline]
     fn len(&self) -> usize {
-        self.len()
+        self.len
     }
 
     #[inline]
     fn data(&self) -> &[U256] {
-        &self.data
+        self.data()
     }
 
     #[inline]
     fn clear(&mut self) {
-        self.data.clear();
+        self.len = 0;
     }
 
     #[inline]
     fn popn<const N: usize>(&mut self) -> Option<[U256; N]> {
-        if self.len() < N {
+        if self.len < N {
             return None;
         }
         // SAFETY: Stack length is checked above.
@@ -74,7 +105,7 @@ impl StackTr for Stack {
 
     #[inline]
     fn popn_top<const POPN: usize>(&mut self) -> Option<([U256; POPN], &mut U256)> {
-        if self.len() < POPN + 1 {
+        if self.len < POPN + 1 {
             return None;
         }
         // SAFETY: Stack length is checked above.
@@ -106,46 +137,81 @@ impl Stack {
     /// Instantiate a new stack with the [default stack limit][STACK_LIMIT].
     #[inline]
     pub fn new() -> Self {
+        let backing = Arc::new(vec![U256::ZERO; STACK_LIMIT]);
+        let ptr = backing.as_ptr().cast_mut();
         Self {
-            // SAFETY: Expansion functions assume that capacity is `STACK_LIMIT`.
-            data: Vec::with_capacity(STACK_LIMIT),
+            ptr,
+            len: 0,
+            _backing: backing,
+        }
+    }
+
+    /// Instantiate a new stack backed by a shared arena at the given frame offset.
+    ///
+    /// The arena must have been pre-allocated with at least
+    /// `(frame_index + 1) * STACK_LIMIT` elements.
+    #[inline]
+    pub fn new_with_arena(arena: Arc<Vec<U256>>, frame_index: usize) -> Self {
+        debug_assert!(arena.len() >= (frame_index + 1) * STACK_LIMIT);
+        let ptr = unsafe { arena.as_ptr().cast_mut().add(frame_index * STACK_LIMIT) };
+        Self {
+            ptr,
+            len: 0,
+            _backing: arena,
         }
     }
 
     /// Instantiate a new invalid Stack.
     #[inline]
     pub fn invalid() -> Self {
-        Self { data: Vec::new() }
+        Self {
+            ptr: core::ptr::null_mut(),
+            len: 0,
+            _backing: Arc::new(Vec::new()),
+        }
+    }
+
+    /// Returns whether this stack was created via [`Stack::invalid`].
+    #[inline]
+    pub fn is_valid(&self) -> bool {
+        !self.ptr.is_null()
     }
 
     /// Returns the length of the stack in words.
     #[inline]
     pub fn len(&self) -> usize {
-        self.data.len()
+        self.len
     }
 
     /// Returns whether the stack is empty.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.data.is_empty()
+        self.len == 0
     }
 
-    /// Returns a reference to the underlying data buffer.
+    /// Returns a reference to the underlying data buffer as a slice.
     #[inline]
-    pub fn data(&self) -> &Vec<U256> {
-        &self.data
+    pub fn data(&self) -> &[U256] {
+        unsafe {
+            let ptr = self.ptr;
+            core::slice::from_raw_parts(ptr, self.len)
+        }
     }
 
-    /// Returns a mutable reference to the underlying data buffer.
+    /// Returns a mutable reference to the underlying data buffer as a slice.
     #[inline]
-    pub fn data_mut(&mut self) -> &mut Vec<U256> {
-        &mut self.data
+    pub fn data_mut(&mut self) -> &mut [U256] {
+        unsafe {
+            let ptr = self.ptr;
+            core::slice::from_raw_parts_mut(ptr, self.len)
+        }
     }
 
     /// Consumes the stack and returns the underlying data buffer.
     #[inline]
     pub fn into_data(self) -> Vec<U256> {
-        self.data
+        // Convert arena slice to owned Vec
+        self.data().to_vec()
     }
 
     /// Removes the topmost element from the stack and returns it, or `StackUnderflow` if it is
@@ -153,13 +219,13 @@ impl Stack {
     #[inline]
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn pop(&mut self) -> Result<U256, InstructionResult> {
-        let len = self.data.len();
-        if primitives::hints_util::unlikely(len == 0) {
+        if primitives::hints_util::unlikely(self.len == 0) {
             Err(InstructionResult::StackUnderflow)
         } else {
             unsafe {
-                self.data.set_len(len - 1);
-                Ok(core::ptr::read(self.data.as_ptr().add(len - 1)))
+                let ptr = self.ptr;
+                self.len -= 1;
+                Ok(core::ptr::read(ptr.add(self.len)))
             }
         }
     }
@@ -172,8 +238,10 @@ impl Stack {
     #[inline]
     #[cfg_attr(debug_assertions, track_caller)]
     pub unsafe fn pop_unsafe(&mut self) -> U256 {
-        assume!(!self.data.is_empty());
-        self.data.pop().unwrap_unchecked()
+        assume!(self.len > 0);
+        let ptr = self.ptr;
+        self.len -= 1;
+        core::ptr::read(ptr.add(self.len))
     }
 
     /// Peeks the top of the stack.
@@ -184,8 +252,9 @@ impl Stack {
     #[inline]
     #[cfg_attr(debug_assertions, track_caller)]
     pub unsafe fn top_unsafe(&mut self) -> &mut U256 {
-        assume!(!self.data.is_empty());
-        self.data.last_mut().unwrap_unchecked()
+        assume!(self.len > 0);
+        let ptr = self.ptr;
+        &mut *ptr.add(self.len - 1)
     }
 
     /// Pops `N` values from the stack.
@@ -196,7 +265,7 @@ impl Stack {
     #[inline]
     #[cfg_attr(debug_assertions, track_caller)]
     pub unsafe fn popn<const N: usize>(&mut self) -> [U256; N] {
-        assume!(self.data.len() >= N);
+        assume!(self.len >= N);
         core::array::from_fn(|_| unsafe { self.pop_unsafe() })
     }
 
@@ -221,16 +290,13 @@ impl Stack {
     #[must_use]
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn push(&mut self, value: U256) -> bool {
-        // In debug builds, verify we have sufficient capacity provisioned.
-        debug_assert!(self.data.capacity() >= STACK_LIMIT);
-        let len = self.data.len();
-        if len == STACK_LIMIT {
+        if self.len == STACK_LIMIT {
             return false;
         }
         unsafe {
-            let end = self.data.as_mut_ptr().add(len);
-            core::ptr::write(end, value);
-            self.data.set_len(len + 1);
+            let ptr = self.ptr;
+            core::ptr::write(ptr.add(self.len), value);
+            self.len += 1;
         }
         true
     }
@@ -240,8 +306,11 @@ impl Stack {
     /// `StackError::Underflow` is returned.
     #[inline]
     pub fn peek(&self, no_from_top: usize) -> Result<U256, InstructionResult> {
-        if self.data.len() > no_from_top {
-            Ok(self.data[self.data.len() - no_from_top - 1])
+        if self.len > no_from_top {
+            unsafe {
+                let ptr = self.ptr;
+                Ok(ptr::read(ptr.add(self.len - no_from_top - 1)))
+            }
         } else {
             Err(InstructionResult::StackUnderflow)
         }
@@ -257,15 +326,15 @@ impl Stack {
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn dup(&mut self, n: usize) -> bool {
         assume!(n > 0, "attempted to dup 0");
-        let len = self.data.len();
-        if len < n || len + 1 > STACK_LIMIT {
+        if self.len < n || self.len + 1 > STACK_LIMIT {
             false
         } else {
             // SAFETY: Check for out of bounds is done above and it makes this safe to do.
             unsafe {
-                let ptr = self.data.as_mut_ptr().add(len);
-                ptr::copy_nonoverlapping(ptr.sub(n), ptr, 1);
-                self.data.set_len(len + 1);
+                let ptr = self.ptr;
+                let top = ptr.add(self.len);
+                ptr::copy_nonoverlapping(top.sub(n), top, 1);
+                self.len += 1;
             }
             true
         }
@@ -293,9 +362,8 @@ impl Stack {
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn exchange(&mut self, n: usize, m: usize) -> bool {
         assume!(m > 0, "overlapping exchange");
-        let len = self.data.len();
         let n_m_index = n + m;
-        if n_m_index >= len {
+        if n_m_index >= self.len {
             return false;
         }
         // SAFETY: `n` and `n_m` are checked to be within bounds, and they don't overlap.
@@ -304,7 +372,8 @@ impl Stack {
             // because it operates under the assumption that the pointers do not overlap,
             // eliminating an intermediate copy,
             // which is a condition we know to be true in this context.
-            let top = self.data.as_mut_ptr().add(len - 1);
+            let ptr = self.ptr;
+            let top = ptr.add(self.len - 1);
             core::ptr::swap_nonoverlapping(top.sub(n), top.sub(n_m_index), 1);
         }
         true
@@ -330,111 +399,42 @@ impl Stack {
         }
 
         let n_words = slice.len().div_ceil(32);
-        let new_len = self.data.len() + n_words;
+        let new_len = self.len + n_words;
         if new_len > STACK_LIMIT {
             return false;
         }
 
-        // In debug builds, ensure underlying capacity is sufficient for the write.
-        debug_assert!(self.data.capacity() >= new_len);
-
         // SAFETY: Length checked above.
         unsafe {
-            let dst = self.data.as_mut_ptr().add(self.data.len()).cast::<u64>();
-            self.data.set_len(new_len);
+            let ptr = self.ptr;
+            let dst = ptr.add(self.len).cast::<u64>();
+            self.len = new_len;
 
-            let mut i: usize = 0;
+            let mut i = 0;
 
             // Write full words
-            let num_full_words = slice.len() / 32;
-            let partial_start = num_full_words * 32;
-
-            for word_idx in 0..num_full_words {
-                let word_start = word_idx * 32;
-                // write 4 limbs (32 bytes) in reverse order for big-endian
-
-                let limb_start = word_start + 24;
-                let limb_bytes = [
-                    slice[limb_start],
-                    slice[limb_start + 1],
-                    slice[limb_start + 2],
-                    slice[limb_start + 3],
-                    slice[limb_start + 4],
-                    slice[limb_start + 5],
-                    slice[limb_start + 6],
-                    slice[limb_start + 7],
-                ];
-                dst.add(i).write(u64::from_be_bytes(limb_bytes));
-
-                let limb_start = word_start + 16;
-                let limb_bytes = [
-                    slice[limb_start],
-                    slice[limb_start + 1],
-                    slice[limb_start + 2],
-                    slice[limb_start + 3],
-                    slice[limb_start + 4],
-                    slice[limb_start + 5],
-                    slice[limb_start + 6],
-                    slice[limb_start + 7],
-                ];
-                dst.add(i + 1).write(u64::from_be_bytes(limb_bytes));
-
-                let limb_start = word_start + 8;
-                let limb_bytes = [
-                    slice[limb_start],
-                    slice[limb_start + 1],
-                    slice[limb_start + 2],
-                    slice[limb_start + 3],
-                    slice[limb_start + 4],
-                    slice[limb_start + 5],
-                    slice[limb_start + 6],
-                    slice[limb_start + 7],
-                ];
-                dst.add(i + 2).write(u64::from_be_bytes(limb_bytes));
-
-                let limb_start = word_start;
-                let limb_bytes = [
-                    slice[limb_start],
-                    slice[limb_start + 1],
-                    slice[limb_start + 2],
-                    slice[limb_start + 3],
-                    slice[limb_start + 4],
-                    slice[limb_start + 5],
-                    slice[limb_start + 6],
-                    slice[limb_start + 7],
-                ];
-                dst.add(i + 3).write(u64::from_be_bytes(limb_bytes));
-
-                i += 4;
+            let words = slice.chunks_exact(32);
+            let partial_last_word = words.remainder();
+            for word in words {
+                // Note: We unroll `U256::from_be_bytes` here to write directly into the buffer,
+                // instead of creating a 32 byte array on the stack and then copying it over.
+                for l in word.rchunks_exact(8) {
+                    dst.add(i).write(u64::from_be_bytes(l.try_into().unwrap()));
+                    i += 1;
+                }
             }
 
-            let partial_last_word = &slice[partial_start..];
             if partial_last_word.is_empty() {
                 return true;
             }
 
-            // Write limbs of partial last word (process from end backwards)
-            let num_full_limbs = partial_last_word.len() / 8;
-            let partial_limb_len = partial_last_word.len() % 8;
-
-            // Process full 8-byte limbs from the end of the slice backwards
-            for limb_offset in 0..num_full_limbs {
-                let limb_start = partial_last_word.len() - (limb_offset + 1) * 8;
-                let limb_bytes = [
-                    partial_last_word[limb_start],
-                    partial_last_word[limb_start + 1],
-                    partial_last_word[limb_start + 2],
-                    partial_last_word[limb_start + 3],
-                    partial_last_word[limb_start + 4],
-                    partial_last_word[limb_start + 5],
-                    partial_last_word[limb_start + 6],
-                    partial_last_word[limb_start + 7],
-                ];
-                dst.add(i).write(u64::from_be_bytes(limb_bytes));
+            // Write limbs of partial last word
+            let limbs = partial_last_word.rchunks_exact(8);
+            let partial_last_limb = limbs.remainder();
+            for l in limbs {
+                dst.add(i).write(u64::from_be_bytes(l.try_into().unwrap()));
                 i += 1;
             }
-
-            let partial_last_limb = &partial_last_word[..partial_limb_len];
 
             // Write partial last limb by padding with zeros
             if !partial_last_limb.is_empty() {
@@ -461,13 +461,28 @@ impl Stack {
     /// `StackError::Underflow` is returned.
     #[inline]
     pub fn set(&mut self, no_from_top: usize, val: U256) -> Result<(), InstructionResult> {
-        if self.data.len() > no_from_top {
-            let len = self.data.len();
-            self.data[len - no_from_top - 1] = val;
+        if self.len > no_from_top {
+            unsafe {
+                let ptr = self.ptr;
+                ptr::write(ptr.add(self.len - no_from_top - 1), val);
+            }
             Ok(())
         } else {
             Err(InstructionResult::StackUnderflow)
         }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Stack {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("Stack", 1)?;
+        state.serialize_field("data", self.data())?;
+        state.end()
     }
 }
 
@@ -482,16 +497,20 @@ impl<'de> serde::Deserialize<'de> for Stack {
             data: Vec<U256>,
         }
 
-        let mut stack = StackSerde::deserialize(deserializer)?;
-        if stack.data.len() > STACK_LIMIT {
+        let stack_serde = StackSerde::deserialize(deserializer)?;
+        if stack_serde.data.len() > STACK_LIMIT {
             return Err(serde::de::Error::custom(std::format!(
                 "stack size exceeds limit: {} > {}",
-                stack.data.len(),
+                stack_serde.data.len(),
                 STACK_LIMIT
             )));
         }
-        stack.data.reserve(STACK_LIMIT - stack.data.len());
-        Ok(Self { data: stack.data })
+        let mut stack = Self::new();
+        unsafe {
+            ptr::copy_nonoverlapping(stack_serde.data.as_ptr(), stack.ptr, stack_serde.data.len());
+            stack.len = stack_serde.data.len();
+        }
+        Ok(stack)
     }
 }
 
@@ -501,11 +520,12 @@ mod tests {
 
     fn run(f: impl FnOnce(&mut Stack)) {
         let mut stack = Stack::new();
-        // Fill capacity with non-zero values
+        // Fill backing region with non-zero values, then reset len
         unsafe {
-            stack.data.set_len(STACK_LIMIT);
-            stack.data.fill(U256::MAX);
-            stack.data.set_len(0);
+            for i in 0..STACK_LIMIT {
+                stack.ptr.add(i).write(U256::MAX);
+            }
+            stack.len = 0;
         }
         f(&mut stack);
     }
@@ -515,44 +535,44 @@ mod tests {
         // No-op
         run(|stack| {
             stack.push_slice(b"").unwrap();
-            assert!(stack.data.is_empty());
+            assert!(stack.is_empty());
         });
 
         // One word
         run(|stack| {
             stack.push_slice(&[42]).unwrap();
-            assert_eq!(stack.data, [U256::from(42)]);
+            assert_eq!(stack.data(), [U256::from(42)]);
         });
 
         let n = 0x1111_2222_3333_4444_5555_6666_7777_8888_u128;
         run(|stack| {
             stack.push_slice(&n.to_be_bytes()).unwrap();
-            assert_eq!(stack.data, [U256::from(n)]);
+            assert_eq!(stack.data(), [U256::from(n)]);
         });
 
         // More than one word
         run(|stack| {
             let b = [U256::from(n).to_be_bytes::<32>(); 2].concat();
             stack.push_slice(&b).unwrap();
-            assert_eq!(stack.data, [U256::from(n); 2]);
+            assert_eq!(stack.data(), [U256::from(n); 2]);
         });
 
         run(|stack| {
             let b = [&[0; 32][..], &[42u8]].concat();
             stack.push_slice(&b).unwrap();
-            assert_eq!(stack.data, [U256::ZERO, U256::from(42)]);
+            assert_eq!(stack.data(), [U256::ZERO, U256::from(42)]);
         });
 
         run(|stack| {
             let b = [&[0; 32][..], &n.to_be_bytes()].concat();
             stack.push_slice(&b).unwrap();
-            assert_eq!(stack.data, [U256::ZERO, U256::from(n)]);
+            assert_eq!(stack.data(), [U256::ZERO, U256::from(n)]);
         });
 
         run(|stack| {
             let b = [&[0; 64][..], &n.to_be_bytes()].concat();
             stack.push_slice(&b).unwrap();
-            assert_eq!(stack.data, [U256::ZERO, U256::ZERO, U256::from(n)]);
+            assert_eq!(stack.data(), [U256::ZERO, U256::ZERO, U256::from(n)]);
         });
     }
 
@@ -563,7 +583,6 @@ mod tests {
         let cloned_empty = empty_stack.clone();
         assert_eq!(empty_stack, cloned_empty);
         assert_eq!(cloned_empty.len(), 0);
-        assert_eq!(cloned_empty.data().capacity(), STACK_LIMIT);
 
         // Test cloning a partially filled stack
         let mut partial_stack = Stack::new();
@@ -573,7 +592,6 @@ mod tests {
         let mut cloned_partial = partial_stack.clone();
         assert_eq!(partial_stack, cloned_partial);
         assert_eq!(cloned_partial.len(), 10);
-        assert_eq!(cloned_partial.data().capacity(), STACK_LIMIT);
 
         // Test that modifying the clone doesn't affect the original
         assert!(cloned_partial.push(U256::from(100)));
@@ -589,7 +607,6 @@ mod tests {
         let mut cloned_full = full_stack.clone();
         assert_eq!(full_stack, cloned_full);
         assert_eq!(cloned_full.len(), STACK_LIMIT);
-        assert_eq!(cloned_full.data().capacity(), STACK_LIMIT);
 
         // Test push to the full original or cloned stack should return StackOverflow
         assert!(!full_stack.push(U256::from(100)));

--- a/crates/interpreter/src/interpreter/stack_arena.rs
+++ b/crates/interpreter/src/interpreter/stack_arena.rs
@@ -1,6 +1,6 @@
 //! Arena allocator for EVM stacks.
 //!
-//! Instead of each frame having its own Vec<U256> stack, we use a single
+//! Instead of each frame having its own `Vec<U256> stack`, we use a single
 //! contiguous arena that pre-allocates space for multiple frames. This reduces
 //! allocations and improves cache locality.
 

--- a/crates/interpreter/src/interpreter/stack_arena.rs
+++ b/crates/interpreter/src/interpreter/stack_arena.rs
@@ -5,7 +5,7 @@
 //! allocations and improves cache locality.
 
 use primitives::U256;
-use std::sync::Arc;
+use std::{sync::Arc, vec::Vec};
 
 /// Maximum number of frames the arena can support.
 pub const MAX_ARENA_FRAMES: usize = 16;

--- a/crates/interpreter/src/interpreter/stack_arena.rs
+++ b/crates/interpreter/src/interpreter/stack_arena.rs
@@ -31,7 +31,7 @@ impl StackArena {
     /// Creates a new stack arena with pre-allocated memory for all frames.
     pub fn new() -> Self {
         Self {
-            memory: Arc::new(vec![U256::ZERO; MAX_ARENA_FRAMES * STACK_LIMIT]),
+            memory: Arc::new(std::vec![U256::ZERO; MAX_ARENA_FRAMES * STACK_LIMIT]),
         }
     }
 

--- a/crates/interpreter/src/interpreter/stack_arena.rs
+++ b/crates/interpreter/src/interpreter/stack_arena.rs
@@ -1,0 +1,152 @@
+//! Arena allocator for EVM stacks.
+//!
+//! Instead of each frame having its own Vec<U256> stack, we use a single
+//! contiguous arena that pre-allocates space for multiple frames. This reduces
+//! allocations and improves cache locality.
+
+use primitives::U256;
+use std::sync::Arc;
+
+/// Maximum number of frames the arena can support.
+pub const MAX_ARENA_FRAMES: usize = 16;
+
+/// Stack limit per frame (EVM spec).
+pub(super) const STACK_LIMIT: usize = 1024;
+
+/// Arena that holds stack memory for multiple frames.
+///
+/// The arena is pre-allocated with space for MAX_ARENA_FRAMES frames,
+/// each with STACK_LIMIT capacity. Frames access non-overlapping slices
+/// of this arena.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct StackArena {
+    /// Single backing buffer: MAX_ARENA_FRAMES * STACK_LIMIT U256s.
+    ///
+    /// Layout: [Frame0 (0..1024) | Frame1 (1024..2048) | ... | Frame15 (15360..16384)]
+    memory: Arc<Vec<U256>>,
+}
+
+impl StackArena {
+    /// Creates a new stack arena with pre-allocated memory for all frames.
+    pub fn new() -> Self {
+        Self {
+            memory: Arc::new(vec![U256::ZERO; MAX_ARENA_FRAMES * STACK_LIMIT]),
+        }
+    }
+
+    /// Returns the memory offset for a given frame index.
+    #[inline]
+    const fn frame_offset(frame_index: usize) -> usize {
+        frame_index * STACK_LIMIT
+    }
+
+    /// Returns a mutable pointer to the start of a frame's stack region.
+    ///
+    /// # Safety
+    ///
+    /// - `frame_index` must be < MAX_ARENA_FRAMES
+    /// - Caller must ensure non-overlapping access (only one frame uses its region at a time)
+    #[inline]
+    pub unsafe fn frame_ptr(&self, frame_index: usize) -> *mut U256 {
+        debug_assert!(frame_index < MAX_ARENA_FRAMES);
+        let offset = Self::frame_offset(frame_index);
+        self.memory.as_ptr().cast_mut().add(offset)
+    }
+
+    /// Returns the capacity available for each frame.
+    #[inline]
+    pub const fn frame_capacity() -> usize {
+        STACK_LIMIT
+    }
+
+    /// Returns a clone of the backing buffer Arc.
+    /// Use this with [`crate::interpreter::Stack::new_with_arena`] to create
+    /// stacks that share this arena's memory.
+    #[inline]
+    pub fn backing(&self) -> Arc<Vec<U256>> {
+        self.memory.clone()
+    }
+}
+
+impl Default for StackArena {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_arena_offsets() {
+        let _arena = StackArena::new();
+
+        // Check frame offsets
+        assert_eq!(StackArena::frame_offset(0), 0);
+        assert_eq!(StackArena::frame_offset(1), 1024);
+        assert_eq!(StackArena::frame_offset(2), 2048);
+        assert_eq!(StackArena::frame_offset(15), 15360);
+    }
+
+    #[test]
+    fn test_arena_non_overlapping() {
+        let arena = StackArena::new();
+
+        unsafe {
+            let ptr0 = arena.frame_ptr(0);
+            let ptr1 = arena.frame_ptr(1);
+
+            // Write to frame 0
+            ptr0.write(U256::from(42));
+
+            // Write to frame 1
+            ptr1.write(U256::from(99));
+
+            // Verify no overlap
+            assert_eq!(ptr0.read(), U256::from(42));
+            assert_eq!(ptr1.read(), U256::from(99));
+        }
+    }
+
+    #[test]
+    fn test_arena_with_stacks() {
+        use crate::interpreter::Stack;
+
+        let arena = StackArena::new();
+        let backing = arena.backing();
+
+        // Create two stacks backed by the same arena
+        let mut s0 = Stack::new_with_arena(backing.clone(), 0);
+        let mut s1 = Stack::new_with_arena(backing.clone(), 1);
+
+        // Push to s0
+        assert!(s0.push(U256::from(10)));
+        assert!(s0.push(U256::from(20)));
+        assert!(s0.push(U256::from(30)));
+
+        // Push to s1 (different region)
+        assert!(s1.push(U256::from(100)));
+        assert!(s1.push(U256::from(200)));
+
+        // Verify they don't interfere
+        assert_eq!(s0.len(), 3);
+        assert_eq!(s1.len(), 2);
+        assert_eq!(s0.data(), [U256::from(10), U256::from(20), U256::from(30)]);
+        assert_eq!(s1.data(), [U256::from(100), U256::from(200)]);
+
+        // Pop from s0, verify s1 unaffected
+        assert_eq!(s0.pop(), Ok(U256::from(30)));
+        assert_eq!(s1.len(), 2);
+    }
+
+    #[test]
+    fn test_arena_clone() {
+        let arena1 = StackArena::new();
+        let arena2 = arena1.clone();
+
+        // Should share the same underlying Arc
+        assert!(Arc::ptr_eq(&arena1.memory, &arena2.memory));
+    }
+}

--- a/crates/interpreter/src/lib.rs
+++ b/crates/interpreter/src/lib.rs
@@ -36,8 +36,8 @@ pub use instruction_context::InstructionContext;
 pub use instruction_result::*;
 pub use instructions::{instruction_table, Instruction, InstructionTable};
 pub use interpreter::{
-    num_words, InputsImpl, Interpreter, InterpreterResult, SharedMemory, Stack, STACK_LIMIT,
-    MAX_ARENA_FRAMES,
+    num_words, InputsImpl, Interpreter, InterpreterResult, SharedMemory, Stack, MAX_ARENA_FRAMES,
+    STACK_LIMIT,
 };
 pub use interpreter_action::{
     CallInput, CallInputs, CallOutcome, CallScheme, CallValue, CreateInputs, CreateOutcome,

--- a/crates/interpreter/src/lib.rs
+++ b/crates/interpreter/src/lib.rs
@@ -37,6 +37,7 @@ pub use instruction_result::*;
 pub use instructions::{instruction_table, Instruction, InstructionTable};
 pub use interpreter::{
     num_words, InputsImpl, Interpreter, InterpreterResult, SharedMemory, Stack, STACK_LIMIT,
+    MAX_ARENA_FRAMES,
 };
 pub use interpreter_action::{
     CallInput, CallInputs, CallOutcome, CallScheme, CallValue, CreateInputs, CreateOutcome,

--- a/crates/op-revm/src/evm.rs
+++ b/crates/op-revm/src/evm.rs
@@ -10,7 +10,7 @@ use revm::{
     },
     inspector::{InspectorEvmTr, JournalExt},
     interpreter::{interpreter::EthInterpreter, InterpreterResult},
-    Database, Inspector,
+    primitives::U256, Database, Inspector,
 };
 
 /// Optimism EVM extends the [`Evm`] type with Optimism specific types and logic.
@@ -38,6 +38,7 @@ impl<CTX: ContextTr<Cfg: Cfg<Spec: Into<OpSpecId> + Clone>>, INSP>
             instruction: EthInstructions::new_mainnet_with_spec(spec.into()),
             precompiles: OpPrecompiles::new_with_spec(spec),
             frame_stack: FrameStack::new_prealloc(8),
+            stack_arena: std::sync::Arc::new(std::vec![U256::ZERO; 16 * 1024]),
         })
     }
 

--- a/crates/op-revm/src/evm.rs
+++ b/crates/op-revm/src/evm.rs
@@ -10,7 +10,8 @@ use revm::{
     },
     inspector::{InspectorEvmTr, JournalExt},
     interpreter::{interpreter::EthInterpreter, InterpreterResult},
-    primitives::U256, Database, Inspector,
+    primitives::U256,
+    Database, Inspector,
 };
 
 /// Optimism EVM extends the [`Evm`] type with Optimism specific types and logic.

--- a/crates/op-revm/src/handler.rs
+++ b/crates/op-revm/src/handler.rs
@@ -150,13 +150,17 @@ where
         let mut caller_account = journal.load_account_with_code_mut(tx.caller())?.data;
 
         // validates account nonce and code
-        validate_account_nonce_and_code_with_components(&caller_account.account().info, tx, cfg)?;
+        validate_account_nonce_and_code_with_components(
+            &caller_account.account().info,
+            &*tx,
+            cfg,
+        )?;
 
         // check additional cost and deduct it from the caller's balances
         let mut balance = caller_account.account().info.balance;
 
         if !cfg.is_fee_charge_disabled() {
-            let Some(additional_cost) = chain.tx_cost_with_tx(tx, spec) else {
+            let Some(additional_cost) = chain.tx_cost_with_tx(&mut *tx, spec) else {
                 return Err(ERROR::from_string(
                     "[OPTIMISM] Failed to load enveloped transaction.".into(),
                 ));
@@ -171,7 +175,7 @@ where
             balance = new_balance
         }
 
-        let balance = calculate_caller_fee(balance, tx, block, cfg)?;
+        let balance = calculate_caller_fee(balance, &*tx, block, cfg)?;
 
         // make changes to the account
         caller_account.set_balance(balance);

--- a/crates/op-revm/src/handler.rs
+++ b/crates/op-revm/src/handler.rs
@@ -150,11 +150,7 @@ where
         let mut caller_account = journal.load_account_with_code_mut(tx.caller())?.data;
 
         // validates account nonce and code
-        validate_account_nonce_and_code_with_components(
-            &caller_account.account().info,
-            &*tx,
-            cfg,
-        )?;
+        validate_account_nonce_and_code_with_components(&caller_account.account().info, &*tx, cfg)?;
 
         // check additional cost and deduct it from the caller's balances
         let mut balance = caller_account.account().info.balance;

--- a/examples/custom_precompile_journal/src/custom_evm.rs
+++ b/examples/custom_precompile_journal/src/custom_evm.rs
@@ -9,7 +9,7 @@ use revm::{
     },
     inspector::{InspectorEvmTr, JournalExt},
     interpreter::interpreter::EthInterpreter,
-    primitives::hardfork::SpecId,
+    primitives::{hardfork::SpecId, U256},
     Database, Inspector,
 };
 
@@ -54,6 +54,7 @@ where
             instruction: EthInstructions::new_mainnet(),
             precompiles: CustomPrecompileProvider::new_with_spec(SpecId::CANCUN),
             frame_stack: FrameStack::new(),
+            stack_arena: std::sync::Arc::new(std::vec![U256::ZERO; 16 * 1024]),
         })
     }
 }

--- a/examples/erc20_gas/src/handler.rs
+++ b/examples/erc20_gas/src/handler.rs
@@ -54,7 +54,11 @@ where
         // Load caller's account.
         let mut caller_account = journal.load_account_with_code_mut(tx.caller())?;
 
-        validate_account_nonce_and_code_with_components(&caller_account.account().info, tx, cfg)?;
+        validate_account_nonce_and_code_with_components(
+            &caller_account.account().info,
+            &*tx,
+            cfg,
+        )?;
 
         // make changes to the account. Account balance stays the same
         caller_account.touch();
@@ -69,7 +73,7 @@ where
         // load account balance
         let account_balance = journal.sload(TOKEN, account_balance_slot)?.data;
 
-        let new_balance = calculate_caller_fee(account_balance, tx, block, cfg)?;
+        let new_balance = calculate_caller_fee(account_balance, &*tx, block, cfg)?;
 
         // store deducted balance.
         journal.sstore(TOKEN, account_balance_slot, new_balance)?;

--- a/examples/erc20_gas/src/handler.rs
+++ b/examples/erc20_gas/src/handler.rs
@@ -54,11 +54,7 @@ where
         // Load caller's account.
         let mut caller_account = journal.load_account_with_code_mut(tx.caller())?;
 
-        validate_account_nonce_and_code_with_components(
-            &caller_account.account().info,
-            &*tx,
-            cfg,
-        )?;
+        validate_account_nonce_and_code_with_components(&caller_account.account().info, &*tx, cfg)?;
 
         // make changes to the account. Account balance stays the same
         caller_account.touch();

--- a/examples/my_evm/src/evm.rs
+++ b/examples/my_evm/src/evm.rs
@@ -6,7 +6,8 @@ use revm::{
     },
     inspector::{InspectorEvmTr, JournalExt},
     interpreter::interpreter::EthInterpreter,
-    primitives::U256, Database, Inspector,
+    primitives::U256,
+    Database, Inspector,
 };
 
 /// MyEvm variant of the EVM.

--- a/examples/my_evm/src/evm.rs
+++ b/examples/my_evm/src/evm.rs
@@ -6,7 +6,7 @@ use revm::{
     },
     inspector::{InspectorEvmTr, JournalExt},
     interpreter::interpreter::EthInterpreter,
-    Database, Inspector,
+    primitives::U256, Database, Inspector,
 };
 
 /// MyEvm variant of the EVM.
@@ -50,6 +50,7 @@ impl<CTX: ContextTr, INSP> MyEvm<CTX, INSP> {
             instruction: EthInstructions::new_mainnet(),
             precompiles: EthPrecompiles::default(),
             frame_stack: FrameStack::new(),
+            stack_arena: std::sync::Arc::new(std::vec![U256::ZERO; 16 * 1024]),
         })
     }
 }


### PR DESCRIPTION
Threads the pre-allocated arena buffer `(Arc<Vec<U256>>)` from Evm through the frame creation chain. Nested `CALL/CREATE` frames now use `Stack::new_with_arena` instead of allocating a fresh Vec per frame.    

                                                                                                                                                                                                                                   