### PR TITLE
chore: bump revm-database-interface to v10.0.0 and all dependents (v107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
 
+# v107
+date: 04.03.2026
+
+Bump revm-database-interface major version. All dependent crates bumped accordingly.
+
+* `revm-database-interface`: 9.0.1 -> 10.0.0 (⚠ API breaking changes)
+* `revm-database`: 11.0.0 -> 12.0.0 (⚠ dependency bump)
+* `revm-context-interface`: 15.0.0 -> 16.0.0 (⚠ dependency bump)
+* `revm-context`: 14.0.0 -> 15.0.0 (⚠ dependency bump)
+* `revm-handler`: 16.0.0 -> 17.0.0 (⚠ dependency bump)
+* `revm-inspector`: 16.0.0 -> 17.0.0 (⚠ dependency bump)
+* `revm`: 35.0.0 -> 36.0.0 (⚠ dependency bump)
+* `op-revm`: 16.0.0 -> 17.0.0 (⚠ dependency bump)
+* `revm-statetest-types`: 15.0.0 -> 16.0.0 (⚠ dependency bump)
+* `revm-ee-tests`: 0.1.0 -> 0.2.0 (⚠ dependency bump)
+* `revme`: 12.0.0 -> 13.0.0 (⚠ dependency bump)
+
 # v104
 date: 03.03.2026
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2953,7 +2953,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-revm"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3606,7 +3606,7 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "14.0.0"
+version = "15.0.0"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3636,7 +3636,7 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "11.0.0"
+version = "12.0.0"
 dependencies = [
  "alloy-eips",
  "alloy-provider",
@@ -3652,7 +3652,7 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "9.0.1"
+version = "10.0.0"
 dependencies = [
  "auto_impl",
  "either",
@@ -3665,21 +3665,17 @@ dependencies = [
 
 [[package]]
 name = "revm-ee-tests"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
- "alloy-primitives",
- "alloy-sol-types",
  "op-revm",
  "revm",
- "rstest",
  "serde",
  "serde_json",
- "sha2",
 ]
 
 [[package]]
 name = "revm-handler"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "alloy-signer",
  "alloy-signer-local",
@@ -3699,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "auto_impl",
  "either",
@@ -3779,7 +3775,7 @@ dependencies = [
 
 [[package]]
 name = "revm-statetest-types"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "alloy-eip7928",
  "k256",
@@ -3796,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "revme"
-version = "12.0.0"
+version = "13.0.0"
 dependencies = [
  "alloy-rlp",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,21 +42,21 @@ default-members = ["crates/revm"]
 
 [workspace.dependencies]
 # revm
-revm = { path = "crates/revm", version = "35.0.0", default-features = false }
+revm = { path = "crates/revm", version = "36.0.0", default-features = false }
 primitives = { path = "crates/primitives", package = "revm-primitives", version = "22.1.0", default-features = false }
 bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "9.0.0", default-features = false }
-database = { path = "crates/database", package = "revm-database", version = "11.0.0", default-features = false }
-database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "9.0.1", default-features = false }
+database = { path = "crates/database", package = "revm-database", version = "12.0.0", default-features = false }
+database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "10.0.0", default-features = false }
 state = { path = "crates/state", package = "revm-state", version = "10.0.0", default-features = false }
 interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "33.0.0", default-features = false }
-inspector = { path = "crates/inspector", package = "revm-inspector", version = "16.0.0", default-features = false }
+inspector = { path = "crates/inspector", package = "revm-inspector", version = "17.0.0", default-features = false }
 precompile = { path = "crates/precompile", package = "revm-precompile", version = "32.1.0", default-features = false }
-statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "15.0.0", default-features = false }
-context = { path = "crates/context", package = "revm-context", version = "14.0.0", default-features = false }
-context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "15.0.0", default-features = false }
-handler = { path = "crates/handler", package = "revm-handler", version = "16.0.0", default-features = false }
-op-revm = { path = "crates/op-revm", package = "op-revm", version = "16.0.0", default-features = false }
-ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "0.1.0", default-features = false }
+statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "16.0.0", default-features = false }
+context = { path = "crates/context", package = "revm-context", version = "15.0.0", default-features = false }
+context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "16.0.0", default-features = false }
+handler = { path = "crates/handler", package = "revm-handler", version = "17.0.0", default-features = false }
+op-revm = { path = "crates/op-revm", package = "op-revm", version = "17.0.0", default-features = false }
+ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "0.2.0", default-features = false }
 
 # alloy
 alloy-eip2930 = { version = "0.2.3", default-features = false }

