### PR TITLE
fix(bal): record storage writes to zero for selfdestructed accounts

### DIFF
--- a/crates/state/src/bal/account.rs
+++ b/crates/state/src/bal/account.rs
@@ -54,7 +54,9 @@ impl AccountBal {
             let empty_info = AccountInfo::default();
             self.account_info
                 .update(bal_index, &account.original_info, &empty_info);
-            self.storage.update_reads(account.storage.keys().copied());
+            // Selfdestruct wipes all storage to zero, record writes accordingly.
+            self.storage
+                .update_selfdestruct(bal_index, &account.storage);
             return;
         }
 
@@ -273,6 +275,20 @@ impl StorageBal {
                 bal_index,
                 &value.original_value,
                 value.present_value,
+            );
+        }
+    }
+
+    /// Update storage for a selfdestructed account.
+    ///
+    /// All accessed slots are recorded as written to zero since selfdestruct wipes storage.
+    #[inline]
+    pub fn update_selfdestruct(&mut self, bal_index: BalIndex, storage: &EvmStorage) {
+        for (key, value) in storage {
+            self.storage.entry(*key).or_default().update(
+                bal_index,
+                &value.original_value,
+                StorageValue::ZERO,
             );
         }
     }


### PR DESCRIPTION
## Summary
- When building the BAL for a selfdestructed account, storage slots were only recorded as reads (`update_reads`), not as writes to zero
- A subsequent transaction consuming the BAL would not see the storage zeroing and fall through to the database, getting stale pre-selfdestruct values
- Added `StorageBal::update_selfdestruct` that records all accessed slots as written to `StorageValue::ZERO`

## Test plan
- [ ] Existing tests pass (`cargo nextest run --workspace`)
- [ ] Add a BAL test with a selfdestructed account that verifies storage slots read back as zero after the selfdestruct index