### PR TITLE
perf(interpreter): separate instruction and gas tables

### DIFF
--- a/crates/handler/src/evm.rs
+++ b/crates/handler/src/evm.rs
@@ -202,9 +202,11 @@ where
         let context = &mut self.ctx;
         let instructions = &mut self.instruction;
 
-        let action = frame
-            .interpreter
-            .run_plain(instructions.instruction_table(), context);
+        let action = frame.interpreter.run_plain(
+            instructions.instruction_table(),
+            instructions.gas_table(),
+            context,
+        );
 
         frame.process_next_action(context, action).inspect(|i| {
             if i.is_result() {

--- a/crates/handler/src/instructions.rs
+++ b/crates/handler/src/instructions.rs
@@ -1,6 +1,6 @@
 use auto_impl::auto_impl;
 use interpreter::{
-    instructions::{instruction_table_gas_changes_spec, InstructionTable},
+    instructions::{gas_table_spec, GasTable, InstructionTable},
     Host, Instruction, InterpreterTypes,
 };
 use primitives::hardfork::SpecId;
@@ -16,15 +16,25 @@ pub trait InstructionProvider {
 
     /// Returns the instruction table that is used by EvmTr to execute instructions.
     fn instruction_table(&self) -> &InstructionTable<Self::InterpreterTypes, Self::Context>;
+
+    /// Returns the gas table for static gas costs.
+    fn gas_table(&self) -> &GasTable;
 }
 
 /// Ethereum instruction contains list of mainnet instructions that is used for Interpreter execution.
 #[derive(Debug)]
 pub struct EthInstructions<WIRE: InterpreterTypes, HOST: ?Sized> {
-    /// Table containing instruction implementations indexed by opcode.
-    pub instruction_table: Box<InstructionTable<WIRE, HOST>>,
     /// Spec that is used to set gas costs for instructions.
     pub spec: SpecId,
+    inner: Box<EthInstructionsInner<WIRE, HOST>>,
+}
+
+#[derive(Debug)]
+struct EthInstructionsInner<WIRE: InterpreterTypes, HOST: ?Sized> {
+    /// Table containing instruction implementations indexed by opcode.
+    instruction_table: InstructionTable<WIRE, HOST>,
+    /// Static gas cost table indexed by opcode.
+    gas_table: GasTable,
 }
 
 impl<WIRE, HOST: Host + ?Sized> Clone for EthInstructions<WIRE, HOST>
@@ -33,10 +43,23 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            instruction_table: self.instruction_table.clone(),
             spec: self.spec,
+            inner: self.inner.clone(),
         }
     }
+}
+
+impl<WIRE, HOST: Host + ?Sized> Clone for EthInstructionsInner<WIRE, HOST>
+where
+    WIRE: InterpreterTypes,
+{
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<WIRE, HOST: Host + ?Sized> Copy for EthInstructionsInner<WIRE, HOST> where
+    WIRE: InterpreterTypes
+{
 }
 
 impl<WIRE, HOST> EthInstructions<WIRE, HOST>
@@ -48,27 +71,63 @@ where
     #[deprecated(since = "0.2.0", note = "use new_mainnet_with_spec instead")]
     pub fn new_mainnet() -> Self {
         let spec = SpecId::default();
-        Self::new(instruction_table_gas_changes_spec(spec), spec)
+        Self::new_mainnet_with_spec(spec)
     }
 
     /// Returns `EthInstructions` with mainnet spec.
     pub fn new_mainnet_with_spec(spec: SpecId) -> Self {
-        Self::new(instruction_table_gas_changes_spec(spec), spec)
+        Self::new(interpreter::instruction_table(), gas_table_spec(spec), spec)
     }
 
-    /// Returns a new instance of `EthInstructions` with custom instruction table.
-    #[inline]
-    pub fn new(base_table: InstructionTable<WIRE, HOST>, spec: SpecId) -> Self {
+    /// Returns a new instance of `EthInstructions` with custom instruction and gas tables.
+    pub fn new(
+        instruction_table: InstructionTable<WIRE, HOST>,
+        gas_table: GasTable,
+        spec: SpecId,
+    ) -> Self {
         Self {
-            instruction_table: Box::new(base_table),
             spec,
+            inner: Box::new(EthInstructionsInner {
+                instruction_table,
+                gas_table,
+            }),
         }
     }
 
     /// Inserts a new instruction into the instruction table.
     #[inline]
     pub fn insert_instruction(&mut self, opcode: u8, instruction: Instruction<WIRE, HOST>) {
-        self.instruction_table[opcode as usize] = instruction;
+        self.inner.instruction_table[opcode as usize] = instruction;
+    }
+
+    /// Inserts a new gas cost into the gas table.
+    #[inline]
+    pub fn insert_gas(&mut self, opcode: u8, gas: u16) {
+        self.inner.gas_table[opcode as usize] = gas;
+    }
+
+    /// Returns a reference to the instruction table.
+    #[inline]
+    pub fn instruction_table(&self) -> &InstructionTable<WIRE, HOST> {
+        &self.inner.instruction_table
+    }
+
+    /// Returns a mutable reference to the instruction table.
+    #[inline]
+    pub fn instruction_table_mut(&mut self) -> &mut InstructionTable<WIRE, HOST> {
+        &mut self.inner.instruction_table
+    }
+
+    /// Returns a reference to the gas table.
+    #[inline]
+    pub fn gas_table(&self) -> &GasTable {
+        &self.inner.gas_table
+    }
+
+    /// Returns a mutable reference to the gas table.
+    #[inline]
+    pub fn gas_table_mut(&mut self) -> &mut GasTable {
+        &mut self.inner.gas_table
     }
 }
 
@@ -80,7 +139,13 @@ where
     type InterpreterTypes = IT;
     type Context = CTX;
 
+    #[inline]
     fn instruction_table(&self) -> &InstructionTable<Self::InterpreterTypes, Self::Context> {
-        &self.instruction_table
+        self.instruction_table()
+    }
+
+    #[inline]
+    fn gas_table(&self) -> &GasTable {
+        self.gas_table()
     }
 }

--- a/crates/handler/src/instructions.rs
+++ b/crates/handler/src/instructions.rs
@@ -96,8 +96,14 @@ where
 
     /// Inserts a new instruction into the instruction table.
     #[inline]
