### PR TITLE
refactor(interpreter): dedup account loading across host instructions

### DIFF
--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -1,9 +1,9 @@
 use crate::{
     instructions::utility::{IntoAddress, IntoU256},
     interpreter_types::{InputsTr, InterpreterTypes, MemoryTr, RuntimeFlag, StackTr},
-    Host, InstructionResult,
+    Gas, Host, InstructionResult,
 };
-use context_interface::host::LoadError;
+use context_interface::{host::LoadError, journaled_state::AccountInfoLoad};
 use core::cmp::min;
 use primitives::{
     hardfork::SpecId::{self, *},
@@ -12,25 +12,35 @@ use primitives::{
 
 use crate::InstructionContext;
 
+/// Loads an account, handling cold load gas accounting.
+///
+/// Pre-Berlin, `cold_account_additional_cost` is 0, so the cold load logic is a no-op.
+fn load_account<'a, H: Host + ?Sized>(
+    gas: &mut Gas,
+    host: &'a mut H,
+    address: primitives::Address,
+    load_code: bool,
+) -> Result<AccountInfoLoad<'a>, LoadError> {
+    let cold_load_gas = host.gas_params().cold_account_additional_cost();
+    let skip_cold_load = gas.remaining() < cold_load_gas;
+    let account = host.load_account_info_skip_cold_load(address, load_code, skip_cold_load)?;
+    if account.is_cold && !gas.record_regular_cost(cold_load_gas) {
+        return Err(LoadError::ColdLoadSkipped);
+    }
+    Ok(account)
+}
+
 /// Implements the BALANCE instruction.
 ///
 /// Gets the balance of the given account.
 pub fn balance<WIRE: InterpreterTypes, H: Host + ?Sized>(context: InstructionContext<'_, H, WIRE>) {
     popn_top!([], top, context.interpreter);
     let address = top.into_address();
-    let spec_id = context.interpreter.runtime_flag.spec_id();
-    if spec_id.is_enabled_in(BERLIN) {
-        let account = berlin_load_account!(context, address, false);
-        *top = account.balance;
-    } else {
-        let Ok(account) = context
-            .host
-            .load_account_info_skip_cold_load(address, false, false)
-        else {
-            return context.interpreter.halt_fatal();
-        };
-        *top = account.balance;
+    let account = match load_account(&mut context.interpreter.gas, context.host, address, false) {
+        Ok(account) => account,
+        Err(e) => return context.interpreter.halt_load_error(e),
     };
+    *top = account.balance;
 }
 
 /// EIP-1884: Repricing for trie-size-dependent opcodes
@@ -56,22 +66,12 @@ pub fn extcodesize<WIRE: InterpreterTypes, H: Host + ?Sized>(
 ) {
     popn_top!([], top, context.interpreter);
     let address = top.into_address();
-
-    let spec_id = context.interpreter.runtime_flag.spec_id();
-    if spec_id.is_enabled_in(BERLIN) {
-        let account = berlin_load_account!(context, address, true);
-        // safe to unwrap because we are loading code
-        *top = U256::from(account.code.as_ref().unwrap().len());
-    } else {
-        let Ok(account) = context
-            .host
-            .load_account_info_skip_cold_load(address, true, false)
-        else {
-            return context.interpreter.halt_fatal();
-        };
-        // safe to unwrap because we are loading code
-        *top = U256::from(account.code.as_ref().unwrap().len());
-    }
+    let account = match load_account(&mut context.interpreter.gas, context.host, address, true) {
+        Ok(account) => account,
+        Err(e) => return context.interpreter.halt_load_error(e),
+    };
+    // safe to unwrap because we are loading code
+    *top = U256::from(account.code.as_ref().unwrap().len());
 }
 
 /// EIP-1052: EXTCODEHASH opcode
@@ -81,18 +81,9 @@ pub fn extcodehash<WIRE: InterpreterTypes, H: Host + ?Sized>(
     check!(context.interpreter, CONSTANTINOPLE);
     popn_top!([], top, context.interpreter);
     let address = top.into_address();
-
-    let spec_id = context.interpreter.runtime_flag.spec_id();
-    let account = if spec_id.is_enabled_in(BERLIN) {
-        berlin_load_account!(context, address, false)
-    } else {
-        let Ok(account) = context
-            .host
-            .load_account_info_skip_cold_load(address, false, false)
-        else {
-            return context.interpreter.halt_fatal();
-        };
-        account
+    let account = match load_account(&mut context.interpreter.gas, context.host, address, false) {
+        Ok(account) => account,
+        Err(e) => return context.interpreter.halt_load_error(e),
     };
     // if account is empty, code hash is zero
     let code_hash = if account.is_empty() {
@@ -115,8 +106,6 @@ pub fn extcodecopy<WIRE: InterpreterTypes, H: Host + ?Sized>(
     );
     let address = address.into_address();
 
-    let spec_id = context.interpreter.runtime_flag.spec_id();
-
     let len = as_usize_or_fail!(context.interpreter, len_u256);
     gas!(
         context.interpreter,
@@ -137,15 +126,11 @@ pub fn extcodecopy<WIRE: InterpreterTypes, H: Host + ?Sized>(
         );
     }
 
-    let code = if spec_id.is_enabled_in(BERLIN) {
-        let account = berlin_load_account!(context, address, true);
-        account.code.as_ref().unwrap().original_bytes()
-    } else {
-        let Some(code) = context.host.load_account_code(address) else {
-            return context.interpreter.halt_fatal();
-        };
-        code.data
+    let account = match load_account(&mut context.interpreter.gas, context.host, address, true) {
+        Ok(account) => account,
+        Err(e) => return context.interpreter.halt_load_error(e),
     };
+    let code = account.code.as_ref().unwrap().original_bytes();
 
     let code_offset_usize = min(as_usize_saturated!(code_offset), code.len());
 

--- a/crates/interpreter/src/instructions/macros.rs
+++ b/crates/interpreter/src/instructions/macros.rs
@@ -62,38 +62,6 @@ macro_rules! gas {
     };
 }
 
-/// Loads account and account berlin gas cost accounting.
-#[macro_export]
-#[collapse_debuginfo(yes)]
-macro_rules! berlin_load_account {
-    ($context:expr, $address:expr, $load_code:expr) => {
-        $crate::berlin_load_account!($context, $address, $load_code, ())
-    };
-    ($context:expr, $address:expr, $load_code:expr, $ret:expr) => {{
-        let cold_load_gas = $context.host.gas_params().cold_account_additional_cost();
-        let skip_cold_load = $context.interpreter.gas.remaining() < cold_load_gas;
-        match $context
-            .host
-            .load_account_info_skip_cold_load($address, $load_code, skip_cold_load)
-        {
-            Ok(account) => {
-                if account.is_cold {
-                    $crate::gas!($context.interpreter, cold_load_gas, $ret);
-                }
-                account
-            }
-            Err(LoadError::ColdLoadSkipped) => {
-                $context.interpreter.halt_oog();
-                return $ret;
-            }
-            Err(LoadError::DBError) => {
-                $context.interpreter.halt_fatal();
-                return $ret;
-            }
-        }
-    }};
-}
-
 /// Resizes the interpreter memory if necessary. Fails the instruction if the memory or gas limit
 /// is exceeded.
 #[macro_export]

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -223,6 +223,19 @@ impl<IW: InterpreterTypes> Interpreter<IW> {
         ));
     }
 
+    /// Halt the interpreter due to a [`LoadError`].
+    ///
+    /// [`LoadError::ColdLoadSkipped`] results in an out-of-gas error,
+    /// [`LoadError::DBError`] results in a fatal error.
+    #[cold]
+    #[inline(never)]
+    pub fn halt_load_error(&mut self, err: context_interface::host::LoadError) {
+        match err {
+            context_interface::host::LoadError::ColdLoadSkipped => self.halt_oog(),
+            context_interface::host::LoadError::DBError => self.halt_fatal(),
+        }
+    }
+
     /// Halt the interpreter with an out-of-gas error.
     #[cold]
     #[inline(never)]

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -8,7 +8,6 @@ mod runtime_flags;
 mod shared_memory;
 mod stack;
 
-use context_interface::cfg::GasParams;
 // re-exports
 pub use ext_bytecode::ExtBytecode;
 pub use input::InputsImpl;
@@ -23,6 +22,7 @@ use crate::{
     InstructionResult, InstructionTable, InterpreterAction,
 };
 use bytecode::Bytecode;
+use context_interface::{cfg::GasParams, host::LoadError};
 use primitives::{hardfork::SpecId, Bytes};
 
 /// Main interpreter structure that contains all components defined in [`InterpreterTypes`].
@@ -224,15 +224,12 @@ impl<IW: InterpreterTypes> Interpreter<IW> {
     }
 
     /// Halt the interpreter due to a [`LoadError`].
-    ///
-    /// [`LoadError::ColdLoadSkipped`] results in an out-of-gas error,
-    /// [`LoadError::DBError`] results in a fatal error.
     #[cold]
     #[inline(never)]
-    pub fn halt_load_error(&mut self, err: context_interface::host::LoadError) {
+    pub fn halt_load_error(&mut self, err: LoadError) {
         match err {
-            context_interface::host::LoadError::ColdLoadSkipped => self.halt_oog(),
-            context_interface::host::LoadError::DBError => self.halt_fatal(),
+            LoadError::ColdLoadSkipped => self.halt_oog(),
+            LoadError::DBError => self.halt_fatal(),
         }
     }
 


### PR DESCRIPTION
Replace the duplicated `if berlin { berlin_load_account!() } else { load_account_info_skip_cold_load() }` pattern in balance, extcodesize, extcodehash, and extcodecopy with a single `load_account` function.

Pre-Berlin, `cold_account_additional_cost` is 0, so the cold load gas logic is a no-op and the function works correctly for all spec versions.

Removes the `berlin_load_account!` macro entirely and adds `Interpreter::halt_load_error` to map `LoadError` variants to the appropriate halt.