### PR TITLE
fix(database): allow EIP161 state clear for empty Loaded and Changed accounts

### DIFF
--- a/crates/database/src/states/account_status.rs
+++ b/crates/database/src/states/account_status.rs
@@ -96,8 +96,6 @@ impl AccountStatus {
     }
 
     /// Returns the next account status on touched empty account post state clear EIP (EIP-161).
-/// Returns the next account status on touched empty account post state clear EIP (EIP-161).
-    /// If current status is [AccountStatus::Changed].
     pub fn on_touched_empty_post_eip161(&self) -> Self {
         match self {
             // Account can be touched but not existing. The status should remain the same.


### PR DESCRIPTION
## Summary                                                                                                                                                            
                                                                                                                                                                        
 - Fix `on_touched_empty_post_eip161()` panic when called on a `Loaded` `AccountStatus`                                                                                
 - Allow `Loaded` and `Changed` → `Destroyed` transition unconditionally

On EVM chains where the native token is an ERC20, an EOA can hold the native token (balance > 0, nonce=0, no code) and spend it all as an ERC20 via a meta-transaction (relayer pays gas, no nonce change on the EOA), making the account empty. In this scenario, the account was loaded from DB with `Loaded` status, and since the balance change is tracked in the Journal — not through `CacheAccount::change()` — the `CacheAccount` status remains `Loaded` when `touch_empty_eip161` is called.

The fix allows `Loaded` → `Destroyed` unconditionally. This is safe because `touch_empty_eip161` is only reachable when `account.is_empty()` is true on the Journal output, which requires no code (`code_hash == KECCAK_EMPTY`). A contract in `Loaded` status cannot reach this path — SELFDESTRUCT is the only way to remove code, and it's handled by the `is_selfdestructed()` early return before this point. This is consistent with [geth](https://github.com/ethereum/go-ethereum/blob/995fa79bf505542f3bdf0dbf8528b3dc8ad05bbc/core/state/statedb.go#L764), which has no status distinction and simply deletes any dirty empty account in `Finalise()`.

## Test plan                                                                                                                                                          

 - [x] Added unit test for `Loaded` → `Destroyed` transition in `on_touched_empty_post_eip161`                                                                         
 - [x] Added `#[should_panic]` test confirming `Changed` still panics                                                                                                  
 - [x] `cargo test -p revm-database` — 31 passed                                                                                                                       
 - [x] `cargo nextest run --workspace` — 369 passed, 0 failed                                                                                                          
 - [x] `cargo clippy --workspace --all-targets --all-features` — 0 warnings