### PR TITLE
fix: expose JournalLoadError from load_account_mut_skip_cold_load

### DIFF
--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -204,6 +204,7 @@ pub trait JournalTr {
         address: Address,
     ) -> Result<StateLoad<Self::JournaledAccount<'_>>, <Self::Database as Database>::Error> {
         self.load_account_mut_skip_cold_load(address, false)
+            .map_err(JournalLoadError::unwrap_db_error)
     }
 
     /// Loads the journaled account.
@@ -211,7 +212,10 @@ pub trait JournalTr {
         &mut self,
         address: Address,
         skip_cold_load: bool,
-    ) -> Result<StateLoad<Self::JournaledAccount<'_>>, <Self::Database as Database>::Error>;
+    ) -> Result<
+        StateLoad<Self::JournaledAccount<'_>>,
+        JournalLoadError<<Self::Database as Database>::Error>,
+    >;
 
     /// Loads the journaled account.
     #[inline]

--- a/crates/context/src/journal.rs
+++ b/crates/context/src/journal.rs
@@ -270,10 +270,9 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
         &mut self,
         address: Address,
         skip_cold_load: bool,
-    ) -> Result<StateLoad<Self::JournaledAccount<'_>>, DB::Error> {
+    ) -> Result<StateLoad<Self::JournaledAccount<'_>>, JournalLoadError<DB::Error>> {
         self.inner
             .load_account_mut_optional(&mut self.database, address, skip_cold_load)
-            .map_err(JournalLoadError::unwrap_db_error)
     }
 
     #[inline]

--- a/examples/cheatcode_inspector/src/main.rs
+++ b/examples/cheatcode_inspector/src/main.rs
@@ -302,7 +302,7 @@ impl JournalTr for Backend {
         &mut self,
         address: Address,
         skip_cold_load: bool,
-    ) -> Result<StateLoad<Self::JournaledAccount<'_>>, Infallible> {
+    ) -> Result<StateLoad<Self::JournaledAccount<'_>>, JournalLoadError<Infallible>> {
         self.journaled_state
             .load_account_mut_skip_cold_load(address, skip_cold_load)
     }


### PR DESCRIPTION
## Summary

Changes the return type of `load_account_mut_skip_cold_load` from `Result<StateLoad<...>, DB::Error>` to `Result<StateLoad<...>, JournalLoadError<DB::Error>>`.

This exposes richer error information to callers, allowing them to distinguish between:
- Account load failures (e.g., account doesn't exist)
- Database errors

The error conversion is now handled at the trait method level rather than in each implementation, improving consistency.

## Changes

- Update `JournalTr::load_account_mut_skip_cold_load` return type to include `JournalLoadError`
- Move error conversion from implementation to trait wrapper method
- Update all implementations to use the new signature

## Testing

- Existing tests pass
- Example implementations updated to match new signature