### PR TITLE
perf(interpreter): direct dispatch for hot opcodes in run_plain

### DIFF
--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -317,14 +317,150 @@ impl<IW: InterpreterTypes> Interpreter<IW> {
     }
 
     /// Executes the interpreter until it returns or stops.
+    ///
+    /// Uses direct dispatch for the most common opcodes to enable inlining
+    /// and avoid indirect function pointer call overhead. Less common opcodes
+    /// fall back to the instruction table.
     #[inline]
     pub fn run_plain<H: Host + ?Sized>(
         &mut self,
         instruction_table: &InstructionTable<IW, H>,
         host: &mut H,
     ) -> InterpreterAction {
+        use bytecode::opcode::*;
+        use crate::instructions::{arithmetic, bitwise, control, memory, stack, system};
+
         while self.bytecode.is_not_end() {
-            self.step(instruction_table, host);
+            let opcode = self.bytecode.opcode();
+            self.bytecode.relative_jump(1);
+
+            let instruction = unsafe { instruction_table.get_unchecked(opcode as usize) };
+
+            if self.gas.record_cost_unsafe(instruction.static_gas()) {
+                self.halt_oog();
+                continue;
+            }
+
+            match opcode {
+                // Control flow (very common, tiny bodies)
+                STOP => control::stop(InstructionContext { interpreter: self, host }),
+                JUMPDEST => {}
+
+                // Stack: PUSH
+                PUSH0 => stack::push0(InstructionContext { interpreter: self, host }),
+                PUSH1 => stack::push::<1, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH2 => stack::push::<2, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH3 => stack::push::<3, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH4 => stack::push::<4, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH5 => stack::push::<5, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH6 => stack::push::<6, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH7 => stack::push::<7, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH8 => stack::push::<8, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH9 => stack::push::<9, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH10 => stack::push::<10, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH11 => stack::push::<11, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH12 => stack::push::<12, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH13 => stack::push::<13, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH14 => stack::push::<14, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH15 => stack::push::<15, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH16 => stack::push::<16, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH17 => stack::push::<17, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH18 => stack::push::<18, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH19 => stack::push::<19, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH20 => stack::push::<20, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH21 => stack::push::<21, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH22 => stack::push::<22, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH23 => stack::push::<23, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH24 => stack::push::<24, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH25 => stack::push::<25, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH26 => stack::push::<26, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH27 => stack::push::<27, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH28 => stack::push::<28, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH29 => stack::push::<29, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH30 => stack::push::<30, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH31 => stack::push::<31, _, _>(InstructionContext { interpreter: self, host }),
+                PUSH32 => stack::push::<32, _, _>(InstructionContext { interpreter: self, host }),
+
+                // Stack: POP
+                POP => stack::pop(InstructionContext { interpreter: self, host }),
+
+                // Stack: DUP
+                DUP1 => stack::dup::<1, _, _>(InstructionContext { interpreter: self, host }),
+                DUP2 => stack::dup::<2, _, _>(InstructionContext { interpreter: self, host }),
+                DUP3 => stack::dup::<3, _, _>(InstructionContext { interpreter: self, host }),
+                DUP4 => stack::dup::<4, _, _>(InstructionContext { interpreter: self, host }),
+                DUP5 => stack::dup::<5, _, _>(InstructionContext { interpreter: self, host }),
+                DUP6 => stack::dup::<6, _, _>(InstructionContext { interpreter: self, host }),
+                DUP7 => stack::dup::<7, _, _>(InstructionContext { interpreter: self, host }),
+                DUP8 => stack::dup::<8, _, _>(InstructionContext { interpreter: self, host }),
+                DUP9 => stack::dup::<9, _, _>(InstructionContext { interpreter: self, host }),
+                DUP10 => stack::dup::<10, _, _>(InstructionContext { interpreter: self, host }),
+                DUP11 => stack::dup::<11, _, _>(InstructionContext { interpreter: self, host }),
+                DUP12 => stack::dup::<12, _, _>(InstructionContext { interpreter: self, host }),
+                DUP13 => stack::dup::<13, _, _>(InstructionContext { interpreter: self, host }),
+                DUP14 => stack::dup::<14, _, _>(InstructionContext { interpreter: self, host }),
+                DUP15 => stack::dup::<15, _, _>(InstructionContext { interpreter: self, host }),
+                DUP16 => stack::dup::<16, _, _>(InstructionContext { interpreter: self, host }),
+
+                // Stack: SWAP
+                SWAP1 => stack::swap::<1, _, _>(InstructionContext { interpreter: self, host }),
+                SWAP2 => stack::swap::<2, _, _>(InstructionContext { interpreter: self, host }),
+                SWAP3 => stack::swap::<3, _, _>(InstructionContext { interpreter: self, host }),
+                SWAP4 => stack::swap::<4, _, _>(InstructionContext { interpreter: self, host }),
+                SWAP5 => stack::swap::<5, _, _>(InstructionContext { interpreter: self, host }),
+                SWAP6 => stack::swap::<6, _, _>(InstructionContext { interpreter: self, host }),
+                SWAP7 => stack::swap::<7, _, _>(InstructionContext { interpreter: self, host }),
+                SWAP8 => stack::swap::<8, _, _>(InstructionContext { interpreter: self, host }),
+                SWAP9 => stack::swap::<9, _, _>(InstructionContext { interpreter: self, host }),
+                SWAP10 => stack::swap::<10, _, _>(InstructionContext { interpreter: self, host }),
+                SWAP11 => stack::swap::<11, _, _>(InstructionContext { interpreter: self, host }),
+                SWAP12 => stack::swap::<12, _, _>(InstructionContext { interpreter: self, host }),
+                SWAP13 => stack::swap::<13, _, _>(InstructionContext { interpreter: self, host }),
+                SWAP14 => stack::swap::<14, _, _>(InstructionContext { interpreter: self, host }),
+                SWAP15 => stack::swap::<15, _, _>(InstructionContext { interpreter: self, host }),
+                SWAP16 => stack::swap::<16, _, _>(InstructionContext { interpreter: self, host }),
+
+                // Arithmetic (very common)
+                ADD => arithmetic::add(InstructionContext { interpreter: self, host }),
+                MUL => arithmetic::mul(InstructionContext { interpreter: self, host }),
+                SUB => arithmetic::sub(InstructionContext { interpreter: self, host }),
+                DIV => arithmetic::div(InstructionContext { interpreter: self, host }),
+                MOD => arithmetic::rem(InstructionContext { interpreter: self, host }),
+                ADDMOD => arithmetic::addmod(InstructionContext { interpreter: self, host }),
+                MULMOD => arithmetic::mulmod(InstructionContext { interpreter: self, host }),
+
+                // Bitwise/comparison (very common)
+                LT => bitwise::lt(InstructionContext { interpreter: self, host }),
+                GT => bitwise::gt(InstructionContext { interpreter: self, host }),
+                EQ => bitwise::eq(InstructionContext { interpreter: self, host }),
+                ISZERO => bitwise::iszero(InstructionContext { interpreter: self, host }),
+                AND => bitwise::bitand(InstructionContext { interpreter: self, host }),
+                OR => bitwise::bitor(InstructionContext { interpreter: self, host }),
+                XOR => bitwise::bitxor(InstructionContext { interpreter: self, host }),
+                NOT => bitwise::not(InstructionContext { interpreter: self, host }),
+                SHL => bitwise::shl(InstructionContext { interpreter: self, host }),
+                SHR => bitwise::shr(InstructionContext { interpreter: self, host }),
+
+                // Memory (common)
+                MLOAD => memory::mload(InstructionContext { interpreter: self, host }),
+                MSTORE => memory::mstore(InstructionContext { interpreter: self, host }),
+                MSTORE8 => memory::mstore8(InstructionContext { interpreter: self, host }),
+
+                // Control flow
+                JUMP => control::jump(InstructionContext { interpreter: self, host }),
+                JUMPI => control::jumpi(InstructionContext { interpreter: self, host }),
+
+                // System
+                CALLDATALOAD => system::calldataload(InstructionContext { interpreter: self, host }),
+                CALLDATASIZE => system::calldatasize(InstructionContext { interpreter: self, host }),
+                CALLER => system::caller(InstructionContext { interpreter: self, host }),
+                CALLVALUE => system::callvalue(InstructionContext { interpreter: self, host }),
+                ADDRESS => system::address(InstructionContext { interpreter: self, host }),
+                GAS => system::gas(InstructionContext { interpreter: self, host }),
+
+                // Fallback: use instruction table for all other opcodes
+                _ => instruction.execute(InstructionContext { interpreter: self, host }),
+            }
         }
         self.take_next_action()
     }


