### PR TITLE
refactor: state gas cleanup and EIP-8037 validation consolidation

### DIFF
--- a/crates/context/interface/src/cfg/gas.rs
+++ b/crates/context/interface/src/cfg/gas.rs
@@ -312,6 +312,15 @@ impl InitialAndFloorGas {
             eip7702_reservoir_refund: 0,
         }
     }
+
+    /// Regular (non-state) portion of the initial intrinsic gas.
+    ///
+    /// Under EIP-8037, this is the part constrained by `TX_MAX_GAS_LIMIT`;
+    /// state gas uses its own reservoir and is not subject to that cap.
+    #[inline]
+    pub const fn initial_regular_gas(&self) -> u64 {
+        self.initial_total_gas - self.initial_state_gas
+    }
 }
 
 /// Initial gas that is deducted for transaction to be included.

--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -211,9 +211,7 @@ pub trait Handler {
     ) -> Result<FrameResult, Self::Error> {
         // Deduct regular initial gas from the transaction gas limit.
         // State gas is handled separately via the reservoir.
-        let regular_initial_gas =
-            init_and_floor_gas.initial_total_gas - init_and_floor_gas.initial_state_gas;
-        let gas_limit = evm.ctx().tx().gas_limit() - regular_initial_gas;
+        let gas_limit = evm.ctx().tx().gas_limit() - init_and_floor_gas.initial_regular_gas();
         // Create first frame action
         // Note: first_frame_input now handles state gas deduction from the reservoir
         let first_frame_input = self.first_frame_input(evm, gas_limit, init_and_floor_gas)?;
@@ -288,26 +286,9 @@ pub trait Handler {
             ctx.tx(),
             ctx.cfg().spec().into(),
             ctx.cfg().is_eip7623_disabled(),
+            ctx.cfg().is_amsterdam_eip8037_enabled(),
+            ctx.cfg().tx_gas_limit_cap(),
         )?;
-
-        // EIP-8037: When state gas is enabled and gas_limit exceeds TX_MAX_GAS_LIMIT,
-        // the regular gas portion is capped at TX_MAX_GAS_LIMIT. Validate that
-        // max(intrinsic_regular_gas, floor_gas) fits within the cap.
-        // State gas is excluded as it uses its own reservoir.
-        if ctx.cfg().is_amsterdam_eip8037_enabled()
-            && ctx.tx().gas_limit() > ctx.cfg().tx_gas_limit_cap()
-        {
-            let cap = ctx.cfg().tx_gas_limit_cap();
-            let initial_regular_gas = gas.initial_total_gas - gas.initial_state_gas;
-            let effective_min = initial_regular_gas.max(gas.floor_gas);
-            if effective_min > cap {
-                return Err(InvalidTransaction::GasFloorMoreThanGasLimit {
-                    gas_floor: effective_min,
-                    gas_limit: cap,
-                }
-                .into());
-            }
-        }
 
         Ok(gas)
     }
