### PR TITLE
chore: configure dependabot to run on Mondays with grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Schedule dependabot to run specifically on Mondays instead of any day of the week
- Group all dependency updates into a single PR to reduce noise

## Test plan
- Verify dependabot.yml syntax is valid
- Dependabot will create grouped PRs starting next Monday