### PR TITLE
fix: make Bytecode Ord consistent with PartialEq and Hash

### DIFF
--- a/crates/bytecode/src/bytecode/mod.rs
+++ b/crates/bytecode/src/bytecode/mod.rs
@@ -90,9 +90,7 @@ impl PartialOrd for Bytecode {
 impl Ord for Bytecode {
     #[inline]
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.kind()
-            .cmp(&other.kind())
-            .then_with(|| self.original_byte_slice().cmp(other.original_byte_slice()))
+        self.original_byte_slice().cmp(other.original_byte_slice())
     }
 }
 


### PR DESCRIPTION
Ord implementation was comparing kind() first, then original_byte_slice(), while PartialEq and Hash only use original_byte_slice(). This violates Rust's trait contract where a == b must imply a.cmp(b) == Equal.

Introduced during the flatten Bytecode refactor (540ec38b) when manual trait impls replaced the derived ones.