### PR TITLE
refactor: deprecate set_spec and clean up deprecation attrs

### DIFF
--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -211,6 +211,7 @@ impl<SPEC> CfgEnv<SPEC> {
 
     /// Sets the spec for the `CfgEnv`.
     #[inline]
+    #[deprecated(note = "Use [`CfgEnv::with_spec_and_mainnet_gas_params`] instead")]
     pub fn set_spec(&mut self, spec: SPEC) {
         self.spec = spec;
     }
@@ -235,10 +236,7 @@ impl<SPEC> CfgEnv<SPEC> {
 
     /// Sets the spec for the `CfgEnv`.
     #[inline]
-    #[deprecated(
-        since = "0.1.0",
-        note = "Use [`CfgEnv::with_spec_and_mainnet_gas_params`] instead"
-    )]
+    #[deprecated(note = "Use [`CfgEnv::with_spec_and_mainnet_gas_params`] instead")]
     pub fn with_spec(mut self, spec: SPEC) -> Self {
         self.spec = spec;
         self
@@ -369,7 +367,7 @@ impl<SPEC: Into<SpecId> + Clone> CfgEnv<SPEC> {
     /// Sets the spec for the `CfgEnv` and the gas params to the mainnet gas params.
     #[inline]
     pub fn set_spec_and_mainnet_gas_params(&mut self, spec: SPEC) {
-        self.set_spec(spec.clone());
+        self.spec = spec.clone();
         self.set_gas_params(GasParams::new_spec(spec.into()));
     }
 }

--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -211,7 +211,7 @@ impl<SPEC> CfgEnv<SPEC> {
 
     /// Sets the spec for the `CfgEnv`.
     #[inline]
-    #[deprecated(note = "Use [`CfgEnv::with_spec_and_mainnet_gas_params`] instead")]
+    #[deprecated(note = "Use [`CfgEnv::set_spec_and_mainnet_gas_params`] instead")]
     pub fn set_spec(&mut self, spec: SPEC) {
         self.spec = spec;
     }

--- a/crates/interpreter/src/interpreter_action/call_inputs.rs
+++ b/crates/interpreter/src/interpreter_action/call_inputs.rs
@@ -315,7 +315,7 @@ impl CallValue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core::cell::{Ref, RefCell};
+    use core::cell::RefCell;
     use std::rc::Rc;
 
     struct TestLocalContext {


### PR DESCRIPTION
## Summary
- Deprecate `CfgEnv::set_spec` in favor of `set_spec_and_mainnet_gas_params` to guide users toward the correct API that also updates gas params
- Clean up verbose `#[deprecated]` attributes (remove unnecessary `since` field)
- Avoid calling deprecated `set_spec` internally in `set_spec_and_mainnet_gas_params`
- Remove unused `Ref` import in call_inputs tests

## Test plan
- [ ] CI passes (clippy, tests, formatting)