### PR TITLE
fix(revme): return error instead of process::exit in statetest runner

### DIFF
--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -42,6 +42,8 @@ pub enum TestErrorKind {
     StateRootMismatch { got: B256, expected: B256 },
     #[error("unknown private key: {0:?}")]
     UnknownPrivateKey(B256),
+    #[error("{0} tests failed")]
+    TestsFailed(usize),
     #[error("unexpected exception: got {got_exception:?}, expected {expected_exception:?}")]
     UnexpectedException {
         expected_exception: Option<String>,
@@ -638,7 +640,11 @@ pub fn run(
         println!("Encountered {n_errors} errors out of {n_files} total tests");
 
         if n_thread_errors == 0 {
-            std::process::exit(1);
+            return Err(TestError {
+                name: String::new(),
+                path: String::new(),
+                kind: TestErrorKind::TestsFailed(n_errors),
+            });
         }
 
         if n_thread_errors > 1 {


### PR DESCRIPTION
When tests fail without thread panics (`n_errors > 0 && n_thread_errors == 0`),
`runner::run()` calls `process::exit(1)` instead of returning an `Err`. This
skips all `Drop` impls and bypasses the error reporting in `main()`:

```
main()                          // Err => eprintln, never reached
  └─ MainCmd::run()             // ?, never reached
      └─ statetest::Cmd::run()  // ?, never reached
          └─ runner::run()      // process::exit(1) here
```

Add a `TestsFailed(usize)` variant to `TestErrorKind` and return it properly:

```diff
     if n_thread_errors == 0 {
-        std::process::exit(1);
+        return Err(TestError {
+            name: String::new(),
+            path: String::new(),
+            kind: TestErrorKind::TestsFailed(n_errors),
+        });
     }
```
