### PR TITLE
perf(database): add reserve calls in merge_transitions and extend_state

### DIFF
--- a/crates/database/src/states/bundle_account.rs
+++ b/crates/database/src/states/bundle_account.rs
@@ -146,6 +146,7 @@ impl BundleAccount {
         let extend_storage =
             |this_storage: &mut StorageWithOriginalValues,
              storage_update: StorageWithOriginalValues| {
+                this_storage.reserve(storage_update.len());
                 for (key, value) in storage_update {
                     this_storage.entry(key).or_insert(value).present_value = value.present_value;
                 }

--- a/crates/database/src/states/bundle_state.rs
+++ b/crates/database/src/states/bundle_state.rs
@@ -564,6 +564,7 @@ impl BundleState {
         };
         let mut reverts = Vec::with_capacity(reverts_capacity);
 
+        self.state.reserve(transitions.transitions.len());
         for (address, transition) in transitions.transitions.into_iter() {
             // Add new contract if it was created/changed.
             if let Some((hash, new_bytecode)) = transition.has_new_contract() {
@@ -691,6 +692,7 @@ impl BundleState {
     ///
     /// Updates the `other` state only if `other` is not flagged as destroyed.
     pub fn extend_state(&mut self, other_state: AddressMap<BundleAccount>) {
+        self.state.reserve(other_state.len());
         for (address, other_account) in other_state {
             match self.state.entry(address) {
                 Entry::Occupied(mut entry) => {
@@ -703,6 +705,7 @@ impl BundleState {
                         this.storage = other_account.storage;
                     } else {
                         // Otherwise extend this storage with other
+                        this.storage.reserve(other_account.storage.len());
                         for (key, storage_slot) in other_account.storage {
                             // Update present value or insert storage slot.
                             this.storage


### PR DESCRIPTION
## Summary
Pre-allocate hashmap capacity before inserting in loops to reduce rehashing overhead.

## Changes
- `apply_transitions_and_create_reverts`: reserve `self.state` for incoming transitions
- `update_and_create_revert` / `extend_storage`: reserve `this_storage` for `storage_update`
- `extend_state`: reserve `self.state` for `other_state`, and `this.storage` for per-account storage

Prompted by: DaniPopes