### PR TITLE
fix(interpreter): swap/swapn/exchange report StackOverflow on underflow

### DIFF
--- a/crates/interpreter/src/instructions/stack.rs
+++ b/crates/interpreter/src/instructions/stack.rs
@@ -56,7 +56,7 @@ pub fn swap<const N: usize, WIRE: InterpreterTypes, H: ?Sized>(
 ) {
     assert!(N != 0);
     if !context.interpreter.stack.exchange(0, N) {
-        context.interpreter.halt(InstructionResult::StackOverflow);
+        context.interpreter.halt(InstructionResult::StackUnderflow);
     }
 }
 
@@ -86,7 +86,7 @@ pub fn swapn<WIRE: InterpreterTypes, H: ?Sized>(context: InstructionContext<'_, 
     let x: usize = context.interpreter.bytecode.read_u8().into();
     if let Some(n) = decode_single(x) {
         if !context.interpreter.stack.exchange(0, n) {
-            context.interpreter.halt(InstructionResult::StackOverflow);
+            context.interpreter.halt(InstructionResult::StackUnderflow);
         }
         context.interpreter.bytecode.relative_jump(1);
     } else {
@@ -104,7 +104,7 @@ pub fn exchange<WIRE: InterpreterTypes, H: ?Sized>(context: InstructionContext<'
     let x: usize = context.interpreter.bytecode.read_u8().into();
     if let Some((n, m)) = decode_pair(x) {
         if !context.interpreter.stack.exchange(n, m - n) {
-            context.interpreter.halt(InstructionResult::StackOverflow);
+            context.interpreter.halt(InstructionResult::StackUnderflow);
         }
         context.interpreter.bytecode.relative_jump(1);
     } else {


### PR DESCRIPTION
`swap`, `swapn`, and `exchange` report `StackOverflow` when `Stack::exchange()` fails, but `exchange()` only swaps in place — it never grows the stack. Failure means `n + m >= len`, i.e. not enough elements. That's underflow.

Verified by running SWAP1 with 1 element on stack:

```
SWAP1 underflow result: StackOverflow   ← wrong, should be StackUnderflow
SWAPN underflow result: StackOverflow
EXCHANGE underflow result: StackOverflow
```

`dup`/`dupn` left unchanged — `Stack::dup()` can fail from either underflow or overflow, so it's a separate concern.
