### PR TITLE
chore: bump c-kzg from 2.1.4 to 2.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.5"
+version = "2.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e00bf4b112b07b505472dbefd19e37e53307e2bfed5a79e0cc161d58ccd0e687"
+checksum = "1a0f582957c24870b7bfd12bf562c40b4734b533cafbaf8ded31d6d85f462c01"
 dependencies = [
  "blst",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ aurora-engine-modexp = { version = "1.2", default-features = false }
 gmp-mpfr-sys = { version = "1.6", default-features = false }
 blst = "0.3.15"
 bn = { package = "substrate-bn", version = "0.6", default-features = false }
-c-kzg = { version = "2.1.4", default-features = false }
+c-kzg = { version = "2.1.6", default-features = false }
 k256 = { version = "0.13.4", default-features = false }
 secp256k1 = { version = "0.31.1", default-features = false }
 sha2 = { version = "0.10.9", default-features = false }


### PR DESCRIPTION
## Summary
- Bumps `c-kzg` dependency from 2.1.4 to 2.1.6

### Notable changes in c-kzg
- **2.1.5**: Fix weak Fiat-Shamir vulnerability in `verify_cell_kzg_proof_batch`
- **2.1.6**: ~10% performance improvement for `compute_cells_and_kzg_proofs` and `recover_cells_and_kzg_proofs`, improved portability (FreeBSD support)