### PR TITLE
refactor: thread reservoir through OOG constructors

### DIFF
--- a/crates/handler/src/frame_data.rs
+++ b/crates/handler/src/frame_data.rs
@@ -44,14 +44,18 @@ pub enum FrameResult {
 impl FrameResult {
     /// Creates a new call frame result for an out-of-gas error.
     #[inline]
-    pub fn new_call_oog(gas_limit: u64, memory_offset: core::ops::Range<usize>) -> Self {
-        Self::Call(CallOutcome::new_oog(gas_limit, memory_offset))
+    pub fn new_call_oog(
+        gas_limit: u64,
+        memory_offset: core::ops::Range<usize>,
+        reservoir: u64,
+    ) -> Self {
+        Self::Call(CallOutcome::new_oog(gas_limit, memory_offset, reservoir))
     }
 
     /// Creates a new create frame result for an out-of-gas error.
     #[inline]
-    pub fn new_create_oog(gas_limit: u64) -> Self {
-        Self::Create(CreateOutcome::new_oog(gas_limit))
+    pub fn new_create_oog(gas_limit: u64, reservoir: u64) -> Self {
+        Self::Create(CreateOutcome::new_oog(gas_limit, reservoir))
     }
 
     /// Casts frame result to interpreter result.

--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -372,7 +372,7 @@ pub trait Handler {
         let state_gas_spent = gas.state_gas_spent();
 
         // Spend the gas limit. Gas is reimbursed when the tx returns successfully.
-        *gas = Gas::new_spent(evm.ctx().tx().gas_limit());
+        *gas = Gas::new_spent_with_reservoir(evm.ctx().tx().gas_limit(), reservoir);
 
         if instruction_result.is_ok_or_revert() {
             // Return unused regular gas. Reservoir is handled separately via state_gas_spent.
@@ -393,7 +393,6 @@ pub trait Handler {
         // instruction_result kind. This is a bug in the devnet3 spec.
         if instruction_result.is_ok() {
             gas.set_state_gas_spent(state_gas_spent);
-            gas.set_reservoir(reservoir);
         } else {
             // State changes rolled back, so no execution state gas was consumed.
             gas.set_state_gas_spent(0);

--- a/crates/interpreter/src/gas.rs
+++ b/crates/interpreter/src/gas.rs
@@ -67,9 +67,9 @@ impl Gas {
 
     /// Creates a new `Gas` struct with the given gas limit, but without any gas remaining.
     #[inline]
-    pub const fn new_spent(limit: u64) -> Self {
+    pub const fn new_spent_with_reservoir(limit: u64, reservoir: u64) -> Self {
         Self {
-            tracker: GasTracker::new(limit, 0, 0),
+            tracker: GasTracker::new(limit, 0, reservoir),
             memory: MemoryGas::new(),
         }
     }

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -381,11 +381,11 @@ impl InterpreterResult {
     }
 
     /// Returns a new `InterpreterResult` for an out-of-gas error with the given gas limit.
-    pub fn new_oog(gas_limit: u64) -> Self {
+    pub fn new_oog(gas_limit: u64, reservoir: u64) -> Self {
         Self {
             result: InstructionResult::OutOfGas,
             output: Bytes::default(),
-            gas: Gas::new_spent(gas_limit),
+            gas: Gas::new_spent_with_reservoir(gas_limit, reservoir),
         }
     }
 

--- a/crates/interpreter/src/interpreter_action/call_outcome.rs
+++ b/crates/interpreter/src/interpreter_action/call_outcome.rs
@@ -51,8 +51,11 @@ impl CallOutcome {
     ///
     /// * `gas_limit` - The gas limit that was exceeded.
     /// * `memory_offset` - The range in memory indicating where the output data is stored.
-    pub fn new_oog(gas_limit: u64, memory_offset: Range<usize>) -> Self {
-        Self::new(InterpreterResult::new_oog(gas_limit), memory_offset)
+    pub fn new_oog(gas_limit: u64, memory_offset: Range<usize>, reservoir: u64) -> Self {
+        Self::new(
+            InterpreterResult::new_oog(gas_limit, reservoir),
+            memory_offset,
+        )
     }
 
     /// Returns a reference to the instruction result.

--- a/crates/interpreter/src/interpreter_action/create_outcome.rs
+++ b/crates/interpreter/src/interpreter_action/create_outcome.rs
@@ -39,8 +39,8 @@ impl CreateOutcome {
     /// # Returns
     ///
     /// A new [`CreateOutcome`] instance with no address.
-    pub fn new_oog(gas_limit: u64) -> Self {
-        Self::new(InterpreterResult::new_oog(gas_limit), None)
+    pub fn new_oog(gas_limit: u64, reservoir: u64) -> Self {
+        Self::new(InterpreterResult::new_oog(gas_limit, reservoir), None)
     }
 
     /// Retrieves a reference to the [`InstructionResult`] from the [`InterpreterResult`].


### PR DESCRIPTION
## Summary
- Rename `Gas::new_spent` → `new_spent_with_reservoir(limit, reservoir)` and propagate the reservoir parameter through `InterpreterResult::new_oog`, `CallOutcome::new_oog`, `CreateOutcome::new_oog`, and the `FrameResult::new_*_oog` helpers.
- Bakes the reservoir into OOG construction instead of setting it via a follow-up `gas.set_reservoir(reservoir)` call, removing the now-redundant call from the success branch in `last_frame_result`.
- No behavioral change — revert/halt path still overrides the reservoir to `reservoir + state_gas_spent`.

## Test plan
- [x] `cargo check -p revm-handler -p revm-interpreter`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo clippy --workspace --all-targets --all-features`