### PR TITLE
fix(context): use EIP-7907 code size limits for Prague+

### DIFF
--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -2,7 +2,7 @@
 pub use context_interface::Cfg;
 
 use context_interface::cfg::GasParams;
-use primitives::{eip170, eip3860, eip7825, hardfork::SpecId};
+use primitives::{eip170, eip3860, eip7825, eip7907, hardfork::SpecId};
 
 /// EVM configuration
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -409,7 +409,11 @@ impl<SPEC: Into<SpecId> + Clone> Cfg for CfgEnv<SPEC> {
 
     fn max_code_size(&self) -> usize {
         self.limit_contract_code_size
-            .unwrap_or(eip170::MAX_CODE_SIZE)
+            .unwrap_or(if self.spec.clone().into().is_enabled_in(SpecId::PRAGUE) {
+                eip7907::MAX_CODE_SIZE
+            } else {
+                eip170::MAX_CODE_SIZE
+            })
     }
 
     fn max_initcode_size(&self) -> usize {
@@ -418,7 +422,11 @@ impl<SPEC: Into<SpecId> + Clone> Cfg for CfgEnv<SPEC> {
                 self.limit_contract_code_size
                     .map(|size| size.saturating_mul(2))
             })
-            .unwrap_or(eip3860::MAX_INITCODE_SIZE)
+            .unwrap_or(if self.spec.clone().into().is_enabled_in(SpecId::PRAGUE) {
+                eip7907::MAX_INITCODE_SIZE
+            } else {
+                eip3860::MAX_INITCODE_SIZE
+            })
     }
 
     fn is_eip3541_disabled(&self) -> bool {


### PR DESCRIPTION
max_code_size() and max_initcode_size() were hardcoded to EIP-170/EIP-3860 limits regardless of the active spec. The eip7907 constants were already defined in primitives but never actually used. Now these methods check the spec and return the correct limits for Prague+ (0xC000 for code, 0x12000 for initcode), matching the pattern already used by tx_gas_limit_cap(). Manual overrides via limit_contract_code_size/limit_contract_initcode_size still take priority.

Quick question @rakita — is there a timeline for the next revm release? This fix could affect downstream consumers like reth.
