### PR TITLE
chore(revme): handle system call errors

### DIFF
--- a/bins/revme/src/cmd/blockchaintest.rs
+++ b/bins/revme/src/cmd/blockchaintest.rs
@@ -752,7 +752,11 @@ fn execute_blockchain_test(
         let mut evm = evm_context.build_mainnet_with_inspector(TracerEip3155::new_stdout());
 
         // Pre block system calls
-        pre_block::pre_block_transition(&mut evm, spec_id, parent_block_hash, beacon_root);
+        pre_block::pre_block_transition(&mut evm, spec_id, parent_block_hash, beacon_root)
+            .map_err(|e| TestExecutionError::PreBlockSystemCall {
+                block_idx,
+                error: format!("{e:?}"),
+            })?;
 
         // Track cumulative gas used across all transactions in this block
         let mut cumulative_gas_used: u64 = 0;
@@ -984,7 +988,11 @@ fn execute_blockchain_test(
             &block_env,
             block.withdrawals.as_deref().unwrap_or_default(),
             spec_id,
-        );
+        )
+        .map_err(|e| TestExecutionError::PostBlockSystemCall {
+            block_idx,
+            error: format!("{e:?}"),
+        })?;
 
         // insert present block hash.
         state
@@ -1169,6 +1177,12 @@ pub enum TestExecutionError {
         expected: u64,
         actual: u64,
     },
+
+    #[error("Pre-block system call failed at block {block_idx}: {error}")]
+    PreBlockSystemCall { block_idx: usize, error: String },
+
+    #[error("Post-block system call failed at block {block_idx}: {error}")]
+    PostBlockSystemCall { block_idx: usize, error: String },
 
     #[error("BAL error")]
     BalMismatchError,

--- a/bins/revme/src/cmd/blockchaintest/post_block.rs
+++ b/bins/revme/src/cmd/blockchaintest/post_block.rs
@@ -24,7 +24,7 @@ pub fn post_block_transition<
     block: impl Block,
     withdrawals: &[Withdrawal],
     spec: SpecId,
