### PR TITLE
chore: v106 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
 
-# v107
+# v106
+date 10.04.2026
+
+Eth devnet3. EIP-8037 State gas support
+
+* `revm-primitives`: 22.1.0 -> 23.0.0 (⚠ API breaking changes)
+* `revm-bytecode`: 9.0.0 -> 10.0.0 (✓ API compatible changes)
+* `revm-database-interface`: 10.0.0 -> 11.0.0 (✓ API compatible changes)
+* `revm-context-interface`: 16.0.0 -> 17.0.0 (⚠ API breaking changes)
+* `revm-context`: 15.0.0 -> 16.0.0 (⚠ API breaking changes)
+* `revm-database`: 12.0.0 -> 13.0.0 (⚠ API breaking changes)
+* `revm-interpreter`: 34.0.0 -> 35.0.0 (⚠ API breaking changes)
+* `revm-precompile`: 32.1.0 -> 33.0.0 (⚠ API breaking changes)
+* `revm-handler`: 17.0.0 -> 18.0.0 (⚠ API breaking changes)
+* `revm-inspector`: 17.0.0 -> 18.0.0 (✓ API compatible changes)
+* `revm-statetest-types`: 16.0.0 -> 17.0.0 (✓ API compatible changes)
+* `revme`: 13.0.0 -> 14.0.0 (⚠ API breaking changes)
+* `op-revm`: 17.0.0 -> 18.0.0 (✓ API compatible changes)
+* `revm-state`: 10.0.0 -> 11.0.0
+* `revm`: 36.0.0 -> 37.0.0
+
+# v105
 date: 04.03.2026
 
 Bump revm-database-interface major version. All dependent crates bumped accordingly.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,9 +1006,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -1016,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -2974,7 +2974,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-revm"
-version = "17.1.0"
+version = "18.0.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -3600,7 +3600,7 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "36.0.1"
+version = "37.0.0"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3620,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "9.1.0"
+version = "10.0.0"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -3680,7 +3680,7 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "10.1.0"
+version = "11.0.0"
 dependencies = [
  "auto_impl",
  "either",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "17.1.0"
+version = "18.0.0"
 dependencies = [
  "auto_impl",
  "either",
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "10.0.1"
+version = "11.0.0"
 dependencies = [
  "alloy-eip7928",
  "bitflags",
@@ -3804,7 +3804,7 @@ dependencies = [
 
 [[package]]
 name = "revm-statetest-types"
-version = "16.0.1"
+version = "17.0.0"
 dependencies = [
  "alloy-eip7928",
  "k256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,20 +42,20 @@ default-members = ["crates/revm"]
 
 [workspace.dependencies]
 # revm
-revm = { path = "crates/revm", version = "36.0.1", default-features = false }
+revm = { path = "crates/revm", version = "37.0.0", default-features = false }
 primitives = { path = "crates/primitives", package = "revm-primitives", version = "23.0.0", default-features = false }
-bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "9.1.0", default-features = false }
+bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "10.0.0", default-features = false }
 database = { path = "crates/database", package = "revm-database", version = "13.0.0", default-features = false }
-database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "10.1.0", default-features = false }
-state = { path = "crates/state", package = "revm-state", version = "10.0.1", default-features = false }
+database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "11.0.0", default-features = false }
+state = { path = "crates/state", package = "revm-state", version = "11.0.0", default-features = false }
 interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "35.0.0", default-features = false }
-inspector = { path = "crates/inspector", package = "revm-inspector", version = "17.1.0", default-features = false }
+inspector = { path = "crates/inspector", package = "revm-inspector", version = "18.0.0", default-features = false }
 precompile = { path = "crates/precompile", package = "revm-precompile", version = "33.0.0", default-features = false }
-statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "16.0.1", default-features = false }
+statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "17.0.0", default-features = false }
 context = { path = "crates/context", package = "revm-context", version = "16.0.0", default-features = false }
 context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "17.0.0", default-features = false }
 handler = { path = "crates/handler", package = "revm-handler", version = "18.0.0", default-features = false }
-op-revm = { path = "crates/op-revm", package = "op-revm", version = "17.1.0", default-features = false }
+op-revm = { path = "crates/op-revm", package = "op-revm", version = "18.0.0", default-features = false }
 ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "0.2.0", default-features = false }
 
 # alloy
@@ -92,7 +92,7 @@ secp256k1 = { version = "0.31.1", default-features = false }
 sha2 = { version = "0.10.9", default-features = false }
 ripemd = { version = "0.1.3", default-features = false }
 p256 = { version = "0.13.2", default-features = false }
-aws-lc-rs = { version = "1.16.1", default-features = false, features = ["aws-lc-sys"] }
+aws-lc-rs = { version = "1.16.2", default-features = false, features = ["aws-lc-sys"] }
 
 # bytecode
 bitvec = { version = "1", default-features = false }

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,5 +1,5 @@
 
