### PR TITLE
refactor(precompile): take large array args by reference

### DIFF
--- a/crates/precompile/bench/blake2.rs
+++ b/crates/precompile/bench/blake2.rs
@@ -107,8 +107,8 @@ pub fn add_benches(group: &mut BenchmarkGroup<'_, criterion::measurement::WallTi
             blake2::algo::compress(
                 black_box(12),
                 &mut h_copy,
-                black_box(m),
-                black_box(t),
+                &black_box(m),
+                &black_box(t),
                 black_box(false),
             );
         });

--- a/crates/precompile/src/blake2.rs
+++ b/crates/precompile/src/blake2.rs
@@ -54,7 +54,7 @@ pub fn run(input: &[u8], gas_limit: u64) -> PrecompileResult {
     let t_0 = u64::from_le_bytes(input[196..204].try_into().unwrap());
     let t_1 = u64::from_le_bytes(input[204..212].try_into().unwrap());
 
-    crypto().blake2_compress(rounds, &mut h, m, [t_0, t_1], f);
+    crypto().blake2_compress(rounds, &mut h, &m, &[t_0, t_1], f);
 
     let mut out = [0u8; 64];
     for (i, h) in (0..64).step_by(8).zip(h.iter()) {
@@ -124,7 +124,7 @@ pub mod algo {
     /// returns a new state vector.  The number of rounds, "r", is 12 for
     /// BLAKE2b and 10 for BLAKE2s.  Rounds are numbered from 0 to r - 1.
     #[allow(clippy::many_single_char_names)]
-    pub fn compress(rounds: usize, h: &mut [u64; 8], m: [u64; 16], t: [u64; 2], f: bool) {
+    pub fn compress(rounds: usize, h: &mut [u64; 8], m: &[u64; 16], t: &[u64; 2], f: bool) {
         #[cfg(all(target_feature = "avx2", feature = "std"))]
         {
             // only if it is compiled with avx2 flag and it is std, we can use avx2.
@@ -133,7 +133,7 @@ pub mod algo {
                 unsafe {
                     super::avx2::compress_block(
                         rounds,
-                        &m,
+                        m,
                         h,
                         ((t[1] as u128) << 64) | (t[0] as u128),
                         if f { !0 } else { 0 },

--- a/crates/precompile/src/blake2.rs
+++ b/crates/precompile/src/blake2.rs
@@ -157,7 +157,7 @@ pub mod algo {
             v[14] = !v[14] // Invert all bits if the last-block-flag is set.
         }
         for i in 0..rounds {
-            round(&mut v, &m, i);
+            round(&mut v, m, i);
         }
 
         for i in 0..8 {

--- a/crates/precompile/src/interface.rs
+++ b/crates/precompile/src/interface.rs
@@ -126,7 +126,7 @@ pub trait Crypto: Send + Sync + Debug {
 
     /// Blake2 compression function.
     #[inline]
-    fn blake2_compress(&self, rounds: u32, h: &mut [u64; 8], m: [u64; 16], t: [u64; 2], f: bool) {
+    fn blake2_compress(&self, rounds: u32, h: &mut [u64; 8], m: &[u64; 16], t: &[u64; 2], f: bool) {
         crate::blake2::algo::compress(rounds as usize, h, m, t, f);
     }
 

--- a/crates/precompile/src/interface.rs
+++ b/crates/precompile/src/interface.rs
@@ -133,7 +133,7 @@ pub trait Crypto: Send + Sync + Debug {
     /// secp256r1 (P-256) signature verification.
     #[inline]
     fn secp256r1_verify_signature(&self, msg: &[u8; 32], sig: &[u8; 64], pk: &[u8; 64]) -> bool {
-        crate::secp256r1::verify_signature(*msg, *sig, *pk).is_some()
+        crate::secp256r1::verify_signature(msg, sig, pk).is_some()
     }
 
     /// KZG point evaluation.

--- a/crates/precompile/src/interface.rs
+++ b/crates/precompile/src/interface.rs
@@ -114,7 +114,7 @@ pub trait Crypto: Send + Sync + Debug {
         recid: u8,
         msg: &[u8; 32],
     ) -> Result<[u8; 32], PrecompileError> {
-        crate::secp256k1::ecrecover_bytes(*sig, recid, *msg)
+        crate::secp256k1::ecrecover_bytes(sig, recid, msg)
             .ok_or(PrecompileError::Secp256k1RecoverFailed)
     }
 

--- a/crates/precompile/src/secp256k1.rs
+++ b/crates/precompile/src/secp256k1.rs
@@ -54,10 +54,7 @@ pub fn ec_recover_run(input: &[u8], gas_limit: u64) -> PrecompileResult {
 }
 
 pub(crate) fn ecrecover_bytes(sig: &[u8; 64], recid: u8, msg: &[u8; 32]) -> Option<[u8; 32]> {
-    let sig = B512::from_slice(sig);
-    let msg = B256::from_slice(msg);
-
-    match ecrecover(&sig, recid, &msg) {
+    match ecrecover(sig.into(), recid, msg.into()) {
         Ok(address) => Some(address.0),
         Err(_) => None,
     }

--- a/crates/precompile/src/secp256k1.rs
+++ b/crates/precompile/src/secp256k1.rs
@@ -53,9 +53,9 @@ pub fn ec_recover_run(input: &[u8], gas_limit: u64) -> PrecompileResult {
     Ok(PrecompileOutput::new(ECRECOVER_BASE, out))
 }
 
-pub(crate) fn ecrecover_bytes(sig: [u8; 64], recid: u8, msg: [u8; 32]) -> Option<[u8; 32]> {
-    let sig = B512::from_slice(&sig);
-    let msg = B256::from_slice(&msg);
+pub(crate) fn ecrecover_bytes(sig: &[u8; 64], recid: u8, msg: &[u8; 32]) -> Option<[u8; 32]> {
+    let sig = B512::from_slice(sig);
+    let msg = B256::from_slice(msg);
 
     match ecrecover(&sig, recid, &msg) {
         Ok(address) => Some(address.0),

--- a/crates/precompile/src/secp256r1.rs
+++ b/crates/precompile/src/secp256r1.rs
@@ -95,22 +95,22 @@ pub fn verify_impl(input: &[u8]) -> bool {
     crypto().secp256r1_verify_signature(&msg.0, &sig.0, &pk.0)
 }
 
-pub(crate) fn verify_signature(msg: [u8; 32], sig: [u8; 64], pk: [u8; 64]) -> Option<()> {
+pub(crate) fn verify_signature(msg: &[u8; 32], sig: &[u8; 64], pk: &[u8; 64]) -> Option<()> {
     cfg_if::cfg_if! {
         if #[cfg(feature = "p256-aws-lc-rs")] {
             use aws_lc_rs::{digest, signature::{self, UnparsedPublicKey}};
 
             // Construct a Digest from the raw prehashed message bytes.
-            let digest = digest::Digest::import_less_safe(&msg, &digest::SHA256).ok()?;
+            let digest = digest::Digest::import_less_safe(msg, &digest::SHA256).ok()?;
 
             // Build uncompressed public key: 0x04 || x || y
             let mut pubkey_bytes = [0u8; 65];
             pubkey_bytes[0] = 0x04;
-            pubkey_bytes[1..].copy_from_slice(&pk);
+            pubkey_bytes[1..].copy_from_slice(pk);
 
             let public_key = UnparsedPublicKey::new(&signature::ECDSA_P256_SHA256_FIXED, &pubkey_bytes);
 
-            public_key.verify_digest(&digest, &sig).ok()
+            public_key.verify_digest(&digest, sig).ok()
         } else {
             use p256::{
                 ecdsa::{signature::hazmat::PrehashVerifier, Signature, VerifyingKey},
@@ -118,13 +118,13 @@ pub(crate) fn verify_signature(msg: [u8; 32], sig: [u8; 64], pk: [u8; 64]) -> Op
             };
 
             // Can fail only if the input is not exact length.
-            let signature = Signature::from_slice(&sig).ok()?;
+            let signature = Signature::from_slice(sig).ok()?;
             // Decode the public key bytes (x,y coordinates) using EncodedPoint
-            let encoded_point = EncodedPoint::from_untagged_bytes(&pk.into());
+            let encoded_point = EncodedPoint::from_untagged_bytes(&(*pk).into());
             // Create VerifyingKey from the encoded point
             let public_key = VerifyingKey::from_encoded_point(&encoded_point).ok()?;
 
-            public_key.verify_prehash(&msg, &signature).ok()
+            public_key.verify_prehash(msg, &signature).ok()
         }
     }
 }


### PR DESCRIPTION
Take large fixed-size array parameters by reference instead of by value in precompile functions:

- `secp256r1::verify_signature`: `msg: [u8; 32]`, `sig: [u8; 64]`, `pk: [u8; 64]`
- `secp256k1::ecrecover_bytes`: `sig: [u8; 64]`, `msg: [u8; 32]`
- `blake2::algo::compress`: `m: [u64; 16]`, `t: [u64; 2]`
- Corresponding `Crypto` trait methods updated to pass refs through directly

Co-Authored-By: DaniPopes <57450786+DaniPopes@users.noreply.github.com>

Prompted by: DaniPopes