-    pub fn insert_instruction(&mut self, opcode: u8, instruction: Instruction<WIRE, HOST>) {
+    pub fn insert_instruction(
+        &mut self,
+        opcode: u8,
+        instruction: Instruction<WIRE, HOST>,
+        gas: u16,
+    ) {
         self.inner.instruction_table[opcode as usize] = instruction;
+        self.inner.gas_table[opcode as usize] = gas;
     }
 
     /// Inserts a new gas cost into the gas table.

--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -5,7 +5,7 @@ use context::{
 };
 use handler::{evm::FrameTr, EvmTr, FrameResult, Handler, ItemOrResult};
 use interpreter::{
-    instructions::InstructionTable,
+    instructions::{GasTable, InstructionTable},
     interpreter_types::{Jumps, LoopControl},
     FrameInput, Host, InitialAndFloorGas, InstructionResult, Interpreter, InterpreterAction,
     InterpreterTypes,
@@ -232,6 +232,7 @@ pub fn inspect_instructions<CTX, IT>(
     interpreter: &mut Interpreter<IT>,
     mut inspector: impl Inspector<CTX, IT>,
     instructions: &InstructionTable<IT, CTX>,
+    gas_table: &GasTable,
 ) -> InterpreterAction
 where
     CTX: ContextTr<Journal: JournalExt> + Host,
@@ -244,7 +245,7 @@ where
         }
 
         let opcode = interpreter.bytecode.opcode();
-        interpreter.step(instructions, context);
+        interpreter.step(instructions, gas_table, context);
 
         if (opcode::LOG0..=opcode::LOG4).contains(&opcode) {
             inspect_log(interpreter, context, &mut inspector);

--- a/crates/inspector/src/traits.rs
+++ b/crates/inspector/src/traits.rs
@@ -155,6 +155,7 @@ pub trait InspectorEvmTr:
             &mut frame.interpreter,
             inspector,
             instructions.instruction_table(),
+            instructions.gas_table(),
         );
         let mut result = frame.process_next_action(ctx, next_action);
 

--- a/crates/interpreter/src/instructions.rs
+++ b/crates/interpreter/src/instructions.rs
@@ -32,18 +32,17 @@ pub use context_interface::cfg::gas::{self, *};
 use crate::{interpreter_types::InterpreterTypes, Host, InstructionContext};
 use primitives::hardfork::SpecId;
 
-/// EVM opcode function signature.
+/// EVM opcode function pointer.
 #[derive(Debug)]
 pub struct Instruction<W: InterpreterTypes, H: ?Sized> {
     fn_: fn(InstructionContext<'_, H, W>),
-    static_gas: u64,
 }
 
 impl<W: InterpreterTypes, H: Host + ?Sized> Instruction<W, H> {
-    /// Creates a new instruction with the given function and static gas cost.
+    /// Creates a new instruction with the given function.
     #[inline]
-    pub const fn new(fn_: fn(InstructionContext<'_, H, W>), static_gas: u64) -> Self {
-        Self { fn_, static_gas }
+    pub const fn new(fn_: fn(InstructionContext<'_, H, W>)) -> Self {
+        Self { fn_ }
     }
 
     /// Creates an unknown/invalid instruction.
@@ -51,7 +50,6 @@ impl<W: InterpreterTypes, H: Host + ?Sized> Instruction<W, H> {
     pub const fn unknown() -> Self {
         Self {
             fn_: control::unknown,
-            static_gas: 0,
         }
     }
 
@@ -59,12 +57,6 @@ impl<W: InterpreterTypes, H: Host + ?Sized> Instruction<W, H> {
     #[inline(always)]
     pub fn execute(self, ctx: InstructionContext<'_, H, W>) {
         (self.fn_)(ctx)
-    }
-
-    /// Returns the static gas cost of this instruction.
-    #[inline(always)]
-    pub const fn static_gas(&self) -> u64 {
-        self.static_gas
     }
 }
 
@@ -78,229 +70,409 @@ impl<W: InterpreterTypes, H: Host + ?Sized> Clone for Instruction<W, H> {
 /// Instruction table is list of instruction function pointers mapped to 256 EVM opcodes.
 pub type InstructionTable<W, H> = [Instruction<W, H>; 256];
 
+/// Static gas cost table mapped to 256 EVM opcodes.
+pub type GasTable = [u16; 256];
+
 /// Returns the default instruction table for the given interpreter types and host.
 #[inline]
-pub const fn instruction_table<WIRE: InterpreterTypes, H: Host>() -> [Instruction<WIRE, H>; 256] {
+pub const fn instruction_table<WIRE: InterpreterTypes, H: Host>() -> InstructionTable<WIRE, H> {
     const { instruction_table_impl::<WIRE, H>() }
 }
 
-/// Create a instruction table with applied spec changes to static gas cost.
+/// Returns the default gas table.
 #[inline]
-pub fn instruction_table_gas_changes_spec<WIRE: InterpreterTypes, H: Host>(
-    spec: SpecId,
-) -> [Instruction<WIRE, H>; 256] {
+pub const fn gas_table() -> GasTable {
+    const { gas_table_impl() }
+}
+
+/// Create a gas table with applied spec changes to static gas cost.
+#[inline]
+pub fn gas_table_spec(spec: SpecId) -> GasTable {
     use bytecode::opcode::*;
     use SpecId::*;
-    let mut table = instruction_table();
+    let mut table = gas_table();
 
     if spec.is_enabled_in(TANGERINE) {
         // EIP-150: Gas cost changes for IO-heavy operations
-        table[SLOAD as usize].static_gas = 200;
-        table[BALANCE as usize].static_gas = 400;
-        table[EXTCODESIZE as usize].static_gas = 700;
-        table[EXTCODECOPY as usize].static_gas = 700;
-        table[CALL as usize].static_gas = 700;
-        table[CALLCODE as usize].static_gas = 700;
-        table[DELEGATECALL as usize].static_gas = 700;
-        table[STATICCALL as usize].static_gas = 700;
-        table[SELFDESTRUCT as usize].static_gas = 5000;
+        table[SLOAD as usize] = 200;
+        table[BALANCE as usize] = 400;
+        table[EXTCODESIZE as usize] = 700;
+        table[EXTCODECOPY as usize] = 700;
+        table[CALL as usize] = 700;
+        table[CALLCODE as usize] = 700;
+        table[DELEGATECALL as usize] = 700;
+        table[STATICCALL as usize] = 700;
+        table[SELFDESTRUCT as usize] = 5000;
     }
 
     if spec.is_enabled_in(ISTANBUL) {
         // EIP-1884: Repricing for trie-size-dependent opcodes
-        table[SLOAD as usize].static_gas = gas::ISTANBUL_SLOAD_GAS;
-        table[BALANCE as usize].static_gas = 700;
-        table[EXTCODEHASH as usize].static_gas = 700;
+        table[SLOAD as usize] = gas::ISTANBUL_SLOAD_GAS as u16;
+        table[BALANCE as usize] = 700;
+        table[EXTCODEHASH as usize] = 700;
     }
 
     if spec.is_enabled_in(BERLIN) {
         // warm account cost is base gas that is spend. Additional gas depends if account is cold loaded.
-        table[SLOAD as usize].static_gas = gas::WARM_STORAGE_READ_COST;
-        table[BALANCE as usize].static_gas = gas::WARM_STORAGE_READ_COST;
-        table[EXTCODESIZE as usize].static_gas = gas::WARM_STORAGE_READ_COST;
-        table[EXTCODEHASH as usize].static_gas = gas::WARM_STORAGE_READ_COST;
-        table[EXTCODECOPY as usize].static_gas = gas::WARM_STORAGE_READ_COST;
-        table[CALL as usize].static_gas = gas::WARM_STORAGE_READ_COST;
-        table[CALLCODE as usize].static_gas = gas::WARM_STORAGE_READ_COST;
-        table[DELEGATECALL as usize].static_gas = gas::WARM_STORAGE_READ_COST;
-        table[STATICCALL as usize].static_gas = gas::WARM_STORAGE_READ_COST;
+        table[SLOAD as usize] = gas::WARM_STORAGE_READ_COST as u16;
+        table[BALANCE as usize] = gas::WARM_STORAGE_READ_COST as u16;
+        table[EXTCODESIZE as usize] = gas::WARM_STORAGE_READ_COST as u16;
+        table[EXTCODEHASH as usize] = gas::WARM_STORAGE_READ_COST as u16;
+        table[EXTCODECOPY as usize] = gas::WARM_STORAGE_READ_COST as u16;
+        table[CALL as usize] = gas::WARM_STORAGE_READ_COST as u16;
+        table[CALLCODE as usize] = gas::WARM_STORAGE_READ_COST as u16;
+        table[DELEGATECALL as usize] = gas::WARM_STORAGE_READ_COST as u16;
+        table[STATICCALL as usize] = gas::WARM_STORAGE_READ_COST as u16;
     }
 
     table
 }
 
-const fn instruction_table_impl<WIRE: InterpreterTypes, H: Host>() -> [Instruction<WIRE, H>; 256] {
+const fn instruction_table_impl<WIRE: InterpreterTypes, H: Host>() -> InstructionTable<WIRE, H> {
     use bytecode::opcode::*;
     let mut table = [Instruction::unknown(); 256];
 
-    table[STOP as usize] = Instruction::new(control::stop, 0);
-    table[ADD as usize] = Instruction::new(arithmetic::add, 3);
-    table[MUL as usize] = Instruction::new(arithmetic::mul, 5);
-    table[SUB as usize] = Instruction::new(arithmetic::sub, 3);
-    table[DIV as usize] = Instruction::new(arithmetic::div, 5);
-    table[SDIV as usize] = Instruction::new(arithmetic::sdiv, 5);
-    table[MOD as usize] = Instruction::new(arithmetic::rem, 5);
-    table[SMOD as usize] = Instruction::new(arithmetic::smod, 5);
-    table[ADDMOD as usize] = Instruction::new(arithmetic::addmod, 8);
-    table[MULMOD as usize] = Instruction::new(arithmetic::mulmod, 8);
-    table[EXP as usize] = Instruction::new(arithmetic::exp, gas::EXP); // base
-    table[SIGNEXTEND as usize] = Instruction::new(arithmetic::signextend, 5);
+    table[STOP as usize] = Instruction::new(control::stop);
+    table[ADD as usize] = Instruction::new(arithmetic::add);
+    table[MUL as usize] = Instruction::new(arithmetic::mul);
+    table[SUB as usize] = Instruction::new(arithmetic::sub);
+    table[DIV as usize] = Instruction::new(arithmetic::div);
+    table[SDIV as usize] = Instruction::new(arithmetic::sdiv);
+    table[MOD as usize] = Instruction::new(arithmetic::rem);
+    table[SMOD as usize] = Instruction::new(arithmetic::smod);
+    table[ADDMOD as usize] = Instruction::new(arithmetic::addmod);
+    table[MULMOD as usize] = Instruction::new(arithmetic::mulmod);
+    table[EXP as usize] = Instruction::new(arithmetic::exp);
+    table[SIGNEXTEND as usize] = Instruction::new(arithmetic::signextend);
 
-    table[LT as usize] = Instruction::new(bitwise::lt, 3);
-    table[GT as usize] = Instruction::new(bitwise::gt, 3);
-    table[SLT as usize] = Instruction::new(bitwise::slt, 3);
-    table[SGT as usize] = Instruction::new(bitwise::sgt, 3);
-    table[EQ as usize] = Instruction::new(bitwise::eq, 3);
-    table[ISZERO as usize] = Instruction::new(bitwise::iszero, 3);
-    table[AND as usize] = Instruction::new(bitwise::bitand, 3);
-    table[OR as usize] = Instruction::new(bitwise::bitor, 3);
-    table[XOR as usize] = Instruction::new(bitwise::bitxor, 3);
-    table[NOT as usize] = Instruction::new(bitwise::not, 3);
-    table[BYTE as usize] = Instruction::new(bitwise::byte, 3);
-    table[SHL as usize] = Instruction::new(bitwise::shl, 3);
-    table[SHR as usize] = Instruction::new(bitwise::shr, 3);
-    table[SAR as usize] = Instruction::new(bitwise::sar, 3);
-    table[CLZ as usize] = Instruction::new(bitwise::clz, 5);
+    table[LT as usize] = Instruction::new(bitwise::lt);
+    table[GT as usize] = Instruction::new(bitwise::gt);
+    table[SLT as usize] = Instruction::new(bitwise::slt);
+    table[SGT as usize] = Instruction::new(bitwise::sgt);
+    table[EQ as usize] = Instruction::new(bitwise::eq);
+    table[ISZERO as usize] = Instruction::new(bitwise::iszero);
+    table[AND as usize] = Instruction::new(bitwise::bitand);
+    table[OR as usize] = Instruction::new(bitwise::bitor);
+    table[XOR as usize] = Instruction::new(bitwise::bitxor);
+    table[NOT as usize] = Instruction::new(bitwise::not);
+    table[BYTE as usize] = Instruction::new(bitwise::byte);
+    table[SHL as usize] = Instruction::new(bitwise::shl);
+    table[SHR as usize] = Instruction::new(bitwise::shr);
+    table[SAR as usize] = Instruction::new(bitwise::sar);
+    table[CLZ as usize] = Instruction::new(bitwise::clz);
 
-    table[KECCAK256 as usize] = Instruction::new(system::keccak256, gas::KECCAK256);
+    table[KECCAK256 as usize] = Instruction::new(system::keccak256);
 
-    table[ADDRESS as usize] = Instruction::new(system::address, 2);
-    table[BALANCE as usize] = Instruction::new(host::balance, 20);
-    table[ORIGIN as usize] = Instruction::new(tx_info::origin, 2);
-    table[CALLER as usize] = Instruction::new(system::caller, 2);
-    table[CALLVALUE as usize] = Instruction::new(system::callvalue, 2);
-    table[CALLDATALOAD as usize] = Instruction::new(system::calldataload, 3);
-    table[CALLDATASIZE as usize] = Instruction::new(system::calldatasize, 2);
-    table[CALLDATACOPY as usize] = Instruction::new(system::calldatacopy, 3);
-    table[CODESIZE as usize] = Instruction::new(system::codesize, 2);
-    table[CODECOPY as usize] = Instruction::new(system::codecopy, 3);
+    table[ADDRESS as usize] = Instruction::new(system::address);
+    table[BALANCE as usize] = Instruction::new(host::balance);
+    table[ORIGIN as usize] = Instruction::new(tx_info::origin);
+    table[CALLER as usize] = Instruction::new(system::caller);
+    table[CALLVALUE as usize] = Instruction::new(system::callvalue);
+    table[CALLDATALOAD as usize] = Instruction::new(system::calldataload);
+    table[CALLDATASIZE as usize] = Instruction::new(system::calldatasize);
+    table[CALLDATACOPY as usize] = Instruction::new(system::calldatacopy);
+    table[CODESIZE as usize] = Instruction::new(system::codesize);
+    table[CODECOPY as usize] = Instruction::new(system::codecopy);
 
-    table[GASPRICE as usize] = Instruction::new(tx_info::gasprice, 2);
-    table[EXTCODESIZE as usize] = Instruction::new(host::extcodesize, 20);
-    table[EXTCODECOPY as usize] = Instruction::new(host::extcodecopy, 20);
-    table[RETURNDATASIZE as usize] = Instruction::new(system::returndatasize, 2);
-    table[RETURNDATACOPY as usize] = Instruction::new(system::returndatacopy, 3);
-    table[EXTCODEHASH as usize] = Instruction::new(host::extcodehash, 400);
-    table[BLOCKHASH as usize] = Instruction::new(host::blockhash, 20);
-    table[COINBASE as usize] = Instruction::new(block_info::coinbase, 2);
-    table[TIMESTAMP as usize] = Instruction::new(block_info::timestamp, 2);
-    table[NUMBER as usize] = Instruction::new(block_info::block_number, 2);
-    table[DIFFICULTY as usize] = Instruction::new(block_info::difficulty, 2);
-    table[GASLIMIT as usize] = Instruction::new(block_info::gaslimit, 2);
-    table[CHAINID as usize] = Instruction::new(block_info::chainid, 2);
-    table[SELFBALANCE as usize] = Instruction::new(host::selfbalance, 5);
-    table[BASEFEE as usize] = Instruction::new(block_info::basefee, 2);
-    table[BLOBHASH as usize] = Instruction::new(tx_info::blob_hash, 3);
-    table[BLOBBASEFEE as usize] = Instruction::new(block_info::blob_basefee, 2);
-    table[SLOTNUM as usize] = Instruction::new(block_info::slot_num, 2);
+    table[GASPRICE as usize] = Instruction::new(tx_info::gasprice);
+    table[EXTCODESIZE as usize] = Instruction::new(host::extcodesize);
+    table[EXTCODECOPY as usize] = Instruction::new(host::extcodecopy);
+    table[RETURNDATASIZE as usize] = Instruction::new(system::returndatasize);
+    table[RETURNDATACOPY as usize] = Instruction::new(system::returndatacopy);
+    table[EXTCODEHASH as usize] = Instruction::new(host::extcodehash);
+    table[BLOCKHASH as usize] = Instruction::new(host::blockhash);
+    table[COINBASE as usize] = Instruction::new(block_info::coinbase);
+    table[TIMESTAMP as usize] = Instruction::new(block_info::timestamp);
+    table[NUMBER as usize] = Instruction::new(block_info::block_number);
+    table[DIFFICULTY as usize] = Instruction::new(block_info::difficulty);
+    table[GASLIMIT as usize] = Instruction::new(block_info::gaslimit);
+    table[CHAINID as usize] = Instruction::new(block_info::chainid);
+    table[SELFBALANCE as usize] = Instruction::new(host::selfbalance);
+    table[BASEFEE as usize] = Instruction::new(block_info::basefee);
+    table[BLOBHASH as usize] = Instruction::new(tx_info::blob_hash);
+    table[BLOBBASEFEE as usize] = Instruction::new(block_info::blob_basefee);
+    table[SLOTNUM as usize] = Instruction::new(block_info::slot_num);
 
-    table[POP as usize] = Instruction::new(stack::pop, 2);
-    table[MLOAD as usize] = Instruction::new(memory::mload, 3);
-    table[MSTORE as usize] = Instruction::new(memory::mstore, 3);
-    table[MSTORE8 as usize] = Instruction::new(memory::mstore8, 3);
-    table[SLOAD as usize] = Instruction::new(host::sload, 50);
+    table[POP as usize] = Instruction::new(stack::pop);
+    table[MLOAD as usize] = Instruction::new(memory::mload);
+    table[MSTORE as usize] = Instruction::new(memory::mstore);
+    table[MSTORE8 as usize] = Instruction::new(memory::mstore8);
+    table[SLOAD as usize] = Instruction::new(host::sload);
+    table[SSTORE as usize] = Instruction::new(host::sstore);
+    table[JUMP as usize] = Instruction::new(control::jump);
+    table[JUMPI as usize] = Instruction::new(control::jumpi);
+    table[PC as usize] = Instruction::new(control::pc);
+    table[MSIZE as usize] = Instruction::new(memory::msize);
+    table[GAS as usize] = Instruction::new(system::gas);
+    table[JUMPDEST as usize] = Instruction::new(control::jumpdest);
+    table[TLOAD as usize] = Instruction::new(host::tload);
+    table[TSTORE as usize] = Instruction::new(host::tstore);
+    table[MCOPY as usize] = Instruction::new(memory::mcopy);
+
+    table[PUSH0 as usize] = Instruction::new(stack::push0);
+    table[PUSH1 as usize] = Instruction::new(stack::push::<1, _, _>);
+    table[PUSH2 as usize] = Instruction::new(stack::push::<2, _, _>);
+    table[PUSH3 as usize] = Instruction::new(stack::push::<3, _, _>);
+    table[PUSH4 as usize] = Instruction::new(stack::push::<4, _, _>);
+    table[PUSH5 as usize] = Instruction::new(stack::push::<5, _, _>);
+    table[PUSH6 as usize] = Instruction::new(stack::push::<6, _, _>);
+    table[PUSH7 as usize] = Instruction::new(stack::push::<7, _, _>);
+    table[PUSH8 as usize] = Instruction::new(stack::push::<8, _, _>);
+    table[PUSH9 as usize] = Instruction::new(stack::push::<9, _, _>);
+    table[PUSH10 as usize] = Instruction::new(stack::push::<10, _, _>);
+    table[PUSH11 as usize] = Instruction::new(stack::push::<11, _, _>);
+    table[PUSH12 as usize] = Instruction::new(stack::push::<12, _, _>);
+    table[PUSH13 as usize] = Instruction::new(stack::push::<13, _, _>);
+    table[PUSH14 as usize] = Instruction::new(stack::push::<14, _, _>);
+    table[PUSH15 as usize] = Instruction::new(stack::push::<15, _, _>);
+    table[PUSH16 as usize] = Instruction::new(stack::push::<16, _, _>);
+    table[PUSH17 as usize] = Instruction::new(stack::push::<17, _, _>);
+    table[PUSH18 as usize] = Instruction::new(stack::push::<18, _, _>);
+    table[PUSH19 as usize] = Instruction::new(stack::push::<19, _, _>);
+    table[PUSH20 as usize] = Instruction::new(stack::push::<20, _, _>);
+    table[PUSH21 as usize] = Instruction::new(stack::push::<21, _, _>);
+    table[PUSH22 as usize] = Instruction::new(stack::push::<22, _, _>);
+    table[PUSH23 as usize] = Instruction::new(stack::push::<23, _, _>);
+    table[PUSH24 as usize] = Instruction::new(stack::push::<24, _, _>);
+    table[PUSH25 as usize] = Instruction::new(stack::push::<25, _, _>);
+    table[PUSH26 as usize] = Instruction::new(stack::push::<26, _, _>);
+    table[PUSH27 as usize] = Instruction::new(stack::push::<27, _, _>);
+    table[PUSH28 as usize] = Instruction::new(stack::push::<28, _, _>);
+    table[PUSH29 as usize] = Instruction::new(stack::push::<29, _, _>);
+    table[PUSH30 as usize] = Instruction::new(stack::push::<30, _, _>);
+    table[PUSH31 as usize] = Instruction::new(stack::push::<31, _, _>);
+    table[PUSH32 as usize] = Instruction::new(stack::push::<32, _, _>);
+
+    table[DUP1 as usize] = Instruction::new(stack::dup::<1, _, _>);
+    table[DUP2 as usize] = Instruction::new(stack::dup::<2, _, _>);
+    table[DUP3 as usize] = Instruction::new(stack::dup::<3, _, _>);
+    table[DUP4 as usize] = Instruction::new(stack::dup::<4, _, _>);
+    table[DUP5 as usize] = Instruction::new(stack::dup::<5, _, _>);
+    table[DUP6 as usize] = Instruction::new(stack::dup::<6, _, _>);
+    table[DUP7 as usize] = Instruction::new(stack::dup::<7, _, _>);
+    table[DUP8 as usize] = Instruction::new(stack::dup::<8, _, _>);
+    table[DUP9 as usize] = Instruction::new(stack::dup::<9, _, _>);
+    table[DUP10 as usize] = Instruction::new(stack::dup::<10, _, _>);
+    table[DUP11 as usize] = Instruction::new(stack::dup::<11, _, _>);
+    table[DUP12 as usize] = Instruction::new(stack::dup::<12, _, _>);
+    table[DUP13 as usize] = Instruction::new(stack::dup::<13, _, _>);
+    table[DUP14 as usize] = Instruction::new(stack::dup::<14, _, _>);
+    table[DUP15 as usize] = Instruction::new(stack::dup::<15, _, _>);
+    table[DUP16 as usize] = Instruction::new(stack::dup::<16, _, _>);
+
+    table[SWAP1 as usize] = Instruction::new(stack::swap::<1, _, _>);
+    table[SWAP2 as usize] = Instruction::new(stack::swap::<2, _, _>);
+    table[SWAP3 as usize] = Instruction::new(stack::swap::<3, _, _>);
+    table[SWAP4 as usize] = Instruction::new(stack::swap::<4, _, _>);
+    table[SWAP5 as usize] = Instruction::new(stack::swap::<5, _, _>);
+    table[SWAP6 as usize] = Instruction::new(stack::swap::<6, _, _>);
+    table[SWAP7 as usize] = Instruction::new(stack::swap::<7, _, _>);
+    table[SWAP8 as usize] = Instruction::new(stack::swap::<8, _, _>);
+    table[SWAP9 as usize] = Instruction::new(stack::swap::<9, _, _>);
+    table[SWAP10 as usize] = Instruction::new(stack::swap::<10, _, _>);
+    table[SWAP11 as usize] = Instruction::new(stack::swap::<11, _, _>);
+    table[SWAP12 as usize] = Instruction::new(stack::swap::<12, _, _>);
+    table[SWAP13 as usize] = Instruction::new(stack::swap::<13, _, _>);
+    table[SWAP14 as usize] = Instruction::new(stack::swap::<14, _, _>);
+    table[SWAP15 as usize] = Instruction::new(stack::swap::<15, _, _>);
+    table[SWAP16 as usize] = Instruction::new(stack::swap::<16, _, _>);
+
+    table[DUPN as usize] = Instruction::new(stack::dupn);
+    table[SWAPN as usize] = Instruction::new(stack::swapn);
+    table[EXCHANGE as usize] = Instruction::new(stack::exchange);
+
+    table[LOG0 as usize] = Instruction::new(host::log::<0, _>);
+    table[LOG1 as usize] = Instruction::new(host::log::<1, _>);
+    table[LOG2 as usize] = Instruction::new(host::log::<2, _>);
+    table[LOG3 as usize] = Instruction::new(host::log::<3, _>);
+    table[LOG4 as usize] = Instruction::new(host::log::<4, _>);
+
+    table[CREATE as usize] = Instruction::new(contract::create::<_, false, _>);
+    table[CALL as usize] = Instruction::new(contract::call);
+    table[CALLCODE as usize] = Instruction::new(contract::call_code);
+    table[RETURN as usize] = Instruction::new(control::ret);
+    table[DELEGATECALL as usize] = Instruction::new(contract::delegate_call);
+    table[CREATE2 as usize] = Instruction::new(contract::create::<_, true, _>);
+
+    table[STATICCALL as usize] = Instruction::new(contract::static_call);
+    table[REVERT as usize] = Instruction::new(control::revert);
+    table[INVALID as usize] = Instruction::new(control::invalid);
+    table[SELFDESTRUCT as usize] = Instruction::new(host::selfdestruct);
+    table
+}
+
+const fn gas_table_impl() -> GasTable {
+    use bytecode::opcode::*;
+    let mut table = [0u16; 256];
+
+    table[STOP as usize] = 0;
+    table[ADD as usize] = 3;
+    table[MUL as usize] = 5;
+    table[SUB as usize] = 3;
+    table[DIV as usize] = 5;
+    table[SDIV as usize] = 5;
+    table[MOD as usize] = 5;
+    table[SMOD as usize] = 5;
+    table[ADDMOD as usize] = 8;
+    table[MULMOD as usize] = 8;
+    table[EXP as usize] = gas::EXP as u16; // base
+    table[SIGNEXTEND as usize] = 5;
+
+    table[LT as usize] = 3;
+    table[GT as usize] = 3;
+    table[SLT as usize] = 3;
+    table[SGT as usize] = 3;
+    table[EQ as usize] = 3;
+    table[ISZERO as usize] = 3;
+    table[AND as usize] = 3;
+    table[OR as usize] = 3;
+    table[XOR as usize] = 3;
+    table[NOT as usize] = 3;
+    table[BYTE as usize] = 3;
+    table[SHL as usize] = 3;
+    table[SHR as usize] = 3;
+    table[SAR as usize] = 3;
+    table[CLZ as usize] = 5;
+
+    table[KECCAK256 as usize] = gas::KECCAK256 as u16;
+
+    table[ADDRESS as usize] = 2;
+    table[BALANCE as usize] = 20;
+    table[ORIGIN as usize] = 2;
+    table[CALLER as usize] = 2;
+    table[CALLVALUE as usize] = 2;
+    table[CALLDATALOAD as usize] = 3;
+    table[CALLDATASIZE as usize] = 2;
+    table[CALLDATACOPY as usize] = 3;
+    table[CODESIZE as usize] = 2;
+    table[CODECOPY as usize] = 3;
+
+    table[GASPRICE as usize] = 2;
+    table[EXTCODESIZE as usize] = 20;
+    table[EXTCODECOPY as usize] = 20;
+    table[RETURNDATASIZE as usize] = 2;
+    table[RETURNDATACOPY as usize] = 3;
+    table[EXTCODEHASH as usize] = 400;
+    table[BLOCKHASH as usize] = 20;
+    table[COINBASE as usize] = 2;
+    table[TIMESTAMP as usize] = 2;
+    table[NUMBER as usize] = 2;
+    table[DIFFICULTY as usize] = 2;
+    table[GASLIMIT as usize] = 2;
+    table[CHAINID as usize] = 2;
+    table[SELFBALANCE as usize] = 5;
+    table[BASEFEE as usize] = 2;
+    table[BLOBHASH as usize] = 3;
+    table[BLOBBASEFEE as usize] = 2;
+    table[SLOTNUM as usize] = 2;
+
+    table[POP as usize] = 2;
+    table[MLOAD as usize] = 3;
+    table[MSTORE as usize] = 3;
+    table[MSTORE8 as usize] = 3;
+    table[SLOAD as usize] = 50;
     // SSTORE static gas can be found in GasParams as check for minimal stipend
     // needs to be done before deduction of static gas.
-    table[SSTORE as usize] = Instruction::new(host::sstore, 0);
-    table[JUMP as usize] = Instruction::new(control::jump, 8);
-    table[JUMPI as usize] = Instruction::new(control::jumpi, 10);
-    table[PC as usize] = Instruction::new(control::pc, 2);
-    table[MSIZE as usize] = Instruction::new(memory::msize, 2);
-    table[GAS as usize] = Instruction::new(system::gas, 2);
-    table[JUMPDEST as usize] = Instruction::new(control::jumpdest, 1);
-    table[TLOAD as usize] = Instruction::new(host::tload, 100);
-    table[TSTORE as usize] = Instruction::new(host::tstore, 100);
-    table[MCOPY as usize] = Instruction::new(memory::mcopy, 3); // static 2, mostly dynamic
+    table[SSTORE as usize] = 0;
+    table[JUMP as usize] = 8;
+    table[JUMPI as usize] = 10;
+    table[PC as usize] = 2;
+    table[MSIZE as usize] = 2;
+    table[GAS as usize] = 2;
+    table[JUMPDEST as usize] = 1;
+    table[TLOAD as usize] = 100;
+    table[TSTORE as usize] = 100;
+    table[MCOPY as usize] = 3; // static 2, mostly dynamic
 
-    table[PUSH0 as usize] = Instruction::new(stack::push0, 2);
-    table[PUSH1 as usize] = Instruction::new(stack::push::<1, _, _>, 3);
-    table[PUSH2 as usize] = Instruction::new(stack::push::<2, _, _>, 3);
-    table[PUSH3 as usize] = Instruction::new(stack::push::<3, _, _>, 3);
-    table[PUSH4 as usize] = Instruction::new(stack::push::<4, _, _>, 3);
-    table[PUSH5 as usize] = Instruction::new(stack::push::<5, _, _>, 3);
-    table[PUSH6 as usize] = Instruction::new(stack::push::<6, _, _>, 3);
-    table[PUSH7 as usize] = Instruction::new(stack::push::<7, _, _>, 3);
-    table[PUSH8 as usize] = Instruction::new(stack::push::<8, _, _>, 3);
-    table[PUSH9 as usize] = Instruction::new(stack::push::<9, _, _>, 3);
-    table[PUSH10 as usize] = Instruction::new(stack::push::<10, _, _>, 3);
-    table[PUSH11 as usize] = Instruction::new(stack::push::<11, _, _>, 3);
-    table[PUSH12 as usize] = Instruction::new(stack::push::<12, _, _>, 3);
-    table[PUSH13 as usize] = Instruction::new(stack::push::<13, _, _>, 3);
-    table[PUSH14 as usize] = Instruction::new(stack::push::<14, _, _>, 3);
-    table[PUSH15 as usize] = Instruction::new(stack::push::<15, _, _>, 3);
-    table[PUSH16 as usize] = Instruction::new(stack::push::<16, _, _>, 3);
-    table[PUSH17 as usize] = Instruction::new(stack::push::<17, _, _>, 3);
-    table[PUSH18 as usize] = Instruction::new(stack::push::<18, _, _>, 3);
-    table[PUSH19 as usize] = Instruction::new(stack::push::<19, _, _>, 3);
-    table[PUSH20 as usize] = Instruction::new(stack::push::<20, _, _>, 3);
-    table[PUSH21 as usize] = Instruction::new(stack::push::<21, _, _>, 3);
-    table[PUSH22 as usize] = Instruction::new(stack::push::<22, _, _>, 3);
-    table[PUSH23 as usize] = Instruction::new(stack::push::<23, _, _>, 3);
-    table[PUSH24 as usize] = Instruction::new(stack::push::<24, _, _>, 3);
-    table[PUSH25 as usize] = Instruction::new(stack::push::<25, _, _>, 3);
-    table[PUSH26 as usize] = Instruction::new(stack::push::<26, _, _>, 3);
-    table[PUSH27 as usize] = Instruction::new(stack::push::<27, _, _>, 3);
-    table[PUSH28 as usize] = Instruction::new(stack::push::<28, _, _>, 3);
-    table[PUSH29 as usize] = Instruction::new(stack::push::<29, _, _>, 3);
-    table[PUSH30 as usize] = Instruction::new(stack::push::<30, _, _>, 3);
-    table[PUSH31 as usize] = Instruction::new(stack::push::<31, _, _>, 3);
-    table[PUSH32 as usize] = Instruction::new(stack::push::<32, _, _>, 3);
+    table[PUSH0 as usize] = 2;
+    table[PUSH1 as usize] = 3;
+    table[PUSH2 as usize] = 3;
+    table[PUSH3 as usize] = 3;
+    table[PUSH4 as usize] = 3;
+    table[PUSH5 as usize] = 3;
+    table[PUSH6 as usize] = 3;
+    table[PUSH7 as usize] = 3;
+    table[PUSH8 as usize] = 3;
+    table[PUSH9 as usize] = 3;
+    table[PUSH10 as usize] = 3;
+    table[PUSH11 as usize] = 3;
+    table[PUSH12 as usize] = 3;
+    table[PUSH13 as usize] = 3;
+    table[PUSH14 as usize] = 3;
+    table[PUSH15 as usize] = 3;
+    table[PUSH16 as usize] = 3;
+    table[PUSH17 as usize] = 3;
+    table[PUSH18 as usize] = 3;
+    table[PUSH19 as usize] = 3;
+    table[PUSH20 as usize] = 3;
+    table[PUSH21 as usize] = 3;
+    table[PUSH22 as usize] = 3;
+    table[PUSH23 as usize] = 3;
+    table[PUSH24 as usize] = 3;
+    table[PUSH25 as usize] = 3;
+    table[PUSH26 as usize] = 3;
+    table[PUSH27 as usize] = 3;
+    table[PUSH28 as usize] = 3;
+    table[PUSH29 as usize] = 3;
+    table[PUSH30 as usize] = 3;
+    table[PUSH31 as usize] = 3;
+    table[PUSH32 as usize] = 3;
 
-    table[DUP1 as usize] = Instruction::new(stack::dup::<1, _, _>, 3);
-    table[DUP2 as usize] = Instruction::new(stack::dup::<2, _, _>, 3);
-    table[DUP3 as usize] = Instruction::new(stack::dup::<3, _, _>, 3);
-    table[DUP4 as usize] = Instruction::new(stack::dup::<4, _, _>, 3);
-    table[DUP5 as usize] = Instruction::new(stack::dup::<5, _, _>, 3);
-    table[DUP6 as usize] = Instruction::new(stack::dup::<6, _, _>, 3);
-    table[DUP7 as usize] = Instruction::new(stack::dup::<7, _, _>, 3);
-    table[DUP8 as usize] = Instruction::new(stack::dup::<8, _, _>, 3);
-    table[DUP9 as usize] = Instruction::new(stack::dup::<9, _, _>, 3);
-    table[DUP10 as usize] = Instruction::new(stack::dup::<10, _, _>, 3);
-    table[DUP11 as usize] = Instruction::new(stack::dup::<11, _, _>, 3);
-    table[DUP12 as usize] = Instruction::new(stack::dup::<12, _, _>, 3);
-    table[DUP13 as usize] = Instruction::new(stack::dup::<13, _, _>, 3);
-    table[DUP14 as usize] = Instruction::new(stack::dup::<14, _, _>, 3);
-    table[DUP15 as usize] = Instruction::new(stack::dup::<15, _, _>, 3);
-    table[DUP16 as usize] = Instruction::new(stack::dup::<16, _, _>, 3);
+    table[DUP1 as usize] = 3;
+    table[DUP2 as usize] = 3;
+    table[DUP3 as usize] = 3;
+    table[DUP4 as usize] = 3;
+    table[DUP5 as usize] = 3;
+    table[DUP6 as usize] = 3;
+    table[DUP7 as usize] = 3;
+    table[DUP8 as usize] = 3;
+    table[DUP9 as usize] = 3;
+    table[DUP10 as usize] = 3;
+    table[DUP11 as usize] = 3;
+    table[DUP12 as usize] = 3;
+    table[DUP13 as usize] = 3;
+    table[DUP14 as usize] = 3;
+    table[DUP15 as usize] = 3;
+    table[DUP16 as usize] = 3;
 
-    table[SWAP1 as usize] = Instruction::new(stack::swap::<1, _, _>, 3);
-    table[SWAP2 as usize] = Instruction::new(stack::swap::<2, _, _>, 3);
-    table[SWAP3 as usize] = Instruction::new(stack::swap::<3, _, _>, 3);
-    table[SWAP4 as usize] = Instruction::new(stack::swap::<4, _, _>, 3);
-    table[SWAP5 as usize] = Instruction::new(stack::swap::<5, _, _>, 3);
-    table[SWAP6 as usize] = Instruction::new(stack::swap::<6, _, _>, 3);
-    table[SWAP7 as usize] = Instruction::new(stack::swap::<7, _, _>, 3);
-    table[SWAP8 as usize] = Instruction::new(stack::swap::<8, _, _>, 3);
-    table[SWAP9 as usize] = Instruction::new(stack::swap::<9, _, _>, 3);
-    table[SWAP10 as usize] = Instruction::new(stack::swap::<10, _, _>, 3);
-    table[SWAP11 as usize] = Instruction::new(stack::swap::<11, _, _>, 3);
-    table[SWAP12 as usize] = Instruction::new(stack::swap::<12, _, _>, 3);
-    table[SWAP13 as usize] = Instruction::new(stack::swap::<13, _, _>, 3);
-    table[SWAP14 as usize] = Instruction::new(stack::swap::<14, _, _>, 3);
-    table[SWAP15 as usize] = Instruction::new(stack::swap::<15, _, _>, 3);
-    table[SWAP16 as usize] = Instruction::new(stack::swap::<16, _, _>, 3);
+    table[SWAP1 as usize] = 3;
+    table[SWAP2 as usize] = 3;
+    table[SWAP3 as usize] = 3;
+    table[SWAP4 as usize] = 3;
+    table[SWAP5 as usize] = 3;
+    table[SWAP6 as usize] = 3;
+    table[SWAP7 as usize] = 3;
+    table[SWAP8 as usize] = 3;
+    table[SWAP9 as usize] = 3;
+    table[SWAP10 as usize] = 3;
+    table[SWAP11 as usize] = 3;
+    table[SWAP12 as usize] = 3;
+    table[SWAP13 as usize] = 3;
+    table[SWAP14 as usize] = 3;
+    table[SWAP15 as usize] = 3;
+    table[SWAP16 as usize] = 3;
 
-    table[DUPN as usize] = Instruction::new(stack::dupn, 3);
-    table[SWAPN as usize] = Instruction::new(stack::swapn, 3);
-    table[EXCHANGE as usize] = Instruction::new(stack::exchange, 3);
+    table[DUPN as usize] = 3;
+    table[SWAPN as usize] = 3;
+    table[EXCHANGE as usize] = 3;
 
-    table[LOG0 as usize] = Instruction::new(host::log::<0, _>, gas::LOG);
-    table[LOG1 as usize] = Instruction::new(host::log::<1, _>, gas::LOG);
-    table[LOG2 as usize] = Instruction::new(host::log::<2, _>, gas::LOG);
-    table[LOG3 as usize] = Instruction::new(host::log::<3, _>, gas::LOG);
-    table[LOG4 as usize] = Instruction::new(host::log::<4, _>, gas::LOG);
+    table[LOG0 as usize] = gas::LOG as u16;
+    table[LOG1 as usize] = gas::LOG as u16;
+    table[LOG2 as usize] = gas::LOG as u16;
+    table[LOG3 as usize] = gas::LOG as u16;
+    table[LOG4 as usize] = gas::LOG as u16;
 
-    table[CREATE as usize] = Instruction::new(contract::create::<_, false, _>, 0);
-    table[CALL as usize] = Instruction::new(contract::call, 40);
-    table[CALLCODE as usize] = Instruction::new(contract::call_code, 40);
-    table[RETURN as usize] = Instruction::new(control::ret, 0);
-    table[DELEGATECALL as usize] = Instruction::new(contract::delegate_call, 40);
-    table[CREATE2 as usize] = Instruction::new(contract::create::<_, true, _>, 0);
+    table[CREATE as usize] = 0;
+    table[CALL as usize] = 40;
+    table[CALLCODE as usize] = 40;
+    table[RETURN as usize] = 0;
+    table[DELEGATECALL as usize] = 40;
+    table[CREATE2 as usize] = 0;
 
-    table[STATICCALL as usize] = Instruction::new(contract::static_call, 40);
-    table[REVERT as usize] = Instruction::new(control::revert, 0);
-    table[INVALID as usize] = Instruction::new(control::invalid, 0);
-    table[SELFDESTRUCT as usize] = Instruction::new(host::selfdestruct, 0);
+    table[STATICCALL as usize] = 40;
+    table[REVERT as usize] = 0;
+    table[INVALID as usize] = 0;
+    table[SELFDESTRUCT as usize] = 0;
     table
 }
 

--- a/crates/interpreter/src/instructions/stack.rs
+++ b/crates/interpreter/src/instructions/stack.rs
@@ -140,7 +140,7 @@ fn decode_pair(x: usize) -> Option<(usize, usize)> {
 mod tests {
     use crate::{
         host::DummyHost,
-        instructions::instruction_table,
+        instructions::{gas_table, instruction_table},
         interpreter::{EthInterpreter, ExtBytecode, InputsImpl, SharedMemory},
         interpreter_types::LoopControl,
         Interpreter,
@@ -160,8 +160,9 @@ mod tests {
             u64::MAX,
         );
         let table = instruction_table::<EthInterpreter, DummyHost>();
+        let gas = gas_table();
         let mut host = DummyHost::new(SpecId::AMSTERDAM);
-        interpreter.run_plain(&table, &mut host);
+        interpreter.run_plain(&table, &gas, &mut host);
         interpreter
     }
 

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -19,8 +19,8 @@ pub use stack::{Stack, STACK_LIMIT};
 
 // imports
 use crate::{
-    host::DummyHost, instruction_context::InstructionContext, interpreter_types::*, Gas, Host,
-    InstructionResult, InstructionTable, InterpreterAction,
+    host::DummyHost, instruction_context::InstructionContext, interpreter_types::*, Gas, GasTable,
+    Host, InstructionResult, InstructionTable, InterpreterAction,
 };
 use bytecode::Bytecode;
 use primitives::{hardfork::SpecId, Bytes};
@@ -284,6 +284,7 @@ impl<IW: InterpreterTypes> Interpreter<IW> {
     pub fn step<H: Host + ?Sized>(
         &mut self,
         instruction_table: &InstructionTable<IW, H>,
+        gas_table: &GasTable,
         host: &mut H,
     ) {
         // Get current opcode.
@@ -295,10 +296,12 @@ impl<IW: InterpreterTypes> Interpreter<IW> {
         self.bytecode.relative_jump(1);
 
         let instruction = unsafe { instruction_table.get_unchecked(opcode as usize) };
+        let static_gas = unsafe { *gas_table.get_unchecked(opcode as usize) };
 
-        if self.gas.record_cost_unsafe(instruction.static_gas()) {
+        if self.gas.record_cost_unsafe(static_gas as u64) {
             return self.halt_oog();
         }
+
         let context = InstructionContext {
             interpreter: self,
             host,
@@ -312,8 +315,12 @@ impl<IW: InterpreterTypes> Interpreter<IW> {
     ///
     /// This uses dummy Host.
     #[inline]
-    pub fn step_dummy(&mut self, instruction_table: &InstructionTable<IW, DummyHost>) {
-        self.step(instruction_table, &mut DummyHost::default());
+    pub fn step_dummy(
+        &mut self,
+        instruction_table: &InstructionTable<IW, DummyHost>,
+        gas_table: &GasTable,
+    ) {
+        self.step(instruction_table, gas_table, &mut DummyHost::default());
     }
 
     /// Executes the interpreter until it returns or stops.
@@ -321,10 +328,11 @@ impl<IW: InterpreterTypes> Interpreter<IW> {
     pub fn run_plain<H: Host + ?Sized>(
         &mut self,
         instruction_table: &InstructionTable<IW, H>,
+        gas_table: &GasTable,
         host: &mut H,
     ) -> InterpreterAction {
         while self.bytecode.is_not_end() {
-            self.step(instruction_table, host);
+            self.step(instruction_table, gas_table, host);
         }
         self.take_next_action()
     }
@@ -334,17 +342,19 @@ impl<IW: InterpreterTypes> Interpreter<IW> {
 pub fn asm_step(
     interpreter: &mut Interpreter<EthInterpreter>,
     instruction_table: &InstructionTable<EthInterpreter, DummyHost>,
+    gas_table: &GasTable,
     host: &mut DummyHost,
 ) {
-    interpreter.step(instruction_table, host);
+    interpreter.step(instruction_table, gas_table, host);
 }
 
 pub fn asm_run(
     interpreter: &mut Interpreter<EthInterpreter>,
     instruction_table: &InstructionTable<EthInterpreter, DummyHost>,
+    gas_table: &GasTable,
     host: &mut DummyHost,
 ) {
-    interpreter.run_plain(instruction_table, host);
+    interpreter.run_plain(instruction_table, gas_table, host);
 }
 */
 
@@ -414,9 +424,10 @@ where
     pub fn run_plain_as_output<H: Host + ?Sized>(
         &mut self,
         instruction_table: &InstructionTable<IW, H>,
+        gas_table: &GasTable,
         host: &mut H,
     ) -> IW::Output {
-        From::from(self.run_plain(instruction_table, host))
+        From::from(self.run_plain(instruction_table, gas_table, host))
     }
 }
 
@@ -453,7 +464,10 @@ mod tests {
 #[test]
 fn test_mstore_big_offset_memory_oog() {
     use super::*;
-    use crate::{host::DummyHost, instructions::instruction_table};
+    use crate::{
+        host::DummyHost,
+        instructions::{gas_table, instruction_table},
+    };
     use bytecode::Bytecode;
     use primitives::Bytes;
 
@@ -477,8 +491,9 @@ fn test_mstore_big_offset_memory_oog() {
     );
 
     let table = instruction_table::<EthInterpreter, DummyHost>();
+    let gas = gas_table();
     let mut host = DummyHost::default();
-    let action = interpreter.run_plain(&table, &mut host);
+    let action = interpreter.run_plain(&table, &gas, &mut host);
 
     assert!(action.is_return());
     assert_eq!(
@@ -491,7 +506,10 @@ fn test_mstore_big_offset_memory_oog() {
 #[cfg(feature = "memory_limit")]
 fn test_mstore_big_offset_memory_limit_oog() {
     use super::*;
-    use crate::{host::DummyHost, instructions::instruction_table};
+    use crate::{
+        host::DummyHost,
+        instructions::{gas_table, instruction_table},
+    };
     use bytecode::Bytecode;
     use primitives::Bytes;
 
@@ -515,8 +533,9 @@ fn test_mstore_big_offset_memory_limit_oog() {
     );
 
     let table = instruction_table::<EthInterpreter, DummyHost>();
+    let gas = gas_table();
     let mut host = DummyHost::default();
-    let action = interpreter.run_plain(&table, &mut host);
+    let action = interpreter.run_plain(&table, &gas, &mut host);
 
     assert!(action.is_return());
     assert_eq!(

--- a/crates/interpreter/src/lib.rs
+++ b/crates/interpreter/src/lib.rs
@@ -39,7 +39,7 @@ pub use context_interface::{
 pub use gas::Gas;
 pub use instruction_context::InstructionContext;
 pub use instruction_result::*;
-pub use instructions::{instruction_table, Instruction, InstructionTable};
+pub use instructions::{gas_table, instruction_table, GasTable, Instruction, InstructionTable};
 pub use interpreter::{
     num_words, InputsImpl, Interpreter, InterpreterResult, SharedMemory, Stack, STACK_LIMIT,
 };

--- a/examples/custom_opcodes/src/main.rs
+++ b/examples/custom_opcodes/src/main.rs
@@ -46,6 +46,7 @@ pub fn main() {
             let offset = ctx.interpreter.bytecode.read_i16();
             ctx.interpreter.bytecode.relative_jump(offset as isize);
         }),
+        0,
     );
 
     // Create a new EVM instance.

--- a/examples/custom_opcodes/src/main.rs
+++ b/examples/custom_opcodes/src/main.rs
@@ -42,13 +42,10 @@ pub fn main() {
     // insert our custom opcode
     instructions.insert_instruction(
         MY_STATIC_JUMP,
-        Instruction::new(
-            |ctx: InstructionContext<'_, _, EthInterpreter>| {
-                let offset = ctx.interpreter.bytecode.read_i16();
-                ctx.interpreter.bytecode.relative_jump(offset as isize);
-            },
-            0,
-        ),
+        Instruction::new(|ctx: InstructionContext<'_, _, EthInterpreter>| {
+            let offset = ctx.interpreter.bytecode.read_i16();
+            ctx.interpreter.bytecode.relative_jump(offset as isize);
+        }),
     );
 
     // Create a new EVM instance.


### PR DESCRIPTION
Split the combined `Instruction` struct (fn pointer + u64 gas) into two separate tables: `InstructionTable` for function pointers and `GasTable` (`[u16; 256]`) for static gas costs.

This reduces the `Instruction` struct size and allows the gas table to be more cache-friendly during execution. All static gas values fit in u16.