### PR TITLE
impl Display and Error for TxEnvBuildError and DeriveTxTypeError

### DIFF
--- a/crates/context/src/tx.rs
+++ b/crates/context/src/tx.rs
@@ -612,9 +612,7 @@ impl core::fmt::Display for TxEnvBuildError {
             Self::MissingGasPriorityFeeForEip1559 => {
                 f.write_str("missing gas priority fee for EIP-1559")
             }
-            Self::MissingBlobHashesForEip4844 => {
-                f.write_str("missing blob hashes for EIP-4844")
-            }
+            Self::MissingBlobHashesForEip4844 => f.write_str("missing blob hashes for EIP-4844"),
             Self::MissingAuthorizationListForEip7702 => {
                 f.write_str("missing authorization list for EIP-7702")
             }


### PR DESCRIPTION
Adds `Display` and `Error` trait implementations for `TxEnvBuildError` and `DeriveTxTypeError`, so they can be used with `Box<dyn Error>`, `?` operator, and error chains.

Follows the existing pattern in the codebase (`core::fmt::Display` + `core::error::Error`).

Fixes #3404