-) {
+) -> Result<(), EVM::Error> {
     // block reward
     let block_reward = block_reward(spec, 0);
     if block_reward != 0 {
@@ -51,13 +51,15 @@ pub fn post_block_transition<
 
     // EIP-7002: Withdrawal requests system call
     if spec.is_enabled_in(SpecId::PRAGUE) {
-        system_call_eip7002_withdrawal_request(evm);
+        system_call_eip7002_withdrawal_request(evm)?;
     }
 
     // EIP-7251: Consolidation requests system call
     if spec.is_enabled_in(SpecId::PRAGUE) {
-        system_call_eip7251_consolidation_request(evm);
+        system_call_eip7251_consolidation_request(evm)?;
     }
+
+    Ok(())
 }
 
 /// Block reward for a block.
@@ -82,29 +84,25 @@ pub const WITHDRAWAL_REQUEST_ADDRESS: Address =
     address!("0x00000961Ef480Eb55e80D19ad83579A64c007002");
 
 /// EIP-7002: Withdrawal requests system call
-pub(crate) fn system_call_eip7002_withdrawal_request(
-    evm: &mut impl SystemCallCommitEvm<Error: core::fmt::Debug>,
-) {
+pub(crate) fn system_call_eip7002_withdrawal_request<EVM>(evm: &mut EVM) -> Result<(), EVM::Error>
+where
+    EVM: SystemCallCommitEvm<Error: core::fmt::Debug>,
+{
     // empty data is valid for EIP-7002
-    let _ = match evm.system_call_commit(WITHDRAWAL_REQUEST_ADDRESS, Bytes::new()) {
-        Ok(res) => res,
-        Err(e) => {
-            panic!("System call failed: {e:?}");
-        }
-    };
+    evm.system_call_commit(WITHDRAWAL_REQUEST_ADDRESS, Bytes::new())?;
+    Ok(())
 }
 
 pub const CONSOLIDATION_REQUEST_ADDRESS: Address =
     address!("0x0000BBdDc7CE488642fb579F8B00f3a590007251");
 
 /// EIP-7251: Consolidation requests system call
-pub(crate) fn system_call_eip7251_consolidation_request(
-    evm: &mut impl SystemCallCommitEvm<Error: core::fmt::Debug>,
-) {
-    let _ = match evm.system_call_commit(CONSOLIDATION_REQUEST_ADDRESS, Bytes::new()) {
-        Ok(res) => res,
-        Err(e) => {
-            panic!("System call failed: {e:?}");
-        }
-    };
+pub(crate) fn system_call_eip7251_consolidation_request<EVM>(
+    evm: &mut EVM,
+) -> Result<(), EVM::Error>
+where
+    EVM: SystemCallCommitEvm<Error: core::fmt::Debug>,
+{
+    evm.system_call_commit(CONSOLIDATION_REQUEST_ADDRESS, Bytes::new())?;
+    Ok(())
 }

--- a/bins/revme/src/cmd/blockchaintest/pre_block.rs
+++ b/bins/revme/src/cmd/blockchaintest/pre_block.rs
@@ -22,53 +22,53 @@ pub fn pre_block_transition<
     spec: SpecId,
     parent_block_hash: Option<B256>,
     parent_beacon_block_root: Option<B256>,
-) {
+) -> Result<(), EVM::Error> {
     // skip system calls for block number 0 (Gensis block)
     if evm.ctx().block().number() == 0 {
-        return;
+        return Ok(());
     }
 
     // blockhash system call
     if let Some(parent_block_hash) = parent_block_hash {
         if spec.is_enabled_in(SpecId::PRAGUE) {
-            system_call_eip2935_blockhash(evm, parent_block_hash);
+            system_call_eip2935_blockhash(evm, parent_block_hash)?;
         }
     }
 
     if let Some(parent_beacon_block_root) = parent_beacon_block_root {
         if spec.is_enabled_in(SpecId::CANCUN) {
-            system_call_eip4788_beacon_root(evm, parent_beacon_block_root);
+            system_call_eip4788_beacon_root(evm, parent_beacon_block_root)?;
         }
     }
+
+    Ok(())
 }
 
 pub const HISTORY_STORAGE_ADDRESS: Address = address!("0x0000F90827F1C53a10cb7A02335B175320002935");
 
 /// Blockhash system callEIP-2935
 #[inline]
-pub(crate) fn system_call_eip2935_blockhash(
-    evm: &mut impl SystemCallCommitEvm<Error: core::fmt::Debug>,
+pub(crate) fn system_call_eip2935_blockhash<EVM>(
+    evm: &mut EVM,
     parent_block_hash: B256,
-) {
-    let _ = match evm.system_call_commit(HISTORY_STORAGE_ADDRESS, parent_block_hash.0.into()) {
-        Ok(res) => res,
-        Err(e) => {
-            panic!("System call failed: {e:?}");
-        }
-    };
+) -> Result<(), EVM::Error>
+where
+    EVM: SystemCallCommitEvm<Error: core::fmt::Debug>,
+{
+    evm.system_call_commit(HISTORY_STORAGE_ADDRESS, parent_block_hash.0.into())?;
+    Ok(())
 }
 
 pub const BEACON_ROOTS_ADDRESS: Address = address!("000F3df6D732807Ef1319fB7B8bB8522d0Beac02");
 
 /// Beacon root system call EIP-4788
-pub(crate) fn system_call_eip4788_beacon_root(
-    evm: &mut impl SystemCallCommitEvm<Error: core::fmt::Debug>,
+pub(crate) fn system_call_eip4788_beacon_root<EVM>(
+    evm: &mut EVM,
     parent_beacon_block_root: B256,
-) {
-    let _ = match evm.system_call_commit(BEACON_ROOTS_ADDRESS, parent_beacon_block_root.0.into()) {
-        Ok(res) => res,
-        Err(e) => {
-            panic!("System call failed: {e:?}");
-        }
-    };
+) -> Result<(), EVM::Error>
+where
+    EVM: SystemCallCommitEvm<Error: core::fmt::Debug>,
+{
+    evm.system_call_commit(BEACON_ROOTS_ADDRESS, parent_beacon_block_root.0.into())?;
+    Ok(())
 }


### PR DESCRIPTION
Convert blockchaintest pre/post system call helpers from panic-based failure handling to `Result` propagation, map propagated failures to dedicated `PreBlockSystemCall` and `PostBlockSystemCall` execution errors with block  index context.