### PR DESCRIPTION
## Summary

Replace indirect function-pointer dispatch with a direct `match` for ~90 common opcodes in the `run_plain` interpreter loop. This allows LLVM to inline small instruction bodies (PUSH, DUP, SWAP, arithmetic, bitwise, memory, control flow) directly into the hot loop, eliminating indirect call overhead.

Inspired by [NethermindEth/nethermind#10120](https://github.com/NethermindEth/nethermind/pull/10120) which applies similar hot/cold path splitting to the .NET EVM interpreter.

## Changes

- `crates/interpreter/src/interpreter.rs`: `run_plain` now uses a `match` on the opcode for the most common instructions (STOP, JUMPDEST, PUSH0-32, POP, DUP1-16, SWAP1-16, ADD/MUL/SUB/DIV/MOD/ADDMOD/MULMOD, LT/GT/EQ/ISZERO/AND/OR/XOR/NOT/SHL/SHR, MLOAD/MSTORE/MSTORE8, JUMP/JUMPI, CALLDATALOAD/CALLDATASIZE/CALLER/CALLVALUE/ADDRESS/GAS), falling back to the instruction table for everything else.
- Gas accounting and `InstructionTable` lookup remain unchanged — static gas is still read from the table entry, preserving spec-dependent gas changes.
- No trait or API changes. Custom instruction tables still work via the fallback path.

## Benchmark Results (reth-bench)

Benchmarked via [reth CI](https://github.com/paradigmxyz/reth/tree/auto-opt/20260207-fast-dispatch) on mainnet blocks:

**Normal blocks (2000 blocks):**
| Metric | Baseline | Feature | Change |
|--------|----------|---------|--------|
| Mean | 31.95ms | 31.9ms | -0.16% ≈ |
| P50 | 29.82ms | 29.93ms | +0.36% ≈ |
| Mgas/s | 951.42 | 952.94 | +0.16% ≈ |

**Big blocks (55 blocks, ~1.4 Ggas):**
| Metric | Baseline | Feature | Change |
|--------|----------|---------|--------|
| Mean | 1140.78ms | 1189.97ms | +4.31% ≈ |
| P50 | 797.02ms | 801.01ms | +0.5% ≈ |
| Mgas/s | 874.35 | 838.21 | -4.13% ≈ |

Results are within noise on both workloads. In reth's real workload, state access (SLOAD/SSTORE) and state root computation dominate — interpreter dispatch overhead is a small fraction. However, this change may benefit EVM-execution-heavy workloads (e.g., fuzzing, testing, foundry) where state I/O is not the bottleneck.

## Testing

- All 30 interpreter tests pass
- Full workspace `cargo check` passes
- reth compiles and benchmarks successfully with the patched revm