### PR TITLE
refactor(handler): add FrameBuilder for configurable frame initialization

### DIFF
--- a/crates/handler/src/evm.rs
+++ b/crates/handler/src/evm.rs
@@ -183,10 +183,11 @@ where
 
         let ctx = &mut self.ctx;
         let precompiles = &mut self.precompiles;
-        let res = Self::Frame::build_frame(frame_input)
-            .build::<_, ContextDbError<CTX>>(new_frame, ctx, |ctx, inputs| {
-                precompiles.run(ctx, inputs)
-            })?;
+        let res = Self::Frame::build_frame(frame_input).build::<_, ContextDbError<CTX>>(
+            new_frame,
+            ctx,
+            |ctx, inputs| precompiles.run(ctx, inputs),
+        )?;
 
         Ok(res.map_item(|token| {
             if is_first_init {

--- a/crates/handler/src/evm.rs
+++ b/crates/handler/src/evm.rs
@@ -183,7 +183,10 @@ where
 
         let ctx = &mut self.ctx;
         let precompiles = &mut self.precompiles;
-        let res = Self::Frame::init_with_context(new_frame, ctx, precompiles, frame_input)?;
+        let res = Self::Frame::build_frame(frame_input)
+            .build::<_, ContextDbError<CTX>>(new_frame, ctx, |ctx, inputs| {
+                precompiles.run(ctx, inputs)
+            })?;
 
         Ok(res.map_item(|token| {
             if is_first_init {

--- a/crates/handler/src/evm.rs
+++ b/crates/handler/src/evm.rs
@@ -192,16 +192,14 @@ where
         let precompiles = &mut self.precompiles;
 
         let res = match frame_input {
-            FrameInput::Call(inputs) => {
-                EthFrame::build_call_frame(depth, memory, inputs)
-                    .build::<_, ContextDbError<CTX>>(new_frame, ctx, |ctx, inputs| {
-                        precompiles.run(ctx, inputs)
-                    })?
-            }
-            FrameInput::Create(inputs) => {
-                EthFrame::build_create_frame(depth, memory, inputs)
-                    .build::<_, ContextDbError<CTX>>(new_frame, ctx)?
-            }
+            FrameInput::Call(inputs) => EthFrame::build_call_frame(depth, memory, inputs)
+                .build::<_, ContextDbError<CTX>>(
+                new_frame,
+                ctx,
+                |ctx, inputs| precompiles.run(ctx, inputs),
+            )?,
+            FrameInput::Create(inputs) => EthFrame::build_create_frame(depth, memory, inputs)
+                .build::<_, ContextDbError<CTX>>(new_frame, ctx)?,
             FrameInput::Empty => unreachable!(),
         };
 

--- a/crates/handler/src/evm.rs
+++ b/crates/handler/src/evm.rs
@@ -5,7 +5,9 @@ use crate::{
 use auto_impl::auto_impl;
 use context::{ContextTr, Database, Evm, FrameStack};
 use context_interface::context::ContextError;
-use interpreter::{interpreter::EthInterpreter, interpreter_action::FrameInit, InterpreterResult};
+use interpreter::{
+    interpreter::EthInterpreter, interpreter_action::FrameInit, FrameInput, InterpreterResult,
+};
 
 /// Type alias for database error within a context
 pub type ContextDbError<CTX> = ContextError<ContextTrDbError<CTX>>;
@@ -181,13 +183,27 @@ where
             self.frame_stack.get_next()
         };
 
+        let FrameInit {
+            depth,
+            memory,
+            frame_input,
+        } = frame_input;
         let ctx = &mut self.ctx;
         let precompiles = &mut self.precompiles;
-        let res = Self::Frame::build_frame(frame_input).build::<_, ContextDbError<CTX>>(
-            new_frame,
-            ctx,
-            |ctx, inputs| precompiles.run(ctx, inputs),
-        )?;
+
+        let res = match frame_input {
+            FrameInput::Call(inputs) => {
+                EthFrame::build_call_frame(depth, memory, inputs)
+                    .build::<_, ContextDbError<CTX>>(new_frame, ctx, |ctx, inputs| {
+                        precompiles.run(ctx, inputs)
+                    })?
+            }
+            FrameInput::Create(inputs) => {
+                EthFrame::build_create_frame(depth, memory, inputs)
+                    .build::<_, ContextDbError<CTX>>(new_frame, ctx)?
+            }
+            FrameInput::Empty => unreachable!(),
+        };
 
         Ok(res.map_item(|token| {
             if is_first_init {

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -94,6 +94,9 @@ pub fn call_load_bytecode<J: JournalTr>(
 }
 
 /// Check that the caller has sufficient balance for the create value transfer.
+///
+/// This is a standalone step function for composing custom create flows.
+/// The [`FrameBuilder`] inlines this logic to avoid redundant account loads.
 #[inline]
 pub fn create_check_balance<J: JournalTr>(
     journal: &mut J,
@@ -110,6 +113,9 @@ pub fn create_check_balance<J: JournalTr>(
 /// Bump caller nonce. Returns the old nonce.
 ///
 /// Errors on nonce overflow.
+///
+/// This is a standalone step function for composing custom create flows.
+/// The [`FrameBuilder`] inlines this logic to avoid redundant account loads.
 #[inline]
 pub fn create_bump_nonce<J: JournalTr>(
     journal: &mut J,
@@ -201,27 +207,14 @@ pub struct CreateKind {
 }
 
 // ────────────────────────────────────────────────────────────────────────────────
-// FrameKind trait
+// Build implementations
 // ────────────────────────────────────────────────────────────────────────────────
 
-/// Trait enabling a single [`FrameBuilder::build`] method for both [`CallKind`] and [`CreateKind`].
-pub trait FrameKind: Sized {
-    /// Build a frame from the builder, consuming it.
-    fn build_frame<CTX, ERROR>(
-        builder: FrameBuilder<Self>,
-        this: OutFrame<'_, EthFrame>,
-        ctx: &mut CTX,
-        precompile_fn: impl FnMut(&mut CTX, &CallInputs) -> Result<Option<InterpreterResult>, String>,
-    ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR>
-    where
-        CTX: ContextTr,
-        ERROR: From<ContextTrDbError<CTX>> + FromStringError;
-}
-
-impl FrameKind for CallKind {
+impl FrameBuilder<CallKind> {
+    /// Consume the builder and produce a call frame (or an early result).
     #[inline]
-    fn build_frame<CTX, ERROR>(
-        builder: FrameBuilder<Self>,
+    pub fn build<CTX, ERROR>(
+        self,
         mut this: OutFrame<'_, EthFrame>,
         ctx: &mut CTX,
         mut precompile_fn: impl FnMut(
@@ -249,7 +242,7 @@ impl FrameKind for CallKind {
                     bytecode: override_bytecode,
                     is_static: override_is_static,
                 },
-        } = builder;
+        } = self;
 
         let gas = Gas::new(override_gas_limit.unwrap_or(inputs.gas_limit));
         let return_result = |instruction_result: InstructionResult| {
@@ -348,13 +341,13 @@ impl FrameKind for CallKind {
     }
 }
 
-impl FrameKind for CreateKind {
+impl FrameBuilder<CreateKind> {
+    /// Consume the builder and produce a create frame (or an early result).
     #[inline]
-    fn build_frame<CTX, ERROR>(
-        builder: FrameBuilder<Self>,
+    pub fn build<CTX, ERROR>(
+        self,
         mut this: OutFrame<'_, EthFrame>,
         ctx: &mut CTX,
-        _precompile_fn: impl FnMut(&mut CTX, &CallInputs) -> Result<Option<InterpreterResult>, String>,
     ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR>
     where
         CTX: ContextTr,
@@ -375,7 +368,7 @@ impl FrameKind for CreateKind {
                     created_address: override_address,
                     bytecode: override_bytecode,
                 },
-        } = builder;
+        } = self;
 
         let spec: SpecId = ctx.cfg().spec().into();
         let gas_limit = override_gas_limit.unwrap_or_else(|| inputs.gas_limit());
@@ -516,9 +509,9 @@ impl FrameKind for CreateKind {
 /// (`call`, `create`, `call_end`, `create_end`, `initialize_interp`).
 pub struct FrameBuilder<Kind> {
     /// Call depth in the execution stack.
-    pub depth: usize,
+    depth: usize,
     /// Shared memory for the frame.
-    pub memory: SharedMemory,
+    memory: SharedMemory,
     check_depth: bool,
     checkpoint: Option<JournalCheckpoint>,
     interpreter_input: Option<InputsImpl>,
@@ -541,6 +534,18 @@ impl<Kind: core::fmt::Debug> core::fmt::Debug for FrameBuilder<Kind> {
 
 // Shared methods for any Kind.
 impl<K> FrameBuilder<K> {
+    /// Returns the call depth.
+    #[inline]
+    pub fn depth(&self) -> usize {
+        self.depth
+    }
+
+    /// Returns a reference to the shared memory.
+    #[inline]
+    pub fn memory(&self) -> &SharedMemory {
+        &self.memory
+    }
+
     /// Skip the call-depth check (`CALL_STACK_LIMIT`).
     #[inline]
     pub fn skip_depth_check(mut self) -> Self {
@@ -573,25 +578,6 @@ impl<K> FrameBuilder<K> {
     }
 }
 
-// Build method for any Kind that implements FrameKind.
-impl<K: FrameKind> FrameBuilder<K> {
-    /// Consume the builder and produce a frame (or an early result).
-    ///
-    /// The `precompile_fn` closure is only used by [`CallKind`]; [`CreateKind`] ignores it.
-    #[inline]
-    pub fn build<CTX, ERROR>(
-        self,
-        this: OutFrame<'_, EthFrame>,
-        ctx: &mut CTX,
-        precompile_fn: impl FnMut(&mut CTX, &CallInputs) -> Result<Option<InterpreterResult>, String>,
-    ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR>
-    where
-        CTX: ContextTr,
-        ERROR: From<ContextTrDbError<CTX>> + FromStringError,
-    {
-        K::build_frame(self, this, ctx, precompile_fn)
-    }
-}
 
 // Call-specific methods.
 impl FrameBuilder<CallKind> {
@@ -731,6 +717,7 @@ impl FrameBuilderKind {
     /// Consume the builder and produce a frame (or an early result).
     ///
     /// Dispatches to [`FrameBuilder::build`] on the inner variant.
+    /// The `precompile_fn` closure is only used by the [`Call`](Self::Call) variant.
     #[inline]
     pub fn build<CTX, ERROR>(
         self,
@@ -744,7 +731,7 @@ impl FrameBuilderKind {
     {
         match self {
             Self::Call(builder) => builder.build(this, ctx, precompile_fn),
-            Self::Create(builder) => builder.build(this, ctx, precompile_fn),
+            Self::Create(builder) => builder.build(this, ctx),
         }
     }
 }
@@ -934,7 +921,7 @@ impl EthFrame<EthInterpreter> {
         memory: SharedMemory,
         inputs: Box<CreateInputs>,
     ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR> {
-        Self::build_create_frame(depth, memory, inputs).build(this, context, |_, _| Ok(None))
+        Self::build_create_frame(depth, memory, inputs).build(this, context)
     }
 
     /// Initializes a frame with the given context and precompiles.
@@ -1165,4 +1152,329 @@ pub fn return_create<JOURNAL: JournalTr, CFG: Cfg>(
     journal.set_code(address, bytecode);
 
     interpreter_result.result = InstructionResult::Return;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use context::Context;
+    use context_interface::context::ContextError;
+    use context_interface::local::OutFrame;
+    use database::InMemoryDB;
+    use interpreter::{CallInput, CallScheme};
+    use primitives::{address, hardfork::SpecId};
+    use state::AccountInfo;
+    use std::convert::Infallible;
+
+    type TestError = ContextError<Infallible>;
+
+    const CALLER: Address = address!("0x0000000000000000000000000000000000000001");
+    const TARGET: Address = address!("0x0000000000000000000000000000000000000002");
+
+    fn test_call_inputs() -> Box<CallInputs> {
+        Box::new(CallInputs {
+            input: CallInput::Bytes(Bytes::new()),
+            return_memory_offset: 0..0,
+            gas_limit: 100_000,
+            bytecode_address: TARGET,
+            known_bytecode: None,
+            target_address: TARGET,
+            caller: CALLER,
+            value: CallValue::Transfer(U256::ZERO),
+            scheme: CallScheme::Call,
+            is_static: false,
+        })
+    }
+
+    fn test_create_inputs() -> Box<CreateInputs> {
+        Box::new(CreateInputs::new(
+            CALLER,
+            CreateScheme::Create,
+            U256::ZERO,
+            Bytes::from_static(&[0x60, 0x00]),
+            100_000,
+        ))
+    }
+
+    fn test_ctx() -> Context<context::BlockEnv, context::TxEnv, context::CfgEnv, InMemoryDB> {
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            CALLER,
+            AccountInfo {
+                balance: U256::from(1_000_000),
+                nonce: 0,
+                ..Default::default()
+            },
+        );
+        Context::new(db, SpecId::CANCUN)
+    }
+
+    // ─── Standalone function tests ───
+
+    #[test]
+    fn test_check_depth_within_limit() {
+        assert!(check_depth(0).is_ok());
+        assert!(check_depth(CALL_STACK_LIMIT as usize - 1).is_ok());
+        assert!(check_depth(CALL_STACK_LIMIT as usize).is_ok());
+    }
+
+    #[test]
+    fn test_check_depth_exceeds_limit() {
+        assert_eq!(
+            check_depth(CALL_STACK_LIMIT as usize + 1),
+            Err(InstructionResult::CallTooDeep)
+        );
+    }
+
+    #[test]
+    fn test_create_compute_address_create() {
+        let (addr, hash) =
+            create_compute_address(CALLER, 0, &CreateScheme::Create, &Bytes::new());
+        assert_eq!(addr, CALLER.create(0));
+        assert!(hash.is_none());
+    }
+
+    #[test]
+    fn test_create_compute_address_create2() {
+        let init_code = Bytes::from_static(&[0x60, 0x00]);
+        let salt = U256::from(42);
+        let (addr, hash) = create_compute_address(
+            CALLER,
+            0,
+            &CreateScheme::Create2 { salt },
+            &init_code,
+        );
+        let expected_hash = keccak256(&init_code);
+        assert_eq!(addr, CALLER.create2(salt.to_be_bytes(), expected_hash));
+        assert_eq!(hash, Some(expected_hash));
+    }
+
+    // ─── Builder depth check tests ───
+
+    #[test]
+    fn test_call_builder_depth_check_returns_early() {
+        let mut ctx = test_ctx();
+        let mut frame = EthFrame::invalid();
+        let out = OutFrame::new_init(&mut frame);
+
+        let result: Result<_, TestError> = FrameBuilder::new_call(
+            CALL_STACK_LIMIT as usize + 1,
+            SharedMemory::new(),
+            test_call_inputs(),
+        )
+        .build(out, &mut ctx, |_, _| Ok(None));
+
+        match result.unwrap() {
+            ItemOrResult::Result(FrameResult::Call(outcome)) => {
+                assert_eq!(outcome.result.result, InstructionResult::CallTooDeep);
+            }
+            _ => panic!("expected early return with CallTooDeep"),
+        }
+    }
+
+    #[test]
+    fn test_call_builder_skip_depth_check_succeeds() {
+        let mut ctx = test_ctx();
+        let mut frame = EthFrame::invalid();
+        let out = OutFrame::new_init(&mut frame);
+
+        let bytecode = Bytecode::new_legacy(Bytes::from_static(&[0x00])); // STOP
+        let hash = B256::ZERO;
+
+        let result: Result<_, TestError> = FrameBuilder::new_call(
+            CALL_STACK_LIMIT as usize + 1,
+            SharedMemory::new(),
+            test_call_inputs(),
+        )
+        .skip_depth_check()
+        .skip_value_transfer()
+        .with_bytecode(bytecode, hash) // also skips precompile check
+        .build(out, &mut ctx, |_, _| Ok(None));
+
+        match result.unwrap() {
+            ItemOrResult::Item(_) => {} // Frame was created successfully
+            ItemOrResult::Result(r) => panic!("expected frame creation, got result: {r:?}"),
+        }
+    }
+
+    #[test]
+    fn test_create_builder_depth_check_returns_early() {
+        let mut ctx = test_ctx();
+        let mut frame = EthFrame::invalid();
+        let out = OutFrame::new_init(&mut frame);
+
+        let result: Result<_, TestError> = FrameBuilder::new_create(
+            CALL_STACK_LIMIT as usize + 1,
+            SharedMemory::new(),
+            test_create_inputs(),
+        )
+        .build(out, &mut ctx);
+
+        match result.unwrap() {
+            ItemOrResult::Result(FrameResult::Create(outcome)) => {
+                assert_eq!(outcome.result.result, InstructionResult::CallTooDeep);
+            }
+            _ => panic!("expected early return with CallTooDeep"),
+        }
+    }
+
+    // ─── Builder balance / nonce tests ───
+
+    #[test]
+    fn test_create_builder_balance_check_fails() {
+        let mut ctx = test_ctx();
+        let mut frame = EthFrame::invalid();
+        let out = OutFrame::new_init(&mut frame);
+
+        // Request more value than the caller has
+        let mut inputs = test_create_inputs();
+        inputs.set_value(U256::from(999_999_999));
+
+        let result: Result<_, TestError> = FrameBuilder::new_create(
+            0,
+            SharedMemory::new(),
+            inputs,
+        )
+        .build(out, &mut ctx);
+
+        match result.unwrap() {
+            ItemOrResult::Result(FrameResult::Create(outcome)) => {
+                assert_eq!(outcome.result.result, InstructionResult::OutOfFunds);
+            }
+            _ => panic!("expected OutOfFunds"),
+        }
+    }
+
+    #[test]
+    fn test_create_builder_skip_balance_check_succeeds() {
+        let mut ctx = test_ctx();
+        let mut frame = EthFrame::invalid();
+        let out = OutFrame::new_init(&mut frame);
+
+        // Request more value than the caller has, but skip balance check
+        let mut inputs = test_create_inputs();
+        inputs.set_value(U256::from(999_999_999));
+
+        let result: Result<_, TestError> = FrameBuilder::new_create(
+            0,
+            SharedMemory::new(),
+            inputs,
+        )
+        .skip_balance_check()
+        .build(out, &mut ctx);
+
+        match result.unwrap() {
+            ItemOrResult::Item(_) => {} // Frame created despite insufficient balance
+            ItemOrResult::Result(r) => panic!("expected frame creation, got result: {r:?}"),
+        }
+    }
+
+    #[test]
+    fn test_create_builder_with_created_address() {
+        let mut ctx = test_ctx();
+        let mut frame = EthFrame::invalid();
+        let out = OutFrame::new_init(&mut frame);
+        let custom_addr = address!("0x00000000000000000000000000000000deadbeef");
+
+        let result: Result<_, TestError> = FrameBuilder::new_create(
+            0,
+            SharedMemory::new(),
+            test_create_inputs(),
+        )
+        .with_created_address(custom_addr)
+        .build(out, &mut ctx);
+
+        match result.unwrap() {
+            ItemOrResult::Item(_) => {
+                // Verify the frame was created with the custom address
+                match &frame.data {
+                    FrameData::Create(cf) => assert_eq!(cf.created_address, custom_addr),
+                    _ => panic!("expected Create frame data"),
+                }
+            }
+            ItemOrResult::Result(r) => panic!("expected frame creation, got result: {r:?}"),
+        }
+    }
+
+    // ─── Builder call-specific tests ───
+
+    #[test]
+    fn test_call_builder_empty_bytecode_returns_stop() {
+        let mut ctx = test_ctx();
+        let mut frame = EthFrame::invalid();
+        let out = OutFrame::new_init(&mut frame);
+
+        // Target has no code, so bytecode is empty
+        let result: Result<_, TestError> = FrameBuilder::new_call(
+            0,
+            SharedMemory::new(),
+            test_call_inputs(),
+        )
+        .skip_value_transfer()
+        .build(out, &mut ctx, |_, _| Ok(None));
+
+        match result.unwrap() {
+            ItemOrResult::Result(FrameResult::Call(outcome)) => {
+                assert_eq!(outcome.result.result, InstructionResult::Stop);
+            }
+            _ => panic!("expected Stop for empty bytecode"),
+        }
+    }
+
+    #[test]
+    fn test_call_builder_skip_empty_bytecode_check() {
+        let mut ctx = test_ctx();
+        let mut frame = EthFrame::invalid();
+        let out = OutFrame::new_init(&mut frame);
+
+        // Target has no code, but we skip the empty bytecode check
+        let result: Result<_, TestError> = FrameBuilder::new_call(
+            0,
+            SharedMemory::new(),
+            test_call_inputs(),
+        )
+        .skip_value_transfer()
+        .skip_empty_bytecode_check()
+        .build(out, &mut ctx, |_, _| Ok(None));
+
+        match result.unwrap() {
+            ItemOrResult::Item(_) => {} // Frame created despite empty bytecode
+            ItemOrResult::Result(r) => panic!("expected frame creation, got result: {r:?}"),
+        }
+    }
+
+    #[test]
+    fn test_call_builder_with_bytecode_skips_precompile() {
+        let mut ctx = test_ctx();
+        let mut frame = EthFrame::invalid();
+        let out = OutFrame::new_init(&mut frame);
+
+        let bytecode = Bytecode::new_legacy(Bytes::from_static(&[0x00]));
+        let hash = B256::ZERO;
+
+        // Precompile fn that would panic if called
+        let result: Result<_, TestError> = FrameBuilder::new_call(
+            0,
+            SharedMemory::new(),
+            test_call_inputs(),
+        )
+        .skip_value_transfer()
+        .with_bytecode(bytecode, hash)
+        .build(out, &mut ctx, |_, _| panic!("precompile should not be called"));
+
+        match result.unwrap() {
+            ItemOrResult::Item(_) => {} // Success — precompile was skipped
+            ItemOrResult::Result(r) => panic!("expected frame creation, got result: {r:?}"),
+        }
+    }
+
+    // ─── Builder getter tests ───
+
+    #[test]
+    fn test_builder_getters() {
+        let builder = FrameBuilder::new_call(5, SharedMemory::new(), test_call_inputs());
+        assert_eq!(builder.depth(), 5);
+        // memory() returns a reference — just verify it doesn't panic
+        let _ = builder.memory();
+    }
 }

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -578,7 +578,6 @@ impl<K> FrameBuilder<K> {
     }
 }
 
-
 // Call-specific methods.
 impl FrameBuilder<CallKind> {
     /// Create a new call frame builder with default Ethereum behavior.
@@ -1228,8 +1227,7 @@ mod tests {
 
     #[test]
     fn test_create_compute_address_create() {
-        let (addr, hash) =
-            create_compute_address(CALLER, 0, &CreateScheme::Create, &Bytes::new());
+        let (addr, hash) = create_compute_address(CALLER, 0, &CreateScheme::Create, &Bytes::new());
         assert_eq!(addr, CALLER.create(0));
         assert!(hash.is_none());
     }
@@ -1238,12 +1236,8 @@ mod tests {
     fn test_create_compute_address_create2() {
         let init_code = Bytes::from_static(&[0x60, 0x00]);
         let salt = U256::from(42);
-        let (addr, hash) = create_compute_address(
-            CALLER,
-            0,
-            &CreateScheme::Create2 { salt },
-            &init_code,
-        );
+        let (addr, hash) =
+            create_compute_address(CALLER, 0, &CreateScheme::Create2 { salt }, &init_code);
         let expected_hash = keccak256(&init_code);
         assert_eq!(addr, CALLER.create2(salt.to_be_bytes(), expected_hash));
         assert_eq!(hash, Some(expected_hash));
@@ -1330,12 +1324,8 @@ mod tests {
         let mut inputs = test_create_inputs();
         inputs.set_value(U256::from(999_999_999));
 
-        let result: Result<_, TestError> = FrameBuilder::new_create(
-            0,
-            SharedMemory::new(),
-            inputs,
-        )
-        .build(out, &mut ctx);
+        let result: Result<_, TestError> =
+            FrameBuilder::new_create(0, SharedMemory::new(), inputs).build(out, &mut ctx);
 
         match result.unwrap() {
             ItemOrResult::Result(FrameResult::Create(outcome)) => {
@@ -1355,13 +1345,9 @@ mod tests {
         let mut inputs = test_create_inputs();
         inputs.set_value(U256::from(999_999_999));
 
-        let result: Result<_, TestError> = FrameBuilder::new_create(
-            0,
-            SharedMemory::new(),
-            inputs,
-        )
-        .skip_balance_check()
-        .build(out, &mut ctx);
+        let result: Result<_, TestError> = FrameBuilder::new_create(0, SharedMemory::new(), inputs)
+            .skip_balance_check()
+            .build(out, &mut ctx);
 
         match result.unwrap() {
             ItemOrResult::Item(_) => {} // Frame created despite insufficient balance
@@ -1376,13 +1362,10 @@ mod tests {
         let out = OutFrame::new_init(&mut frame);
         let custom_addr = address!("0x00000000000000000000000000000000deadbeef");
 
-        let result: Result<_, TestError> = FrameBuilder::new_create(
-            0,
-            SharedMemory::new(),
-            test_create_inputs(),
-        )
-        .with_created_address(custom_addr)
-        .build(out, &mut ctx);
+        let result: Result<_, TestError> =
+            FrameBuilder::new_create(0, SharedMemory::new(), test_create_inputs())
+                .with_created_address(custom_addr)
+                .build(out, &mut ctx);
 
         match result.unwrap() {
             ItemOrResult::Item(_) => {
@@ -1405,13 +1388,10 @@ mod tests {
         let out = OutFrame::new_init(&mut frame);
 
         // Target has no code, so bytecode is empty
-        let result: Result<_, TestError> = FrameBuilder::new_call(
-            0,
-            SharedMemory::new(),
-            test_call_inputs(),
-        )
-        .skip_value_transfer()
-        .build(out, &mut ctx, |_, _| Ok(None));
+        let result: Result<_, TestError> =
+            FrameBuilder::new_call(0, SharedMemory::new(), test_call_inputs())
+                .skip_value_transfer()
+                .build(out, &mut ctx, |_, _| Ok(None));
 
         match result.unwrap() {
             ItemOrResult::Result(FrameResult::Call(outcome)) => {
@@ -1428,14 +1408,11 @@ mod tests {
         let out = OutFrame::new_init(&mut frame);
 
         // Target has no code, but we skip the empty bytecode check
-        let result: Result<_, TestError> = FrameBuilder::new_call(
-            0,
-            SharedMemory::new(),
-            test_call_inputs(),
-        )
-        .skip_value_transfer()
-        .skip_empty_bytecode_check()
-        .build(out, &mut ctx, |_, _| Ok(None));
+        let result: Result<_, TestError> =
+            FrameBuilder::new_call(0, SharedMemory::new(), test_call_inputs())
+                .skip_value_transfer()
+                .skip_empty_bytecode_check()
+                .build(out, &mut ctx, |_, _| Ok(None));
 
         match result.unwrap() {
             ItemOrResult::Item(_) => {} // Frame created despite empty bytecode
@@ -1453,14 +1430,13 @@ mod tests {
         let hash = B256::ZERO;
 
         // Precompile fn that would panic if called
-        let result: Result<_, TestError> = FrameBuilder::new_call(
-            0,
-            SharedMemory::new(),
-            test_call_inputs(),
-        )
-        .skip_value_transfer()
-        .with_bytecode(bytecode, hash)
-        .build(out, &mut ctx, |_, _| panic!("precompile should not be called"));
+        let result: Result<_, TestError> =
+            FrameBuilder::new_call(0, SharedMemory::new(), test_call_inputs())
+                .skip_value_transfer()
+                .with_bytecode(bytecode, hash)
+                .build(out, &mut ctx, |_, _| {
+                    panic!("precompile should not be called")
+                });
 
         match result.unwrap() {
             ItemOrResult::Item(_) => {} // Success — precompile was skipped

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -344,6 +344,26 @@ impl FrameBuilder<CallKind> {
     }
 }
 
+/// Build an early-return error for a create frame.
+///
+/// Marked `#[cold]` so the compiler lays out error-path code away from
+/// the hot instruction stream, keeping `build()` small enough to inline.
+#[cold]
+#[inline(never)]
+fn create_error_result(
+    result: InstructionResult,
+    gas_limit: u64,
+) -> ItemOrResult<FrameToken, FrameResult> {
+    ItemOrResult::Result(FrameResult::Create(CreateOutcome {
+        result: InterpreterResult {
+            result,
+            gas: Gas::new(gas_limit),
+            output: Bytes::new(),
+        },
+        address: None,
+    }))
+}
+
 impl FrameBuilder<CreateKind> {
     /// Consume the builder and produce a create frame (or an early result).
     #[inline]
@@ -371,29 +391,18 @@ impl FrameBuilder<CreateKind> {
                 },
         } = self;
 
-        let (override_checkpoint, override_input, override_gas_limit) = match overrides {
-            Some(o) => (o.checkpoint, o.interpreter_input, o.gas_limit),
-            None => (None, None, None),
-        };
-
         let spec: SpecId = ctx.cfg().spec().into();
-        let gas_limit = override_gas_limit.unwrap_or_else(|| inputs.gas_limit());
-        let return_error = |e| {
-            Ok(ItemOrResult::Result(FrameResult::Create(CreateOutcome {
-                result: InterpreterResult {
-                    result: e,
-                    gas: Gas::new(gas_limit),
-                    output: Bytes::new(),
-                },
-                address: None,
-            })))
-        };
+        let gas_limit = overrides
+            .as_ref()
+            .and_then(|o| o.gas_limit)
+            .unwrap_or_else(|| inputs.gas_limit());
 
         // Check depth
-        if do_check_depth {
-            if let Err(e) = check_depth(depth) {
-                return return_error(e);
-            }
+        if do_check_depth && depth > CALL_STACK_LIMIT as usize {
+            return Ok(create_error_result(
+                InstructionResult::CallTooDeep,
+                gas_limit,
+            ));
         }
 
         // Load caller account once for balance check, nonce bump, and/or address computation.
@@ -402,13 +411,16 @@ impl FrameBuilder<CreateKind> {
             let mut caller_info = ctx.journal_mut().load_account_mut(inputs.caller())?;
 
             if check_balance && *caller_info.balance() < inputs.value() {
-                return return_error(InstructionResult::OutOfFunds);
+                return Ok(create_error_result(
+                    InstructionResult::OutOfFunds,
+                    gas_limit,
+                ));
             }
 
             let old_nonce = caller_info.nonce();
 
             if bump_nonce && !caller_info.bump_nonce() {
-                return return_error(InstructionResult::Return);
+                return Ok(create_error_result(InstructionResult::Return, gas_limit));
             }
 
             drop(caller_info);
@@ -425,13 +437,17 @@ impl FrameBuilder<CreateKind> {
             }
         } else {
             // No balance check, no nonce bump, and override address is provided.
-            (override_address.unwrap(), None)
+            (
+                override_address.expect("override_address must be set when caller load is skipped"),
+                None,
+            )
         };
 
         // Warm load account.
         ctx.journal_mut().load_account(created_address)?;
 
         // Create account, transfer funds and make the journal checkpoint.
+        let override_checkpoint = overrides.as_ref().and_then(|o| o.checkpoint);
         let checkpoint = if let Some(cp) = override_checkpoint {
             cp
         } else {
@@ -442,7 +458,9 @@ impl FrameBuilder<CreateKind> {
                 spec,
             ) {
                 Ok(checkpoint) => checkpoint,
-                Err(e) => return return_error(e.into()),
+                Err(e) => {
+                    return Ok(create_error_result(e.into(), gas_limit));
+                }
             }
         };
 
@@ -453,9 +471,12 @@ impl FrameBuilder<CreateKind> {
             )
         });
 
-        let interpreter_input = override_input.unwrap_or_else(|| {
-            create_interpreter_input(created_address, inputs.caller(), inputs.value())
-        });
+        // Consume `overrides` here to move out interpreter_input without copying.
+        let interpreter_input = overrides
+            .and_then(|o| o.interpreter_input)
+            .unwrap_or_else(|| {
+                create_interpreter_input(created_address, inputs.caller(), inputs.value())
+            });
 
         this.get(EthFrame::invalid).clear(
             FrameData::Create(CreateFrame { created_address }),
@@ -595,7 +616,8 @@ impl<K> FrameBuilder<K> {
     /// Returns a mutable reference to the overrides, allocating the box on first use.
     #[inline]
     fn overrides_mut(&mut self) -> &mut FrameOverrides {
-        self.overrides.get_or_insert_with(|| Box::new(FrameOverrides::default()))
+        self.overrides
+            .get_or_insert_with(|| Box::new(FrameOverrides::default()))
     }
 }
 

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -958,8 +958,7 @@ impl EthFrame<EthInterpreter> {
         ItemOrResult<FrameToken, FrameResult>,
         ContextError<<<CTX as ContextTr>::Db as Database>::Error>,
     > {
-        Self::build_frame(frame_init)
-            .build(this, ctx, |ctx, inputs| precompiles.run(ctx, inputs))
+        Self::build_frame(frame_init).build(this, ctx, |ctx, inputs| precompiles.run(ctx, inputs))
     }
 }
 

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -22,10 +22,707 @@ use interpreter::{
 use primitives::{
     constants::CALL_STACK_LIMIT,
     hardfork::SpecId::{self, HOMESTEAD, LONDON, SPURIOUS_DRAGON},
-    keccak256, Address, Bytes, U256,
+    keccak256, Address, Bytes, B256, U256,
 };
 use state::Bytecode;
-use std::{borrow::ToOwned, boxed::Box, vec::Vec};
+use std::{borrow::ToOwned, boxed::Box, string::String, vec::Vec};
+
+// ────────────────────────────────────────────────────────────────────────────────
+// Standalone step functions
+// ────────────────────────────────────────────────────────────────────────────────
+
+/// Returns `Err(CallTooDeep)` if `depth > CALL_STACK_LIMIT`.
+#[inline]
+pub fn check_depth(depth: usize) -> Result<(), InstructionResult> {
+    if depth > CALL_STACK_LIMIT as usize {
+        Err(InstructionResult::CallTooDeep)
+    } else {
+        Ok(())
+    }
+}
+
+/// Transfer value from caller to target. Reverts checkpoint on failure.
+///
+/// Also touches the target account for EIP-158 state clear.
+#[inline]
+pub fn call_transfer_value<J: JournalTr>(
+    journal: &mut J,
+    caller: Address,
+    target: Address,
+    value: &CallValue,
+    checkpoint: JournalCheckpoint,
+) -> Result<(), InstructionResult> {
+    if let CallValue::Transfer(value) = *value {
+        if let Some(e) = journal.transfer_loaded(caller, target, value) {
+            journal.checkpoint_revert(checkpoint);
+            return Err(e.into());
+        }
+    }
+    Ok(())
+}
+
+/// Build [`InputsImpl`] from [`CallInputs`].
+#[inline]
+pub fn call_interpreter_input(inputs: &CallInputs) -> InputsImpl {
+    InputsImpl {
+        target_address: inputs.target_address,
+        caller_address: inputs.caller,
+        bytecode_address: Some(inputs.bytecode_address),
+        input: inputs.input.clone(),
+        call_value: inputs.value.get(),
+    }
+}
+
+/// Load bytecode from account, or use `known_bytecode` if provided.
+///
+/// Returns `(Bytecode, B256)` — the bytecode and its hash.
+#[inline]
+pub fn call_load_bytecode<J: JournalTr>(
+    journal: &mut J,
+    bytecode_address: Address,
+    known_bytecode: Option<(B256, Bytecode)>,
+) -> Result<(Bytecode, B256), <J::Database as Database>::Error> {
+    if let Some((hash, code)) = known_bytecode {
+        Ok((code, hash))
+    } else {
+        let account = journal.load_account_with_code(bytecode_address)?;
+        Ok((
+            account.info.code.clone().unwrap_or_default(),
+            account.info.code_hash,
+        ))
+    }
+}
+
+/// Check that the caller has sufficient balance for the create value transfer.
+#[inline]
+pub fn create_check_balance<J: JournalTr>(
+    journal: &mut J,
+    caller: Address,
+    value: U256,
+) -> Result<(), CreateCheckError<<J::Database as Database>::Error>> {
+    let caller_info = journal.load_account_mut(caller)?;
+    if *caller_info.balance() < value {
+        return Err(CreateCheckError::Instruction(InstructionResult::OutOfFunds));
+    }
+    Ok(())
+}
+
+/// Bump caller nonce. Returns the old nonce.
+///
+/// Errors on nonce overflow.
+#[inline]
+pub fn create_bump_nonce<J: JournalTr>(
+    journal: &mut J,
+    caller: Address,
+) -> Result<u64, CreateCheckError<<J::Database as Database>::Error>> {
+    let mut caller_info = journal.load_account_mut(caller)?;
+    let old_nonce = caller_info.nonce();
+    if !caller_info.bump_nonce() {
+        return Err(CreateCheckError::Instruction(InstructionResult::Return));
+    }
+    Ok(old_nonce)
+}
+
+/// Error type for create check/nonce operations that can fail
+/// with either a database error or an instruction result.
+#[derive(Debug)]
+pub enum CreateCheckError<DbError> {
+    /// Database error.
+    Db(DbError),
+    /// Instruction-level failure (e.g. OutOfFunds, nonce overflow).
+    Instruction(InstructionResult),
+}
+
+impl<DbError> From<DbError> for CreateCheckError<DbError> {
+    fn from(e: DbError) -> Self {
+        Self::Db(e)
+    }
+}
+
+/// Compute the created address from the scheme, caller, nonce, and init_code.
+///
+/// Returns `(address, Option<init_code_hash>)` — the hash is present for CREATE2.
+#[inline]
+pub fn create_compute_address(
+    caller: Address,
+    old_nonce: u64,
+    scheme: &CreateScheme,
+    init_code: &Bytes,
+) -> (Address, Option<B256>) {
+    match scheme {
+        CreateScheme::Create => (caller.create(old_nonce), None),
+        CreateScheme::Create2 { salt } => {
+            let hash = keccak256(init_code);
+            (caller.create2(salt.to_be_bytes(), hash), Some(hash))
+        }
+        CreateScheme::Custom { address } => (*address, None),
+    }
+}
+
+/// Build [`InputsImpl`] for a create frame.
+#[inline]
+pub fn create_interpreter_input(
+    created_address: Address,
+    caller: Address,
+    value: U256,
+) -> InputsImpl {
+    InputsImpl {
+        target_address: created_address,
+        caller_address: caller,
+        bytecode_address: None,
+        input: CallInput::Bytes(Bytes::new()),
+        call_value: value,
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────────
+// Kind marker types
+// ────────────────────────────────────────────────────────────────────────────────
+
+/// Call frame builder configuration.
+#[derive(Debug)]
+pub struct CallKind {
+    inputs: Box<CallInputs>,
+    transfer_value: bool,
+    check_precompiles: bool,
+    check_empty_bytecode: bool,
+    bytecode: Option<(Bytecode, B256)>,
+    is_static: Option<bool>,
+}
+
+/// Create frame builder configuration.
+#[derive(Debug)]
+pub struct CreateKind {
+    inputs: Box<CreateInputs>,
+    check_balance: bool,
+    bump_nonce: bool,
+    created_address: Option<Address>,
+    bytecode: Option<ExtBytecode>,
+}
+
+// ────────────────────────────────────────────────────────────────────────────────
+// FrameKind trait
+// ────────────────────────────────────────────────────────────────────────────────
+
+/// Trait enabling a single [`FrameBuilder::build`] method for both [`CallKind`] and [`CreateKind`].
+pub trait FrameKind: Sized {
+    /// Build a frame from the builder, consuming it.
+    fn build_frame<CTX, ERROR>(
+        builder: FrameBuilder<Self>,
+        this: OutFrame<'_, EthFrame>,
+        ctx: &mut CTX,
+        precompile_fn: impl FnMut(&mut CTX, &CallInputs) -> Result<Option<InterpreterResult>, String>,
+    ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR>
+    where
+        CTX: ContextTr,
+        ERROR: From<ContextTrDbError<CTX>> + FromStringError;
+}
+
+impl FrameKind for CallKind {
+    #[inline]
+    fn build_frame<CTX, ERROR>(
+        builder: FrameBuilder<Self>,
+        mut this: OutFrame<'_, EthFrame>,
+        ctx: &mut CTX,
+        mut precompile_fn: impl FnMut(
+            &mut CTX,
+            &CallInputs,
+        ) -> Result<Option<InterpreterResult>, String>,
+    ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR>
+    where
+        CTX: ContextTr,
+        ERROR: From<ContextTrDbError<CTX>> + FromStringError,
+    {
+        let FrameBuilder {
+            depth,
+            memory,
+            check_depth: do_check_depth,
+            checkpoint: override_checkpoint,
+            interpreter_input: override_input,
+            gas_limit: override_gas_limit,
+            kind:
+                CallKind {
+                    inputs,
+                    transfer_value,
+                    check_precompiles,
+                    check_empty_bytecode,
+                    bytecode: override_bytecode,
+                    is_static: override_is_static,
+                },
+        } = builder;
+
+        let gas = Gas::new(override_gas_limit.unwrap_or(inputs.gas_limit));
+        let return_result = |instruction_result: InstructionResult| {
+            Ok(ItemOrResult::Result(FrameResult::Call(CallOutcome {
+                result: InterpreterResult {
+                    result: instruction_result,
+                    gas,
+                    output: Bytes::new(),
+                },
+                memory_offset: inputs.return_memory_offset.clone(),
+                was_precompile_called: false,
+                precompile_call_logs: Vec::new(),
+            })))
+        };
+
+        // Check depth
+        if do_check_depth {
+            if let Err(e) = check_depth(depth) {
+                return return_result(e);
+            }
+        }
+
+        // Derive interpreter input and other fields before any moves.
+        let interpreter_input = override_input.unwrap_or_else(|| call_interpreter_input(&inputs));
+        let is_static = override_is_static.unwrap_or(inputs.is_static);
+        let gas_limit = override_gas_limit.unwrap_or(inputs.gas_limit);
+
+        // Create subroutine checkpoint
+        let checkpoint = override_checkpoint.unwrap_or_else(|| ctx.journal_mut().checkpoint());
+
+        // Touch address. For "EIP-158 State Clear", this will erase empty accounts.
+        if transfer_value {
+            if let Err(e) = call_transfer_value(
+                ctx.journal_mut(),
+                inputs.caller,
+                inputs.target_address,
+                &inputs.value,
+                checkpoint,
+            ) {
+                return return_result(e);
+            }
+        }
+
+        // Check precompiles
+        if check_precompiles {
+            if let Some(result) = precompile_fn(ctx, &inputs).map_err(ERROR::from_string)? {
+                let mut logs = Vec::new();
+                if result.result.is_ok() {
+                    ctx.journal_mut().checkpoint_commit();
+                } else {
+                    logs = ctx.journal_mut().logs()[checkpoint.log_i..].to_vec();
+                    ctx.journal_mut().checkpoint_revert(checkpoint);
+                }
+                return Ok(ItemOrResult::Result(FrameResult::Call(CallOutcome {
+                    result,
+                    memory_offset: inputs.return_memory_offset.clone(),
+                    was_precompile_called: true,
+                    precompile_call_logs: logs,
+                })));
+            }
+        }
+
+        // Get bytecode and hash
+        let (bytecode, bytecode_hash) = if let Some(bch) = override_bytecode {
+            bch
+        } else {
+            call_load_bytecode(
+                ctx.journal_mut(),
+                inputs.bytecode_address,
+                inputs.known_bytecode.clone(),
+            )?
+        };
+
+        // Returns success if bytecode is empty.
+        if check_empty_bytecode && bytecode.is_empty() {
+            ctx.journal_mut().checkpoint_commit();
+            return return_result(InstructionResult::Stop);
+        }
+
+        // Create interpreter and push new CallStackFrame.
+        this.get(EthFrame::invalid).clear(
+            FrameData::Call(CallFrame {
+                return_memory_range: inputs.return_memory_offset.clone(),
+            }),
+            FrameInput::Call(inputs),
+            depth,
+            memory,
+            ExtBytecode::new_with_hash(bytecode, bytecode_hash),
+            interpreter_input,
+            is_static,
+            ctx.cfg().spec().into(),
+            gas_limit,
+            checkpoint,
+        );
+        Ok(ItemOrResult::Item(this.consume()))
+    }
+}
+
+impl FrameKind for CreateKind {
+    #[inline]
+    fn build_frame<CTX, ERROR>(
+        builder: FrameBuilder<Self>,
+        mut this: OutFrame<'_, EthFrame>,
+        ctx: &mut CTX,
+        _precompile_fn: impl FnMut(&mut CTX, &CallInputs) -> Result<Option<InterpreterResult>, String>,
+    ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR>
+    where
+        CTX: ContextTr,
+        ERROR: From<ContextTrDbError<CTX>> + FromStringError,
+    {
+        let FrameBuilder {
+            depth,
+            memory,
+            check_depth: do_check_depth,
+            checkpoint: override_checkpoint,
+            interpreter_input: override_input,
+            gas_limit: override_gas_limit,
+            kind:
+                CreateKind {
+                    inputs,
+                    check_balance,
+                    bump_nonce,
+                    created_address: override_address,
+                    bytecode: override_bytecode,
+                },
+        } = builder;
+
+        let spec: SpecId = ctx.cfg().spec().into();
+        let gas_limit = override_gas_limit.unwrap_or_else(|| inputs.gas_limit());
+        let return_error = |e| {
+            Ok(ItemOrResult::Result(FrameResult::Create(CreateOutcome {
+                result: InterpreterResult {
+                    result: e,
+                    gas: Gas::new(gas_limit),
+                    output: Bytes::new(),
+                },
+                address: None,
+            })))
+        };
+
+        // Check depth
+        if do_check_depth {
+            if let Err(e) = check_depth(depth) {
+                return return_error(e);
+            }
+        }
+
+        // Check balance
+        if check_balance {
+            match create_check_balance(ctx.journal_mut(), inputs.caller(), inputs.value()) {
+                Err(CreateCheckError::Db(e)) => return Err(e.into()),
+                Err(CreateCheckError::Instruction(e)) => return return_error(e),
+                Ok(()) => {}
+            }
+        }
+
+        // Bump nonce and compute address (or use override)
+        let (created_address, init_code_hash) = if let Some(addr) = override_address {
+            // If nonce bump is requested even with an override address, do it.
+            if bump_nonce {
+                match create_bump_nonce(ctx.journal_mut(), inputs.caller()) {
+                    Err(CreateCheckError::Db(e)) => return Err(e.into()),
+                    Err(CreateCheckError::Instruction(e)) => return return_error(e),
+                    Ok(_) => {}
+                }
+            }
+            (addr, None)
+        } else if bump_nonce {
+            let old_nonce = match create_bump_nonce(ctx.journal_mut(), inputs.caller()) {
+                Err(CreateCheckError::Db(e)) => return Err(e.into()),
+                Err(CreateCheckError::Instruction(e)) => return return_error(e),
+                Ok(n) => n,
+            };
+            create_compute_address(
+                inputs.caller(),
+                old_nonce,
+                &inputs.scheme(),
+                inputs.init_code(),
+            )
+        } else {
+            // No nonce bump and no override address — use current nonce for address computation.
+            let caller_info = ctx.journal_mut().load_account_mut(inputs.caller())?;
+            let nonce = caller_info.nonce();
+            drop(caller_info);
+            create_compute_address(inputs.caller(), nonce, &inputs.scheme(), inputs.init_code())
+        };
+
+        // Warm load account.
+        ctx.journal_mut().load_account(created_address)?;
+
+        // Create account, transfer funds and make the journal checkpoint.
+        let checkpoint = if let Some(cp) = override_checkpoint {
+            cp
+        } else {
+            match ctx.journal_mut().create_account_checkpoint(
+                inputs.caller(),
+                created_address,
+                inputs.value(),
+                spec,
+            ) {
+                Ok(checkpoint) => checkpoint,
+                Err(e) => return return_error(e.into()),
+            }
+        };
+
+        let bytecode = override_bytecode.unwrap_or_else(|| {
+            ExtBytecode::new_with_optional_hash(
+                Bytecode::new_legacy(inputs.init_code().clone()),
+                init_code_hash,
+            )
+        });
+
+        let interpreter_input = override_input.unwrap_or_else(|| {
+            create_interpreter_input(created_address, inputs.caller(), inputs.value())
+        });
+
+        this.get(EthFrame::invalid).clear(
+            FrameData::Create(CreateFrame { created_address }),
+            FrameInput::Create(inputs),
+            depth,
+            memory,
+            bytecode,
+            interpreter_input,
+            false,
+            spec,
+            gas_limit,
+            checkpoint,
+        );
+        Ok(ItemOrResult::Item(this.consume()))
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────────
+// FrameBuilder<Kind>
+// ────────────────────────────────────────────────────────────────────────────────
+
+/// Configurable builder for constructing EVM call and create frames.
+///
+/// `FrameBuilder` is parameterized by a `Kind` type ([`CallKind`] or [`CreateKind`])
+/// that determines which frame-specific methods and build logic are available.
+///
+/// # Usage
+///
+/// **Default (unchanged behavior):**
+/// ```ignore
+/// FrameBuilder::new_call(depth, memory, inputs)
+///     .build(out_frame, ctx, |ctx, inputs| precompiles.run(ctx, inputs))?
+/// ```
+///
+/// **Custom call frame:**
+/// ```ignore
+/// FrameBuilder::new_call(depth, memory, inputs)
+///     .skip_precompile_check()
+///     .skip_depth_check()
+///     .with_bytecode(my_bytecode, my_hash)
+///     .build(out_frame, ctx, |ctx, inputs| precompiles.run(ctx, inputs))?
+/// ```
+///
+/// **Custom create frame:**
+/// ```ignore
+/// FrameBuilder::new_create(depth, memory, inputs)
+///     .skip_balance_check()
+///     .with_created_address(addr)
+///     .build(out_frame, ctx, |_, _| Ok(None))?
+/// ```
+///
+/// # Note on inspector hooks
+///
+/// The builder operates below the inspector layer. Direct builder usage
+/// (outside [`EthFrame::init_with_context`]) bypasses inspector hooks
+/// (`call`, `create`, `call_end`, `create_end`, `initialize_interp`).
+pub struct FrameBuilder<Kind> {
+    /// Call depth in the execution stack.
+    pub depth: usize,
+    /// Shared memory for the frame.
+    pub memory: SharedMemory,
+    check_depth: bool,
+    checkpoint: Option<JournalCheckpoint>,
+    interpreter_input: Option<InputsImpl>,
+    gas_limit: Option<u64>,
+    kind: Kind,
+}
+
+impl<Kind: core::fmt::Debug> core::fmt::Debug for FrameBuilder<Kind> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FrameBuilder")
+            .field("depth", &self.depth)
+            .field("check_depth", &self.check_depth)
+            .field("checkpoint", &self.checkpoint)
+            .field("interpreter_input", &self.interpreter_input)
+            .field("gas_limit", &self.gas_limit)
+            .field("kind", &self.kind)
+            .finish()
+    }
+}
+
+// Shared methods for any Kind.
+impl<K> FrameBuilder<K> {
+    /// Skip the call-depth check (`CALL_STACK_LIMIT`).
+    #[inline]
+    pub fn skip_depth_check(mut self) -> Self {
+        self.check_depth = false;
+        self
+    }
+
+    /// Provide an externally-created journal checkpoint instead of
+    /// letting the builder create one.
+    ///
+    /// The caller must ensure the checkpoint matches the current journal state.
+    #[inline]
+    pub fn with_checkpoint(mut self, cp: JournalCheckpoint) -> Self {
+        self.checkpoint = Some(cp);
+        self
+    }
+
+    /// Override the interpreter input that would normally be derived from the call/create inputs.
+    #[inline]
+    pub fn with_interpreter_input(mut self, input: InputsImpl) -> Self {
+        self.interpreter_input = Some(input);
+        self
+    }
+
+    /// Override the gas limit from the call/create inputs.
+    #[inline]
+    pub fn with_gas_limit(mut self, gas: u64) -> Self {
+        self.gas_limit = Some(gas);
+        self
+    }
+}
+
+// Build method for any Kind that implements FrameKind.
+impl<K: FrameKind> FrameBuilder<K> {
+    /// Consume the builder and produce a frame (or an early result).
+    ///
+    /// The `precompile_fn` closure is only used by [`CallKind`]; [`CreateKind`] ignores it.
+    #[inline]
+    pub fn build<CTX, ERROR>(
+        self,
+        this: OutFrame<'_, EthFrame>,
+        ctx: &mut CTX,
+        precompile_fn: impl FnMut(&mut CTX, &CallInputs) -> Result<Option<InterpreterResult>, String>,
+    ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR>
+    where
+        CTX: ContextTr,
+        ERROR: From<ContextTrDbError<CTX>> + FromStringError,
+    {
+        K::build_frame(self, this, ctx, precompile_fn)
+    }
+}
+
+// Call-specific methods.
+impl FrameBuilder<CallKind> {
+    /// Create a new call frame builder with default Ethereum behavior.
+    #[inline]
+    pub fn new_call(depth: usize, memory: SharedMemory, inputs: Box<CallInputs>) -> Self {
+        Self {
+            depth,
+            memory,
+            check_depth: true,
+            checkpoint: None,
+            interpreter_input: None,
+            gas_limit: None,
+            kind: CallKind {
+                inputs,
+                transfer_value: true,
+                check_precompiles: true,
+                check_empty_bytecode: true,
+                bytecode: None,
+                is_static: None,
+            },
+        }
+    }
+
+    /// Skip value transfer (and the EIP-158 account touch).
+    #[inline]
+    pub fn skip_value_transfer(mut self) -> Self {
+        self.kind.transfer_value = false;
+        self
+    }
+
+    /// Skip the precompile dispatch check.
+    #[inline]
+    pub fn skip_precompile_check(mut self) -> Self {
+        self.kind.check_precompiles = false;
+        self
+    }
+
+    /// Skip the empty-bytecode early-return check.
+    #[inline]
+    pub fn skip_empty_bytecode_check(mut self) -> Self {
+        self.kind.check_empty_bytecode = false;
+        self
+    }
+
+    /// Provide bytecode directly instead of loading it from the account.
+    ///
+    /// Also auto-skips the precompile check (custom bytecode implies no precompile dispatch).
+    #[inline]
+    pub fn with_bytecode(mut self, bytecode: Bytecode, hash: B256) -> Self {
+        self.kind.bytecode = Some((bytecode, hash));
+        self.kind.check_precompiles = false;
+        self
+    }
+
+    /// Override the `is_static` flag from the call inputs.
+    #[inline]
+    pub fn with_is_static(mut self, is_static: bool) -> Self {
+        self.kind.is_static = Some(is_static);
+        self
+    }
+}
+
+// Create-specific methods.
+impl FrameBuilder<CreateKind> {
+    /// Create a new create frame builder with default Ethereum behavior.
+    #[inline]
+    pub fn new_create(depth: usize, memory: SharedMemory, inputs: Box<CreateInputs>) -> Self {
+        Self {
+            depth,
+            memory,
+            check_depth: true,
+            checkpoint: None,
+            interpreter_input: None,
+            gas_limit: None,
+            kind: CreateKind {
+                inputs,
+                check_balance: true,
+                bump_nonce: true,
+                created_address: None,
+                bytecode: None,
+            },
+        }
+    }
+
+    /// Skip the caller balance check.
+    #[inline]
+    pub fn skip_balance_check(mut self) -> Self {
+        self.kind.check_balance = false;
+        self
+    }
+
+    /// Skip the caller nonce bump.
+    ///
+    /// When nonce bump is skipped, a `created_address` should be provided
+    /// externally since the CREATE address depends on the old nonce.
+    #[inline]
+    pub fn skip_nonce_bump(mut self) -> Self {
+        self.kind.bump_nonce = false;
+        self
+    }
+
+    /// Provide a pre-computed created address.
+    ///
+    /// Also auto-skips the nonce bump (the nonce bump is only needed
+    /// for computing the CREATE address).
+    #[inline]
+    pub fn with_created_address(mut self, addr: Address) -> Self {
+        self.kind.created_address = Some(addr);
+        self.kind.bump_nonce = false;
+        self
+    }
+
+    /// Provide init bytecode directly instead of deriving it from the create inputs.
+    #[inline]
+    pub fn with_bytecode(mut self, bytecode: ExtBytecode) -> Self {
+        self.kind.bytecode = Some(bytecode);
+        self
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────────
+// EthFrame
+// ────────────────────────────────────────────────────────────────────────────────
 
 /// Frame implementation for Ethereum.
 #[derive_where(Clone, Debug; IW,
@@ -137,113 +834,15 @@ impl EthFrame<EthInterpreter> {
         PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
         ERROR: From<ContextTrDbError<CTX>> + FromStringError,
     >(
-        mut this: OutFrame<'_, Self>,
+        this: OutFrame<'_, Self>,
         ctx: &mut CTX,
         precompiles: &mut PRECOMPILES,
         depth: usize,
         memory: SharedMemory,
         inputs: Box<CallInputs>,
     ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR> {
-        let gas = Gas::new(inputs.gas_limit);
-        let return_result = |instruction_result: InstructionResult| {
-            Ok(ItemOrResult::Result(FrameResult::Call(CallOutcome {
-                result: InterpreterResult {
-                    result: instruction_result,
-                    gas,
-                    output: Bytes::new(),
-                },
-                memory_offset: inputs.return_memory_offset.clone(),
-                was_precompile_called: false,
-                precompile_call_logs: Vec::new(),
-            })))
-        };
-
-        // Check depth
-        if depth > CALL_STACK_LIMIT as usize {
-            return return_result(InstructionResult::CallTooDeep);
-        }
-
-        // Create subroutine checkpoint
-        let checkpoint = ctx.journal_mut().checkpoint();
-
-        // Touch address. For "EIP-158 State Clear", this will erase empty accounts.
-        if let CallValue::Transfer(value) = inputs.value {
-            // Transfer value from caller to called account
-            // Target will get touched even if balance transferred is zero.
-            if let Some(i) =
-                ctx.journal_mut()
-                    .transfer_loaded(inputs.caller, inputs.target_address, value)
-            {
-                ctx.journal_mut().checkpoint_revert(checkpoint);
-                return return_result(i.into());
-            }
-        }
-
-        let interpreter_input = InputsImpl {
-            target_address: inputs.target_address,
-            caller_address: inputs.caller,
-            bytecode_address: Some(inputs.bytecode_address),
-            input: inputs.input.clone(),
-            call_value: inputs.value.get(),
-        };
-        let is_static = inputs.is_static;
-        let gas_limit = inputs.gas_limit;
-
-        if let Some(result) = precompiles.run(ctx, &inputs).map_err(ERROR::from_string)? {
-            let mut logs = Vec::new();
-            if result.result.is_ok() {
-                ctx.journal_mut().checkpoint_commit();
-            } else {
-                // clone logs that precompile created, only possible with custom precompiles.
-                // checkpoint.log_i will be always correct.
-                logs = ctx.journal_mut().logs()[checkpoint.log_i..].to_vec();
-                ctx.journal_mut().checkpoint_revert(checkpoint);
-            }
-            return Ok(ItemOrResult::Result(FrameResult::Call(CallOutcome {
-                result,
-                memory_offset: inputs.return_memory_offset.clone(),
-                was_precompile_called: true,
-                precompile_call_logs: logs,
-            })));
-        }
-
-        // Get bytecode and hash - either from known_bytecode or load from account
-        let (bytecode, bytecode_hash) = if let Some((hash, code)) = inputs.known_bytecode.clone() {
-            // Use provided bytecode and hash
-            (code, hash)
-        } else {
-            // Load account and get its bytecode
-            let account = ctx
-                .journal_mut()
-                .load_account_with_code(inputs.bytecode_address)?;
-            (
-                account.info.code.clone().unwrap_or_default(),
-                account.info.code_hash,
-            )
-        };
-
-        // Returns success if bytecode is empty.
-        if bytecode.is_empty() {
-            ctx.journal_mut().checkpoint_commit();
-            return return_result(InstructionResult::Stop);
-        }
-
-        // Create interpreter and executes call and push new CallStackFrame.
-        this.get(EthFrame::invalid).clear(
-            FrameData::Call(CallFrame {
-                return_memory_range: inputs.return_memory_offset.clone(),
-            }),
-            FrameInput::Call(inputs),
-            depth,
-            memory,
-            ExtBytecode::new_with_hash(bytecode, bytecode_hash),
-            interpreter_input,
-            is_static,
-            ctx.cfg().spec().into(),
-            gas_limit,
-            checkpoint,
-        );
-        Ok(ItemOrResult::Item(this.consume()))
+        FrameBuilder::new_call(depth, memory, inputs)
+            .build(this, ctx, |ctx, inputs| precompiles.run(ctx, inputs))
     }
 
     /// Make create frame.
@@ -252,99 +851,13 @@ impl EthFrame<EthInterpreter> {
         CTX: ContextTr,
         ERROR: From<ContextTrDbError<CTX>> + FromStringError,
     >(
-        mut this: OutFrame<'_, Self>,
+        this: OutFrame<'_, Self>,
         context: &mut CTX,
         depth: usize,
         memory: SharedMemory,
         inputs: Box<CreateInputs>,
     ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR> {
-        let spec = context.cfg().spec().into();
-        let return_error = |e| {
-            Ok(ItemOrResult::Result(FrameResult::Create(CreateOutcome {
-                result: InterpreterResult {
-                    result: e,
-                    gas: Gas::new(inputs.gas_limit()),
-                    output: Bytes::new(),
-                },
-                address: None,
-            })))
-        };
-
-        // Check depth
-        if depth > CALL_STACK_LIMIT as usize {
-            return return_error(InstructionResult::CallTooDeep);
-        }
-
-        // Fetch balance of caller.
-        let journal = context.journal_mut();
-        let mut caller_info = journal.load_account_mut(inputs.caller())?;
-
-        // Check if caller has enough balance to send to the created contract.
-        // decrement of balance is done in the create_account_checkpoint.
-        if *caller_info.balance() < inputs.value() {
-            return return_error(InstructionResult::OutOfFunds);
-        }
-
-        // Increase nonce of caller and check if it overflows
-        let old_nonce = caller_info.nonce();
-        if !caller_info.bump_nonce() {
-            return return_error(InstructionResult::Return);
-        };
-
-        // Create address
-        let mut init_code_hash = None;
-        let created_address = match inputs.scheme() {
-            CreateScheme::Create => inputs.caller().create(old_nonce),
-            CreateScheme::Create2 { salt } => {
-                let init_code_hash = *init_code_hash.insert(keccak256(inputs.init_code()));
-                inputs.caller().create2(salt.to_be_bytes(), init_code_hash)
-            }
-            CreateScheme::Custom { address } => address,
-        };
-
-        drop(caller_info); // Drop caller info to avoid borrow checker issues.
-
-        // warm load account.
-        journal.load_account(created_address)?;
-
-        // Create account, transfer funds and make the journal checkpoint.
-        let checkpoint = match context.journal_mut().create_account_checkpoint(
-            inputs.caller(),
-            created_address,
-            inputs.value(),
-            spec,
-        ) {
-            Ok(checkpoint) => checkpoint,
-            Err(e) => return return_error(e.into()),
-        };
-
-        let bytecode = ExtBytecode::new_with_optional_hash(
-            Bytecode::new_legacy(inputs.init_code().clone()),
-            init_code_hash,
-        );
-
-        let interpreter_input = InputsImpl {
-            target_address: created_address,
-            caller_address: inputs.caller(),
-            bytecode_address: None,
-            input: CallInput::Bytes(Bytes::new()),
-            call_value: inputs.value(),
-        };
-        let gas_limit = inputs.gas_limit();
-
-        this.get(EthFrame::invalid).clear(
-            FrameData::Create(CreateFrame { created_address }),
-            FrameInput::Create(inputs),
-            depth,
-            memory,
-            bytecode,
-            interpreter_input,
-            false,
-            spec,
-            gas_limit,
-            checkpoint,
-        );
-        Ok(ItemOrResult::Item(this.consume()))
+        FrameBuilder::new_create(depth, memory, inputs).build(this, context, |_, _| Ok(None))
     }
 
     /// Initializes a frame with the given context and precompiles.
@@ -360,7 +873,6 @@ impl EthFrame<EthInterpreter> {
         ItemOrResult<FrameToken, FrameResult>,
         ContextError<<<CTX as ContextTr>::Db as Database>::Error>,
     > {
-        // TODO cleanup inner make functions
         let FrameInit {
             depth,
             memory,
@@ -369,9 +881,12 @@ impl EthFrame<EthInterpreter> {
 
         match frame_input {
             FrameInput::Call(inputs) => {
-                Self::make_call_frame(this, ctx, precompiles, depth, memory, inputs)
+                FrameBuilder::new_call(depth, memory, inputs)
+                    .build(this, ctx, |ctx, inputs| precompiles.run(ctx, inputs))
             }
-            FrameInput::Create(inputs) => Self::make_create_frame(this, ctx, depth, memory, inputs),
+            FrameInput::Create(inputs) => {
+                FrameBuilder::new_create(depth, memory, inputs).build(this, ctx, |_, _| Ok(None))
+            }
             FrameInput::Empty => unreachable!(),
         }
     }

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -397,44 +397,36 @@ impl FrameKind for CreateKind {
             }
         }
 
-        // Check balance
-        if check_balance {
-            match create_check_balance(ctx.journal_mut(), inputs.caller(), inputs.value()) {
-                Err(CreateCheckError::Db(e)) => return Err(e.into()),
-                Err(CreateCheckError::Instruction(e)) => return return_error(e),
-                Ok(()) => {}
-            }
-        }
+        // Load caller account once for balance check, nonce bump, and/or address computation.
+        let needs_caller_load = check_balance || bump_nonce || override_address.is_none();
+        let (created_address, init_code_hash) = if needs_caller_load {
+            let mut caller_info = ctx.journal_mut().load_account_mut(inputs.caller())?;
 
-        // Bump nonce and compute address (or use override)
-        let (created_address, init_code_hash) = if let Some(addr) = override_address {
-            // If nonce bump is requested even with an override address, do it.
-            if bump_nonce {
-                match create_bump_nonce(ctx.journal_mut(), inputs.caller()) {
-                    Err(CreateCheckError::Db(e)) => return Err(e.into()),
-                    Err(CreateCheckError::Instruction(e)) => return return_error(e),
-                    Ok(_) => {}
-                }
+            if check_balance && *caller_info.balance() < inputs.value() {
+                return return_error(InstructionResult::OutOfFunds);
             }
-            (addr, None)
-        } else if bump_nonce {
-            let old_nonce = match create_bump_nonce(ctx.journal_mut(), inputs.caller()) {
-                Err(CreateCheckError::Db(e)) => return Err(e.into()),
-                Err(CreateCheckError::Instruction(e)) => return return_error(e),
-                Ok(n) => n,
-            };
-            create_compute_address(
-                inputs.caller(),
-                old_nonce,
-                &inputs.scheme(),
-                inputs.init_code(),
-            )
-        } else {
-            // No nonce bump and no override address — use current nonce for address computation.
-            let caller_info = ctx.journal_mut().load_account_mut(inputs.caller())?;
-            let nonce = caller_info.nonce();
+
+            let old_nonce = caller_info.nonce();
+
+            if bump_nonce && !caller_info.bump_nonce() {
+                return return_error(InstructionResult::Return);
+            }
+
             drop(caller_info);
-            create_compute_address(inputs.caller(), nonce, &inputs.scheme(), inputs.init_code())
+
+            if let Some(addr) = override_address {
+                (addr, None)
+            } else {
+                create_compute_address(
+                    inputs.caller(),
+                    old_nonce,
+                    &inputs.scheme(),
+                    inputs.init_code(),
+                )
+            }
+        } else {
+            // No balance check, no nonce bump, and override address is provided.
+            (override_address.unwrap(), None)
         };
 
         // Warm load account.
@@ -512,6 +504,7 @@ impl FrameKind for CreateKind {
 /// ```ignore
 /// FrameBuilder::new_create(depth, memory, inputs)
 ///     .skip_balance_check()
+///     .skip_nonce_bump()
 ///     .with_created_address(addr)
 ///     .build(out_frame, ctx, |_, _| Ok(None))?
 /// ```
@@ -703,12 +696,12 @@ impl FrameBuilder<CreateKind> {
 
     /// Provide a pre-computed created address.
     ///
-    /// Also auto-skips the nonce bump (the nonce bump is only needed
-    /// for computing the CREATE address).
+    /// This only overrides the address; the nonce bump still happens
+    /// by default. Chain [`.skip_nonce_bump()`](Self::skip_nonce_bump)
+    /// explicitly if the nonce bump should also be skipped.
     #[inline]
     pub fn with_created_address(mut self, addr: Address) -> Self {
         self.kind.created_address = Some(addr);
-        self.kind.bump_nonce = false;
         self
     }
 

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -192,7 +192,7 @@ pub struct CallKind {
     transfer_value: bool,
     check_precompiles: bool,
     check_empty_bytecode: bool,
-    bytecode: Option<(Bytecode, B256)>,
+    bytecode: Option<Box<(Bytecode, B256)>>,
     is_static: Option<bool>,
 }
 
@@ -203,7 +203,7 @@ pub struct CreateKind {
     check_balance: bool,
     bump_nonce: bool,
     created_address: Option<Address>,
-    bytecode: Option<ExtBytecode>,
+    bytecode: Option<Box<ExtBytecode>>,
 }
 
 // ────────────────────────────────────────────────────────────────────────────────
@@ -230,9 +230,7 @@ impl FrameBuilder<CallKind> {
             depth,
             memory,
             check_depth: do_check_depth,
-            checkpoint: override_checkpoint,
-            interpreter_input: override_input,
-            gas_limit: override_gas_limit,
+            overrides,
             kind:
                 CallKind {
                     inputs,
@@ -243,6 +241,11 @@ impl FrameBuilder<CallKind> {
                     is_static: override_is_static,
                 },
         } = self;
+
+        let (override_checkpoint, override_input, override_gas_limit) = match overrides {
+            Some(o) => (o.checkpoint, o.interpreter_input, o.gas_limit),
+            None => (None, None, None),
+        };
 
         let gas = Gas::new(override_gas_limit.unwrap_or(inputs.gas_limit));
         let return_result = |instruction_result: InstructionResult| {
@@ -307,7 +310,7 @@ impl FrameBuilder<CallKind> {
 
         // Get bytecode and hash
         let (bytecode, bytecode_hash) = if let Some(bch) = override_bytecode {
-            bch
+            *bch
         } else {
             call_load_bytecode(
                 ctx.journal_mut(),
@@ -357,9 +360,7 @@ impl FrameBuilder<CreateKind> {
             depth,
             memory,
             check_depth: do_check_depth,
-            checkpoint: override_checkpoint,
-            interpreter_input: override_input,
-            gas_limit: override_gas_limit,
+            overrides,
             kind:
                 CreateKind {
                     inputs,
@@ -369,6 +370,11 @@ impl FrameBuilder<CreateKind> {
                     bytecode: override_bytecode,
                 },
         } = self;
+
+        let (override_checkpoint, override_input, override_gas_limit) = match overrides {
+            Some(o) => (o.checkpoint, o.interpreter_input, o.gas_limit),
+            None => (None, None, None),
+        };
 
         let spec: SpecId = ctx.cfg().spec().into();
         let gas_limit = override_gas_limit.unwrap_or_else(|| inputs.gas_limit());
@@ -440,7 +446,7 @@ impl FrameBuilder<CreateKind> {
             }
         };
 
-        let bytecode = override_bytecode.unwrap_or_else(|| {
+        let bytecode = override_bytecode.map(|b| *b).unwrap_or_else(|| {
             ExtBytecode::new_with_optional_hash(
                 Bytecode::new_legacy(inputs.init_code().clone()),
                 init_code_hash,
@@ -470,6 +476,18 @@ impl FrameBuilder<CreateKind> {
 // ────────────────────────────────────────────────────────────────────────────────
 // FrameBuilder<Kind>
 // ────────────────────────────────────────────────────────────────────────────────
+
+/// Rarely-used override fields, heap-allocated only when customization
+/// methods are called. On the default (hot) path this is `None` (8 bytes).
+#[derive(Debug, Default)]
+pub struct FrameOverrides {
+    /// Externally-created journal checkpoint.
+    pub checkpoint: Option<JournalCheckpoint>,
+    /// Override for the interpreter input derived from call/create inputs.
+    pub interpreter_input: Option<InputsImpl>,
+    /// Override for the gas limit from the call/create inputs.
+    pub gas_limit: Option<u64>,
+}
 
 /// Configurable builder for constructing EVM call and create frames.
 ///
@@ -513,9 +531,8 @@ pub struct FrameBuilder<Kind> {
     /// Shared memory for the frame.
     memory: SharedMemory,
     check_depth: bool,
-    checkpoint: Option<JournalCheckpoint>,
-    interpreter_input: Option<InputsImpl>,
-    gas_limit: Option<u64>,
+    /// Boxed overrides — `None` on the default path (no heap allocation).
+    overrides: Option<Box<FrameOverrides>>,
     kind: Kind,
 }
 
@@ -524,9 +541,7 @@ impl<Kind: core::fmt::Debug> core::fmt::Debug for FrameBuilder<Kind> {
         f.debug_struct("FrameBuilder")
             .field("depth", &self.depth)
             .field("check_depth", &self.check_depth)
-            .field("checkpoint", &self.checkpoint)
-            .field("interpreter_input", &self.interpreter_input)
-            .field("gas_limit", &self.gas_limit)
+            .field("overrides", &self.overrides)
             .field("kind", &self.kind)
             .finish()
     }
@@ -559,22 +574,28 @@ impl<K> FrameBuilder<K> {
     /// The caller must ensure the checkpoint matches the current journal state.
     #[inline]
     pub fn with_checkpoint(mut self, cp: JournalCheckpoint) -> Self {
-        self.checkpoint = Some(cp);
+        self.overrides_mut().checkpoint = Some(cp);
         self
     }
 
     /// Override the interpreter input that would normally be derived from the call/create inputs.
     #[inline]
     pub fn with_interpreter_input(mut self, input: InputsImpl) -> Self {
-        self.interpreter_input = Some(input);
+        self.overrides_mut().interpreter_input = Some(input);
         self
     }
 
     /// Override the gas limit from the call/create inputs.
     #[inline]
     pub fn with_gas_limit(mut self, gas: u64) -> Self {
-        self.gas_limit = Some(gas);
+        self.overrides_mut().gas_limit = Some(gas);
         self
+    }
+
+    /// Returns a mutable reference to the overrides, allocating the box on first use.
+    #[inline]
+    fn overrides_mut(&mut self) -> &mut FrameOverrides {
+        self.overrides.get_or_insert_with(|| Box::new(FrameOverrides::default()))
     }
 }
 
@@ -587,9 +608,7 @@ impl FrameBuilder<CallKind> {
             depth,
             memory,
             check_depth: true,
-            checkpoint: None,
-            interpreter_input: None,
-            gas_limit: None,
+            overrides: None,
             kind: CallKind {
                 inputs,
                 transfer_value: true,
@@ -627,7 +646,7 @@ impl FrameBuilder<CallKind> {
     /// Also auto-skips the precompile check (custom bytecode implies no precompile dispatch).
     #[inline]
     pub fn with_bytecode(mut self, bytecode: Bytecode, hash: B256) -> Self {
-        self.kind.bytecode = Some((bytecode, hash));
+        self.kind.bytecode = Some(Box::new((bytecode, hash)));
         self.kind.check_precompiles = false;
         self
     }
@@ -649,9 +668,7 @@ impl FrameBuilder<CreateKind> {
             depth,
             memory,
             check_depth: true,
-            checkpoint: None,
-            interpreter_input: None,
-            gas_limit: None,
+            overrides: None,
             kind: CreateKind {
                 inputs,
                 check_balance: true,
@@ -693,7 +710,7 @@ impl FrameBuilder<CreateKind> {
     /// Provide init bytecode directly instead of deriving it from the create inputs.
     #[inline]
     pub fn with_bytecode(mut self, bytecode: ExtBytecode) -> Self {
-        self.kind.bytecode = Some(bytecode);
+        self.kind.bytecode = Some(Box::new(bytecode));
         self
     }
 }
@@ -1452,5 +1469,21 @@ mod tests {
         assert_eq!(builder.depth(), 5);
         // memory() returns a reference — just verify it doesn't panic
         let _ = builder.memory();
+    }
+
+    #[test]
+    fn test_frame_builder_size_reduction() {
+        let call_size = std::mem::size_of::<FrameBuilder<CallKind>>();
+        let create_size = std::mem::size_of::<FrameBuilder<CreateKind>>();
+        // With boxed overrides, builders should be well under 100 bytes on the default path.
+        // Before boxing, CallKind builder was ~300 bytes.
+        assert!(
+            call_size < 100,
+            "FrameBuilder<CallKind> is {call_size} bytes, expected < 100"
+        );
+        assert!(
+            create_size < 100,
+            "FrameBuilder<CreateKind> is {create_size} bytes, expected < 100"
+        );
     }
 }

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -519,7 +519,7 @@ impl FrameKind for CreateKind {
 /// # Note on inspector hooks
 ///
 /// The builder operates below the inspector layer. Direct builder usage
-/// (outside [`EthFrame::init_with_context`]) bypasses inspector hooks
+/// (outside [`EthFrame::build_frame`]) bypasses inspector hooks
 /// (`call`, `create`, `call_end`, `create_end`, `initialize_interp`).
 pub struct FrameBuilder<Kind> {
     /// Call depth in the execution stack.
@@ -721,6 +721,42 @@ impl FrameBuilder<CreateKind> {
 }
 
 // ────────────────────────────────────────────────────────────────────────────────
+// FrameBuilderKind
+// ────────────────────────────────────────────────────────────────────────────────
+
+/// Wraps either a [`FrameBuilder<CallKind>`] or [`FrameBuilder<CreateKind>`],
+/// returned by [`EthFrame::build_frame`] when the frame type is determined at runtime.
+#[derive(Debug)]
+pub enum FrameBuilderKind {
+    /// Call frame builder.
+    Call(FrameBuilder<CallKind>),
+    /// Create frame builder.
+    Create(FrameBuilder<CreateKind>),
+}
+
+impl FrameBuilderKind {
+    /// Consume the builder and produce a frame (or an early result).
+    ///
+    /// Dispatches to [`FrameBuilder::build`] on the inner variant.
+    #[inline]
+    pub fn build<CTX, ERROR>(
+        self,
+        this: OutFrame<'_, EthFrame>,
+        ctx: &mut CTX,
+        precompile_fn: impl FnMut(&mut CTX, &CallInputs) -> Result<Option<InterpreterResult>, String>,
+    ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR>
+    where
+        CTX: ContextTr,
+        ERROR: From<ContextTrDbError<CTX>> + FromStringError,
+    {
+        match self {
+            Self::Call(builder) => builder.build(this, ctx, precompile_fn),
+            Self::Create(builder) => builder.build(this, ctx, precompile_fn),
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────────
 // EthFrame
 // ────────────────────────────────────────────────────────────────────────────────
 
@@ -827,7 +863,54 @@ impl EthFrame<EthInterpreter> {
         *checkpoint_ref = checkpoint;
     }
 
+    /// Returns a [`FrameBuilder<CallKind>`] for constructing a call frame.
+    ///
+    /// The builder can be customized before calling [`.build()`](FrameBuilder::build).
+    #[inline]
+    pub fn build_call_frame(
+        depth: usize,
+        memory: SharedMemory,
+        inputs: Box<CallInputs>,
+    ) -> FrameBuilder<CallKind> {
+        FrameBuilder::new_call(depth, memory, inputs)
+    }
+
+    /// Returns a [`FrameBuilder<CreateKind>`] for constructing a create frame.
+    ///
+    /// The builder can be customized before calling [`.build()`](FrameBuilder::build).
+    #[inline]
+    pub fn build_create_frame(
+        depth: usize,
+        memory: SharedMemory,
+        inputs: Box<CreateInputs>,
+    ) -> FrameBuilder<CreateKind> {
+        FrameBuilder::new_create(depth, memory, inputs)
+    }
+
+    /// Returns a [`FrameBuilderKind`] for constructing a call or create frame
+    /// based on the given [`FrameInput`].
+    ///
+    /// The builder can be customized before calling [`.build()`](FrameBuilderKind::build).
+    pub fn build_frame(frame_init: FrameInit) -> FrameBuilderKind {
+        let FrameInit {
+            depth,
+            memory,
+            frame_input,
+        } = frame_init;
+
+        match frame_input {
+            FrameInput::Call(inputs) => {
+                FrameBuilderKind::Call(FrameBuilder::new_call(depth, memory, inputs))
+            }
+            FrameInput::Create(inputs) => {
+                FrameBuilderKind::Create(FrameBuilder::new_create(depth, memory, inputs))
+            }
+            FrameInput::Empty => unreachable!(),
+        }
+    }
+
     /// Make call frame
+    #[deprecated(note = "Use `build_call_frame` instead")]
     #[inline]
     pub fn make_call_frame<
         CTX: ContextTr,
@@ -841,11 +924,12 @@ impl EthFrame<EthInterpreter> {
         memory: SharedMemory,
         inputs: Box<CallInputs>,
     ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR> {
-        FrameBuilder::new_call(depth, memory, inputs)
+        Self::build_call_frame(depth, memory, inputs)
             .build(this, ctx, |ctx, inputs| precompiles.run(ctx, inputs))
     }
 
     /// Make create frame.
+    #[deprecated(note = "Use `build_create_frame` instead")]
     #[inline]
     pub fn make_create_frame<
         CTX: ContextTr,
@@ -857,10 +941,11 @@ impl EthFrame<EthInterpreter> {
         memory: SharedMemory,
         inputs: Box<CreateInputs>,
     ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR> {
-        FrameBuilder::new_create(depth, memory, inputs).build(this, context, |_, _| Ok(None))
+        Self::build_create_frame(depth, memory, inputs).build(this, context, |_, _| Ok(None))
     }
 
     /// Initializes a frame with the given context and precompiles.
+    #[deprecated(note = "Use `build_frame` instead")]
     pub fn init_with_context<
         CTX: ContextTr,
         PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
@@ -873,22 +958,8 @@ impl EthFrame<EthInterpreter> {
         ItemOrResult<FrameToken, FrameResult>,
         ContextError<<<CTX as ContextTr>::Db as Database>::Error>,
     > {
-        let FrameInit {
-            depth,
-            memory,
-            frame_input,
-        } = frame_init;
-
-        match frame_input {
-            FrameInput::Call(inputs) => {
-                FrameBuilder::new_call(depth, memory, inputs)
-                    .build(this, ctx, |ctx, inputs| precompiles.run(ctx, inputs))
-            }
-            FrameInput::Create(inputs) => {
-                FrameBuilder::new_create(depth, memory, inputs).build(this, ctx, |_, _| Ok(None))
-            }
-            FrameInput::Empty => unreachable!(),
-        }
+        Self::build_frame(frame_init)
+            .build(this, ctx, |ctx, inputs| precompiles.run(ctx, inputs))
     }
 }
 

--- a/crates/handler/src/lib.rs
+++ b/crates/handler/src/lib.rs
@@ -51,6 +51,7 @@ pub use frame::{
     CreateKind,
     EthFrame,
     FrameBuilder,
+    FrameBuilderKind,
     FrameKind,
 };
 pub use frame_data::{CallFrame, CreateFrame, FrameData, FrameResult};

--- a/crates/handler/src/lib.rs
+++ b/crates/handler/src/lib.rs
@@ -52,6 +52,7 @@ pub use frame::{
     EthFrame,
     FrameBuilder,
     FrameBuilderKind,
+    FrameOverrides,
 };
 pub use frame_data::{CallFrame, CreateFrame, FrameData, FrameResult};
 pub use handler::{EvmTrError, Handler};

--- a/crates/handler/src/lib.rs
+++ b/crates/handler/src/lib.rs
@@ -52,7 +52,6 @@ pub use frame::{
     EthFrame,
     FrameBuilder,
     FrameBuilderKind,
-    FrameKind,
 };
 pub use frame_data::{CallFrame, CreateFrame, FrameData, FrameResult};
 pub use handler::{EvmTrError, Handler};

--- a/crates/handler/src/lib.rs
+++ b/crates/handler/src/lib.rs
@@ -34,7 +34,25 @@ pub mod validation;
 // Public exports
 pub use api::{ExecuteCommitEvm, ExecuteEvm};
 pub use evm::{EvmTr, FrameTr};
-pub use frame::{return_create, ContextTrDbError, EthFrame};
+pub use frame::{
+    // Standalone step functions
+    call_interpreter_input,
+    call_load_bytecode,
+    call_transfer_value,
+    check_depth,
+    create_bump_nonce,
+    create_check_balance,
+    create_compute_address,
+    create_interpreter_input,
+    return_create,
+    CallKind,
+    ContextTrDbError,
+    CreateCheckError,
+    CreateKind,
+    EthFrame,
+    FrameBuilder,
+    FrameKind,
+};
 pub use frame_data::{CallFrame, CreateFrame, FrameData, FrameResult};
 pub use handler::{EvmTrError, Handler};
 pub use item_or_result::{FrameInitOrResult, ItemOrResult};


### PR DESCRIPTION
## Summary

- Extract each step from `make_call_frame`/`make_create_frame` into standalone public functions (`check_depth`, `call_transfer_value`, `call_load_bytecode`, `create_check_balance`, `create_bump_nonce`, `create_compute_address`, etc.) for fine-grained reuse
- Introduce a generic `FrameBuilder<Kind>` (with `CallKind` and `CreateKind` marker types) so custom EVM variants (L2s, deposit txs) can skip or override individual steps (balance check, nonce bump, precompile dispatch, value transfer) without rewriting the entire frame initialization
- Refactor `make_call_frame`, `make_create_frame`, and `init_with_context` to thin wrappers that delegate to the builder, preserving identical behavior

## Usage examples

**Default (unchanged behavior):**
```rust
EthFrame::init_with_context(frame, ctx, precompiles, frame_init)?
```

**Custom call frame (e.g. skip precompile check, provide bytecode directly):**
```rust
FrameBuilder::new_call(depth, memory, inputs)
    .skip_precompile_check()
    .skip_depth_check()
    .with_bytecode(my_bytecode, my_hash)
    .build(out_frame, ctx, |ctx, inputs| precompiles.run(ctx, inputs))?
```

**Custom create frame (e.g. deposit tx skipping balance/nonce):**
```rust
FrameBuilder::new_create(depth, memory, inputs)
    .skip_balance_check()
    .with_created_address(addr)  // auto-skips nonce bump
    .build(out_frame, ctx, |_, _| Ok(None))?
```

**Using step functions directly:**
```rust
check_depth(depth)?;
let journal = ctx.journal_mut();
let checkpoint = journal.checkpoint();
call_transfer_value(journal, caller, target, &value, checkpoint)?;
let (bytecode, hash) = call_load_bytecode(journal, addr, known)?;
```

## Test plan

- [x] `cargo build` — clean
- [x] `cargo nextest run --workspace` — 363 tests passed, 0 failures
- [x] `cargo clippy --workspace --all-targets --all-features` — clean
- [x] `cargo check --target riscv32imac-unknown-none-elf --no-default-features` — no_std OK
- [x] `cargo check --target riscv64imac-unknown-none-elf --no-default-features` — no_std OK