### PR TITLE
fix: make DummyHost return defaults instead of errors for storage ops

### DIFF
--- a/crates/context/interface/src/host.rs
+++ b/crates/context/interface/src/host.rs
@@ -290,7 +290,7 @@ impl Host for DummyHost {
         _target: Address,
         _skip_cold_load: bool,
     ) -> Result<StateLoad<SelfDestructResult>, LoadError> {
-        Err(LoadError::ColdLoadSkipped)
+        Ok(Default::default())
     }
 
     fn log(&mut self, _log: Log) {}
@@ -307,7 +307,7 @@ impl Host for DummyHost {
         _load_code: bool,
         _skip_cold_load: bool,
     ) -> Result<AccountInfoLoad<'_>, LoadError> {
-        Err(LoadError::DBError)
+        Ok(Default::default())
     }
 
     fn sstore_skip_cold_load(
@@ -317,7 +317,7 @@ impl Host for DummyHost {
         _value: StorageValue,
         _skip_cold_load: bool,
     ) -> Result<StateLoad<SStoreResult>, LoadError> {
-        Err(LoadError::DBError)
+        Ok(Default::default())
     }
 
     fn sload_skip_cold_load(
@@ -326,6 +326,6 @@ impl Host for DummyHost {
         _key: StorageKey,
         _skip_cold_load: bool,
     ) -> Result<StateLoad<StorageValue>, LoadError> {
-        Err(LoadError::DBError)
+        Ok(Default::default())
     }
 }


### PR DESCRIPTION
Changes `selfdestruct`, `load_account_info_skip_cold_load`, `sstore_skip_cold_load`, and `sload_skip_cold_load` on `DummyHost` to return `Ok(Default::default())` instead of `Err(LoadError::...)`, so callers can use `DummyHost` without hitting errors on storage operations.

Co-Authored-By: DaniPopes <57450786+DaniPopes@users.noreply.github.com>

Prompted by: DaniPopes