### PR TITLE
Amsterdam devnet3: EIP-8037 state gas (reservoir model)

### DIFF
--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -383,22 +383,13 @@ pub trait Handler {
             gas.record_refund(refunded);
         }
 
-        // Reservoir handling at the top-level frame:
-        // - On success: use the frame's final reservoir as-is, state gas was consumed.
-        // - On revert/halt: restore state gas spent back to the reservoir,
-        //   because state changes are rolled back so state gas should be refunded.
-        //
-        // Note: eth devnet3 does NOT do this — it ignores state_gas_spent and
-        // unconditionally sets gas.set_reservoir(reservoir) regardless of the
-        // instruction_result kind. This is a bug in the devnet3 spec.
-        if instruction_result.is_ok() {
-            gas.set_state_gas_spent(state_gas_spent);
-            gas.set_reservoir(reservoir);
-        } else {
-            // State changes rolled back, so no execution state gas was consumed.
-            gas.set_state_gas_spent(0);
-            gas.set_reservoir(reservoir + state_gas_spent);
-        }
+        // Always track state gas spent regardless of outcome.
+        gas.set_state_gas_spent(state_gas_spent);
+
+        // Reservoir handling at the top-level frame.
+        // Use the frame's final reservoir directly — it already reflects
+        // child frame restorations and any state gas consumed/spilled during execution.
+        gas.set_reservoir(reservoir);
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Implements **EIP-8037 state gas** using the reservoir model for Amsterdam devnet3. This is a major change to how gas accounting works in revm.

### Core changes

- **GasTracker struct** (`context/interface/src/cfg/gas.rs`): New centralized gas tracker with `remaining`, `reservoir`, `state_gas_spent`, and `refunded` fields. The reservoir holds execution gas exceeding `TX_MAX_GAS_LIMIT`, creating a separate budget for state gas operations.
- **Gas struct updated** (`interpreter/src/gas.rs`): Delegates to `GasTracker` internally. Adds `record_state_cost()` (draws from reservoir first, then spills to remaining) alongside existing `record_cost()` for regular gas. The `GAS` opcode returns only `remaining` (excludes reservoir per EIP-8037).
- **GasParams / GasId** (`context/interface/src/cfg/gas_params.rs`): New parameterized gas cost system with `GasId` constants (1-45) and `GasParams::get(GasId)` lookup, replacing some hardcoded gas values.
- **ResultGas** (`context/interface/src/result.rs`): Extended to carry `state_gas_spent` and `reservoir` through execution results, enabling proper gas accounting in receipts and post-execution.

### Handler changes

- **Frame gas propagation** (`handler/src/frame.rs`): Child frames receive reservoir from parent. On return, parent absorbs child's reservoir and accumulates `state_gas_spent`.
- **Pre-execution** (`handler/src/pre_execution.rs`): EIP-7702 auth list state gas split into separate accounting via `split_eip7702_refund()`.
- **Post-execution** (`handler/src/post_execution.rs`): Floor gas (EIP-7623) and refund cap calculations updated to work with reservoir model. State gas spent excluded from regular refund caps.
- **Validation** (`handler/src/validation.rs`): Transaction validation updated for state gas budget.
- **System calls** (`handler/src/system_call.rs`): Gas handling updated for reservoir model.

### Instruction changes

- **SSTORE** (`interpreter/src/instructions/host.rs`): State gas charging for storage writes.
- **CREATE/CREATE2** (`interpreter/src/instructions/contract.rs`): State gas for code deposit and contract creation. Static call check ordering aligned with execution-specs `generic_create()`.
- **CALL variants** (`interpreter/src/instructions/contract/call_helpers.rs`): State gas for account creation (value transfer to new accounts).
- **SELFDESTRUCT** (`interpreter/src/instructions/system.rs`): State gas for beneficiary account creation.

### Precompile changes

- **Simplified interface** (`precompile/src/interface.rs`): Removed `gas_limit` from `PrecompileOutput`, flattened `PrecompileError`.
- **PrecompileProvider** (`handler/src/precompile_provider.rs`): Updated for reservoir handling.

### op-revm

- Updated `handler.rs` and `precompiles.rs` to work with the new gas model.

### Testing

- **37 EIP-8037 test fixtures** covering: SSTORE (new/overwrite/clear/refund), CALL (new/existing account, value transfer), CREATE/CREATE2 (code deposit, size limits), SELFDESTRUCT, nested frames, reservoir refill on revert/halt, gas opcode behavior, block gas limits, and regular gas cap scenarios.
- **~2000 lines of test code** in `ee-tests/src/eip8037.rs`.

### Devnet3-specific adjustments

Two reverts from the full spec implementation to match devnet3 behavior:
- Reservoir is **not** restored on revert/halt (state gas consumed is final regardless of outcome)
- CREATE/CREATE2 static call check happens **after** gas charging (matches execution-specs ordering)

## Test plan
- [ ] `cargo nextest run --workspace`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] Ethereum state tests via `cargo run -p revme statetest`
- [ ] no_std compatibility check
- [ ] EIP-8037 specific tests: `cargo test -p ee-tests eip8037`