--- a/bins/revme/CHANGELOG.md
+++ b/bins/revme/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [13.0.0](https://github.com/bluealloy/revm/compare/revme-v12.0.0...revme-v13.0.0) - 2026-03-04
+
+### Other
+
+- bump revm-database-interface to v10.0.0
+
 ## [12.0.0](https://github.com/bluealloy/revm/compare/revme-v11.0.0...revme-v12.0.0) - 2026-03-02
 
 ### Added

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revme"
 description = "Rust Ethereum Virtual Machine Executable"
-version = "12.0.0"
+version = "13.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/context/CHANGELOG.md
+++ b/crates/context/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.0](https://github.com/bluealloy/revm/compare/revm-context-v14.0.0...revm-context-v15.0.0) - 2026-03-04
+
+### Other
+
+- bump revm-database-interface to v10.0.0
+
 ## [14.0.0](https://github.com/bluealloy/revm/compare/revm-context-v13.0.0...revm-context-v14.0.0) - 2026-03-02
 
 ### Added

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-context"
 description = "Revm context crates"
-version = "14.0.0"
+version = "15.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/context/interface/CHANGELOG.md
+++ b/crates/context/interface/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [16.0.0](https://github.com/bluealloy/revm/compare/revm-context-interface-v15.0.0...revm-context-interface-v16.0.0) - 2026-03-04
+
+### Other
+
+- bump revm-database-interface to v10.0.0
+
 ## [15.0.0](https://github.com/bluealloy/revm/compare/revm-context-interface-v14.0.0...revm-context-interface-v15.0.0) - 2026-03-02
 
 ### Added

--- a/crates/context/interface/Cargo.toml
+++ b/crates/context/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-context-interface"
 description = "Revm context interface crates"
-version = "15.0.0"
+version = "16.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/database/CHANGELOG.md
+++ b/crates/database/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [12.0.0](https://github.com/bluealloy/revm/compare/revm-database-v11.0.0...revm-database-v12.0.0) - 2026-03-04
+
+### Other
+
+- bump revm-database-interface to v10.0.0
+
 ## [11.0.0](https://github.com/bluealloy/revm/compare/revm-database-v10.0.0...revm-database-v11.0.0) - 2026-03-02
 
 ### Added

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-database"
 description = "Revm Database implementations"
-version = "11.0.0"
+version = "12.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/database/interface/CHANGELOG.md
+++ b/crates/database/interface/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.0](https://github.com/bluealloy/revm/compare/revm-database-interface-v9.0.1...revm-database-interface-v10.0.0) - 2026-03-04
+
+### Other
+
+- bump revm-database-interface major version
+
 ## [9.0.1](https://github.com/bluealloy/revm/compare/revm-database-interface-v9.0.0...revm-database-interface-v9.0.1) - 2026-03-02
 
 ### Fixed

--- a/crates/database/interface/Cargo.toml
+++ b/crates/database/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-database-interface"
 description = "Revm Database interface"
-version = "9.0.1"
+version = "10.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/ee-tests/CHANGELOG.md
+++ b/crates/ee-tests/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/bluealloy/revm/compare/revm-ee-tests-v0.1.0...revm-ee-tests-v0.2.0) - 2026-03-04
+
+### Other
+
+- bump revm-database-interface to v10.0.0
+
 ## [0.1.0](https://github.com/bluealloy/revm/releases/tag/revm-ee-tests-v0.1.0) - 2025-08-06
 
 ### Added

--- a/crates/ee-tests/Cargo.toml
+++ b/crates/ee-tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-ee-tests"
 description = "Common test utilities for REVM crates"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/handler/CHANGELOG.md
+++ b/crates/handler/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [17.0.0](https://github.com/bluealloy/revm/compare/revm-handler-v16.0.0...revm-handler-v17.0.0) - 2026-03-04
+
+### Other
+
+- bump revm-database-interface to v10.0.0
+
 ## [16.0.0](https://github.com/bluealloy/revm/compare/revm-handler-v15.0.0...revm-handler-v16.0.0) - 2026-03-02
 
 ### Added

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-handler"
 description = "Revm handler crates"
-version = "16.0.0"
+version = "17.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/inspector/CHANGELOG.md
+++ b/crates/inspector/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [17.0.0](https://github.com/bluealloy/revm/compare/revm-inspector-v16.0.0...revm-inspector-v17.0.0) - 2026-03-04
+
+### Other
+
+- bump revm-database-interface to v10.0.0
+
 ## [16.0.0](https://github.com/bluealloy/revm/compare/revm-inspector-v15.0.0...revm-inspector-v16.0.0) - 2026-03-02
 
 ### Other

--- a/crates/inspector/Cargo.toml
+++ b/crates/inspector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-inspector"
 description = "Revm inspector interface"
-version = "16.0.0"
+version = "17.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/op-revm/CHANGELOG.md
+++ b/crates/op-revm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [17.0.0](https://github.com/bluealloy/revm/compare/op-revm-v16.0.0...op-revm-v17.0.0) - 2026-03-04
+
+### Other
+
+- bump revm-database-interface to v10.0.0
+
 ## [16.0.0](https://github.com/bluealloy/revm/compare/op-revm-v15.0.0...op-revm-v16.0.0) - 2026-03-02
 
 ### Other

--- a/crates/op-revm/Cargo.toml
+++ b/crates/op-revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "op-revm"
 description = "Optimism variant of Revm"
-version = "16.0.0"
+version = "17.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/revm/CHANGELOG.md
+++ b/crates/revm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [36.0.0](https://github.com/bluealloy/revm/compare/revm-v35.0.0...revm-v36.0.0) - 2026-03-04
+
+### Other
+
+- bump revm-database-interface to v10.0.0
+
 ## [35.0.0](https://github.com/bluealloy/revm/compare/revm-v34.0.0...revm-v35.0.0) - 2026-03-02
 
 ### Added

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm"
 description = "Revm - Rust Ethereum Virtual Machine"
-version = "35.0.0"
+version = "36.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/statetest-types/CHANGELOG.md
+++ b/crates/statetest-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [16.0.0](https://github.com/bluealloy/revm/compare/revm-statetest-types-v15.0.0...revm-statetest-types-v16.0.0) - 2026-03-04
+
+### Other
+
+- bump revm-database-interface to v10.0.0
+
 ## [15.0.0](https://github.com/bluealloy/revm/compare/revm-statetest-types-v14.0.0...revm-statetest-types-v15.0.0) - 2026-03-02
 
 ### Added

--- a/crates/statetest-types/Cargo.toml
+++ b/crates/statetest-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-statetest-types"
 description = "Statetest types for revme"
-version = "15.0.0"
+version = "16.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
## Summary

Bump revm-database-interface major version. All dependent crates bumped accordingly.

* `revm-database-interface`: 9.0.1 -> 10.0.0 (⚠ API breaking changes)
* `revm-database`: 11.0.0 -> 12.0.0 (⚠ dependency bump)
* `revm-context-interface`: 15.0.0 -> 16.0.0 (⚠ dependency bump)
* `revm-context`: 14.0.0 -> 15.0.0 (⚠ dependency bump)
* `revm-handler`: 16.0.0 -> 17.0.0 (⚠ dependency bump)
* `revm-inspector`: 16.0.0 -> 17.0.0 (⚠ dependency bump)
* `revm`: 35.0.0 -> 36.0.0 (⚠ dependency bump)
* `op-revm`: 16.0.0 -> 17.0.0 (⚠ dependency bump)
* `revm-statetest-types`: 15.0.0 -> 16.0.0 (⚠ dependency bump)
* `revm-ee-tests`: 0.1.0 -> 0.2.0 (⚠ dependency bump)
* `revme`: 12.0.0 -> 13.0.0 (⚠ dependency bump)