### PR TITLE
fix(handler): reject EIP-4844 blob transactions with create kind

### DIFF
--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -179,6 +179,11 @@ pub fn validate_tx_env<CTX: ContextTr>(
                 return Err(InvalidTransaction::Eip4844NotSupported);
             }
 
+            // Blob transactions cannot be create transactions.
+            if tx.kind().is_create() {
+                return Err(InvalidTransaction::BlobCreateTransaction);
+            }
+
             validate_priority_fee_for_tx(tx, base_fee, disable_priority_fee_check)?;
 
             validate_eip4844_tx(


### PR DESCRIPTION
using revm as a standalone execution engine for a custom block builder, where transactions are constructed via TxEnv::builder() rather than decoded from RLP. During testing found that a type-3 blob tx with kind=Create passes validate_tx_env() without error, even though EIP-4844 explicitly forbids this (blob txs must have a `to` address).

The BlobCreateTransaction error variant already exists in result.rs with the comment "Blob transaction can't be a create transaction. `to` must be present" — it's just never returned. This adds the missing is_create() guard in the Eip4844 branch, same pattern as the empty auth list check in the Eip7702 branch right below it.
