### PR TITLE
handler: reject nonce-max senders before execution

### DIFF
--- a/bins/revme/src/cmd/blockchaintest.rs
+++ b/bins/revme/src/cmd/blockchaintest.rs
@@ -1090,11 +1090,8 @@ fn skip_test(path: &Path) -> bool {
     // Add any problematic tests here that should be skipped
     matches!(
         name,
-        // Test check if gas price overflows, we handle this correctly but does not match tests specific exception.
-        "CreateTransactionHighNonce.json"
-
         // Test with some storage check.
-        | "RevertInCreateInInit_Paris.json"
+        "RevertInCreateInInit_Paris.json"
         | "RevertInCreateInInit.json"
         | "dynamicAccountOverwriteEmpty.json"
         | "dynamicAccountOverwriteEmpty_Paris.json"

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -77,7 +77,8 @@ fn skip_test(path: &Path) -> bool {
     matches!(
         name,
         // Test with some storage check.
-        |"RevertInCreateInInit_Paris.json"| "RevertInCreateInInit.json"
+        "RevertInCreateInInit_Paris.json"
+        | "RevertInCreateInInit.json"
         | "dynamicAccountOverwriteEmpty.json"
         | "dynamicAccountOverwriteEmpty_Paris.json"
         | "RevertInCreateInInitCreate2Paris.json"

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -76,12 +76,8 @@ fn skip_test(path: &Path) -> bool {
 
     matches!(
         name,
-        // Test check if gas price overflows, we handle this correctly but does not match tests specific exception.
-        | "CreateTransactionHighNonce.json"
-
         // Test with some storage check.
-        | "RevertInCreateInInit_Paris.json"
-        | "RevertInCreateInInit.json"
+        |"RevertInCreateInInit_Paris.json"| "RevertInCreateInInit.json"
         | "dynamicAccountOverwriteEmpty.json"
         | "dynamicAccountOverwriteEmpty_Paris.json"
         | "RevertInCreateInInitCreate2Paris.json"

--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -105,6 +105,9 @@ pub fn validate_account_nonce_and_code(
     if !is_nonce_check_disabled {
         let tx = tx_nonce;
         let state = caller_info.nonce;
+        if tx == u64::MAX && state == u64::MAX {
+            return Err(InvalidTransaction::NonceOverflowInTransaction);
+        }
         match tx.cmp(&state) {
             Ordering::Greater => {
                 return Err(InvalidTransaction::NonceTooHigh { tx, state });
@@ -280,4 +283,34 @@ pub fn apply_auth_list<
     let refunded_gas = refunded_accounts * refund_per_auth;
 
     Ok(refunded_gas)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_account_nonce_and_code;
+    use context_interface::result::InvalidTransaction;
+    use state::AccountInfo;
+
+    #[test]
+    fn rejects_transactions_when_sender_nonce_is_max() {
+        let caller_info = AccountInfo {
+            nonce: u64::MAX,
+            ..AccountInfo::default()
+        };
+
+        let err = validate_account_nonce_and_code(&caller_info, u64::MAX, false, false)
+            .expect_err("nonce-max sender should be rejected before execution");
+
+        assert_eq!(err, InvalidTransaction::NonceOverflowInTransaction);
+    }
+
+    #[test]
+    fn allows_matching_non_max_nonce() {
+        let caller_info = AccountInfo {
+            nonce: 7,
+            ..AccountInfo::default()
+        };
+
+        assert!(validate_account_nonce_and_code(&caller_info, 7, false, false).is_ok());
+    }
 }


### PR DESCRIPTION
CreateTransactionHighNonce expects the transaction to fail before execution when both the sender nonce and tx nonce are already `u64::MAX`. Today the nonce equality check passes, so revm lets the transaction proceed instead of surfacing `InvalidTransaction::NonceOverflowInTransaction`, even though that error already exists. This change adds the missing guard in `validate_account_nonce_and_code`, adds handler coverage for the nonce-max and normal matching-nonce paths, and removes `CreateTransactionHighNonce.json` from the `revme` skip lists. This is also the upstream fix for the same case that currently needs a temporary statetest workaround in `revmc`.