### PR TITLE
Gate EIP-7702 delegation-follow behind Prague in call paths

### DIFF
--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -758,17 +758,19 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
             account.is_cold,
         );
 
-        // load delegate code if account is EIP-7702
-        if let Some(address) = account
-            .info
-            .code
-            .as_ref()
-            .and_then(Bytecode::eip7702_address)
-        {
-            let delegate_account = self
-                .load_account_optional(db, address, true, false)
-                .map_err(JournalLoadError::unwrap_db_error)?;
-            account_load.data.is_delegate_account_cold = Some(delegate_account.is_cold);
+        // load delegate code if account is EIP-7702 and Prague is enabled.
+        if is_eip7702_enabled {
+            if let Some(address) = account
+                .info
+                .code
+                .as_ref()
+                .and_then(Bytecode::eip7702_address)
+            {
+                let delegate_account = self
+                    .load_account_optional(db, address, true, false)
+                    .map_err(JournalLoadError::unwrap_db_error)?;
+                account_load.data.is_delegate_account_cold = Some(delegate_account.is_cold);
+            }
         }
 
         Ok(account_load)
@@ -1144,8 +1146,8 @@ mod tests {
     use super::*;
     use context_interface::journaled_state::entry::JournalEntry;
     use database_interface::EmptyDB;
-    use primitives::{address, HashSet, U256};
-    use state::AccountInfo;
+    use primitives::{address, hardfork::SpecId, HashSet, U256};
+    use state::{AccountInfo, Bytecode};
 
     #[test]
     fn test_sload_skip_cold_load() {
@@ -1181,5 +1183,59 @@ mod tests {
         let state_load = result.unwrap();
         assert!(!state_load.is_cold); // Should be warm
         assert_eq!(state_load.data, U256::ZERO); // Empty slot
+    }
+
+    #[test]
+    fn load_account_delegated_pre_prague_does_not_follow_delegation() {
+        let mut journal = JournalInner::<JournalEntry>::new();
+        journal.set_spec_id(SpecId::CANCUN);
+
+        let target = Address::with_last_byte(0x10);
+        let delegate = Address::with_last_byte(0x20);
+
+        journal.state.insert(
+            target,
+            Account::from(AccountInfo::default().with_code(Bytecode::new_eip7702(delegate))),
+        );
+        journal.state.insert(
+            delegate,
+            Account::from(
+                AccountInfo::default().with_code(Bytecode::new_legacy(vec![0x00].into())),
+            ),
+        );
+
+        let mut db = EmptyDB::new();
+        let load = journal
+            .load_account_delegated(&mut db, target)
+            .expect("delegated load should succeed");
+
+        assert_eq!(load.data.is_delegate_account_cold, None);
+    }
+
+    #[test]
+    fn load_account_delegated_prague_follows_delegation() {
+        let mut journal = JournalInner::<JournalEntry>::new();
+        journal.set_spec_id(SpecId::PRAGUE);
+
+        let target = Address::with_last_byte(0x11);
+        let delegate = Address::with_last_byte(0x21);
+
+        journal.state.insert(
+            target,
+            Account::from(AccountInfo::default().with_code(Bytecode::new_eip7702(delegate))),
+        );
+        journal.state.insert(
+            delegate,
+            Account::from(
+                AccountInfo::default().with_code(Bytecode::new_legacy(vec![0x00].into())),
+            ),
+        );
+
+        let mut db = EmptyDB::new();
+        let load = journal
+            .load_account_delegated(&mut db, target)
+            .expect("delegated load should succeed");
+
+        assert!(load.data.is_delegate_account_cold.is_some());
     }
 }

--- a/crates/handler/src/execution.rs
+++ b/crates/handler/src/execution.rs
@@ -1,9 +1,9 @@
 use context::{ContextTr, Database, JournalTr};
-use context_interface::Transaction;
+use context_interface::{Cfg, Transaction};
 use interpreter::{
     CallInput, CallInputs, CallScheme, CallValue, CreateInputs, CreateScheme, FrameInput,
 };
-use primitives::TxKind;
+use primitives::{hardfork::SpecId, TxKind};
 use state::Bytecode;
 use std::boxed::Box;
 
@@ -13,6 +13,7 @@ pub fn create_init_frame<CTX: ContextTr>(
     ctx: &mut CTX,
     gas_limit: u64,
 ) -> Result<FrameInput, <<CTX::Journal as JournalTr>::Database as Database>::Error> {
+    let is_prague = ctx.cfg().spec().into().is_enabled_in(SpecId::PRAGUE);
     let (tx, journal) = ctx.tx_journal_mut();
     let input = tx.input().clone();
 
@@ -20,14 +21,21 @@ pub fn create_init_frame<CTX: ContextTr>(
         TxKind::Call(target_address) => {
             let account = &journal.load_account_with_code(target_address)?.info;
 
-            let known_bytecode = if let Some(delegated_address) =
-                account.code.as_ref().and_then(Bytecode::eip7702_address)
-            {
-                let account = &journal.load_account_with_code(delegated_address)?.info;
-                (
-                    account.code_hash(),
-                    account.code.clone().unwrap_or_default(),
-                )
+            let known_bytecode = if is_prague {
+                if let Some(delegated_address) =
+                    account.code.as_ref().and_then(Bytecode::eip7702_address)
+                {
+                    let account = &journal.load_account_with_code(delegated_address)?.info;
+                    (
+                        account.code_hash(),
+                        account.code.clone().unwrap_or_default(),
+                    )
+                } else {
+                    (
+                        account.code_hash(),
+                        account.code.clone().unwrap_or_default(),
+                    )
+                }
             } else {
                 (
                     account.code_hash(),
@@ -54,5 +62,91 @@ pub fn create_init_frame<CTX: ContextTr>(
             input,
             gas_limit,
         )))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::create_init_frame;
+    use crate::MainContext;
+    use context::{Context, TxEnv};
+    use context_interface::ContextSetters;
+    use database::{CacheDB, EmptyDB};
+    use interpreter::FrameInput;
+    use primitives::{hardfork::SpecId, Address, TxKind};
+    use state::{AccountInfo, Bytecode};
+
+    #[test]
+    fn create_init_frame_pre_prague_does_not_follow_delegation() {
+        let target = Address::with_last_byte(0x10);
+        let delegate = Address::with_last_byte(0x20);
+        let target_code = Bytecode::new_eip7702(delegate);
+        let delegate_code = Bytecode::new_legacy(vec![0x00].into());
+
+        let mut db = CacheDB::<EmptyDB>::default();
+        db.insert_account_info(
+            target,
+            AccountInfo::default().with_code(target_code.clone()),
+        );
+        db.insert_account_info(delegate, AccountInfo::default().with_code(delegate_code));
+
+        let mut ctx = Context::mainnet()
+            .with_db(db)
+            .modify_cfg_chained(|cfg| cfg.set_spec_and_mainnet_gas_params(SpecId::CANCUN));
+        ctx.set_tx(
+            TxEnv::builder()
+                .kind(TxKind::Call(target))
+                .caller(Address::with_last_byte(0xAA))
+                .gas_limit(100_000)
+                .build()
+                .expect("tx setup should be valid"),
+        );
+
+        let frame = create_init_frame(&mut ctx, 100_000).expect("frame creation should succeed");
+
+        let FrameInput::Call(inputs) = frame else {
+            panic!("expected call frame");
+        };
+
+        assert_eq!(inputs.known_bytecode.1, target_code);
+        assert_eq!(inputs.known_bytecode.0, target_code.hash_slow());
+    }
+
+    #[test]
+    fn create_init_frame_prague_follows_delegation() {
+        let target = Address::with_last_byte(0x11);
+        let delegate = Address::with_last_byte(0x21);
+        let delegate_code = Bytecode::new_legacy(vec![0x00].into());
+
+        let mut db = CacheDB::<EmptyDB>::default();
+        db.insert_account_info(
+            target,
+            AccountInfo::default().with_code(Bytecode::new_eip7702(delegate)),
+        );
+        db.insert_account_info(
+            delegate,
+            AccountInfo::default().with_code(delegate_code.clone()),
+        );
+
+        let mut ctx = Context::mainnet()
+            .with_db(db)
+            .modify_cfg_chained(|cfg| cfg.set_spec_and_mainnet_gas_params(SpecId::PRAGUE));
+        ctx.set_tx(
+            TxEnv::builder()
+                .kind(TxKind::Call(target))
+                .caller(Address::with_last_byte(0xAA))
+                .gas_limit(100_000)
+                .build()
+                .expect("tx setup should be valid"),
+        );
+
+        let frame = create_init_frame(&mut ctx, 100_000).expect("frame creation should succeed");
+
+        let FrameInput::Call(inputs) = frame else {
+            panic!("expected call frame");
+        };
+
+        assert_eq!(inputs.known_bytecode.1, delegate_code);
+        assert_eq!(inputs.known_bytecode.0, delegate_code.hash_slow());
     }
 }

--- a/crates/interpreter/src/instructions/contract/call_helpers.rs
+++ b/crates/interpreter/src/instructions/contract/call_helpers.rs
@@ -162,25 +162,228 @@ pub fn load_account_delegated<H: Host + ?Sized>(
         return Ok((cost, bytecode, code_hash));
     }
 
-    // load delegate code if account is EIP-7702
-    if let Some(address) = account.code.as_ref().and_then(Bytecode::eip7702_address) {
-        // EIP-7702 is enabled after berlin hardfork.
-        cost += warm_storage_read_cost;
-        if cost > remaining_gas {
-            return Err(LoadError::ColdLoadSkipped);
-        }
+    // load delegate code if account is EIP-7702 and Prague is enabled.
+    if spec.is_enabled_in(SpecId::PRAGUE) {
+        if let Some(address) = account.code.as_ref().and_then(Bytecode::eip7702_address) {
+            cost += warm_storage_read_cost;
+            if cost > remaining_gas {
+                return Err(LoadError::ColdLoadSkipped);
+            }
 
-        // skip cold load if there is enough gas to cover the cost.
-        let skip_cold_load = remaining_gas < cost + additional_cold_cost;
-        let delegate_account =
-            host.load_account_info_skip_cold_load(address, true, skip_cold_load)?;
+            // skip cold load if there is enough gas to cover the cost.
+            let skip_cold_load = remaining_gas < cost + additional_cold_cost;
+            let delegate_account =
+                host.load_account_info_skip_cold_load(address, true, skip_cold_load)?;
 
-        if delegate_account.is_cold {
-            cost += additional_cold_cost;
+            if delegate_account.is_cold {
+                cost += additional_cold_cost;
+            }
+            bytecode = delegate_account.code.clone().unwrap_or_default();
+            code_hash = delegate_account.code_hash();
         }
-        bytecode = delegate_account.code.clone().unwrap_or_default();
-        code_hash = delegate_account.code_hash();
     }
 
     Ok((cost, bytecode, code_hash))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::load_account_delegated;
+    use context_interface::{
+        cfg::GasParams,
+        context::{SStoreResult, SelfDestructResult, StateLoad},
+        host::{Host, LoadError},
+        journaled_state::AccountInfoLoad,
+    };
+    use primitives::{
+        hardfork::SpecId, Address, HashMap, Log, StorageKey, StorageValue, B256, U256,
+    };
+    use state::{AccountInfo, Bytecode};
+    use std::borrow::Cow;
+    use std::vec::Vec;
+
+    #[derive(Debug)]
+    struct TestHost {
+        gas_params: GasParams,
+        accounts: HashMap<Address, AccountInfo>,
+        loads: Vec<Address>,
+    }
+
+    impl TestHost {
+        fn new(spec: SpecId) -> Self {
+            Self {
+                gas_params: GasParams::new_spec(spec),
+                accounts: HashMap::default(),
+                loads: Vec::new(),
+            }
+        }
+
+        fn insert_account(&mut self, address: Address, account: AccountInfo) {
+            self.accounts.insert(address, account);
+        }
+    }
+
+    impl Host for TestHost {
+        fn basefee(&self) -> U256 {
+            U256::ZERO
+        }
+
+        fn blob_gasprice(&self) -> U256 {
+            U256::ZERO
+        }
+
+        fn gas_limit(&self) -> U256 {
+            U256::ZERO
+        }
+
+        fn difficulty(&self) -> U256 {
+            U256::ZERO
+        }
+
+        fn prevrandao(&self) -> Option<U256> {
+            None
+        }
+
+        fn block_number(&self) -> U256 {
+            U256::ZERO
+        }
+
+        fn timestamp(&self) -> U256 {
+            U256::ZERO
+        }
+
+        fn beneficiary(&self) -> Address {
+            Address::ZERO
+        }
+
+        fn slot_num(&self) -> U256 {
+            U256::ZERO
+        }
+
+        fn chain_id(&self) -> U256 {
+            U256::ZERO
+        }
+
+        fn effective_gas_price(&self) -> U256 {
+            U256::ZERO
+        }
+
+        fn caller(&self) -> Address {
+            Address::ZERO
+        }
+
+        fn blob_hash(&self, _number: usize) -> Option<U256> {
+            None
+        }
+
+        fn max_initcode_size(&self) -> usize {
+            0
+        }
+
+        fn gas_params(&self) -> &GasParams {
+            &self.gas_params
+        }
+
+        fn block_hash(&mut self, _number: u64) -> Option<B256> {
+            None
+        }
+
+        fn selfdestruct(
+            &mut self,
+            _address: Address,
+            _target: Address,
+            _skip_cold_load: bool,
+        ) -> Result<StateLoad<SelfDestructResult>, LoadError> {
+            Ok(StateLoad::new(SelfDestructResult::default(), false))
+        }
+
+        fn log(&mut self, _log: Log) {}
+
+        fn sstore_skip_cold_load(
+            &mut self,
+            _address: Address,
+            _key: StorageKey,
+            _value: StorageValue,
+            _skip_cold_load: bool,
+        ) -> Result<StateLoad<SStoreResult>, LoadError> {
+            Ok(StateLoad::new(SStoreResult::default(), false))
+        }
+
+        fn sload_skip_cold_load(
+            &mut self,
+            _address: Address,
+            _key: StorageKey,
+            _skip_cold_load: bool,
+        ) -> Result<StateLoad<StorageValue>, LoadError> {
+            Ok(StateLoad::new(StorageValue::ZERO, false))
+        }
+
+        fn tstore(&mut self, _address: Address, _key: StorageKey, _value: StorageValue) {}
+
+        fn tload(&mut self, _address: Address, _key: StorageKey) -> StorageValue {
+            StorageValue::ZERO
+        }
+
+        fn load_account_info_skip_cold_load(
+            &mut self,
+            address: Address,
+            _load_code: bool,
+            _skip_cold_load: bool,
+        ) -> Result<AccountInfoLoad<'_>, LoadError> {
+            self.loads.push(address);
+            let account = self.accounts.get(&address).cloned().unwrap_or_default();
+            let is_empty = account.is_empty();
+            Ok(AccountInfoLoad {
+                account: Cow::Owned(account),
+                is_cold: false,
+                is_empty,
+            })
+        }
+    }
+
+    #[test]
+    fn pre_prague_does_not_follow_delegation() {
+        let target = Address::with_last_byte(0x10);
+        let delegate = Address::with_last_byte(0x20);
+        let delegated_marker = Bytecode::new_eip7702(delegate);
+        let delegate_code = Bytecode::new_legacy(vec![0x00].into());
+
+        let mut host = TestHost::new(SpecId::CANCUN);
+        host.insert_account(
+            target,
+            AccountInfo::default().with_code(delegated_marker.clone()),
+        );
+        host.insert_account(delegate, AccountInfo::default().with_code(delegate_code));
+
+        let (_, bytecode, code_hash) =
+            load_account_delegated(&mut host, SpecId::CANCUN, 1_000_000, target, false, false)
+                .expect("account load should succeed");
+
+        assert_eq!(bytecode, delegated_marker);
+        assert_eq!(code_hash, delegated_marker.hash_slow());
+        assert_eq!(host.loads, vec![target]);
+    }
+
+    #[test]
+    fn prague_follows_delegation() {
+        let target = Address::with_last_byte(0x11);
+        let delegate = Address::with_last_byte(0x21);
+        let delegated_marker = Bytecode::new_eip7702(delegate);
+        let delegate_code = Bytecode::new_legacy(vec![0x00].into());
+
+        let mut host = TestHost::new(SpecId::PRAGUE);
+        host.insert_account(target, AccountInfo::default().with_code(delegated_marker));
+        host.insert_account(
+            delegate,
+            AccountInfo::default().with_code(delegate_code.clone()),
+        );
+
+        let (_, bytecode, code_hash) =
+            load_account_delegated(&mut host, SpecId::PRAGUE, 1_000_000, target, false, false)
+                .expect("account load should succeed");
+
+        assert_eq!(bytecode, delegate_code);
+        assert_eq!(code_hash, delegate_code.hash_slow());
+        assert_eq!(host.loads, vec![target, delegate]);
+    }
 }


### PR DESCRIPTION
## Summary
This PR adds explicit Prague gating for EIP-7702 delegation-follow behavior in call resolution paths.

Without explicit fork gating, delegation-shaped code could be followed in pre-Prague contexts in call paths where Prague rules should not apply.

## What changed
- Gate delegation extraction in `load_account_delegated` behind `SpecId::PRAGUE` in interpreter call helpers.
- Gate top-level call-frame delegation extraction in `create_init_frame` behind `SpecId::PRAGUE`.
- Align journal delegated-load extraction with the existing `is_eip7702_enabled` flag.
- Add regressions for both pre-Prague no-delegation and Prague delegation behavior across these paths.

## Tests
- `cargo fmt --check`
- `cargo build`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo test -p revm-interpreter call_helpers::tests -- --nocapture`
- `cargo test -p revm-handler execution::tests -- --nocapture`
- `cargo test -p revm-context journal::inner::tests::load_account_delegated_ -- --nocapture`
