### PR TITLE
fix: forward account_id in BalDatabase::storage_by_account_id fallback

### DIFF
--- a/crates/database/interface/src/bal.rs
+++ b/crates/database/interface/src/bal.rs
@@ -373,7 +373,7 @@ impl<DB: Database> Database for BalDatabase<DB> {
         }
 
         self.db
-            .storage(address, storage_key)
+            .storage_by_account_id(address, account_id, storage_key)
             .map_err(EvmDatabaseError::Database)
     }
 


### PR DESCRIPTION
Fix BalDatabase::storage_by_account_id fallback to call self.db.storage_by_account_id() instead of self.db.storage()

Without this fix, when the BAL layer misses, the account_id is silently discarded and the inner database falls back to address-based lookup, defeating any index-based fast path the inner database may implement.