### PR TITLE
fix(bytecode): mark `Bytecode::new_analyzed` as unsafe

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -42,7 +42,7 @@
   * `bytecode.legacy_jump_table()` instead of matching `Bytecode::LegacyAnalyzed(...)`.
 * Constructors:
   * `Bytecode::new_legacy(raw_bytes)` — replaces `Bytecode::LegacyRaw(...)` (analysis happens on creation).
-  * `unsafe { Bytecode::new_analyzed(bytecode, original_len, jump_table) }` — replaces `Bytecode::LegacyAnalyzed(Arc::new(...))`. Marked `unsafe` because the caller must ensure bytecode padding is sufficient (see doc comment).
+  * `Bytecode::new_analyzed(bytecode, original_len, jump_table)` — replaces `Bytecode::LegacyAnalyzed(Arc::new(...))`.
   * `Bytecode::new_eip7702(address)` — replaces `Bytecode::Eip7702(Arc::new(...))`.
   * `Bytecode::new_raw(bytes)` — auto-detects EIP-7702 delegation.
 * `LegacyAnalyzedBytecode`, `LegacyRawBytecode`, `Eip7702Bytecode` structs are no longer publicly exported.

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -42,7 +42,7 @@
   * `bytecode.legacy_jump_table()` instead of matching `Bytecode::LegacyAnalyzed(...)`.
 * Constructors:
   * `Bytecode::new_legacy(raw_bytes)` — replaces `Bytecode::LegacyRaw(...)` (analysis happens on creation).
-  * `Bytecode::new_analyzed(bytecode, original_len, jump_table)` — replaces `Bytecode::LegacyAnalyzed(Arc::new(...))`.
+  * `unsafe { Bytecode::new_analyzed(bytecode, original_len, jump_table) }` — replaces `Bytecode::LegacyAnalyzed(Arc::new(...))`. Marked `unsafe` because the caller must ensure bytecode padding is sufficient (see doc comment).
   * `Bytecode::new_eip7702(address)` — replaces `Bytecode::Eip7702(Arc::new(...))`.
   * `Bytecode::new_raw(bytes)` — auto-detects EIP-7702 delegation.
 * `LegacyAnalyzedBytecode`, `LegacyRawBytecode`, `Eip7702Bytecode` structs are no longer publicly exported.

