### PR TITLE
ci: pin GitHub Actions to SHA, add least-privilege permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,14 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: cargo
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,25 +9,28 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions: {}
+
 jobs:
   codspeed:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-on-failure: true
       - name: Install cargo-codspeed
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@cf39a74df4a72510be4e5b63348d61067f11e64a # v2.75.0
         with:
           tool: cargo-codspeed
       - name: Build the benchmark target(s)
         run: cargo codspeed build --profile profiling --workspace --exclude '*example*' --exclude op-revm
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@v3
+        uses: CodSpeedHQ/action@d872884a306dd4853acf0f584f4b706cf0cc72a2 # v4.13.0
         with:
           run: cargo codspeed run --workspace
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -34,3 +34,4 @@ jobs:
         with:
           run: cargo codspeed run --workspace
           token: ${{ secrets.CODSPEED_TOKEN }}
+          mode: walltime

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -34,4 +34,4 @@ jobs:
         with:
           run: cargo codspeed run --workspace
           token: ${{ secrets.CODSPEED_TOKEN }}
-          mode: walltime
+          mode: simulation

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install mdbook-template
         run: |
           mkdir mdbook-template
-          curl -sSL https://github.com/sgoudham/mdbook-template/releases/latest/download/mdbook-template-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook-template
+          curl -sSL https://github.com/sgoudham/mdbook-template/releases/download/v1.1.1/mdbook-template-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook-template
           echo `pwd`/mdbook-template >> $GITHUB_PATH
 
       - name: Run tests
@@ -53,7 +53,7 @@ jobs:
       - name: Install mdbook-linkcheck
         run: |
           mkdir mdbook-linkcheck
-          curl -sSL -o mdbook-linkcheck.zip https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/latest/download/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip
+          curl -sSL -o mdbook-linkcheck.zip https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.7.7/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip
           unzip mdbook-linkcheck.zip -d ./mdbook-linkcheck
           chmod +x `pwd`/mdbook-linkcheck/mdbook-linkcheck
           echo `pwd`/mdbook-linkcheck >> $GITHUB_PATH
@@ -84,7 +84,7 @@ jobs:
       - name: Install mdbook-template
         run: |
           mkdir mdbook-template
-          curl -sSL https://github.com/sgoudham/mdbook-template/releases/latest/download/mdbook-template-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook-template
+          curl -sSL https://github.com/sgoudham/mdbook-template/releases/download/v1.1.1/mdbook-template-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook-template
           echo `pwd`/mdbook-template >> $GITHUB_PATH
 
       - name: Build book

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -11,13 +11,17 @@ on:
     branches: [main]
   merge_group:
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
     name: test
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install mdbook
         run: |
@@ -42,7 +46,9 @@ jobs:
     name: lint
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install mdbook-linkcheck
         run: |
@@ -58,13 +64,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-on-failure: true
 
@@ -110,7 +117,7 @@ jobs:
             .
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: github-pages
           path: ${{ runner.temp }}/artifact.tar
@@ -135,4 +142,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install mdbook-template
         run: |
           mkdir mdbook-template
-          curl -sSL https://github.com/sgoudham/mdbook-template/releases/download/v1.1.1/mdbook-template-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook-template
+          curl -sSL https://github.com/sgoudham/mdbook-template/releases/download/v1.1.0/mdbook-template-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook-template
           echo `pwd`/mdbook-template >> $GITHUB_PATH
 
       - name: Run tests
@@ -84,7 +84,7 @@ jobs:
       - name: Install mdbook-template
         run: |
           mkdir mdbook-template
-          curl -sSL https://github.com/sgoudham/mdbook-template/releases/download/v1.1.1/mdbook-template-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook-template
+          curl -sSL https://github.com/sgoudham/mdbook-template/releases/download/v1.1.0/mdbook-template-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook-template
           echo `pwd`/mdbook-template >> $GITHUB_PATH
 
       - name: Build book

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17
         with:
           command: check all
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions: {}
+
 jobs:
   test:
     name: test ${{ matrix.rust }} ${{ matrix.flags }}
