### PR TITLE
fix(handler): skip gas reimbursement and beneficiary reward when fee charge is disabled

### DIFF
--- a/crates/handler/src/post_execution.rs
+++ b/crates/handler/src/post_execution.rs
@@ -61,6 +61,11 @@ pub fn reimburse_caller<CTX: ContextTr>(
     gas: &Gas,
     additional_refund: U256,
 ) -> Result<(), <CTX::Db as Database>::Error> {
+    // If fee charge was disabled (e.g. eth_call simulations), no gas was
+    // deducted from the caller upfront so there is nothing to reimburse.
+    if context.cfg().is_fee_charge_disabled() {
+        return Ok(());
+    }
     let basefee = context.block().basefee() as u128;
     let caller = context.tx().caller();
     let effective_gas_price = context.tx().effective_gas_price(basefee);
@@ -85,6 +90,11 @@ pub fn reward_beneficiary<CTX: ContextTr>(
     context: &mut CTX,
     gas: &Gas,
 ) -> Result<(), <CTX::Db as Database>::Error> {
+    // If fee charge was disabled (e.g. eth_call simulations), the caller was
+    // never charged for gas so there are no fees to transfer to the beneficiary.
+    if context.cfg().is_fee_charge_disabled() {
+        return Ok(());
+    }
     let (block, tx, cfg, journal, _, _) = context.all_mut();
     let basefee = block.basefee() as u128;
     let effective_gas_price = tx.effective_gas_price(basefee);


### PR DESCRIPTION
 ## Summary      
                                                                                                                                                                                           
  reimburse_caller and reward_beneficiary unconditionally credit the caller and coinbase even when disable_fee_charge is set, causing a phantom balance increase in the caller's     
  account. This patch adds the same is_fee_charge_disabled() guard that calculate_caller_fee already has.
                                                                                                                                                                                           
  ## Problem      

  When cfg.disable_fee_charge = true (used by eth_call, debug_traceCall, debug_traceCallMany, and similar simulation RPCs), there is an asymmetry in how gas fees are handled      
  between pre-execution and post-execution:
                                                                                                                                                                                           
  | Phase | Function | Checks disable_fee_charge? | Behavior when flag is set |                                                                                                          
  |---|---|---|---|
  | Pre-execution | calculate_caller_fee | Yes (since handler v17) | Skips upfront gas deduction |                                                                                   
  | Post-execution | reimburse_caller | No | Still adds back gasPrice × remainingGas |                                                                                             
  | Post-execution | reward_beneficiary | No | Still transfers gasPrice × gasUsed to coinbase |                                                                                    
                                                                                                                                                                                           
  Because the caller is never charged but still reimbursed, the net effect is:                                                                                                             
                                                                                                                                                                                           
  - Caller gains effective_gas_price × (remaining + refunded) ETH                                                                                                                    
  - Coinbase gains coinbase_gas_price × gasUsed ETH
                                                                                                                                                                                           
  Both amounts are minted from thin air within the transaction's state diff.                                                                                                               
   
  ## Impact


This is observable in reth 2.0 via debug_traceCallMany (and debug_traceCall) with prestateTracer in diffMode: true. When the traced call specifies gasPrice > 0 and gas > 0, the prestate diff incorrectly shows the sender's balance *increasing* by approximately gasPrice × gasLimit, instead of remaining unchanged (simulation) or decreasing (real execution).
                                                                                                                                                                                           
  This is a regression between revm-handler v15 (used by reth <2.0) and v17 (used by reth 2.0). In v15, calculate_caller_fee did not check disable_fee_charge — it always deducted gas upfront — so the deduction and reimbursement cancelled out correctly. In v17, the deduction was removed but the reimbursement was not.
                                                                                                                                                                                           
  ## Fix                                                                                                                                                                                   

  Add an is_fee_charge_disabled() early-return to both reimburse_caller and reward_beneficiary, matching the guard already present in calculate_caller_fee.                        

  ## Context                                                                                                                                                                               

  - The disable_fee_charge flag was introduced for OP Stack chains where an operator fee was being charged during eth_call simulations, causing spurious "insufficient funds" errors.  
  See [reth#18470](https://github.com/paradigmxyz/reth/issues/18470).
  - reth sets cfg_env.disable_fee_charge = true in its prepare_call_env for all call/trace simulation endpoints.                                                                       
  - The guard in calculate_caller_fee (pre_execution.rs:131-135) was added in handler v17 but the corresponding post-execution functions were not updated.