### PR TITLE
fix: reject transactions with nonce at u64::MAX

### DIFF
--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -227,7 +227,7 @@ pub fn validate_tx_env<CTX: ContextTr>(
     }
 
     // Check that the transaction's nonce is not at the maximum value.
-    // Incrementing the nonce would overflow.
+    // Incrementing the nonce would overflow. Can't happen in the real world.
     if tx.nonce() == u64::MAX {
         return Err(InvalidTransaction::NonceOverflowInTransaction);
     }

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -226,6 +226,12 @@ pub fn validate_tx_env<CTX: ContextTr>(
         return Err(InvalidTransaction::CreateInitCodeSizeLimit);
     }
 
+    // Check that the transaction's nonce is not at the maximum value.
+    // Incrementing the nonce would overflow.
+    if tx.nonce() == u64::MAX {
+        return Err(InvalidTransaction::NonceOverflowInTransaction);
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Adds validation in `validate_tx_env` to reject transactions where the nonce equals `u64::MAX`, preventing nonce overflow when incrementing.

## Test plan
- [ ] Existing tests pass
- [ ] Verify `InvalidTransaction::NonceOverflowInTransaction` is returned for nonce = u64::MAX