### PR TITLE
chore: bump revm to v35.0.0 for v104 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
 
+# v104
+date: 03.03.2026
+
+Amsterdam hardfork support (EIP-7708, EIP-7843, EIP-8024), ResultGas struct refactor, flatten Bytecode, logs added to Revert/Halt variants, BAL (Block Access List) support, O(1) block hash cache, various performance improvements and bug fixes.
+
+* `revm-primitives`: 22.0.0 -> 22.1.0 (✓ API compatible changes)
+* `revm-bytecode`: 8.0.0 -> 9.0.0 (⚠ API breaking changes)
+* `revm-state`: 9.0.0 -> 10.0.0 (⚠ API breaking changes)
+* `revm-database-interface`: 9.0.0 -> 9.0.1 (✓ API compatible changes)
+* `revm-context-interface`: 14.0.0 -> 15.0.0 (⚠ API breaking changes)
+* `revm-context`: 13.0.0 -> 14.0.0 (⚠ API breaking changes)
+* `revm-database`: 10.0.0 -> 11.0.0 (⚠ API breaking changes)
+* `revm-interpreter`: 32.0.0 -> 33.0.0 (⚠ API breaking changes)
+* `revm-precompile`: 32.0.0 -> 32.1.0 (✓ API compatible changes)
+* `revm-handler`: 15.0.0 -> 16.0.0 (⚠ API breaking changes)
+* `revm-inspector`: 15.0.0 -> 16.0.0 (⚠ API breaking changes)
+* `revm`: 34.0.0 -> 35.0.0 (⚠ API breaking changes)
+* `op-revm`: 15.0.0 -> 16.0.0 (⚠ API breaking changes)
+* `revm-statetest-types`: 14.0.0 -> 15.0.0 (⚠ API breaking changes)
+* `revme`: 11.0.0 -> 12.0.0 (⚠ API breaking changes)
+
+# v103
+date: 15.01.2026
+
+Major release with GasParams moved to Cfg, new gas params for tx initial gas and code deposit, flatten Bytecode, performance improvements and bug fixes.
+
+* `revm-primitives`: 21.0.2 -> 22.0.0 (⚠ API breaking changes)
+* `revm-bytecode`: 7.1.1 -> 8.0.0 (⚠ API breaking changes)
+* `revm-database-interface`: 8.0.5 -> 9.0.0 (⚠ API breaking changes)
+* `revm-context-interface`: 13.1.0 -> 14.0.0 (⚠ API breaking changes)
+* `revm-context`: 12.1.0 -> 13.0.0 (⚠ API breaking changes)
+* `revm-database`: 9.0.6 -> 10.0.0 (⚠ API breaking changes)
+* `revm-interpreter`: 31.1.0 -> 32.0.0 (⚠ API breaking changes)
+* `revm-precompile`: 31.0.0 -> 32.0.0 (⚠ API breaking changes)
+* `revm-handler`: 14.1.0 -> 15.0.0 (⚠ API breaking changes)
+* `revm-inspector`: 14.1.0 -> 15.0.0 (⚠ API breaking changes)
+* `revm`: 33.1.0 -> 34.0.0 (⚠ API breaking changes)
+* `op-revm`: 14.1.0 -> 15.0.0 (⚠ API breaking changes)
+* `revm-statetest-types`: 13.1.0 -> 14.0.0 (⚠ API breaking changes)
+* `revme`: 10.0.2 -> 11.0.0 (⚠ API breaking changes)
+
 # v102
 date: 14.11.2025
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "34.1.0"
+version = "35.0.0"
 dependencies = [
  "revm-bytecode",
  "revm-context",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ default-members = ["crates/revm"]
 
 [workspace.dependencies]
 # revm
-revm = { path = "crates/revm", version = "34.1.0", default-features = false }
+revm = { path = "crates/revm", version = "35.0.0", default-features = false }
 primitives = { path = "crates/primitives", package = "revm-primitives", version = "22.1.0", default-features = false }
 bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "9.0.0", default-features = false }
 database = { path = "crates/database", package = "revm-database", version = "11.0.0", default-features = false }

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -47,6 +47,7 @@ The convenience method `ExecutionResult::gas_used()` still works (delegates to `
 
 ## `ExecutionResult::Revert` and `Halt` now carry `logs` ([#3424](https://github.com/bluealloy/revm/pull/3424))
 
+This is only relevant for revm variant ( Tempo ), ethereum does not contains logs on Halt or Revert.
 Both `Revert` and `Halt` variants gained a `logs: Vec<Log>` field containing logs emitted before the revert/halt:
 
 ```rust
@@ -60,7 +61,6 @@ ExecutionResult::Halt { reason, gas, logs }
 ```
 
 * `logs()` and `into_logs()` now return logs from all variants, not just `Success`.
-* When constructing these variants in tests, include `logs: vec![]`.
 
 ## EIP-161 state clear moved into journal finalize ([#3444](https://github.com/bluealloy/revm/pull/3444))
 

--- a/crates/revm/CHANGELOG.md
+++ b/crates/revm/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [34.1.0](https://github.com/bluealloy/revm/compare/revm-v34.0.0...revm-v34.1.0) - 2026-03-02
+## [35.0.0](https://github.com/bluealloy/revm/compare/revm-v34.0.0...revm-v35.0.0) - 2026-03-02
 
 ### Added
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm"
 description = "Revm - Rust Ethereum Virtual Machine"
-version = "34.1.0"
+version = "35.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
## Summary
- Bump `revm` crate version from 34.1.0 to 35.0.0 (breaking change due to added `aws-lc-rs` precompile backend)
- Add v103 and v104 entries to the main `CHANGELOG.md` with all crate version transitions
- Update `crates/revm/CHANGELOG.md` to reflect v35.0.0
- Minor migration guide fixes

## Test plan
- [ ] Verify `cargo check` passes with updated versions
- [ ] Confirm CHANGELOG entries match published crate versions