--- a/crates/bytecode/src/bytecode/mod.rs
+++ b/crates/bytecode/src/bytecode/mod.rs
@@ -203,13 +203,33 @@ impl Bytecode {
 
     /// Create new checked bytecode from pre-analyzed components.
     ///
+    /// # Safety
+    ///
+    /// `bytecode` must satisfy the same padding invariants produced by
+    /// [`analyze_legacy`]. In particular, execution must never cause the
+    /// interpreter to read past the backing allocation when decoding opcode
+    /// immediates (`PUSH1`–`PUSH32` via `read_slice`, and `DUPN`/`SWAPN`/
+    /// `EXCHANGE` via `read_u8`).
+    ///
+    /// [`Bytecode::new_legacy`] handles this automatically.
+    /// This constructor is only for restoring trusted, previously analyzed
+    /// bytecode (e.g., from database storage) where the padding was already
+    /// applied.
+    ///
+    /// Violating this causes undefined behavior during execution due to
+    /// out-of-bounds reads from raw pointers.
+    ///
     /// # Panics
     ///
     /// * If `original_len` is greater than `bytecode.len()`
     /// * If jump table length is less than `original_len`
     /// * If bytecode is empty
     #[inline]
-    pub fn new_analyzed(bytecode: Bytes, original_len: usize, jump_table: JumpTable) -> Self {
+    pub unsafe fn new_analyzed(
+        bytecode: Bytes,
+        original_len: usize,
+        jump_table: JumpTable,
+    ) -> Self {
         assert!(
             original_len <= bytecode.len(),
             "original_len is greater than bytecode length"
@@ -363,22 +383,28 @@ mod tests {
     fn test_new_analyzed() {
         let raw = Bytes::from_static(&[opcode::PUSH1, 0x01]);
         let bytecode = Bytecode::new_legacy(raw);
-        let _ = Bytecode::new_analyzed(
-            bytecode.bytecode().clone(),
-            bytecode.len(),
-            bytecode.legacy_jump_table().unwrap().clone(),
-        );
+        // SAFETY: bytecode was produced by `new_legacy` which pads correctly.
+        let _ = unsafe {
+            Bytecode::new_analyzed(
+                bytecode.bytecode().clone(),
+                bytecode.len(),
+                bytecode.legacy_jump_table().unwrap().clone(),
+            )
+        };
     }
 
     #[test]
     #[should_panic(expected = "original_len is greater than bytecode length")]
     fn test_panic_on_large_original_len() {
         let bytecode = Bytecode::new_legacy(Bytes::from_static(&[opcode::PUSH1, 0x01]));
-        let _ = Bytecode::new_analyzed(
-            bytecode.bytecode().clone(),
-            100,
-            bytecode.legacy_jump_table().unwrap().clone(),
-        );
+        // SAFETY: testing the panic, not execution safety.
+        let _ = unsafe {
+            Bytecode::new_analyzed(
+                bytecode.bytecode().clone(),
+                100,
+                bytecode.legacy_jump_table().unwrap().clone(),
+            )
+        };
     }
 
     #[test]
@@ -386,7 +412,10 @@ mod tests {
     fn test_panic_on_short_jump_table() {
         let bytecode = Bytecode::new_legacy(Bytes::from_static(&[opcode::PUSH1, 0x01]));
         let jump_table = JumpTable::new(bitvec![u8, Lsb0; 0; 1]);
-        let _ = Bytecode::new_analyzed(bytecode.bytecode().clone(), bytecode.len(), jump_table);
+        // SAFETY: testing the panic, not execution safety.
+        let _ = unsafe {
+            Bytecode::new_analyzed(bytecode.bytecode().clone(), bytecode.len(), jump_table)
+        };
     }
 
     #[test]
@@ -394,7 +423,8 @@ mod tests {
     fn test_panic_on_empty_bytecode() {
         let bytecode = Bytes::from_static(&[]);
         let jump_table = JumpTable::new(bitvec![u8, Lsb0; 0; 0]);
-        let _ = Bytecode::new_analyzed(bytecode, 0, jump_table);
+        // SAFETY: testing the panic, not execution safety.
+        let _ = unsafe { Bytecode::new_analyzed(bytecode, 0, jump_table) };
     }
 
     #[test]

--- a/crates/bytecode/src/bytecode/mod.rs
+++ b/crates/bytecode/src/bytecode/mod.rs
@@ -206,7 +206,7 @@ impl Bytecode {
     /// # Safety
     ///
     /// `bytecode` must satisfy the same padding invariants produced by
-    /// [`analyze_legacy`]. In particular, execution must never cause the
+    /// `analyze_legacy`. In particular, execution must never cause the
     /// interpreter to read past the backing allocation when decoding opcode
     /// immediates (`PUSH1`–`PUSH32` via `read_slice`, and `DUPN`/`SWAPN`/
     /// `EXCHANGE` via `read_u8`).

--- a/crates/bytecode/src/bytecode/serde_impl.rs
+++ b/crates/bytecode/src/bytecode/serde_impl.rs
@@ -1,4 +1,4 @@
-use super::{Arc, Bytecode, BytecodeInner, BytecodeKind, JumpTable, OnceLock};
+use super::{Bytecode, BytecodeKind, JumpTable};
 use primitives::{Address, Bytes};
 use serde::{Deserialize, Serialize};
 
@@ -36,14 +36,17 @@ impl<'de> Deserialize<'de> for Bytecode {
             BytecodeSerde::LegacyAnalyzed {
                 bytecode,
                 original_len,
-                jump_table,
-            } => Ok(Self(Arc::new(BytecodeInner {
-                kind: BytecodeKind::LegacyAnalyzed,
-                bytecode,
-                original_len,
-                jump_table,
-                hash: OnceLock::new(),
-            }))),
+                ..
+            } => {
+                if original_len > bytecode.len() {
+                    return Err(serde::de::Error::custom(
+                        "original_len is greater than bytecode length",
+                    ));
+                }
+                // Re-analyze from original bytes to ensure padding invariants
+                // are satisfied, rather than trusting the serialized form.
+                Ok(Self::new_legacy(bytecode.slice(..original_len)))
+            }
             BytecodeSerde::Eip7702 { delegated_address } => {
                 Ok(Self::new_eip7702(delegated_address))
             }

--- a/crates/interpreter/tests/miri_read_slice_oob.rs
+++ b/crates/interpreter/tests/miri_read_slice_oob.rs
@@ -1,0 +1,63 @@
+//! Miri reproducer: OOB read via `ExtBytecode::read_slice` with a manually crafted
+//! `Bytecode::new_analyzed` that has insufficient padding.
+//!
+//! Run: `cargo +nightly miri test --test miri_read_slice_oob -p revm-interpreter`
+//!
+//! This test intentionally violates the safety contract of `new_analyzed` to
+//! demonstrate that Miri catches the resulting UB. It is gated behind `#[cfg(miri)]`
+//! so it does not run under normal `cargo test`.
+
+#![cfg(miri)]
+
+use bytecode::bitvec::{bitvec, order::Lsb0};
+use bytecode::{opcode, Bytecode, JumpTable};
+use primitives::{hardfork::SpecId, Bytes};
+use revm_interpreter::{
+    host::DummyHost,
+    instructions::instruction_table,
+    interpreter::{EthInterpreter, ExtBytecode, InputsImpl, SharedMemory},
+    Interpreter,
+};
+
+/// Demonstrates that `Bytecode::new_analyzed` with insufficient padding causes
+/// an OOB read in `ExtBytecode::read_slice`, caught by Miri.
+///
+/// Bytecode: [PUSH32, STOP]
+/// original_len = 2, bytecode len = 2 (NO padding at all).
+/// When the interpreter executes PUSH32, `read_slice(32)` will try to read
+/// 32 bytes starting from offset 1, but the backing `Bytes` is only 2 bytes
+/// long → UB (out-of-bounds read).
+#[test]
+fn read_slice_oob_via_new_analyzed() {
+    // Construct a 2-byte bytecode: PUSH32 followed by STOP
+    let raw = Bytes::from_static(&[opcode::PUSH32, opcode::STOP]);
+    let original_len = raw.len(); // 2
+
+    // Jump table: 2 bits, no valid jump destinations
+    let jump_table = JumpTable::new(bitvec![u8, Lsb0; 0; original_len]);
+
+    // new_analyzed only checks:
+    //   - original_len <= bytecode.len()  ✓ (2 <= 2)
+    //   - jump_table.len() >= original_len ✓ (2 >= 2)
+    //   - bytecode non-empty               ✓
+    // It does NOT check that PUSH32 has 32 bytes of immediate data available.
+    //
+    // SAFETY: intentionally violating the padding invariant to demonstrate UB.
+    let bytecode = unsafe { Bytecode::new_analyzed(raw, original_len, jump_table) };
+
+    let mut interpreter = Interpreter::<EthInterpreter>::new(
+        SharedMemory::new(),
+        ExtBytecode::new(bytecode),
+        InputsImpl::default(),
+        false,
+        SpecId::PRAGUE,
+        u64::MAX,
+    );
+
+    let table = instruction_table::<EthInterpreter, DummyHost>();
+    let mut host = DummyHost::new(SpecId::PRAGUE);
+
+    // This triggers read_slice(32) on a 2-byte buffer → UB (OOB read).
+    // Miri should catch this.
+    interpreter.run_plain(&table, &mut host);
+}


### PR DESCRIPTION
`Bytecode::new_analyzed` accepts pre-analyzed bytecode but does not validate
that the padding is sufficient for safe execution of PUSH immediates. Calling
it with insufficient padding causes UB: `ExtBytecode::read_slice` performs an
out-of-bounds read via `core::slice::from_raw_parts`.

This PR:
- marks `new_analyzed` as `unsafe` with a safety doc referencing the `analyze_legacy` padding invariant
- fixes the serde `Deserialize` impl to re-analyze from original bytes instead of trusting serialized padding/jump table
- adds a `#[cfg(miri)]` reproducer that demonstrates the OOB read
- updates `MIGRATION_GUIDE.md`

Miri reproducer:
```
cargo +nightly miri test --test miri_read_slice_oob -p revm-interpreter
```

```
error: Undefined Behavior: pointer not dereferenceable: pointer must be
dereferenceable for 32 bytes, but got alloc16+0x1 which is only 1 byte
from the end of the allocation
 --> crates/interpreter/src/interpreter/ext_bytecode.rs:178:17
```

**Note for downstream (reth):** `reth-primitives-traits` calls `new_analyzed` in
its `Compact::from_compact` DB deserializer. That call site is safe (it restores
previously padded bytes), but will need `unsafe {}` + safety comment after
upgrading `revm-bytecode`.

Prompted by: pep