### PR TITLE
fix(handler): rename misleading `underflow` variable to `success`

### DIFF
--- a/crates/handler/src/precompile_provider.rs
+++ b/crates/handler/src/precompile_provider.rs
@@ -120,8 +120,8 @@ impl<CTX: ContextTr> PrecompileProvider<CTX> for EthPrecompiles {
         match exec_result {
             Ok(output) => {
                 result.gas.record_refund(output.gas_refunded);
-                let underflow = result.gas.record_cost(output.gas_used);
-                assert!(underflow, "Gas underflow is not possible");
+                let success = result.gas.record_cost(output.gas_used);
+                assert!(success, "Gas underflow is not possible");
                 result.result = if output.reverted {
                     InstructionResult::Revert
                 } else {


### PR DESCRIPTION
`record_cost` returns `true` on success, but the result was stored in a variable named `underflow` which implies the opposite. Renamed to `success` to match actual semantics.