### PR TITLE
fix: Refactor hints_util likely/unlikely to remove duplicated cold path logic`

### DIFF
--- a/crates/primitives/src/hints_util.rs
+++ b/crates/primitives/src/hints_util.rs
@@ -9,24 +9,23 @@
 #[cold]
 pub fn cold_path() {}
 
+#[inline(always)]
+fn cold_if(b: bool) {
+    if b {
+        cold_path();
+    }
+}
+
 /// Returns `b` but mark `false` path as cold
 #[inline(always)]
 pub fn likely(b: bool) -> bool {
-    if b {
-        true
-    } else {
-        cold_path();
-        false
-    }
+    cold_if(!b);
+    b
 }
 
 /// Returns `b` but mark `true` path as cold
 #[inline(always)]
 pub fn unlikely(b: bool) -> bool {
-    if b {
-        cold_path();
-        true
-    } else {
-        false
-    }
+    cold_if(b);
+    b
 }


### PR DESCRIPTION


Refactor `revm-primitives` `hints_util::likely` and `hints_util::unlikely` to share the common cold-path logic while preserving their public API and behavior.
