### PR TITLE
feat(revme): add --json output flag to evmrunner command

### DIFF
--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -15,6 +15,7 @@ revm = { workspace = true, features = [
     "std",
     "c-kzg",
     "blst",
+    "serde",
     "tracer",
     "parse",
     "test-types",

--- a/bins/revme/src/cmd/evmrunner.rs
+++ b/bins/revme/src/cmd/evmrunner.rs
@@ -56,6 +56,9 @@ pub struct Cmd {
     /// Whether to print the trace
     #[arg(long)]
     trace: bool,
+    /// Output results in JSON format
+    #[arg(long)]
+    json: bool,
 }
 
 impl Cmd {
@@ -128,12 +131,27 @@ impl Cmd {
         .map_err(|_| Errors::EVMError)?;
         let time = time.elapsed();
 
-        println!("Result: {:#?}", r.result);
-        if self.state {
-            println!("State: {:#?}", r.state);
+        if self.json {
+            let json = if self.state {
+                serde_json::json!({
+                    "result": r.result,
+                    "state": r.state,
+                    "elapsed": time.as_secs_f64(),
+                })
+            } else {
+                serde_json::json!({
+                    "result": r.result,
+                    "elapsed": time.as_secs_f64(),
+                })
+            };
+            println!("{}", serde_json::to_string_pretty(&json).unwrap());
+        } else {
+            println!("Result: {:#?}", r.result);
+            if self.state {
+                println!("State: {:#?}", r.state);
+            }
+            println!("Elapsed: {time:?}");
         }
-
-        println!("Elapsed: {time:?}");
         Ok(())
     }
 }


### PR DESCRIPTION
Noticed that statetest and blockchaintest both have --json but evmrunner doesn't, which makes it a pain to parse output in scripts. Added a --json flag that dumps the execution result as structured JSON instead of Debug format. When combined with --state, it includes the state diff too.

Had to enable the serde feature for revm in revme's Cargo.toml since the result types need it for serialization.