@@ -376,9 +357,9 @@ pub trait Handler {
         let regular_gas_cap = if init_and_floor_gas.initial_total_gas == 0 {
             u64::MAX
         } else if ctx.cfg().is_amsterdam_eip8037_enabled() {
-            let intrinsic_gas =
-                init_and_floor_gas.initial_total_gas - init_and_floor_gas.initial_state_gas;
-            ctx.cfg().tx_gas_limit_cap().saturating_sub(intrinsic_gas)
+            ctx.cfg()
+                .tx_gas_limit_cap()
+                .saturating_sub(init_and_floor_gas.initial_regular_gas())
         } else {
             ctx.cfg().tx_gas_limit_cap()
         };

--- a/crates/handler/src/precompile_provider.rs
+++ b/crates/handler/src/precompile_provider.rs
@@ -83,7 +83,6 @@ pub fn precompile_output_to_interpreter_result(
     output: PrecompileOutput,
     gas_limit: u64,
 ) -> InterpreterResult {
-
     // set output bytes
     let bytes = if output.status.is_success_or_revert() {
         output.bytes

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -234,6 +234,8 @@ pub fn validate_initial_tx_gas(
     tx: impl Transaction,
     spec: SpecId,
     is_eip7623_disabled: bool,
+    is_amsterdam_eip8037_enabled: bool,
+    tx_gas_limit_cap: u64,
 ) -> Result<InitialAndFloorGas, InvalidTransaction> {
     let mut gas = calculate_initial_tx_gas_for_tx(&tx, spec);
 
@@ -257,6 +259,19 @@ pub fn validate_initial_tx_gas(
             gas_limit: tx.gas_limit(),
         });
     };
+
+    // EIP-8037: Regular gas is capped at TX_MAX_GAS_LIMIT.
+    // Validate that both intrinsic regular gas and floor gas fit within the cap.
+    // State gas is excluded — it uses its own reservoir.
+    if is_amsterdam_eip8037_enabled && tx.gas_limit() > tx_gas_limit_cap {
+        let min_regular_gas = gas.initial_regular_gas().max(gas.floor_gas);
+        if min_regular_gas > tx_gas_limit_cap {
+            return Err(InvalidTransaction::GasFloorMoreThanGasLimit {
+                gas_floor: min_regular_gas,
+                gas_limit: tx_gas_limit_cap,
+            });
+        }
+    }
 
     Ok(gas)
 }

--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -82,9 +82,8 @@ where
         init_and_floor_gas: &InitialAndFloorGas,
     ) -> Result<FrameResult, Self::Error> {
         // Deduct regular initial gas from the transaction gas limit.
-        let regular_initial_gas =
-            init_and_floor_gas.initial_total_gas - init_and_floor_gas.initial_state_gas;
-        let gas_limit = evm.ctx().tx().gas_limit() - regular_initial_gas;
+        // State gas is handled separately via the reservoir.
+        let gas_limit = evm.ctx().tx().gas_limit() - init_and_floor_gas.initial_regular_gas();
         // Create first frame action.
         // Note: first_frame_input already handles initial state gas deduction
         // from the reservoir (or gas_limit deficit).

--- a/crates/op-revm/src/handler.rs
+++ b/crates/op-revm/src/handler.rs
@@ -322,13 +322,12 @@ where
 
         let l1_cost = l1_block_info.calculate_tx_l1_cost(enveloped_tx, spec);
         // Exclude reservoir gas (EIP-8037) from used gas — reservoir is unused and reimbursed.
-        let effective_used = frame_result.gas().used().saturating_sub(frame_result.gas().reservoir());
+        let effective_used = frame_result
+            .gas()
+            .used()
+            .saturating_sub(frame_result.gas().reservoir());
         let operator_fee_cost = if spec.is_enabled_in(OpSpecId::ISTHMUS) {
-            l1_block_info.operator_fee_charge(
-                enveloped_tx,
-                U256::from(effective_used),
-                spec,
-            )
+            l1_block_info.operator_fee_charge(enveloped_tx, U256::from(effective_used), spec)
         } else {
             U256::ZERO
         };

--- a/crates/op-revm/src/precompiles.rs
+++ b/crates/op-revm/src/precompiles.rs
@@ -451,7 +451,9 @@ mod tests {
         bad_input_len = bls12_381::JOVIAN_G1_MSM_MAX_INPUT_SIZE + 1;
         assert!(bad_input_len < bls12_381::ISTHMUS_G1_MSM_MAX_INPUT_SIZE);
         let input = vec![0u8; bad_input_len];
-        let res = bls12_381_g1_msm_precompile.execute(&input, u64::MAX, 0).unwrap();
+        let res = bls12_381_g1_msm_precompile
+            .execute(&input, u64::MAX, 0)
+            .unwrap();
         assert!(
             matches!(res.status, PrecompileStatus::Halt(PrecompileHalt::Other(msg)) if msg.contains("input length too long"))
         );
@@ -463,7 +465,9 @@ mod tests {
         bad_input_len = bls12_381::JOVIAN_G2_MSM_MAX_INPUT_SIZE + 1;
         assert!(bad_input_len < bls12_381::ISTHMUS_G2_MSM_MAX_INPUT_SIZE);
         let input = vec![0u8; bad_input_len];
-        let res = bls12_381_g2_msm_precompile.execute(&input, u64::MAX, 0).unwrap();
+        let res = bls12_381_g2_msm_precompile
+            .execute(&input, u64::MAX, 0)
+            .unwrap();
         assert!(
             matches!(res.status, PrecompileStatus::Halt(PrecompileHalt::Other(msg)) if msg.contains("input length too long"))
         );
@@ -475,7 +479,9 @@ mod tests {
         bad_input_len = bls12_381::JOVIAN_PAIRING_MAX_INPUT_SIZE + 1;
         assert!(bad_input_len < bls12_381::ISTHMUS_PAIRING_MAX_INPUT_SIZE);
         let input = vec![0u8; bad_input_len];
-        let res = bls12_381_pairing_precompile.execute(&input, u64::MAX, 0).unwrap();
+        let res = bls12_381_pairing_precompile
+            .execute(&input, u64::MAX, 0)
+            .unwrap();
         assert!(
             matches!(res.status, PrecompileStatus::Halt(PrecompileHalt::Other(msg)) if msg.contains("input length too long"))
         );

--- a/crates/precompile/src/interface.rs
+++ b/crates/precompile/src/interface.rs
@@ -348,7 +348,9 @@ pub type PrecompileFn = fn(&[u8], u64, u64) -> PrecompileResult;
 macro_rules! eth_precompile_fn {
     ($name:ident, $eth_fn:expr) => {
         fn $name(input: &[u8], gas_limit: u64, reservoir: u64) -> $crate::PrecompileResult {
-            Ok($crate::call_eth_precompile($eth_fn, input, gas_limit, reservoir))
+            Ok($crate::call_eth_precompile(
+                $eth_fn, input, gas_limit, reservoir,
+            ))
         }
     };
 }


### PR DESCRIPTION
## Summary
- Add `initial_regular_gas()` helper on `InitialAndFloorGas` to avoid repeated `initial_total_gas - initial_state_gas` calculations
- Move EIP-8037 `TX_MAX_GAS_LIMIT` validation from handler into `validate_initial_tx_gas`, consolidating gas validation logic in one place
- Fix: exclude EIP-8037 reservoir gas from op-revm fee settlement
- Various formatting cleanups across precompile and op-revm crates

## Test plan
- [ ] `cargo nextest run --workspace`
- [ ] EIP-8037 ee-tests pass
- [ ] op-revm tests pass