### PR TITLE
Remove unused `call_depth` field from `TestInspector`

### DIFF
--- a/crates/inspector/src/test_inspector.rs
+++ b/crates/inspector/src/test_inspector.rs
@@ -71,8 +71,6 @@ pub struct TestInspector {
     pub events: Vec<InspectorEvent>,
     /// Total step count.
     pub step_count: usize,
-    /// Current call depth.
-    pub call_depth: usize,
 }
 
 impl TestInspector {
@@ -145,7 +143,6 @@ where
     }
 
     fn call(&mut self, _ctx: &mut CTX, inputs: &mut CallInputs) -> Option<CallOutcome> {
-        self.call_depth += 1;
         self.events.push(InspectorEvent::Call {
             inputs: inputs.clone(),
             outcome: None,
@@ -154,7 +151,6 @@ where
     }
 
     fn call_end(&mut self, _ctx: &mut CTX, _inputs: &CallInputs, outcome: &mut CallOutcome) {
-        self.call_depth -= 1;
         if let Some(InspectorEvent::Call {
             outcome: ref mut out,
             ..


### PR DESCRIPTION
**Description:** `call_depth` is incremented in `call()` and decremented in `call_end()` but never read anywhere — not in assertions, not in event matching, not in any public API. It's dead state that adds noise to the struct. Call nesting is already recoverable from the `events` vector via the `Call { outcome: None }` matching pattern.