### PR TITLE
chore: preserve account_id in BAL storage fallback

### DIFF
--- a/crates/database/interface/src/bal.rs
+++ b/crates/database/interface/src/bal.rs
@@ -373,7 +373,7 @@ impl<DB: Database> Database for BalDatabase<DB> {
         }
 
         self.db
-            .storage(address, storage_key)
+            .storage_by_account_id(address, account_id, storage_key)
             .map_err(EvmDatabaseError::Database)
     }
 


### PR DESCRIPTION
BalDatabase now falls back to `db.storage_by_account_id(address, account_id, storage_key)` when BAL storage misses, preserving `account_id` for downstream account-indexed storage lookups.