### PR TITLE
fix: correct doc comment for `--time` flag in bench command

### DIFF
--- a/bins/revme/src/cmd/bench.rs
+++ b/bins/revme/src/cmd/bench.rs
@@ -51,7 +51,7 @@ pub struct Cmd {
     /// Warmup represents warm up time for benchmarks ran
     #[arg(short = 'w', long)]
     pub warmup: Option<f64>,
-    /// Samples represents default measurement time for benchmarks ran
+    /// Time represents default measurement time for benchmarks ran
     #[arg(short = 'm', long)]
     pub time: Option<f64>,
     /// Samples represents size of the sample for benchmarks ran


### PR DESCRIPTION
The doc comment for the `time` field incorrectly started with "Samples represents..." which made `--help` output confusing since it read the same as the `--samples` description. Fixed it to say "Time represents...".