### PR TITLE
fix(handler): respect is_fee_charge_disabled in calculate_caller_fee

### DIFF
--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -128,6 +128,12 @@ pub fn calculate_caller_fee(
     block: impl Block,
     cfg: impl Cfg,
 ) -> Result<U256, InvalidTransaction> {
+    // If fee charge is disabled, return the balance as-is without deducting fees.
+    // This is useful for `eth_call` and similar simulation scenarios.
+    if cfg.is_fee_charge_disabled() {
+        return Ok(balance);
+    }
+
     let basefee = block.basefee() as u128;
     let blob_price = block.blob_gasprice().unwrap_or_default();
     let is_balance_check_disabled = cfg.is_balance_check_disabled();


### PR DESCRIPTION
Hi, I was testing eth_call with disable_fee_charge=true but fees were still getting deducted. Traced it down to calculate_caller_fee - it checks is_balance_check_disabled but completely skips is_fee_charge_disabled.                                          
                                                                                                                                                                                                                                                             
Funny thing is op-revm already has this check (handler.rs:158), just missing in the main handler.

Before: fees deducted regardless of config
After: early return with original balance when fee charge disabled