-# v106 tag
+# v106 tag (revm v37.0.0)
 
 * EIP-8037 state gas support ([#3406](https://github.com/bluealloy/revm/pull/3406)). Gas is now split into regular gas and state gas tracked via a reservoir. State gas draws from the reservoir first and spills into regular gas when exhausted. This affects gas accounting across the entire stack.
   * `Gas::spent()` and `record_cost()` deprecated. Use `total_gas_spent()`, `record_regular_cost()`, `record_state_cost()`.

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,4 +1,34 @@
 
+# v106 tag
+
+* EIP-8037 state gas support ([#3406](https://github.com/bluealloy/revm/pull/3406)). Gas is now split into regular gas and state gas tracked via a reservoir. State gas draws from the reservoir first and spills into regular gas when exhausted. This affects gas accounting across the entire stack.
+  * `Gas::spent()` and `record_cost()` deprecated. Use `total_gas_spent()`, `record_regular_cost()`, `record_state_cost()`.
+  * New `Gas::new_with_regular_gas_and_reservoir(limit, reservoir)` constructor for creating child frame gas with reservoir.
+  * `ResultGas::new()` deprecated (takes 3 params now). Use `ResultGas::new_with_state_gas(total_gas_spent, refunded, floor_gas, state_gas_spent)`.
+  * `ResultGas::spent()`/`used()` deprecated. Use `total_gas_spent()`/`tx_gas_used()`. New accessors: `state_gas_spent()`, `block_regular_gas_used()`, `block_state_gas_used()`.
+  * `ExecutionResult::gas_used()` deprecated, use `gas().tx_gas_used()`.
+  * `InitialAndFloorGas::initial_gas` field renamed to `initial_total_gas`. New fields added: `initial_state_gas` (state gas portion) and `eip7702_reservoir_refund` (refund for existing EIP-7702 authorities).
+  * `CallInputs` gained `reservoir: u64` field for propagating state gas from parent to child frames.
+  * `Interpreter::clear` takes 7 params (was 6), `EthFrame::clear` takes 11 (was 10) — both gained reservoir parameter.
+  * `Host` and `Cfg` traits gained required method `is_amsterdam_eip8037_enabled() -> bool`. Must be implemented on any custom types.
+  * `Handler::pre_execution` and `apply_eip7702_auth_list` gained `&mut InitialAndFloorGas` param to write back state gas and refund info.
+  * `Handler::first_frame_input` gained `&InitialAndFloorGas` param to compute the reservoir for the first frame.
+  * `validate_initial_tx_gas` takes 5 params (was 3) — added `is_amsterdam_eip8037_enabled` and `tx_gas_limit_cap`.
+  * `create_init_frame` takes 2 params (was 3), gained `CTX: ContextTr` generic. Reservoir is set by `first_frame_input` after creation.
+* `PrecompileError` restructured ([#3496](https://github.com/bluealloy/revm/pull/3496), [#3502](https://github.com/bluealloy/revm/pull/3502)). All specific error variants removed (`OutOfGas`, `Blake2*`, `Bn254*`, `Bls12381*`, `Kzg*`, `Secp256k1*`, `Other`, etc.). `PrecompileError` is now only for fatal/unrecoverable errors with two variants: `Fatal(String)` and `FatalAny(AnyError)`. Non-fatal failures (OOG, invalid input) are now expressed via `PrecompileStatus::Halt` in `PrecompileOutput`.
+  * `PrecompileError::other()`, `other_static()`, `is_oog()` removed.
+* `PrecompileOutput` fields changed: `gas_refunded` and `reverted` removed, new fields `status: PrecompileStatus`, `state_gas_used`, `reservoir`.
+  * `PrecompileOutput::new(gas_used, bytes, reservoir)` — added reservoir param.
+  * `PrecompileOutput::new_reverted()`/`reverted()` removed, use `PrecompileOutput::revert()` instead.
+  * `PrecompileFn` signature changed from `fn(&[u8], u64)` to `fn(&[u8], u64, u64)` — added reservoir param.
+  * `Precompile::execute()` also gained `reservoir: u64` param.
+* `EVMError::CustomAny(AnyError)` variant added ([#3502](https://github.com/bluealloy/revm/pull/3502)). Update exhaustive matches. `EVMError` also lost `UnwindSafe`/`RefUnwindSafe` auto traits.
+* `SELFDESTRUCT_LOG_TOPIC` constant removed from `revm-primitives` ([#3438](https://github.com/bluealloy/revm/pull/3438)).
+* `StateBuilder::with_background_transition_merge` removed (was a no-op) ([#3510](https://github.com/bluealloy/revm/pull/3510)). Simply remove any calls.
+* `CfgEnv::set_spec` deprecated ([#3550](https://github.com/bluealloy/revm/pull/3550)). Use the `spec` field directly.
+* `MemoryGas::record_new_len` and `memory_gas` function removed ([#3534](https://github.com/bluealloy/revm/pull/3534)).
+* Inspector `frame_start` and `frame_end` methods added with default impls ([#3518](https://github.com/bluealloy/revm/pull/3518)). Hooks into frame lifecycle; no action needed unless you want to use them.
+
 # v104 tag (revm v34.1.0)
 
 ## Bytecode flattened from enum to struct ([#3375](https://github.com/bluealloy/revm/pull/3375))

--- a/crates/bytecode/CHANGELOG.md
+++ b/crates/bytecode/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [9.1.0](https://github.com/bluealloy/revm/compare/revm-bytecode-v9.0.0...revm-bytecode-v9.1.0) - 2026-04-10
+## [10.0.0](https://github.com/bluealloy/revm/compare/revm-bytecode-v9.0.0...revm-bytecode-v10.0.0) - 2026-04-10
 
 ### Added
 

--- a/crates/bytecode/Cargo.toml
+++ b/crates/bytecode/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-bytecode"
 description = "EVM Bytecodes"
-version = "9.1.0"
+version = "10.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/database/interface/CHANGELOG.md
+++ b/crates/database/interface/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [10.1.0](https://github.com/bluealloy/revm/compare/revm-database-interface-v10.0.0...revm-database-interface-v10.1.0) - 2026-04-10
+## [11.0.0](https://github.com/bluealloy/revm/compare/revm-database-interface-v10.0.0...revm-database-interface-v11.0.0) - 2026-04-10
 
 ### Added
 

--- a/crates/database/interface/Cargo.toml
+++ b/crates/database/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-database-interface"
 description = "Revm Database interface"
-version = "10.1.0"
+version = "11.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/inspector/CHANGELOG.md
+++ b/crates/inspector/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [17.1.0](https://github.com/bluealloy/revm/compare/revm-inspector-v17.0.0...revm-inspector-v17.1.0) - 2026-04-10
+## [18.0.0](https://github.com/bluealloy/revm/compare/revm-inspector-v17.0.0...revm-inspector-v18.0.0) - 2026-04-10
 
 ### Added
 

--- a/crates/inspector/Cargo.toml
+++ b/crates/inspector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-inspector"
 description = "Revm inspector interface"
-version = "17.1.0"
+version = "18.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/op-revm/CHANGELOG.md
+++ b/crates/op-revm/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [17.1.0](https://github.com/bluealloy/revm/compare/op-revm-v17.0.0...op-revm-v17.1.0) - 2026-04-10
+## [18.0.0](https://github.com/bluealloy/revm/compare/op-revm-v17.0.0...op-revm-v18.0.0) - 2026-04-10
 
 ### Added
 

--- a/crates/op-revm/Cargo.toml
+++ b/crates/op-revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "op-revm"
 description = "Optimism variant of Revm"
-version = "17.1.0"
+version = "18.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/revm/CHANGELOG.md
+++ b/crates/revm/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [36.0.1](https://github.com/bluealloy/revm/compare/revm-v36.0.0...revm-v36.0.1) - 2026-04-10
+## [37.0.0](https://github.com/bluealloy/revm/compare/revm-v36.0.0...revm-v37.0.0) - 2026-04-10
 
 ### Other
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm"
 description = "Revm - Rust Ethereum Virtual Machine"
-version = "36.0.1"
+version = "37.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/state/CHANGELOG.md
+++ b/crates/state/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [10.0.1](https://github.com/bluealloy/revm/compare/revm-state-v10.0.0...revm-state-v10.0.1) - 2026-04-10
+## [11.0.0](https://github.com/bluealloy/revm/compare/revm-state-v10.0.0...revm-state-v11.0.0) - 2026-04-10
 
 ### Other
 

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-state"
 description = "Revm state types"
-version = "10.0.1"
+version = "11.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/statetest-types/CHANGELOG.md
+++ b/crates/statetest-types/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [16.0.1](https://github.com/bluealloy/revm/compare/revm-statetest-types-v16.0.0...revm-statetest-types-v16.0.1) - 2026-04-10
+## [17.0.0](https://github.com/bluealloy/revm/compare/revm-statetest-types-v16.0.0...revm-statetest-types-v17.0.0) - 2026-04-10
 
 ### Other
 

--- a/crates/statetest-types/Cargo.toml
+++ b/crates/statetest-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-statetest-types"
 description = "Statetest types for revme"
-version = "16.0.1"
+version = "17.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
## Summary
- Version bumps and changelog updates for v106 release
- Add v106 migration guide entry covering all breaking changes

## Test plan
- [ ] Review migration guide content against actual API changes
- [ ] Verify version bumps are correct