### PR TITLE
perf(database): use retain to filter storage slots in-place

### DIFF
--- a/crates/database/src/states/cache.rs
+++ b/crates/database/src/states/cache.rs
@@ -215,11 +215,12 @@ impl CacheState {
         let is_created = account.is_created();
         let is_empty = account.is_empty();
 
-        // Transform evm storage to storage with previous value.
-        let changed_storage = account
-            .storage
+        // Filter unchanged storage slots in-place, then convert to StorageSlot.
+        // retain() avoids allocating a new map and gives collect() an exact size hint.
+        let mut storage = account.storage;
+        storage.retain(|_, slot| slot.is_changed());
+        let changed_storage = storage
             .into_iter()
-            .filter(|(_, slot)| slot.is_changed())
             .map(|(key, slot)| (key, slot.into()))
             .collect();
 


### PR DESCRIPTION
Closes #3374

`apply_account_state` builds `changed_storage` by chaining
`into_iter().filter().map().collect()`. Because `filter()` yields
`size_hint (0, N)`, `collect()` cannot pre-allocate the right capacity
and may re-hash as the map grows.

Replace the filter step with `retain()` on the original map, then
`into_iter().map().collect()`. This gives `collect()` an exact
`size_hint (K, K)` where K is the number of changed slots, so only a
single allocation of the correct size is needed.

A zero-alloc path would require changing `StorageWithOriginalValues`
across TransitionAccount/BundleAccount/reverts, which is too invasive
for this fix.