### PR TITLE
perf(interpreter): copy Instruction into local to keep both fields register-resident

### DIFF
--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -294,7 +294,7 @@ impl<IW: InterpreterTypes> Interpreter<IW> {
         // it will do noop and just stop execution of this contract
         self.bytecode.relative_jump(1);
 
-        let instruction = unsafe { instruction_table.get_unchecked(opcode as usize) };
+        let instruction = *unsafe { instruction_table.get_unchecked(opcode as usize) };
 
         if self.gas.record_cost_unsafe(instruction.static_gas()) {
             return self.halt_oog();


### PR DESCRIPTION
## Summary

Copy the `Instruction` struct (16 bytes: fn pointer + `u64` static gas) into a local variable instead of using a reference, avoiding a redundant memory load when `execute()` is called after `static_gas()`.

```diff
- let instruction = unsafe { instruction_table.get_unchecked(opcode as usize) };
+ let instruction = *unsafe { instruction_table.get_unchecked(opcode as usize) };
```

## Why

The `Instruction` struct is 16 bytes (fn pointer + u64 gas) and implements `Copy`. When accessed via reference, the compiler may emit two separate loads from the table — one for `static_gas()` and a second for `execute()`. Copying into a local allows both fields to stay in registers.

## Benchmark Results

### Criterion microbenchmarks (local)

Compared patched vs unpatched (parent commit) using `cargo bench -p revme --bench evm`:

| Benchmark | Unpatched | Patched | Change | p |
|-----------|-----------|---------|--------|---|
| PUSH1_50  | 599.63 ns | 574.82 ns | **-4.1%** | 0.00 |
| POP_50    | 749.96 ns | 722.14 ns | **-3.7%** | 0.01 |
| transfer  | 213.03 ns | 214.20 ns | +0.5% | — |
| snailtracer | 24.97 ms | 25.28 ms | +1.2% | — |

Cheap opcode benchmarks (PUSH1_50, POP_50) show consistent improvement where the dispatch loop dominates. Heavier benchmarks (snailtracer, transfer) are in the noise — expected since dispatch overhead is a smaller fraction of total execution time.

**Note:** CodSpeed CI shows 0% change because it uses CPU simulation (instruction counting), which cannot detect register-vs-memory latency differences. Wall-clock benchmarks are needed to observe this optimization.

### Staging benchmarks (conduit block builder, full block production)

**+1.7% median throughput** on a production-like staging environment under 3000 TPS load, consistent with the microbenchmark signal being partially diluted by real workload overhead.

## Notes

- The `Instruction` struct is `#[derive(Clone, Copy)]` and 16 bytes — copying is trivially cheap
- Single-character change (`*` dereference) with no API or behavioral changes
- Targets the interpreter hot loop where every cycle matters
