### PR TITLE
perf(database): use retain to filter storage slots in-place

### DIFF
--- a/crates/database/src/states/cache.rs
+++ b/crates/database/src/states/cache.rs
@@ -203,11 +203,12 @@ impl CacheState {
         let is_created = account.is_created();
         let is_empty = account.is_empty();
 
-        // Transform evm storage to storage with previous value.
-        let changed_storage = account
-            .storage
+        // Filter unchanged storage slots in-place, then convert to StorageSlot.
+        // retain() avoids allocating a new map and gives collect() an exact size hint.
+        let mut storage = account.storage;
+        storage.retain(|_, slot| slot.is_changed());
+        let changed_storage = storage
             .into_iter()
-            .filter(|(_, slot)| slot.is_changed())
             .map(|(key, slot)| (key, slot.into()))
             .collect();
 


### PR DESCRIPTION
`apply_account_state()` builds `changed_storage` by chaining `.into_iter().filter().map().collect()`, which allocates a new map even though we're just removing unchanged slots.

This replaces the chain with `retain()` to filter in-place, then `.into_iter().map().collect()` on the already-filtered map. `retain()` avoids the intermediate allocation and gives `collect()` an exact size hint.

Fixes #3374.