### PR TITLE
ci: add cargo-semver-checks to catch breaking changes in PRs

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -15,3 +15,5 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          exclude: revm-ee-tests

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,2 +1,7 @@
 [workspace]
 semver_check = true
+
+[[package]]
+name = "revm-ee-tests"
+semver_check = false
+release = false


### PR DESCRIPTION
## Summary

Adds `cargo-semver-checks` as a CI check on every PR to `main` and `release/**` branches.

## Motivation

A recent `revm-database-interface` patch release (`9.0.0` → `9.0.1`) bumped its `revm-state` dep from `^9` to `^10` — a breaking change hidden in a patch. This caused downstream consumers (reth, tempo, foundry) to pull in conflicting `revm-state` versions on `cargo update`, breaking their builds.

`release-plz` comments in the workflow mention semver detection, but there's no explicit `cargo-semver-checks` step in CI that blocks PRs with breaking API changes from merging as patch/minor bumps.

## Changes

- New workflow `.github/workflows/semver-checks.yml` that runs [`cargo-semver-checks`](https://github.com/obi1kenobi/cargo-semver-checks) via the official action on every PR

## Testing

The action auto-detects workspace crates and compares the PR diff against the latest published crates.io versions. No config needed.

Co-Authored-By: Emma Jamieson-Hoare <21029500+emmajam@users.noreply.github.com>

Prompted by: emma