### PR TITLE
refactor(handler): polish TxValidator API and add preset constructors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3634,6 +3634,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "auto_impl",
+ "bitflags",
  "derive-where",
  "revm-bytecode",
  "revm-context",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3634,7 +3634,6 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "auto_impl",
- "bitflags",
  "derive-where",
  "revm-bytecode",
  "revm-context",
@@ -3710,6 +3709,7 @@ name = "revm-primitives"
 version = "22.0.0"
 dependencies = [
  "alloy-primitives",
+ "bitflags",
  "num_enum",
  "once_cell",
  "serde",

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -29,6 +29,7 @@ state.workspace = true
 bytecode.workspace = true
 
 auto_impl.workspace = true
+bitflags.workspace = true
 derive-where.workspace = true
 
 # Optional
@@ -44,6 +45,7 @@ alloy-signer-local.workspace = true
 default = ["std"]
 std = [
 	"serde?/std",
+	"bitflags/std",
 	"bytecode/std",
 	"context/std",
 	"context-interface/std",
@@ -56,6 +58,7 @@ std = [
 ]
 serde = [
 	"dep:serde",
+	"bitflags/serde",
 	"primitives/serde",
 	"state/serde",
 	"context-interface/serde",

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -29,7 +29,6 @@ state.workspace = true
 bytecode.workspace = true
 
 auto_impl.workspace = true
-bitflags.workspace = true
 derive-where.workspace = true
 
 # Optional
@@ -45,7 +44,6 @@ alloy-signer-local.workspace = true
 default = ["std"]
 std = [
 	"serde?/std",
-	"bitflags/std",
 	"bytecode/std",
 	"context/std",
 	"context-interface/std",
@@ -58,7 +56,6 @@ std = [
 ]
 serde = [
 	"dep:serde",
-	"bitflags/serde",
 	"primitives/serde",
 	"state/serde",
 	"context-interface/serde",

--- a/crates/handler/src/lib.rs
+++ b/crates/handler/src/lib.rs
@@ -5,6 +5,9 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc as std;
 
+// Used in tests only, but kept in dependencies for feature propagation
+use bytecode as _;
+
 // Mainnet related handlers.
 
 /// EVM execution API traits and implementations.

--- a/crates/handler/src/lib.rs
+++ b/crates/handler/src/lib.rs
@@ -43,7 +43,6 @@ pub use item_or_result::{FrameInitOrResult, ItemOrResult};
 pub use mainnet_builder::{MainBuilder, MainContext, MainnetContext, MainnetEvm};
 pub use mainnet_handler::MainnetHandler;
 pub use precompile_provider::{EthPrecompiles, PrecompileProvider};
+pub use primitives::ValidationChecks;
 pub use system_call::{SystemCallCommitEvm, SystemCallEvm, SystemCallTx, SYSTEM_ADDRESS};
-pub use tx_validation::{
-    CallerFee, TxValidator, ValidationChecks, ValidationKind, ValidationParams,
-};
+pub use tx_validation::{CallerFee, TxValidator, ValidationKind, ValidationParams};

--- a/crates/handler/src/lib.rs
+++ b/crates/handler/src/lib.rs
@@ -28,6 +28,8 @@ pub mod pre_execution;
 mod precompile_provider;
 /// System call implementations for special EVM operations.
 pub mod system_call;
+/// Configurable transaction validation with bitflags.
+pub mod tx_validation;
 /// Transaction and environment validation utilities.
 pub mod validation;
 
@@ -42,3 +44,6 @@ pub use mainnet_builder::{MainBuilder, MainContext, MainnetContext, MainnetEvm};
 pub use mainnet_handler::MainnetHandler;
 pub use precompile_provider::{EthPrecompiles, PrecompileProvider};
 pub use system_call::{SystemCallCommitEvm, SystemCallEvm, SystemCallTx, SYSTEM_ADDRESS};
+pub use tx_validation::{
+    CallerFee, TxValidator, ValidationChecks, ValidationKind, ValidationParams,
+};

--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -85,7 +85,8 @@ pub fn validate_account_nonce_and_code(
     is_eip3607_disabled: bool,
     is_nonce_check_disabled: bool,
 ) -> Result<(), InvalidTransaction> {
-    let mut checks = ValidationChecks::ALL;
+    // Start with CALLER checks only (NONCE, BALANCE, EIP3607) - not ALL
+    let mut checks = ValidationChecks::CALLER;
     if is_eip3607_disabled {
         checks.remove(ValidationChecks::EIP3607);
     }

--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -2,7 +2,7 @@
 //!
 //! They handle initial setup of the EVM, call loop and the final return of the EVM
 
-use crate::tx_validation::{self, ValidationChecks, ValidationKind, ValidationParams};
+use crate::tx_validation::{self, ValidationKind, ValidationParams};
 use crate::{EvmTr, PrecompileProvider};
 use context_interface::{
     journaled_state::{account::JournaledAccountTr, JournalTr},
@@ -10,8 +10,7 @@ use context_interface::{
     transaction::{AccessListItemTr, AuthorizationTr, Transaction, TransactionType},
     Block, Cfg, ContextTr, Database,
 };
-use core::cmp::Ordering;
-use primitives::{hardfork::SpecId, AddressMap, HashSet, StorageKey, U256};
+use primitives::{hardfork::SpecId, AddressMap, HashSet, StorageKey, ValidationChecks, U256};
 use state::AccountInfo;
 
 /// Loads and warms accounts for execution, including precompiles and access list.

--- a/crates/handler/src/tx_validation.rs
+++ b/crates/handler/src/tx_validation.rs
@@ -40,7 +40,6 @@
 //!     .enable_gas_checks();
 //! ```
 
-use bitflags::bitflags;
 use context_interface::{
     result::{InvalidHeader, InvalidTransaction},
     transaction::{Transaction, TransactionType},
@@ -48,65 +47,8 @@ use context_interface::{
 };
 use core::cmp::{self, Ordering};
 use interpreter::{instructions::calculate_initial_tx_gas_for_tx, InitialAndFloorGas};
-use primitives::{eip4844, hardfork::SpecId, B256, U256};
+use primitives::{eip4844, hardfork::SpecId, ValidationChecks, B256, U256};
 use state::AccountInfo;
-
-bitflags! {
-    /// Bitflags for configurable transaction validation checks.
-    ///
-    /// Each flag represents a specific validation check that can be enabled or disabled.
-    /// Combine flags using bitwise OR to create custom validation configurations.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
-    pub struct ValidationChecks: u16 {
-        /// Validate chain ID matches (EIP-155).
-        const CHAIN_ID = 1 << 0;
-        /// Validate transaction gas limit against cap (EIP-7825).
-        const TX_GAS_LIMIT = 1 << 1;
-        /// Validate gas price against base fee.
-        const BASE_FEE = 1 << 2;
-        /// Validate priority fee for EIP-1559+ transactions.
-        const PRIORITY_FEE = 1 << 3;
-        /// Validate blob fee for EIP-4844 transactions.
-        const BLOB_FEE = 1 << 4;
-        /// Validate authorization list for EIP-7702 transactions.
-        const AUTH_LIST = 1 << 5;
-        /// Validate transaction gas limit against block gas limit.
-        const BLOCK_GAS_LIMIT = 1 << 6;
-        /// Validate initcode size for contract creation (EIP-3860).
-        const MAX_INITCODE_SIZE = 1 << 7;
-        /// Validate nonce matches account state.
-        const NONCE = 1 << 8;
-        /// Validate caller balance for transaction cost.
-        const BALANCE = 1 << 9;
-        /// Validate EIP-3607 (reject senders with deployed code).
-        const EIP3607 = 1 << 10;
-        /// Validate EIP-7623 floor gas.
-        const EIP7623 = 1 << 11;
-        /// Validate block header fields (prevrandao, excess_blob_gas).
-        const HEADER = 1 << 12;
-
-        /// All gas and fee related checks.
-        const GAS_FEES = Self::TX_GAS_LIMIT.bits()
-            | Self::BASE_FEE.bits()
-            | Self::PRIORITY_FEE.bits()
-            | Self::BLOB_FEE.bits()
-            | Self::BLOCK_GAS_LIMIT.bits()
-            | Self::EIP7623.bits();
-
-        /// All stateless transaction checks (no account state needed).
-        const TX_STATELESS = Self::CHAIN_ID.bits()
-            | Self::GAS_FEES.bits()
-            | Self::AUTH_LIST.bits()
-            | Self::MAX_INITCODE_SIZE.bits()
-            | Self::HEADER.bits();
-
-        /// All caller/state checks.
-        const CALLER = Self::NONCE.bits() | Self::BALANCE.bits() | Self::EIP3607.bits();
-
-        /// All validation checks enabled.
-        const ALL = Self::TX_STATELESS.bits() | Self::CALLER.bits();
-    }
-}
 
 /// Transaction validator with configurable checks.
 ///
@@ -234,47 +176,27 @@ impl TxValidator {
     ///
     /// This is the recommended way to create a validator when you have
     /// access to the EVM context.
+    #[inline]
     pub fn from_cfg_and_block(cfg: &impl Cfg, block: &impl Block) -> Self {
-        let mut validator = Self {
+        // Get disabled checks in a single call (pre-computed or aggregated in Cfg)
+        let disabled = cfg.disabled_validation_checks();
+        let checks = ValidationChecks::ALL - disabled;
+
+        Self {
             spec: cfg.spec().into(),
             chain_id: cfg.chain_id(),
-            base_fee: Some(block.basefee() as u128),
+            base_fee: if disabled.contains(ValidationChecks::BASE_FEE) {
+                None
+            } else {
+                Some(block.basefee() as u128)
+            },
             blob_gasprice: block.blob_gasprice(),
             tx_gas_limit_cap: cfg.tx_gas_limit_cap(),
             block_gas_limit: block.gas_limit(),
             max_blobs_per_tx: cfg.max_blobs_per_tx(),
             max_initcode_size: cfg.max_initcode_size(),
-            checks: ValidationChecks::ALL,
-        };
-
-        // Apply cfg skip flags
-        if !cfg.tx_chain_id_check() {
-            validator.checks.remove(ValidationChecks::CHAIN_ID);
+            checks,
         }
-        if cfg.is_base_fee_check_disabled() {
-            validator.checks.remove(ValidationChecks::BASE_FEE);
-            validator.base_fee = None;
-        }
-        if cfg.is_priority_fee_check_disabled() {
-            validator.checks.remove(ValidationChecks::PRIORITY_FEE);
-        }
-        if cfg.is_block_gas_limit_disabled() {
-            validator.checks.remove(ValidationChecks::BLOCK_GAS_LIMIT);
-        }
-        if cfg.is_nonce_check_disabled() {
-            validator.checks.remove(ValidationChecks::NONCE);
-        }
-        if cfg.is_balance_check_disabled() {
-            validator.checks.remove(ValidationChecks::BALANCE);
-        }
-        if cfg.is_eip3607_disabled() {
-            validator.checks.remove(ValidationChecks::EIP3607);
-        }
-        if cfg.is_eip7623_disabled() {
-            validator.checks.remove(ValidationChecks::EIP7623);
-        }
-
-        validator
     }
 
     // === Builder methods for configuration ===
@@ -633,7 +555,8 @@ impl TxValidator {
         }
 
         // Transaction gas limit cap (EIP-7825)
-        if self.should_check(ValidationChecks::TX_GAS_LIMIT) && tx.gas_limit() > self.tx_gas_limit_cap
+        if self.should_check(ValidationChecks::TX_GAS_LIMIT)
+            && tx.gas_limit() > self.tx_gas_limit_cap
         {
             return Err(InvalidTransaction::TxGasLimitGreaterThanCap {
                 gas_limit: tx.gas_limit(),
@@ -665,7 +588,10 @@ impl TxValidator {
 
     /// Calculate initial and floor gas for the transaction.
     #[inline]
-    pub fn initial_gas(&self, tx: &impl Transaction) -> Result<InitialAndFloorGas, InvalidTransaction> {
+    pub fn initial_gas(
+        &self,
+        tx: &impl Transaction,
+    ) -> Result<InitialAndFloorGas, InvalidTransaction> {
         let mut gas = calculate_initial_tx_gas_for_tx(tx, self.spec);
 
         if !self.should_check(ValidationChecks::EIP7623) {
@@ -827,7 +753,8 @@ impl TxValidator {
                     return Err(InvalidTransaction::Eip7702NotSupported);
                 }
                 self.validate_eip1559_fees(tx)?;
-                if self.should_check(ValidationChecks::AUTH_LIST) && tx.authorization_list_len() == 0
+                if self.should_check(ValidationChecks::AUTH_LIST)
+                    && tx.authorization_list_len() == 0
                 {
                     return Err(InvalidTransaction::EmptyAuthorizationList);
                 }

--- a/crates/handler/src/tx_validation.rs
+++ b/crates/handler/src/tx_validation.rs
@@ -1,0 +1,970 @@
+//! Transaction validation logic extracted from Handler.
+//!
+//! This module provides configurable transaction validation through the [`TxValidator`] struct.
+//! It is designed to be reusable outside of the full EVM execution context, such as in
+//! transaction pools or block builders.
+//!
+//! # Quick Start
+//!
+//! ```ignore
+//! use revm_handler::TxValidator;
+//! use primitives::hardfork::SpecId;
+//!
+//! // Create validator from EVM context
+//! let validator = TxValidator::from_cfg_and_block(&cfg, &block);
+//!
+//! // Validate transaction (stateless)
+//! validator.validate_tx(&tx)?;
+//! let gas = validator.initial_gas(&tx)?;
+//!
+//! // Validate against account state
+//! validator.validate_caller(&caller_info, tx.nonce())?;
+//! let fee = validator.caller_fee(caller_balance, &tx)?;
+//! ```
+//!
+//! # Customization
+//!
+//! ```ignore
+//! // Skip all validation (system/deposit transactions)
+//! let validator = TxValidator::new(SpecId::CANCUN).skip_all();
+//!
+//! // Skip specific checks
+//! let validator = TxValidator::new(SpecId::CANCUN)
+//!     .skip_nonce_check()
+//!     .skip_balance_check();
+//!
+//! // Enable only specific checks
+//! let validator = TxValidator::new(SpecId::CANCUN)
+//!     .skip_all()
+//!     .enable_chain_id_check()
+//!     .enable_gas_checks();
+//! ```
+
+use bitflags::bitflags;
+use context_interface::{
+    result::{InvalidHeader, InvalidTransaction},
+    transaction::{Transaction, TransactionType},
+    Block, Cfg,
+};
+use core::cmp::{self, Ordering};
+use interpreter::{instructions::calculate_initial_tx_gas_for_tx, InitialAndFloorGas};
+use primitives::{eip4844, hardfork::SpecId, B256, U256};
+use state::AccountInfo;
+
+bitflags! {
+    /// Bitflags for configurable transaction validation checks.
+    ///
+    /// Each flag represents a specific validation check that can be enabled or disabled.
+    /// Combine flags using bitwise OR to create custom validation configurations.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+    pub struct ValidationChecks: u16 {
+        /// Validate chain ID matches (EIP-155).
+        const CHAIN_ID = 1 << 0;
+        /// Validate transaction gas limit against cap (EIP-7825).
+        const TX_GAS_LIMIT = 1 << 1;
+        /// Validate gas price against base fee.
+        const BASE_FEE = 1 << 2;
+        /// Validate priority fee for EIP-1559+ transactions.
+        const PRIORITY_FEE = 1 << 3;
+        /// Validate blob fee for EIP-4844 transactions.
+        const BLOB_FEE = 1 << 4;
+        /// Validate authorization list for EIP-7702 transactions.
+        const AUTH_LIST = 1 << 5;
+        /// Validate transaction gas limit against block gas limit.
+        const BLOCK_GAS_LIMIT = 1 << 6;
+        /// Validate initcode size for contract creation (EIP-3860).
+        const MAX_INITCODE_SIZE = 1 << 7;
+        /// Validate nonce matches account state.
+        const NONCE = 1 << 8;
+        /// Validate caller balance for transaction cost.
+        const BALANCE = 1 << 9;
+        /// Validate EIP-3607 (reject senders with deployed code).
+        const EIP3607 = 1 << 10;
+        /// Validate EIP-7623 floor gas.
+        const EIP7623 = 1 << 11;
+        /// Validate block header fields (prevrandao, excess_blob_gas).
+        const HEADER = 1 << 12;
+
+        /// All stateless transaction checks (no account state needed).
+        const TX_STATELESS = Self::CHAIN_ID.bits()
+            | Self::TX_GAS_LIMIT.bits()
+            | Self::BASE_FEE.bits()
+            | Self::PRIORITY_FEE.bits()
+            | Self::BLOB_FEE.bits()
+            | Self::AUTH_LIST.bits()
+            | Self::BLOCK_GAS_LIMIT.bits()
+            | Self::MAX_INITCODE_SIZE.bits()
+            | Self::EIP7623.bits()
+            | Self::HEADER.bits();
+
+        /// All caller/state checks.
+        const CALLER = Self::NONCE.bits() | Self::BALANCE.bits() | Self::EIP3607.bits();
+
+        /// All validation checks enabled.
+        const ALL = Self::TX_STATELESS.bits() | Self::CALLER.bits();
+    }
+}
+
+/// Transaction validator with configurable checks.
+///
+/// This struct provides a fluent API for validating Ethereum transactions.
+/// It can be configured to skip certain checks (e.g., for L2 deposit transactions)
+/// or to validate only specific aspects of a transaction.
+///
+/// # Example
+///
+/// ```ignore
+/// // Standard validation
+/// let validator = TxValidator::from_cfg_and_block(&cfg, &block);
+/// validator.validate_tx(&tx)?;
+///
+/// // Optimism deposit - skip fee checks
+/// let validator = TxValidator::new(SpecId::CANCUN)
+///     .skip_base_fee_check()
+///     .skip_priority_fee_check()
+///     .skip_balance_check();
+/// ```
+#[derive(Debug, Clone)]
+pub struct TxValidator {
+    /// Ethereum specification version.
+    pub spec: SpecId,
+    /// Chain ID for validation.
+    pub chain_id: u64,
+    /// Base fee from block (None skips base fee check).
+    pub base_fee: Option<u128>,
+    /// Blob gas price from block.
+    pub blob_gasprice: Option<u128>,
+    /// Transaction gas limit cap (EIP-7825).
+    pub tx_gas_limit_cap: u64,
+    /// Block gas limit.
+    pub block_gas_limit: u64,
+    /// Maximum blobs per transaction.
+    pub max_blobs_per_tx: Option<u64>,
+    /// Maximum initcode size.
+    pub max_initcode_size: usize,
+    /// Enabled validation checks.
+    pub checks: ValidationChecks,
+}
+
+impl Default for TxValidator {
+    fn default() -> Self {
+        Self {
+            spec: SpecId::PRAGUE,
+            chain_id: 1,
+            base_fee: None,
+            blob_gasprice: None,
+            tx_gas_limit_cap: u64::MAX,
+            block_gas_limit: u64::MAX,
+            max_blobs_per_tx: None,
+            max_initcode_size: primitives::eip3860::MAX_INITCODE_SIZE,
+            checks: ValidationChecks::ALL,
+        }
+    }
+}
+
+impl TxValidator {
+    /// Create a new validator for the given spec with all checks enabled.
+    pub fn new(spec: SpecId) -> Self {
+        Self {
+            spec,
+            ..Default::default()
+        }
+    }
+
+    /// Create validator from Cfg and Block traits.
+    ///
+    /// This is the recommended way to create a validator when you have
+    /// access to the EVM context.
+    pub fn from_cfg_and_block(cfg: &impl Cfg, block: &impl Block) -> Self {
+        let mut validator = Self {
+            spec: cfg.spec().into(),
+            chain_id: cfg.chain_id(),
+            base_fee: Some(block.basefee() as u128),
+            blob_gasprice: block.blob_gasprice(),
+            tx_gas_limit_cap: cfg.tx_gas_limit_cap(),
+            block_gas_limit: block.gas_limit(),
+            max_blobs_per_tx: cfg.max_blobs_per_tx(),
+            max_initcode_size: cfg.max_initcode_size(),
+            checks: ValidationChecks::ALL,
+        };
+
+        // Apply cfg skip flags
+        if !cfg.tx_chain_id_check() {
+            validator.checks.remove(ValidationChecks::CHAIN_ID);
+        }
+        if cfg.is_base_fee_check_disabled() {
+            validator.checks.remove(ValidationChecks::BASE_FEE);
+            validator.base_fee = None;
+        }
+        if cfg.is_priority_fee_check_disabled() {
+            validator.checks.remove(ValidationChecks::PRIORITY_FEE);
+        }
+        if cfg.is_block_gas_limit_disabled() {
+            validator.checks.remove(ValidationChecks::BLOCK_GAS_LIMIT);
+        }
+        if cfg.is_nonce_check_disabled() {
+            validator.checks.remove(ValidationChecks::NONCE);
+        }
+        if cfg.is_balance_check_disabled() {
+            validator.checks.remove(ValidationChecks::BALANCE);
+        }
+        if cfg.is_eip3607_disabled() {
+            validator.checks.remove(ValidationChecks::EIP3607);
+        }
+        if cfg.is_eip7623_disabled() {
+            validator.checks.remove(ValidationChecks::EIP7623);
+        }
+
+        validator
+    }
+
+    // === Builder methods for configuration ===
+
+    /// Set the chain ID.
+    pub fn with_chain_id(mut self, chain_id: u64) -> Self {
+        self.chain_id = chain_id;
+        self
+    }
+
+    /// Set the base fee.
+    pub fn with_base_fee(mut self, base_fee: u128) -> Self {
+        self.base_fee = Some(base_fee);
+        self
+    }
+
+    /// Set the blob gas price.
+    pub fn with_blob_gasprice(mut self, price: u128) -> Self {
+        self.blob_gasprice = Some(price);
+        self
+    }
+
+    /// Set the block gas limit.
+    pub fn with_block_gas_limit(mut self, limit: u64) -> Self {
+        self.block_gas_limit = limit;
+        self
+    }
+
+    /// Set the transaction gas limit cap.
+    pub fn with_tx_gas_limit_cap(mut self, cap: u64) -> Self {
+        self.tx_gas_limit_cap = cap;
+        self
+    }
+
+    /// Set maximum blobs per transaction.
+    pub fn with_max_blobs(mut self, max: u64) -> Self {
+        self.max_blobs_per_tx = Some(max);
+        self
+    }
+
+    /// Set maximum initcode size.
+    pub fn with_max_initcode_size(mut self, size: usize) -> Self {
+        self.max_initcode_size = size;
+        self
+    }
+
+    // === Skip methods ===
+
+    /// Skip all validation checks.
+    pub fn skip_all(mut self) -> Self {
+        self.checks = ValidationChecks::empty();
+        self
+    }
+
+    /// Skip chain ID validation.
+    pub fn skip_chain_id_check(mut self) -> Self {
+        self.checks.remove(ValidationChecks::CHAIN_ID);
+        self
+    }
+
+    /// Skip base fee validation.
+    pub fn skip_base_fee_check(mut self) -> Self {
+        self.checks.remove(ValidationChecks::BASE_FEE);
+        self
+    }
+
+    /// Skip priority fee validation.
+    pub fn skip_priority_fee_check(mut self) -> Self {
+        self.checks.remove(ValidationChecks::PRIORITY_FEE);
+        self
+    }
+
+    /// Skip nonce validation.
+    pub fn skip_nonce_check(mut self) -> Self {
+        self.checks.remove(ValidationChecks::NONCE);
+        self
+    }
+
+    /// Skip balance validation.
+    pub fn skip_balance_check(mut self) -> Self {
+        self.checks.remove(ValidationChecks::BALANCE);
+        self
+    }
+
+    /// Skip EIP-3607 code check.
+    pub fn skip_eip3607_check(mut self) -> Self {
+        self.checks.remove(ValidationChecks::EIP3607);
+        self
+    }
+
+    /// Skip block gas limit check.
+    pub fn skip_block_gas_limit_check(mut self) -> Self {
+        self.checks.remove(ValidationChecks::BLOCK_GAS_LIMIT);
+        self
+    }
+
+    /// Skip EIP-7623 floor gas check.
+    pub fn skip_eip7623_check(mut self) -> Self {
+        self.checks.remove(ValidationChecks::EIP7623);
+        self
+    }
+
+    /// Skip header validation.
+    pub fn skip_header_check(mut self) -> Self {
+        self.checks.remove(ValidationChecks::HEADER);
+        self
+    }
+
+    // === Enable methods (for use after skip_all) ===
+
+    /// Enable chain ID validation.
+    pub fn enable_chain_id_check(mut self) -> Self {
+        self.checks.insert(ValidationChecks::CHAIN_ID);
+        self
+    }
+
+    /// Enable all gas-related checks.
+    pub fn enable_gas_checks(mut self) -> Self {
+        self.checks.insert(ValidationChecks::TX_GAS_LIMIT);
+        self.checks.insert(ValidationChecks::BASE_FEE);
+        self.checks.insert(ValidationChecks::PRIORITY_FEE);
+        self.checks.insert(ValidationChecks::BLOCK_GAS_LIMIT);
+        self
+    }
+
+    /// Enable nonce validation.
+    pub fn enable_nonce_check(mut self) -> Self {
+        self.checks.insert(ValidationChecks::NONCE);
+        self
+    }
+
+    /// Enable balance validation.
+    pub fn enable_balance_check(mut self) -> Self {
+        self.checks.insert(ValidationChecks::BALANCE);
+        self
+    }
+
+    /// Set custom validation checks.
+    pub fn with_checks(mut self, checks: ValidationChecks) -> Self {
+        self.checks = checks;
+        self
+    }
+
+    // === Validation methods ===
+
+    /// Check if a specific validation is enabled.
+    #[inline]
+    pub fn should_check(&self, check: ValidationChecks) -> bool {
+        self.checks.contains(check)
+    }
+
+    /// Validate block header fields.
+    ///
+    /// Checks that required header fields are present for the current spec:
+    /// - `prevrandao` is required after the Merge
+    /// - `excess_blob_gas` is required after Cancun
+    pub fn validate_header(&self, block: &impl Block) -> Result<(), InvalidHeader> {
+        if !self.should_check(ValidationChecks::HEADER) {
+            return Ok(());
+        }
+
+        if self.spec.is_enabled_in(SpecId::MERGE) && block.prevrandao().is_none() {
+            return Err(InvalidHeader::PrevrandaoNotSet);
+        }
+
+        if self.spec.is_enabled_in(SpecId::CANCUN) && block.blob_excess_gas_and_price().is_none() {
+            return Err(InvalidHeader::ExcessBlobGasNotSet);
+        }
+
+        Ok(())
+    }
+
+    /// Validate transaction (stateless validation).
+    ///
+    /// This validates the transaction without requiring account state:
+    /// - Chain ID
+    /// - Gas limits and fees
+    /// - Transaction type support
+    /// - Blob and authorization list validation
+    pub fn validate_tx(&self, tx: &impl Transaction) -> Result<(), InvalidTransaction> {
+        if self.checks.is_empty() {
+            return Ok(());
+        }
+
+        let tx_type = TransactionType::from(tx.tx_type());
+
+        // Chain ID validation (EIP-155)
+        if self.should_check(ValidationChecks::CHAIN_ID) {
+            self.validate_chain_id(tx, tx_type)?;
+        }
+
+        // Transaction gas limit cap (EIP-7825)
+        if self.should_check(ValidationChecks::TX_GAS_LIMIT) && tx.gas_limit() > self.tx_gas_limit_cap
+        {
+            return Err(InvalidTransaction::TxGasLimitGreaterThanCap {
+                gas_limit: tx.gas_limit(),
+                cap: self.tx_gas_limit_cap,
+            });
+        }
+
+        // Type-specific validation
+        self.validate_tx_type(tx, tx_type)?;
+
+        // Block gas limit check
+        if self.should_check(ValidationChecks::BLOCK_GAS_LIMIT)
+            && tx.gas_limit() > self.block_gas_limit
+        {
+            return Err(InvalidTransaction::CallerGasLimitMoreThanBlock);
+        }
+
+        // Initcode size limit (EIP-3860)
+        if self.should_check(ValidationChecks::MAX_INITCODE_SIZE)
+            && self.spec.is_enabled_in(SpecId::SHANGHAI)
+            && tx.kind().is_create()
+            && tx.input().len() > self.max_initcode_size
+        {
+            return Err(InvalidTransaction::CreateInitCodeSizeLimit);
+        }
+
+        Ok(())
+    }
+
+    /// Calculate initial and floor gas for the transaction.
+    pub fn initial_gas(&self, tx: &impl Transaction) -> Result<InitialAndFloorGas, InvalidTransaction> {
+        let mut gas = calculate_initial_tx_gas_for_tx(tx, self.spec);
+
+        if !self.should_check(ValidationChecks::EIP7623) {
+            gas.floor_gas = 0;
+        }
+
+        if gas.initial_gas > tx.gas_limit() {
+            return Err(InvalidTransaction::CallGasCostMoreThanGasLimit {
+                gas_limit: tx.gas_limit(),
+                initial_gas: gas.initial_gas,
+            });
+        }
+
+        if self.spec.is_enabled_in(SpecId::PRAGUE) && gas.floor_gas > tx.gas_limit() {
+            return Err(InvalidTransaction::GasFloorMoreThanGasLimit {
+                gas_floor: gas.floor_gas,
+                gas_limit: tx.gas_limit(),
+            });
+        }
+
+        Ok(gas)
+    }
+
+    /// Validate caller account state (nonce, EIP-3607 code check).
+    pub fn validate_caller(
+        &self,
+        caller_info: &AccountInfo,
+        tx_nonce: u64,
+    ) -> Result<(), InvalidTransaction> {
+        // EIP-3607: Reject transactions from senders with deployed code
+        if self.should_check(ValidationChecks::EIP3607) {
+            let bytecode = match caller_info.code.as_ref() {
+                Some(code) => code,
+                None => &bytecode::Bytecode::default(),
+            };
+
+            if !bytecode.is_empty() && !bytecode.is_eip7702() {
+                return Err(InvalidTransaction::RejectCallerWithCode);
+            }
+        }
+
+        // Nonce validation
+        if self.should_check(ValidationChecks::NONCE) {
+            let state = caller_info.nonce;
+            match tx_nonce.cmp(&state) {
+                Ordering::Greater => {
+                    return Err(InvalidTransaction::NonceTooHigh {
+                        tx: tx_nonce,
+                        state,
+                    });
+                }
+                Ordering::Less => {
+                    return Err(InvalidTransaction::NonceTooLow {
+                        tx: tx_nonce,
+                        state,
+                    });
+                }
+                _ => {}
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Calculate fee to deduct from caller.
+    ///
+    /// Returns the new balance and the gas fee to deduct.
+    /// Does NOT mutate state - the caller is responsible for applying the balance change.
+    pub fn caller_fee(
+        &self,
+        caller_balance: U256,
+        tx: &impl Transaction,
+    ) -> Result<CallerFee, InvalidTransaction> {
+        let basefee = self.base_fee.unwrap_or(0);
+        let blob_price = self.blob_gasprice.unwrap_or(0);
+
+        if self.should_check(ValidationChecks::BALANCE) {
+            tx.ensure_enough_balance(caller_balance)?;
+        }
+
+        let effective_balance_spending = tx
+            .effective_balance_spending(basefee, blob_price)
+            .expect("effective balance is always smaller than max balance so it can't overflow");
+
+        let gas_balance_spending = effective_balance_spending - tx.value();
+
+        let mut new_balance = caller_balance.saturating_sub(gas_balance_spending);
+
+        if !self.should_check(ValidationChecks::BALANCE) {
+            new_balance = new_balance.max(tx.value());
+        }
+
+        Ok(CallerFee {
+            gas_fee_to_deduct: gas_balance_spending,
+            new_balance,
+        })
+    }
+
+    // === Internal helpers ===
+
+    fn validate_chain_id(
+        &self,
+        tx: &impl Transaction,
+        tx_type: TransactionType,
+    ) -> Result<(), InvalidTransaction> {
+        if let Some(tx_chain_id) = tx.chain_id() {
+            if tx_chain_id != self.chain_id {
+                return Err(InvalidTransaction::InvalidChainId);
+            }
+        } else if !tx_type.is_legacy() && !tx_type.is_custom() {
+            return Err(InvalidTransaction::MissingChainId);
+        }
+        Ok(())
+    }
+
+    fn validate_tx_type(
+        &self,
+        tx: &impl Transaction,
+        tx_type: TransactionType,
+    ) -> Result<(), InvalidTransaction> {
+        match tx_type {
+            TransactionType::Legacy => {
+                if self.should_check(ValidationChecks::BASE_FEE) {
+                    validate_legacy_gas_price(tx.gas_price(), self.base_fee)?;
+                }
+            }
+            TransactionType::Eip2930 => {
+                if !self.spec.is_enabled_in(SpecId::BERLIN) {
+                    return Err(InvalidTransaction::Eip2930NotSupported);
+                }
+                if self.should_check(ValidationChecks::BASE_FEE) {
+                    validate_legacy_gas_price(tx.gas_price(), self.base_fee)?;
+                }
+            }
+            TransactionType::Eip1559 => {
+                if !self.spec.is_enabled_in(SpecId::LONDON) {
+                    return Err(InvalidTransaction::Eip1559NotSupported);
+                }
+                self.validate_eip1559_fees(tx)?;
+            }
+            TransactionType::Eip4844 => {
+                if !self.spec.is_enabled_in(SpecId::CANCUN) {
+                    return Err(InvalidTransaction::Eip4844NotSupported);
+                }
+                self.validate_eip1559_fees(tx)?;
+                if self.should_check(ValidationChecks::BLOB_FEE) {
+                    validate_eip4844_tx(
+                        tx.blob_versioned_hashes(),
+                        tx.max_fee_per_blob_gas(),
+                        self.blob_gasprice.unwrap_or(0),
+                        self.max_blobs_per_tx,
+                    )?;
+                }
+            }
+            TransactionType::Eip7702 => {
+                if !self.spec.is_enabled_in(SpecId::PRAGUE) {
+                    return Err(InvalidTransaction::Eip7702NotSupported);
+                }
+                self.validate_eip1559_fees(tx)?;
+                if self.should_check(ValidationChecks::AUTH_LIST) && tx.authorization_list_len() == 0
+                {
+                    return Err(InvalidTransaction::EmptyAuthorizationList);
+                }
+            }
+            TransactionType::Custom => {}
+        }
+        Ok(())
+    }
+
+    fn validate_eip1559_fees(&self, tx: &impl Transaction) -> Result<(), InvalidTransaction> {
+        let check_base_fee = self.should_check(ValidationChecks::BASE_FEE);
+        let check_priority_fee = self.should_check(ValidationChecks::PRIORITY_FEE);
+
+        if !check_base_fee && !check_priority_fee {
+            return Ok(());
+        }
+
+        validate_priority_fee(
+            tx.max_fee_per_gas(),
+            tx.max_priority_fee_per_gas().unwrap_or_default(),
+            if check_base_fee { self.base_fee } else { None },
+            !check_priority_fee,
+        )
+    }
+}
+
+// === Standalone helper functions (kept for backward compatibility) ===
+
+/// Validate legacy transaction gas price against basefee.
+#[inline]
+pub fn validate_legacy_gas_price(
+    gas_price: u128,
+    base_fee: Option<u128>,
+) -> Result<(), InvalidTransaction> {
+    if let Some(base_fee) = base_fee {
+        if gas_price < base_fee {
+            return Err(InvalidTransaction::GasPriceLessThanBasefee);
+        }
+    }
+    Ok(())
+}
+
+/// Validate priority fee for EIP-1559+ transactions.
+#[inline]
+pub fn validate_priority_fee(
+    max_fee: u128,
+    max_priority_fee: u128,
+    base_fee: Option<u128>,
+    skip_priority_check: bool,
+) -> Result<(), InvalidTransaction> {
+    if !skip_priority_check && max_priority_fee > max_fee {
+        return Err(InvalidTransaction::PriorityFeeGreaterThanMaxFee);
+    }
+
+    if let Some(base_fee) = base_fee {
+        let effective_gas_price = cmp::min(max_fee, base_fee.saturating_add(max_priority_fee));
+        if effective_gas_price < base_fee {
+            return Err(InvalidTransaction::GasPriceLessThanBasefee);
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate EIP-4844 blob transaction.
+#[inline]
+pub fn validate_eip4844_tx(
+    blobs: &[B256],
+    max_blob_fee: u128,
+    block_blob_gas_price: u128,
+    max_blobs: Option<u64>,
+) -> Result<(), InvalidTransaction> {
+    if block_blob_gas_price > max_blob_fee {
+        return Err(InvalidTransaction::BlobGasPriceGreaterThanMax {
+            block_blob_gas_price,
+            tx_max_fee_per_blob_gas: max_blob_fee,
+        });
+    }
+
+    if blobs.is_empty() {
+        return Err(InvalidTransaction::EmptyBlobs);
+    }
+
+    for blob in blobs {
+        if blob[0] != eip4844::VERSIONED_HASH_VERSION_KZG {
+            return Err(InvalidTransaction::BlobVersionNotSupported);
+        }
+    }
+
+    if let Some(max_blobs) = max_blobs {
+        if blobs.len() > max_blobs as usize {
+            return Err(InvalidTransaction::TooManyBlobs {
+                have: blobs.len(),
+                max: max_blobs as usize,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Result of fee calculation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CallerFee {
+    /// The gas fee amount that was deducted.
+    pub gas_fee_to_deduct: U256,
+    /// The new balance after deducting gas fees.
+    pub new_balance: U256,
+}
+
+// === Legacy API (for backward compatibility with validation.rs and pre_execution.rs) ===
+
+/// Specifies how transaction validation should be performed.
+///
+/// This is kept for backward compatibility. New code should use [`TxValidator`] directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum ValidationKind {
+    /// Skip all validation checks.
+    None,
+    /// Perform validation based on transaction type (default).
+    #[default]
+    ByTxType,
+    /// Perform custom validation with specific checks enabled.
+    Custom(ValidationChecks),
+}
+
+impl ValidationKind {
+    /// Returns true if the given check should be performed.
+    #[inline]
+    pub fn should_check(&self, check: ValidationChecks) -> bool {
+        match self {
+            ValidationKind::None => false,
+            ValidationKind::ByTxType => true,
+            ValidationKind::Custom(checks) => checks.contains(check),
+        }
+    }
+}
+
+/// Legacy parameters struct for backward compatibility.
+#[derive(Debug, Clone)]
+pub struct ValidationParams {
+    /// Ethereum specification version.
+    pub spec: SpecId,
+    /// Chain ID for validation.
+    pub chain_id: u64,
+    /// Base fee from block.
+    pub base_fee: Option<u128>,
+    /// Blob gas price from block.
+    pub blob_gasprice: Option<u128>,
+    /// Transaction gas limit cap.
+    pub tx_gas_limit_cap: u64,
+    /// Block gas limit.
+    pub block_gas_limit: u64,
+    /// Maximum blobs per transaction.
+    pub max_blobs_per_tx: Option<u64>,
+    /// Maximum initcode size.
+    pub max_initcode_size: usize,
+    /// Validation kind to use.
+    pub validation_kind: ValidationKind,
+}
+
+impl ValidationParams {
+    /// Create ValidationParams from Cfg and Block traits.
+    pub fn from_cfg_and_block(cfg: &impl Cfg, block: &impl Block) -> Self {
+        let validator = TxValidator::from_cfg_and_block(cfg, block);
+        Self {
+            spec: validator.spec,
+            chain_id: validator.chain_id,
+            base_fee: validator.base_fee,
+            blob_gasprice: validator.blob_gasprice,
+            tx_gas_limit_cap: validator.tx_gas_limit_cap,
+            block_gas_limit: validator.block_gas_limit,
+            max_blobs_per_tx: validator.max_blobs_per_tx,
+            max_initcode_size: validator.max_initcode_size,
+            validation_kind: if validator.checks == ValidationChecks::ALL {
+                ValidationKind::ByTxType
+            } else if validator.checks.is_empty() {
+                ValidationKind::None
+            } else {
+                ValidationKind::Custom(validator.checks)
+            },
+        }
+    }
+
+    /// Create params for caller validation from Cfg trait.
+    pub fn caller_params_from_cfg(cfg: &impl Cfg) -> Self {
+        let mut checks = ValidationChecks::CALLER;
+
+        if cfg.is_nonce_check_disabled() {
+            checks.remove(ValidationChecks::NONCE);
+        }
+        if cfg.is_balance_check_disabled() {
+            checks.remove(ValidationChecks::BALANCE);
+        }
+        if cfg.is_eip3607_disabled() {
+            checks.remove(ValidationChecks::EIP3607);
+        }
+
+        Self {
+            spec: cfg.spec().into(),
+            chain_id: cfg.chain_id(),
+            base_fee: None,
+            blob_gasprice: None,
+            tx_gas_limit_cap: u64::MAX,
+            block_gas_limit: u64::MAX,
+            max_blobs_per_tx: None,
+            max_initcode_size: usize::MAX,
+            validation_kind: if checks == ValidationChecks::CALLER {
+                ValidationKind::ByTxType
+            } else if checks.is_empty() {
+                ValidationKind::None
+            } else {
+                ValidationKind::Custom(checks)
+            },
+        }
+    }
+}
+
+// === Legacy standalone functions ===
+
+/// Validate block header fields.
+pub fn validate_block_header(
+    spec: SpecId,
+    block: &impl Block,
+    kind: ValidationKind,
+) -> Result<(), InvalidHeader> {
+    let validator = TxValidator {
+        spec,
+        checks: match kind {
+            ValidationKind::None => ValidationChecks::empty(),
+            ValidationKind::ByTxType => ValidationChecks::ALL,
+            ValidationKind::Custom(c) => c,
+        },
+        ..Default::default()
+    };
+    validator.validate_header(block)
+}
+
+/// Validate transaction against parameters.
+pub fn validate_tx(
+    tx: &impl Transaction,
+    params: &ValidationParams,
+) -> Result<(), InvalidTransaction> {
+    let validator = TxValidator {
+        spec: params.spec,
+        chain_id: params.chain_id,
+        base_fee: params.base_fee,
+        blob_gasprice: params.blob_gasprice,
+        tx_gas_limit_cap: params.tx_gas_limit_cap,
+        block_gas_limit: params.block_gas_limit,
+        max_blobs_per_tx: params.max_blobs_per_tx,
+        max_initcode_size: params.max_initcode_size,
+        checks: match params.validation_kind {
+            ValidationKind::None => ValidationChecks::empty(),
+            ValidationKind::ByTxType => ValidationChecks::ALL,
+            ValidationKind::Custom(c) => c,
+        },
+    };
+    validator.validate_tx(tx)
+}
+
+/// Calculate initial and floor gas.
+pub fn calculate_initial_gas(
+    tx: &impl Transaction,
+    spec: SpecId,
+    skip_eip7623: bool,
+) -> Result<InitialAndFloorGas, InvalidTransaction> {
+    let mut validator = TxValidator::new(spec);
+    if skip_eip7623 {
+        validator = validator.skip_eip7623_check();
+    }
+    validator.initial_gas(tx)
+}
+
+/// Validate caller account state.
+pub fn validate_caller(
+    caller_info: &AccountInfo,
+    tx_nonce: u64,
+    kind: ValidationKind,
+) -> Result<(), InvalidTransaction> {
+    let validator = TxValidator {
+        checks: match kind {
+            ValidationKind::None => ValidationChecks::empty(),
+            ValidationKind::ByTxType => ValidationChecks::ALL,
+            ValidationKind::Custom(c) => c,
+        },
+        ..Default::default()
+    };
+    validator.validate_caller(caller_info, tx_nonce)
+}
+
+/// Calculate fee to deduct from caller.
+pub fn calculate_caller_fee(
+    caller_balance: U256,
+    tx: &impl Transaction,
+    block: &impl Block,
+    skip_balance_check: bool,
+) -> Result<CallerFee, InvalidTransaction> {
+    let mut validator = TxValidator::default()
+        .with_base_fee(block.basefee() as u128)
+        .with_blob_gasprice(block.blob_gasprice().unwrap_or(0));
+
+    if skip_balance_check {
+        validator = validator.skip_balance_check();
+    }
+
+    validator.caller_fee(caller_balance, tx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validation_checks_default() {
+        let checks = ValidationChecks::default();
+        assert!(checks.is_empty());
+    }
+
+    #[test]
+    fn test_validation_checks_all() {
+        let checks = ValidationChecks::ALL;
+        assert!(checks.contains(ValidationChecks::CHAIN_ID));
+        assert!(checks.contains(ValidationChecks::NONCE));
+        assert!(checks.contains(ValidationChecks::BALANCE));
+        assert!(checks.contains(ValidationChecks::EIP3607));
+    }
+
+    #[test]
+    fn test_tx_validator_builder() {
+        let validator = TxValidator::new(SpecId::CANCUN)
+            .with_chain_id(42)
+            .with_base_fee(1000)
+            .skip_nonce_check()
+            .skip_balance_check();
+
+        assert_eq!(validator.spec, SpecId::CANCUN);
+        assert_eq!(validator.chain_id, 42);
+        assert_eq!(validator.base_fee, Some(1000));
+        assert!(!validator.should_check(ValidationChecks::NONCE));
+        assert!(!validator.should_check(ValidationChecks::BALANCE));
+        assert!(validator.should_check(ValidationChecks::CHAIN_ID));
+    }
+
+    #[test]
+    fn test_tx_validator_skip_all_then_enable() {
+        let validator = TxValidator::new(SpecId::CANCUN)
+            .skip_all()
+            .enable_chain_id_check()
+            .enable_nonce_check();
+
+        assert!(validator.should_check(ValidationChecks::CHAIN_ID));
+        assert!(validator.should_check(ValidationChecks::NONCE));
+        assert!(!validator.should_check(ValidationChecks::BALANCE));
+        assert!(!validator.should_check(ValidationChecks::BASE_FEE));
+    }
+
+    #[test]
+    fn test_validation_kind_should_check() {
+        assert!(!ValidationKind::None.should_check(ValidationChecks::CHAIN_ID));
+        assert!(ValidationKind::ByTxType.should_check(ValidationChecks::CHAIN_ID));
+
+        let custom = ValidationKind::Custom(ValidationChecks::CHAIN_ID | ValidationChecks::NONCE);
+        assert!(custom.should_check(ValidationChecks::CHAIN_ID));
+        assert!(custom.should_check(ValidationChecks::NONCE));
+        assert!(!custom.should_check(ValidationChecks::BALANCE));
+    }
+}

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -1,26 +1,22 @@
+use crate::tx_validation::{self, validate_block_header, validate_tx, ValidationParams};
 use context_interface::{
     result::{InvalidHeader, InvalidTransaction},
-    transaction::{Transaction, TransactionType},
-    Block, Cfg, ContextTr,
+    transaction::Transaction,
+    ContextTr,
 };
-use core::cmp;
-use interpreter::{instructions::calculate_initial_tx_gas_for_tx, InitialAndFloorGas};
-use primitives::{eip4844, hardfork::SpecId, B256};
+use interpreter::InitialAndFloorGas;
+use primitives::{hardfork::SpecId, B256};
 
 /// Validates the execution environment including block and transaction parameters.
+///
+/// This function uses the [`tx_validation`] module internally to perform validation.
 pub fn validate_env<CTX: ContextTr, ERROR: From<InvalidHeader> + From<InvalidTransaction>>(
     context: CTX,
 ) -> Result<(), ERROR> {
-    let spec = context.cfg().spec().into();
-    // `prevrandao` is required for the merge
-    if spec.is_enabled_in(SpecId::MERGE) && context.block().prevrandao().is_none() {
-        return Err(InvalidHeader::PrevrandaoNotSet.into());
-    }
-    // `excess_blob_gas` is required for Cancun
-    if spec.is_enabled_in(SpecId::CANCUN) && context.block().blob_excess_gas_and_price().is_none() {
-        return Err(InvalidHeader::ExcessBlobGasNotSet.into());
-    }
-    validate_tx_env::<CTX>(context, spec).map_err(Into::into)
+    let params = ValidationParams::from_cfg_and_block(context.cfg(), context.block());
+
+    validate_block_header(params.spec, context.block(), params.validation_kind)?;
+    validate_tx(context.tx(), &params).map_err(Into::into)
 }
 
 /// Validate legacy transaction gas price against basefee.
@@ -29,13 +25,7 @@ pub fn validate_legacy_gas_price(
     gas_price: u128,
     base_fee: Option<u128>,
 ) -> Result<(), InvalidTransaction> {
-    // Gas price must be at least the basefee.
-    if let Some(base_fee) = base_fee {
-        if gas_price < base_fee {
-            return Err(InvalidTransaction::GasPriceLessThanBasefee);
-        }
-    }
-    Ok(())
+    tx_validation::validate_legacy_gas_price(gas_price, base_fee)
 }
 
 /// Validate transaction that has EIP-1559 priority fee
@@ -45,35 +35,7 @@ pub fn validate_priority_fee_tx(
     base_fee: Option<u128>,
     disable_priority_fee_check: bool,
 ) -> Result<(), InvalidTransaction> {
-    if !disable_priority_fee_check && max_priority_fee > max_fee {
-        // Or gas_max_fee for eip1559
-        return Err(InvalidTransaction::PriorityFeeGreaterThanMaxFee);
-    }
-
-    // Check minimal cost against basefee
-    if let Some(base_fee) = base_fee {
-        let effective_gas_price = cmp::min(max_fee, base_fee.saturating_add(max_priority_fee));
-        if effective_gas_price < base_fee {
-            return Err(InvalidTransaction::GasPriceLessThanBasefee);
-        }
-    }
-
-    Ok(())
-}
-
-/// Validate priority fee for transactions that support EIP-1559 (Eip1559, Eip4844, Eip7702).
-#[inline]
-fn validate_priority_fee_for_tx<TX: Transaction>(
-    tx: TX,
-    base_fee: Option<u128>,
-    disable_priority_fee_check: bool,
-) -> Result<(), InvalidTransaction> {
-    validate_priority_fee_tx(
-        tx.max_fee_per_gas(),
-        tx.max_priority_fee_per_gas().unwrap_or_default(),
-        base_fee,
-        disable_priority_fee_check,
-    )
+    tx_validation::validate_priority_fee(max_fee, max_priority_fee, base_fee, disable_priority_fee_check)
 }
 
 /// Validate EIP-4844 transaction.
@@ -83,177 +45,29 @@ pub fn validate_eip4844_tx(
     block_blob_gas_price: u128,
     max_blobs: Option<u64>,
 ) -> Result<(), InvalidTransaction> {
-    // Ensure that the user was willing to at least pay the current blob gasprice
-    if block_blob_gas_price > max_blob_fee {
-        return Err(InvalidTransaction::BlobGasPriceGreaterThanMax {
-            block_blob_gas_price,
-            tx_max_fee_per_blob_gas: max_blob_fee,
-        });
-    }
-
-    // There must be at least one blob
-    if blobs.is_empty() {
-        return Err(InvalidTransaction::EmptyBlobs);
-    }
-
-    // All versioned blob hashes must start with VERSIONED_HASH_VERSION_KZG
-    for blob in blobs {
-        if blob[0] != eip4844::VERSIONED_HASH_VERSION_KZG {
-            return Err(InvalidTransaction::BlobVersionNotSupported);
-        }
-    }
-
-    // Ensure the total blob gas spent is at most equal to the limit
-    // assert blob_gas_used <= MAX_BLOB_GAS_PER_BLOCK
-    if let Some(max_blobs) = max_blobs {
-        if blobs.len() > max_blobs as usize {
-            return Err(InvalidTransaction::TooManyBlobs {
-                have: blobs.len(),
-                max: max_blobs as usize,
-            });
-        }
-    }
-    Ok(())
+    tx_validation::validate_eip4844_tx(blobs, max_blob_fee, block_blob_gas_price, max_blobs)
 }
 
 /// Validate transaction against block and configuration for mainnet.
+///
+/// This function uses the [`tx_validation`] module internally to perform validation.
 pub fn validate_tx_env<CTX: ContextTr>(
     context: CTX,
-    spec_id: SpecId,
+    _spec_id: SpecId,
 ) -> Result<(), InvalidTransaction> {
-    // Check if the transaction's chain id is correct
-    let tx = context.tx();
-    let tx_type = tx.tx_type();
-
-    let base_fee = if context.cfg().is_base_fee_check_disabled() {
-        None
-    } else {
-        Some(context.block().basefee() as u128)
-    };
-
-    let tx_type = TransactionType::from(tx_type);
-
-    // Check chain_id if config is enabled.
-    // EIP-155: Simple replay attack protection
-    if context.cfg().tx_chain_id_check() {
-        if let Some(chain_id) = tx.chain_id() {
-            if chain_id != context.cfg().chain_id() {
-                return Err(InvalidTransaction::InvalidChainId);
-            }
-        } else if !tx_type.is_legacy() && !tx_type.is_custom() {
-            // Legacy transaction are the only one that can omit chain_id.
-            return Err(InvalidTransaction::MissingChainId);
-        }
-    }
-
-    // EIP-7825: Transaction Gas Limit Cap
-    let cap = context.cfg().tx_gas_limit_cap();
-    if tx.gas_limit() > cap {
-        return Err(InvalidTransaction::TxGasLimitGreaterThanCap {
-            gas_limit: tx.gas_limit(),
-            cap,
-        });
-    }
-
-    let disable_priority_fee_check = context.cfg().is_priority_fee_check_disabled();
-
-    match tx_type {
-        TransactionType::Legacy => {
-            validate_legacy_gas_price(tx.gas_price(), base_fee)?;
-        }
-        TransactionType::Eip2930 => {
-            // Enabled in BERLIN hardfork
-            if !spec_id.is_enabled_in(SpecId::BERLIN) {
-                return Err(InvalidTransaction::Eip2930NotSupported);
-            }
-            validate_legacy_gas_price(tx.gas_price(), base_fee)?;
-        }
-        TransactionType::Eip1559 => {
-            if !spec_id.is_enabled_in(SpecId::LONDON) {
-                return Err(InvalidTransaction::Eip1559NotSupported);
-            }
-            validate_priority_fee_for_tx(tx, base_fee, disable_priority_fee_check)?;
-        }
-        TransactionType::Eip4844 => {
-            if !spec_id.is_enabled_in(SpecId::CANCUN) {
-                return Err(InvalidTransaction::Eip4844NotSupported);
-            }
-
-            validate_priority_fee_for_tx(tx, base_fee, disable_priority_fee_check)?;
-
-            validate_eip4844_tx(
-                tx.blob_versioned_hashes(),
-                tx.max_fee_per_blob_gas(),
-                context.block().blob_gasprice().unwrap_or_default(),
-                context.cfg().max_blobs_per_tx(),
-            )?;
-        }
-        TransactionType::Eip7702 => {
-            // Check if EIP-7702 transaction is enabled.
-            if !spec_id.is_enabled_in(SpecId::PRAGUE) {
-                return Err(InvalidTransaction::Eip7702NotSupported);
-            }
-
-            validate_priority_fee_for_tx(tx, base_fee, disable_priority_fee_check)?;
-
-            let auth_list_len = tx.authorization_list_len();
-            // The transaction is considered invalid if the length of authorization_list is zero.
-            if auth_list_len == 0 {
-                return Err(InvalidTransaction::EmptyAuthorizationList);
-            }
-        }
-        TransactionType::Custom => {
-            // Custom transaction type check is not done here.
-        }
-    };
-
-    // Check if gas_limit is more than block_gas_limit
-    if !context.cfg().is_block_gas_limit_disabled() && tx.gas_limit() > context.block().gas_limit()
-    {
-        return Err(InvalidTransaction::CallerGasLimitMoreThanBlock);
-    }
-
-    // EIP-3860: Limit and meter initcode. Still valid with EIP-7907 and increase of initcode size.
-    if spec_id.is_enabled_in(SpecId::SHANGHAI)
-        && tx.kind().is_create()
-        && tx.input().len() > context.cfg().max_initcode_size()
-    {
-        return Err(InvalidTransaction::CreateInitCodeSizeLimit);
-    }
-
-    Ok(())
+    let params = ValidationParams::from_cfg_and_block(context.cfg(), context.block());
+    validate_tx(context.tx(), &params)
 }
 
 /// Validate initial transaction gas.
+///
+/// This function uses the [`tx_validation`] module internally to perform validation.
 pub fn validate_initial_tx_gas(
     tx: impl Transaction,
     spec: SpecId,
     is_eip7623_disabled: bool,
 ) -> Result<InitialAndFloorGas, InvalidTransaction> {
-    let mut gas = calculate_initial_tx_gas_for_tx(&tx, spec);
-
-    if is_eip7623_disabled {
-        gas.floor_gas = 0
-    }
-
-    // Additional check to see if limit is big enough to cover initial gas.
-    if gas.initial_gas > tx.gas_limit() {
-        return Err(InvalidTransaction::CallGasCostMoreThanGasLimit {
-            gas_limit: tx.gas_limit(),
-            initial_gas: gas.initial_gas,
-        });
-    }
-
-    // EIP-7623: Increase calldata cost
-    // floor gas should be less than gas limit.
-    if spec.is_enabled_in(SpecId::PRAGUE) && gas.floor_gas > tx.gas_limit() {
-        return Err(InvalidTransaction::GasFloorMoreThanGasLimit {
-            gas_floor: gas.floor_gas,
-            gas_limit: tx.gas_limit(),
-        });
-    };
-
-    Ok(gas)
+    tx_validation::calculate_initial_gas(&tx, spec, is_eip7623_disabled)
 }
 
 #[cfg(test)]

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -35,7 +35,12 @@ pub fn validate_priority_fee_tx(
     base_fee: Option<u128>,
     disable_priority_fee_check: bool,
 ) -> Result<(), InvalidTransaction> {
-    tx_validation::validate_priority_fee(max_fee, max_priority_fee, base_fee, disable_priority_fee_check)
+    tx_validation::validate_priority_fee(
+        max_fee,
+        max_priority_fee,
+        base_fee,
+        disable_priority_fee_check,
+    )
 }
 
 /// Validate EIP-4844 transaction.

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -26,6 +26,7 @@ alloy-primitives = { workspace = true, features = [
 ] }
 
 # mics
+bitflags.workspace = true
 num_enum = { version = "0.7", default-features = false }
 once_cell = { version = "1.21", default-features = false, features = [
     "alloc",
@@ -37,8 +38,8 @@ serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
 [features]
 default = ["std"]
-std = ["alloy-primitives/std", "serde?/std", "num_enum/std", "once_cell/std"]
-serde = ["dep:serde", "alloy-primitives/serde"]
+std = ["alloy-primitives/std", "bitflags/std", "serde?/std", "num_enum/std", "once_cell/std"]
+serde = ["dep:serde", "alloy-primitives/serde", "bitflags/serde"]
 map-foldhash = ["alloy-primitives/map-foldhash"]
 
 hashbrown = ["alloy-primitives/map-hashbrown"]

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -27,9 +27,11 @@ pub mod eip7907;
 pub mod hardfork;
 pub mod hints_util;
 mod once_lock;
+pub mod validation;
 
 pub use constants::*;
 pub use once_lock::OnceLock;
+pub use validation::ValidationChecks;
 
 // Reexport alloy primitives.
 

--- a/crates/primitives/src/validation.rs
+++ b/crates/primitives/src/validation.rs
@@ -2,6 +2,23 @@
 //!
 //! This module provides [`ValidationChecks`] bitflags for configuring which
 //! transaction validation checks should be performed.
+//!
+//! # Example
+//!
+//! ```
+//! use revm_primitives::ValidationChecks;
+//!
+//! // Default enables all checks
+//! let checks = ValidationChecks::default();
+//! assert_eq!(checks, ValidationChecks::ALL);
+//!
+//! // Disable specific checks
+//! let custom = ValidationChecks::ALL - ValidationChecks::NONCE - ValidationChecks::BALANCE;
+//! assert!(!custom.contains(ValidationChecks::NONCE));
+//!
+//! // Start with no checks and enable specific ones
+//! let minimal = ValidationChecks::CHAIN_ID | ValidationChecks::NONCE;
+//! ```
 
 use bitflags::bitflags;
 
@@ -10,13 +27,26 @@ bitflags! {
     ///
     /// Each flag represents a specific validation check that can be enabled or disabled.
     /// Combine flags using bitwise OR to create custom validation configurations.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+    ///
+    /// # Composite Flags
+    ///
+    /// Several composite flags are provided for common use cases:
+    /// - [`GAS_FEES`](Self::GAS_FEES): All gas and fee related checks
+    /// - [`TX_STATELESS`](Self::TX_STATELESS): Checks that don't require account state
+    /// - [`CALLER`](Self::CALLER): Checks that require caller account state
+    /// - [`ALL`](Self::ALL): All validation checks (default)
+    ///
+    /// # Default
+    ///
+    /// The default value is [`ALL`](Self::ALL), enabling all validation checks.
+    /// Use [`ValidationChecks::empty()`] to start with no checks enabled.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct ValidationChecks: u16 {
         /// Validate chain ID matches (EIP-155).
         const CHAIN_ID = 1 << 0;
         /// Validate transaction gas limit against cap (EIP-7825).
         const TX_GAS_LIMIT = 1 << 1;
-        /// Validate gas price against base fee.
+        /// Validate gas price against base fee (EIP-1559).
         const BASE_FEE = 1 << 2;
         /// Validate priority fee for EIP-1559+ transactions.
         const PRIORITY_FEE = 1 << 3;
@@ -32,14 +62,18 @@ bitflags! {
         const NONCE = 1 << 8;
         /// Validate caller balance for transaction cost.
         const BALANCE = 1 << 9;
-        /// Validate EIP-3607 (reject senders with deployed code).
+        /// Reject transactions from senders with deployed code (EIP-3607).
         const EIP3607 = 1 << 10;
-        /// Validate EIP-7623 floor gas.
+        /// Validate floor gas for calldata (EIP-7623).
         const EIP7623 = 1 << 11;
         /// Validate block header fields (prevrandao, excess_blob_gas).
         const HEADER = 1 << 12;
 
         /// All gas and fee related checks.
+        ///
+        /// Includes: [`TX_GAS_LIMIT`](Self::TX_GAS_LIMIT), [`BASE_FEE`](Self::BASE_FEE),
+        /// [`PRIORITY_FEE`](Self::PRIORITY_FEE), [`BLOB_FEE`](Self::BLOB_FEE),
+        /// [`BLOCK_GAS_LIMIT`](Self::BLOCK_GAS_LIMIT), [`EIP7623`](Self::EIP7623).
         const GAS_FEES = Self::TX_GAS_LIMIT.bits()
             | Self::BASE_FEE.bits()
             | Self::PRIORITY_FEE.bits()
@@ -48,16 +82,87 @@ bitflags! {
             | Self::EIP7623.bits();
 
         /// All stateless transaction checks (no account state needed).
+        ///
+        /// Includes: [`CHAIN_ID`](Self::CHAIN_ID), [`GAS_FEES`](Self::GAS_FEES),
+        /// [`AUTH_LIST`](Self::AUTH_LIST), [`MAX_INITCODE_SIZE`](Self::MAX_INITCODE_SIZE),
+        /// [`HEADER`](Self::HEADER).
         const TX_STATELESS = Self::CHAIN_ID.bits()
             | Self::GAS_FEES.bits()
             | Self::AUTH_LIST.bits()
             | Self::MAX_INITCODE_SIZE.bits()
             | Self::HEADER.bits();
 
-        /// All caller/state checks.
+        /// All caller/state checks (require account state).
+        ///
+        /// Includes: [`NONCE`](Self::NONCE), [`BALANCE`](Self::BALANCE),
+        /// [`EIP3607`](Self::EIP3607).
         const CALLER = Self::NONCE.bits() | Self::BALANCE.bits() | Self::EIP3607.bits();
 
         /// All validation checks enabled.
+        ///
+        /// This is the default value. Equivalent to `TX_STATELESS | CALLER`.
         const ALL = Self::TX_STATELESS.bits() | Self::CALLER.bits();
+    }
+}
+
+impl Default for ValidationChecks {
+    /// Returns [`ValidationChecks::ALL`] - all checks enabled by default.
+    #[inline]
+    fn default() -> Self {
+        Self::ALL
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_is_all() {
+        assert_eq!(ValidationChecks::default(), ValidationChecks::ALL);
+    }
+
+    #[test]
+    fn test_all_equals_stateless_plus_caller() {
+        assert_eq!(
+            ValidationChecks::ALL,
+            ValidationChecks::TX_STATELESS | ValidationChecks::CALLER
+        );
+    }
+
+    #[test]
+    fn test_tx_stateless_composite() {
+        let checks = ValidationChecks::TX_STATELESS;
+        assert!(checks.contains(ValidationChecks::CHAIN_ID));
+        assert!(checks.contains(ValidationChecks::GAS_FEES));
+        assert!(checks.contains(ValidationChecks::AUTH_LIST));
+        assert!(checks.contains(ValidationChecks::MAX_INITCODE_SIZE));
+        assert!(checks.contains(ValidationChecks::HEADER));
+    }
+
+    #[test]
+    fn test_caller_composite() {
+        let checks = ValidationChecks::CALLER;
+        assert!(checks.contains(ValidationChecks::NONCE));
+        assert!(checks.contains(ValidationChecks::BALANCE));
+        assert!(checks.contains(ValidationChecks::EIP3607));
+    }
+
+    #[test]
+    fn test_gas_fees_composite() {
+        let checks = ValidationChecks::GAS_FEES;
+        assert!(checks.contains(ValidationChecks::TX_GAS_LIMIT));
+        assert!(checks.contains(ValidationChecks::BASE_FEE));
+        assert!(checks.contains(ValidationChecks::PRIORITY_FEE));
+        assert!(checks.contains(ValidationChecks::BLOB_FEE));
+        assert!(checks.contains(ValidationChecks::BLOCK_GAS_LIMIT));
+        assert!(checks.contains(ValidationChecks::EIP7623));
+    }
+
+    #[test]
+    fn test_subtract_checks() {
+        let checks = ValidationChecks::ALL - ValidationChecks::NONCE;
+        assert!(!checks.contains(ValidationChecks::NONCE));
+        assert!(checks.contains(ValidationChecks::BALANCE));
     }
 }

--- a/crates/primitives/src/validation.rs
+++ b/crates/primitives/src/validation.rs
@@ -1,0 +1,63 @@
+//! Transaction validation checks configuration.
+//!
+//! This module provides [`ValidationChecks`] bitflags for configuring which
+//! transaction validation checks should be performed.
+
+use bitflags::bitflags;
+
+bitflags! {
+    /// Bitflags for configurable transaction validation checks.
+    ///
+    /// Each flag represents a specific validation check that can be enabled or disabled.
+    /// Combine flags using bitwise OR to create custom validation configurations.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+    pub struct ValidationChecks: u16 {
+        /// Validate chain ID matches (EIP-155).
+        const CHAIN_ID = 1 << 0;
+        /// Validate transaction gas limit against cap (EIP-7825).
+        const TX_GAS_LIMIT = 1 << 1;
+        /// Validate gas price against base fee.
+        const BASE_FEE = 1 << 2;
+        /// Validate priority fee for EIP-1559+ transactions.
+        const PRIORITY_FEE = 1 << 3;
+        /// Validate blob fee for EIP-4844 transactions.
+        const BLOB_FEE = 1 << 4;
+        /// Validate authorization list for EIP-7702 transactions.
+        const AUTH_LIST = 1 << 5;
+        /// Validate transaction gas limit against block gas limit.
+        const BLOCK_GAS_LIMIT = 1 << 6;
+        /// Validate initcode size for contract creation (EIP-3860).
+        const MAX_INITCODE_SIZE = 1 << 7;
+        /// Validate nonce matches account state.
+        const NONCE = 1 << 8;
+        /// Validate caller balance for transaction cost.
+        const BALANCE = 1 << 9;
+        /// Validate EIP-3607 (reject senders with deployed code).
+        const EIP3607 = 1 << 10;
+        /// Validate EIP-7623 floor gas.
+        const EIP7623 = 1 << 11;
+        /// Validate block header fields (prevrandao, excess_blob_gas).
+        const HEADER = 1 << 12;
+
+        /// All gas and fee related checks.
+        const GAS_FEES = Self::TX_GAS_LIMIT.bits()
+            | Self::BASE_FEE.bits()
+            | Self::PRIORITY_FEE.bits()
+            | Self::BLOB_FEE.bits()
+            | Self::BLOCK_GAS_LIMIT.bits()
+            | Self::EIP7623.bits();
+
+        /// All stateless transaction checks (no account state needed).
+        const TX_STATELESS = Self::CHAIN_ID.bits()
+            | Self::GAS_FEES.bits()
+            | Self::AUTH_LIST.bits()
+            | Self::MAX_INITCODE_SIZE.bits()
+            | Self::HEADER.bits();
+
+        /// All caller/state checks.
+        const CALLER = Self::NONCE.bits() | Self::BALANCE.bits() | Self::EIP3607.bits();
+
+        /// All validation checks enabled.
+        const ALL = Self::TX_STATELESS.bits() | Self::CALLER.bits();
+    }
+}

--- a/crates/primitives/src/validation.rs
+++ b/crates/primitives/src/validation.rs
@@ -41,6 +41,7 @@ bitflags! {
     /// The default value is [`ALL`](Self::ALL), enabling all validation checks.
     /// Use [`ValidationChecks::empty()`] to start with no checks enabled.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub struct ValidationChecks: u16 {
         /// Validate chain ID matches (EIP-155).
         const CHAIN_ID = 1 << 0;


### PR DESCRIPTION
## Summary

This PR polishes the `TxValidator` module for better usability, performance, and L2 integration support. The improvements were identified through multiple iterations of analysis focusing on:

1. **API usability** - Easy to use with minimal boilerplate
2. **Performance** - Low initialization overhead with `Copy` semantics
3. **Configurability** - Projects like op-revm and Tempo can reuse validation logic with configurable flows

## Changes

### API Improvements
- Add `Copy` derive to `TxValidator` and `CallerFee` for efficient passing
- Add preset constructors for common use cases:
  - `for_deposit()` - L2 deposit transactions (skips fees, balance, nonce)
  - `for_tx_pool()` - Transaction pool validation (stateless checks only)
  - `for_block_builder()` - Block builder with lenient checks
- Add composite `GAS_FEES` flag for all gas/fee related checks
- Add missing skip methods:
  - `skip_tx_gas_limit_check()`
  - `skip_blob_fee_check()`
  - `skip_auth_list_check()`
  - `skip_max_initcode_size_check()`
  - `skip_caller_checks()` (composite)
  - `skip_gas_fee_checks()` (composite)
- Add missing enable methods for ALL checks (symmetric with skip methods)
- Add query methods: `has_any_checks()`, `has_all_checks()`, `enabled_checks()`

### Performance Improvements
- Add `#[inline]` annotations to all builder methods and validation hot paths
- Derive `Copy` to avoid unnecessary cloning

### Tests
- Add tests for preset constructors
- Add tests for composite skip/enable methods
- Add tests for query methods
- Add test verifying TxValidator is Copy

## Usage Examples

```rust
// L2 deposit transaction
let validator = TxValidator::for_deposit(SpecId::CANCUN)
    .with_chain_id(10);

// Transaction pool validation
let validator = TxValidator::for_tx_pool(SpecId::CANCUN)
    .with_chain_id(1)
    .with_base_fee(30_000_000_000);

// Custom configuration
let validator = TxValidator::new(SpecId::CANCUN)
    .skip_gas_fee_checks()
    .skip_caller_checks()
    .enable_chain_id_check();
```

## Test plan
- [x] `cargo check -p revm-handler` passes
- [x] `cargo test -p revm-handler -- tx_validation` passes (12 tests)