### PR TITLE
chore: remove unused bytecode dependency from revm-statetest-types

### DIFF
--- a/crates/statetest-types/Cargo.toml
+++ b/crates/statetest-types/Cargo.toml
@@ -20,7 +20,6 @@ workspace = true
 [dependencies]
 # revm crates
 primitives = { workspace = true, features = ["std", "serde"] }
-bytecode = { workspace = true, features = ["std", "serde"] }
 state = { workspace = true, features = ["std", "serde"] }
 context = { workspace = true, features = ["std", "serde"] }
 context-interface = { workspace = true, features = ["std", "serde"] }


### PR DESCRIPTION
The bytecode crate was listed as a direct dependency in revm-statetest-types but never importedanywhere in the crate. Bytecode is accessed via state::Bytecode, and the required feature flags (std, serde) are already propagated through state's own features.