### PR TITLE
chore: bump aws-lc-rs from 1.16.0 to 1.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,9 +1008,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -1018,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
 dependencies = [
  "cc",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ secp256k1 = { version = "0.31.1", default-features = false }
 sha2 = { version = "0.10.9", default-features = false }
 ripemd = { version = "0.1.3", default-features = false }
 p256 = { version = "0.13.2", default-features = false }
-aws-lc-rs = { version = "1.16", default-features = false, features = ["aws-lc-sys"] }
+aws-lc-rs = { version = "1.16.1", default-features = false, features = ["aws-lc-sys"] }
 
 # bytecode
 bitvec = { version = "1", default-features = false }


### PR DESCRIPTION
## Summary
- Bumps `aws-lc-rs` from 1.16.0 to 1.16.1
- Also updates `aws-lc-sys` from 0.37.1 to 0.38.0