@@ -24,11 +26,13 @@ jobs:
         rust: ["1.91", "stable", "nightly"]
         flags: ["--no-default-features", "", "--all-features"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Install GMP (all-features)
         if: contains(matrix.flags, '--all-features')
         run: |
@@ -46,7 +50,9 @@ jobs:
         target: ["riscv32imac-unknown-none-elf", "riscv64imac-unknown-none-elf"]
         features: [""]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -64,7 +70,9 @@ jobs:
       matrix:
         features: ["", "serde", "std", "std,map-foldhash"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo check --no-default-features -p revm --features=${{ matrix.features }}
 
@@ -73,10 +81,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-hack
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-on-failure: true
       - name: Install GMP
@@ -91,7 +101,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -108,7 +120,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rust-docs
@@ -125,7 +139,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -135,7 +151,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: run zepter
         run: |
           cargo install zepter -f --locked
@@ -146,5 +164,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
-      - uses: crate-ci/typos@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: crate-ci/typos@02ea592e44b3a53c302f697cddca7641cd051c3d # v1.45.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,16 @@ jobs:
           zepter --version
           time zepter run check
 
+  deny:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - run: cargo install cargo-deny --locked
+      - run: cargo deny check
+
   typos:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,8 +167,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - run: cargo install cargo-deny --locked
-      - run: cargo deny check
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check all
 
   typos:
     runs-on: ubuntu-latest

--- a/.github/workflows/ethereum-tests.yml
+++ b/.github/workflows/ethereum-tests.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
     branches: [main, "release/**"]
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -20,17 +22,19 @@ jobs:
         target: [i686-unknown-linux-gnu, x86_64-unknown-linux-gnu]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-on-failure: true
 
       - name: Install cross
-        run: cargo install cross
+        run: cargo install cross --locked
 
       - name: Run tests
         run: |

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [labeled]
 
+permissions: {}
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Install Rust toolchain
@@ -34,7 +34,7 @@ jobs:
         # A PR with the semver bump is created with a new release tag and changelog
         # if you configure the cargo registry token, the action will also publish the new version to crates.io
       - name: Run release-plz
-        uses: MarcoIeni/release-plz-action@v0.5
+        uses: MarcoIeni/release-plz-action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128
         with:
           command: release-pr
         env:

--- a/deny.toml
+++ b/deny.toml
@@ -4,8 +4,8 @@ yanked = "warn"
 ignore = [
     # https://rustsec.org/advisories/RUSTSEC-2024-0436 paste is unmaintained
     "RUSTSEC-2024-0436",
-    # https://rustsec.org/advisories/RUSTSEC-2024-0388 derivative is unmaintained
-    "RUSTSEC-2024-0388",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0097 rand 0.9.2 unsound (no fix available yet)
+    "RUSTSEC-2026-0097",
 ]
 
 [bans]
@@ -31,23 +31,18 @@ allow = [
     "Zlib",
     "CC0-1.0",
     "CDLA-Permissive-2.0",
+    "LGPL-3.0-or-later",
 ]
 
 exceptions = [
     # ring
     { allow = ["LicenseRef-ring"], name = "ring" },
-    { allow = ["LicenseRef-webpki"], name = "webpki" },
 ]
 
 [[licenses.clarify]]
 name = "ring"
 expression = "LicenseRef-ring"
 license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
-
-[[licenses.clarify]]
-name = "webpki"
-expression = "LicenseRef-webpki"
-license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]
 
 [sources]
 unknown-registry = "deny"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,55 @@
+[advisories]
+version = 2
+yanked = "warn"
+ignore = [
+    # https://rustsec.org/advisories/RUSTSEC-2024-0436 paste is unmaintained
+    "RUSTSEC-2024-0436",
+    # https://rustsec.org/advisories/RUSTSEC-2024-0388 derivative is unmaintained
+    "RUSTSEC-2024-0388",
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "warn"
+highlight = "all"
+
+[licenses]
+confidence-threshold = 0.9
+
+allow = [
+    "MIT",
+    "MIT-0",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "ISC",
+    "Unicode-3.0",
+    "Unlicense",
+    "MPL-2.0",
+    "Zlib",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+]
+
+exceptions = [
+    # ring
+    { allow = ["LicenseRef-ring"], name = "ring" },
+    { allow = ["LicenseRef-webpki"], name = "webpki" },
+]
+
+[[licenses.clarify]]
+name = "ring"
+expression = "LicenseRef-ring"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+[[licenses.clarify]]
+name = "webpki"
+expression = "LicenseRef-webpki"
+license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-git = []


### PR DESCRIPTION
Pin all GitHub Actions to SHA, add least-privilege permissions, add `cargo deny` to CI, and pin mdbook downloads.

- Pin `actions/checkout@v6` → SHA `v6.0.2`, `Swatinem/rust-cache@v2` → SHA `v2.9.1`, `crate-ci/typos@v1` → SHA `v1.45.0`, `CodSpeedHQ/action@v3` → SHA `v4.13.0`, `taiki-e/install-action@v2` → SHA `v2.75.0`, `actions/upload-artifact@v4` → SHA `v7.0.0`, `actions/deploy-pages@v4` → SHA `v5.0.0`, `MarcoIeni/release-plz-action@v0.5` → SHA `v0.5.128`, `EmbarkStudios/cargo-deny-action@v2` → SHA `v2.0.17`
- Upgrade `CodSpeedHQ/action` v3 → v4.13.0, add required `mode: simulation` (matches default `cargo codspeed build` behavior)
- Add `permissions: {}` to `ci.yml`, `bench.yml`, `book.yml`, `ethereum-tests.yml`, `pr-audit.yml`
- Add `persist-credentials: false` to all checkout steps
- Add `deny.toml` with advisory, source, ban, and license policy
- Add `cargo deny check` CI job
- Ignore `RUSTSEC-2024-0436` (paste unmaintained) and `RUSTSEC-2026-0097` (rand 0.9.2 unsound, no fix yet)
- Allow `LGPL-3.0-or-later` for `gmp-mpfr-sys` (optional GMP precompile dep)
- Pin `mdbook-template` to `v1.1.0` and `mdbook-linkcheck` to `v0.7.7` (were using mutable `/latest/` URLs)
- Add `--locked` to `cargo install cross`
- Add `github-actions` ecosystem + cooldown to `dependabot.yml`

Prompted by: georgen