### PR TITLE
feat: add revert inspector example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1876,6 +1876,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-revert-inspector"
+version = "0.0.0"
+dependencies = [
+ "alloy-sol-types",
+ "anyhow",
+ "revm",
+]
+
+[[package]]
 name = "example-uniswap-get-reserves"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "examples/custom_opcodes",
     "examples/custom_precompile_journal",
     "examples/bal_example",
+    "examples/revert_inspector",
 ]
 resolver = "2"
 default-members = ["crates/revm"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,3 +8,4 @@
 * `block_traces`: Uses Alloy to fetch blocks transaction and state from provider to execute full block. It uses Eip3155 opcode tracer and saves output to the file.
 * `custom_opcodes`: Example of introducing a custom instruction to the mainnet Evm.
 * `database_components`: Example of decoupled Database in `State` and `BlockHash` and how to use it inside Revm.
+* `revert_inspect`: Demonstrate how to inspect a revert output from a contract call.

--- a/examples/revert_inspector/Cargo.toml
+++ b/examples/revert_inspector/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "example-revert-inspector"
+version = "0.0.0"
+publish = false
+authors.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
+rust-version.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true
+
+[dependencies]
+revm = { workspace = true, features = ["std"] }
+alloy-sol-types = { workspace = true, features = ["std"] }
+anyhow.workspace = true

--- a/examples/revert_inspector/src/main.rs
+++ b/examples/revert_inspector/src/main.rs
@@ -1,0 +1,156 @@
+//! Revert inspector example.
+//!
+//! This example demonstrates how to handle a revert from a contract call and how to decode it.
+//! Reference:
+//!     1. https://docs.soliditylang.org/en/latest/internals/layout_in_calldata.html
+//!     2. https://docs.soliditylang.org/en/latest/abi-spec.html#abi
+
+use alloy_sol_types::SolValue;
+use anyhow::bail;
+use revm::{
+    bytecode::opcode,
+    context::{result::ExecutionResult, TxEnv},
+    database::{CacheDB, EmptyDB},
+    primitives::{address, hex, keccak256, Bytes, TxKind, U256},
+    state::{AccountInfo, Bytecode},
+    Context, ExecuteEvm, MainBuilder, MainContext,
+};
+
+#[rustfmt::skip]
+/// Bytecode associared with a contract that alway revert when called. The bytecode is composed
+/// as follow:
+///     (0 - 4) | (5 - 36) | (37 - 68) | (69 - 100)
+///        |         |           |           |
+///        |         |           |           ---  "I revert"
+///        |         |           ---  string length
+///        |         ---  string encoding start
+///        ---  error function selector
+const REVERT_CODE: &[u8] = &[
+    // Save in memory the function selector for the revert errror.
+    // Since MSTORE always push a word, and left pad with zeros, we manually
+    // insert all the 32 bytes.
+    opcode::PUSH32,
+    0x08, 0xc3, 0x79, 0xa0, // keccak256("Error(string)")[0..4]
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    opcode::PUSH0,
+    opcode::MSTORE,
+    // Save in memory the pointer to the start of the string.
+    opcode::PUSH1, 0x20,
+    opcode::PUSH1, 0x04,
+    opcode::MSTORE,
+    // Save in memory the length of the string.
+    opcode::PUSH1, 0x08,
+    opcode::PUSH1, 0x24,
+    opcode::MSTORE,
+    // Save in memory the error string value.
+    opcode::PUSH32,
+    0x49, 0x20, 0x72, 0x65, 0x76, 0x65, 0x72, 0x74, // b"I revert"
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    opcode::PUSH1, 0x44,
+    opcode::MSTORE,
+    // Trigger the revert.
+    opcode::PUSH1, 0x64,
+    opcode::PUSH0,
+    opcode::REVERT,
+];
+
+/// Decode the revert data uisng the abi decoding.
+fn decode_revert_output_with_abi(data: &Bytes) -> Option<String> {
+    let function_selector = &keccak256("Error(string)")[0..4];
+
+    if data.len() < 4 || &data[0..4] != function_selector {
+        return None;
+    }
+
+    <String as SolValue>::abi_decode(&data[4..]).ok()
+}
+
+/// Decode the revert data manually.
+fn decode_revert_output_manually(data: &Bytes) -> Option<String> {
+    // Ensure data has the expected length given by the function selector + error string encoding.
+    if data.len() != 100 {
+        return None;
+    }
+
+    let function_selector = &keccak256("Error(string)")[0..4];
+    if &data[0..4] != function_selector {
+        return None;
+    }
+
+    let offset_bytes = &data[4..36];
+    let offset = usize::try_from(U256::from_be_slice(offset_bytes)).unwrap();
+
+    let length_start = 4 + offset;
+    let length_end = length_start + 32;
+    let length = usize::try_from(U256::from_be_slice(&data[length_start..length_end])).unwrap();
+
+    let string_data = &data[length_end..length_end + length];
+
+    String::from_utf8(string_data.to_vec()).ok()
+}
+
+/// Entrypoint for the revert inspector example.
+pub fn main() -> anyhow::Result<()> {
+    println!("=========================");
+    println!("Revert Inspector Exampple");
+    println!("=========================\n");
+
+    let contract_address = address!("1000000000000000000000000000000000000001");
+
+    let code_hash = keccak256(REVERT_CODE);
+
+    let mut db = CacheDB::<EmptyDB>::default();
+    // Instead of going through the contract deployment flow, we just insert the
+    // bytedcode at the selected address.
+    db.insert_account_info(
+        contract_address,
+        AccountInfo {
+            code: Some(Bytecode::new_legacy(REVERT_CODE.into())),
+            code_hash,
+            ..Default::default()
+        },
+    );
+
+    println!(
+        "Bytecode added to the account with address: 0x{}",
+        hex::encode(contract_address)
+    );
+
+    let mut evm = Context::mainnet().with_db(db).build_mainnet();
+    // Directly call into the contract form the EVM.
+    let result_and_state = evm.transact(
+        TxEnv::builder()
+            .kind(TxKind::Call(contract_address))
+            .build()
+            .unwrap(),
+    )?;
+    println!("Transaction executed.");
+
+    // Handle the result of the contract call. We alway expected a revert here.
+    match result_and_state.result {
+        ExecutionResult::Revert { output, .. } => {
+            println!("Transaction reverted as expected!");
+            println!("Output raw bytes: 0x{}", hex::encode(output.clone()));
+
+            if let Some(reason) = decode_revert_output_manually(&output) {
+                println!("Revert reason (manual decoding): {reason}");
+            } else {
+                bail!("Expected a revert reason");
+            }
+
+            if let Some(reason) = decode_revert_output_with_abi(&output) {
+                println!("Revert reason (abi decoding): {reason}");
+            } else {
+                bail!("Expected a revert reason");
+            }
+        }
+        _ => bail!("Expected a revert"),
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Add a simple example demonstrating how to handle and inspect a revert from a contract call.