### PR TITLE
feat: add reverting address to ExecutionResult::Revert

### DIFF
--- a/crates/context/interface/src/result.rs
+++ b/crates/context/interface/src/result.rs
@@ -298,6 +298,11 @@ pub enum ExecutionResult<HaltReasonTy = HaltReason> {
         logs: Vec<Log>,
         /// Output of the transaction.
         output: Bytes,
+        /// The address of the top-level contract or precompile that reverted.
+        ///
+        /// For `TxKind::Call` transactions, this is the target address.
+        /// For `TxKind::Create`, this is `None`.
+        address: Option<Address>,
     },
     /// Reverted for various reasons and spend all gas
     Halt {
@@ -340,7 +345,17 @@ impl<HaltReasonTy> ExecutionResult<HaltReasonTy> {
                 logs,
                 output,
             },
-            Self::Revert { gas, logs, output } => ExecutionResult::Revert { gas, logs, output },
+            Self::Revert {
+                gas,
+                logs,
+                output,
+                address,
+            } => ExecutionResult::Revert {
+                gas,
+                logs,
+                output,
+                address,
+            },
             Self::Halt { reason, gas, logs } => ExecutionResult::Halt {
                 reason: op(reason),
                 gas,
@@ -436,8 +451,16 @@ impl<HaltReasonTy: fmt::Display> fmt::Display for ExecutionResult<HaltReasonTy> 
                 }
                 write!(f, ", {output}")
             }
-            Self::Revert { gas, logs, output } => {
+            Self::Revert {
+                gas,
+                logs,
+                output,
+                address,
+            } => {
                 write!(f, "Revert: {gas}")?;
+                if let Some(addr) = address {
+                    write!(f, ", address: {addr}")?;
+                }
                 if !logs.is_empty() {
                     write!(
                         f,
@@ -1104,6 +1127,7 @@ mod tests {
             gas: ResultGas::new(100000, 100000, 0, 0, 0),
             logs: vec![],
             output: Bytes::from(vec![1, 2, 3, 4]),
+            address: None,
         };
         assert_eq!(
             result.to_string(),

--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -14,7 +14,7 @@ use context_interface::{
     Cfg, ContextTr, Database, JournalTr, Transaction,
 };
 use interpreter::{interpreter_action::FrameInit, Gas, InitialAndFloorGas, SharedMemory};
-use primitives::U256;
+use primitives::{TxKind, U256};
 use state::Bytecode;
 
 /// Trait for errors that can occur during EVM execution.
@@ -480,7 +480,13 @@ pub trait Handler {
     ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
         take_error::<Self::Error, _>(evm.ctx().error())?;
 
-        let exec_result = post_execution::output(evm.ctx(), result, result_gas);
+        // Extract target address for revert context.
+        let address = match evm.ctx().tx().kind() {
+            TxKind::Call(addr) => Some(addr),
+            TxKind::Create => None,
+        };
+
+        let exec_result = post_execution::output(evm.ctx(), result, result_gas, address);
 
         // commit transaction
         evm.ctx().journal_mut().commit_tx();

--- a/crates/handler/src/post_execution.rs
+++ b/crates/handler/src/post_execution.rs
@@ -6,7 +6,7 @@ use context_interface::{
     Block, Cfg, ContextTr, Database, LocalContextTr, Transaction,
 };
 use interpreter::{Gas, InitialAndFloorGas, SuccessOrHalt};
-use primitives::{hardfork::SpecId, U256};
+use primitives::{hardfork::SpecId, Address, U256};
 
 /// Builds a [`ResultGas`] from the execution [`Gas`] struct and [`InitialAndFloorGas`].
 pub fn build_result_gas(gas: &Gas, init_and_floor_gas: InitialAndFloorGas) -> ResultGas {
@@ -99,6 +99,7 @@ pub fn output<CTX: ContextTr<Journal: JournalTr>, HALTREASON: HaltReasonTr>(
     // FrameResult should be a generic that returns gas and interpreter result.
     result: FrameResult,
     result_gas: ResultGas,
+    address: Option<Address>,
 ) -> ExecutionResult<HALTREASON> {
     let output = result.output();
     let instruction_result = result.into_interpreter_result();
@@ -117,6 +118,7 @@ pub fn output<CTX: ContextTr<Journal: JournalTr>, HALTREASON: HaltReasonTr>(
             gas: result_gas,
             logs,
             output: output.into_data(),
+            address,
         },
         SuccessOrHalt::Halt(reason) => {
             // Bubble up precompile errors from context when available

--- a/crates/op-revm/src/handler.rs
+++ b/crates/op-revm/src/handler.rs
@@ -349,7 +349,13 @@ where
     ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
         take_error::<Self::Error, _>(evm.ctx().error())?;
 
-        let exec_result = post_execution::output(evm.ctx(), frame_result, result_gas)
+        // Extract target address for revert context.
+        let address = match evm.ctx().tx().kind() {
+            revm::primitives::TxKind::Call(addr) => Some(addr),
+            revm::primitives::TxKind::Create => None,
+        };
+
+        let exec_result = post_execution::output(evm.ctx(), frame_result, result_gas, address)
             .map_haltreason(OpHaltReason::Base);
 
         if exec_result.is_halt() {


### PR DESCRIPTION
Adds `address: Option<Address>` to `ExecutionResult::Revert` so consumers can identify which contract or precompile produced the revert.

**Motivation:** Chains with custom precompiles (e.g. Tempo) have multiple precompiles that share ABI error selectors (e.g. `Unauthorized` = `0x82b42900` exists in both ValidatorConfig and TIP-20). When a precompile reverts via `PrecompileOutput::new_reverted()`, the revert data flows through `InstructionResult::Revert` → `ExecutionResult::Revert`, but only the raw bytes are preserved—no address. The RPC layer's `FromRevert::from_revert()` receives just `Bytes` and cannot disambiguate which precompile the selector came from.

**Changes:**
- `ExecutionResult::Revert` gains `address: Option<Address>`
- `post_execution::output()` accepts and passes the address
- `Handler::execution_result()` extracts `TxKind::Call(addr)` → `Some(addr)`, `TxKind::Create` → `None`
- Same for op-revm's `execution_result`

**Testing:**
```
cargo test --workspace  # all pass
cargo clippy --workspace --all-targets  # clean
cargo fmt --all --check  # clean
```

Co-Authored-By: Georgios Konstantopoulos <17802178+gakonst@users.noreply.github.com>

Prompted by: georgios