### PR TITLE
feat(gas): EIP-8037 issue #2 — 0→x→0 storage reservoir refill

### DIFF
--- a/crates/context/interface/src/cfg/gas.rs
+++ b/crates/context/interface/src/cfg/gas.rs
@@ -16,8 +16,12 @@ pub struct GasTracker {
     /// State gas reservoir (gas exceeding TX_MAX_GAS_LIMIT). Starts as `execution_gas - min(execution_gas, regular_gas_budget)`.
     /// When 0, all remaining gas is regular gas with hard cap at `TX_MAX_GAS_LIMIT`.
     reservoir: u64,
-    /// Total state gas spent so far.
-    state_gas_spent: u64,
+    /// Net state gas spent so far.
+    ///
+    /// Can be negative within a call frame when 0→x→0 storage restoration refills
+    /// more state gas than the frame itself has charged (the parent previously
+    /// charged the 0→x portion). The net is reconciled on frame return.
+    state_gas_spent: i64,
     /// Refunded gas. Used to refund the gas to the caller at the end of execution.
     refunded: i64,
 }
@@ -79,13 +83,13 @@ impl GasTracker {
 
     /// Returns the state gas spent.
     #[inline]
-    pub const fn state_gas_spent(&self) -> u64 {
+    pub const fn state_gas_spent(&self) -> i64 {
         self.state_gas_spent
     }
 
     /// Sets the state gas spent.
     #[inline]
-    pub fn set_state_gas_spent(&mut self, val: u64) {
+    pub fn set_state_gas_spent(&mut self, val: i64) {
         self.state_gas_spent = val;
     }
 
@@ -125,7 +129,7 @@ impl GasTracker {
     #[must_use = "In case of not enough gas, the interpreter should halt with an out-of-gas error"]
     pub fn record_state_cost(&mut self, cost: u64) -> bool {
         if self.reservoir >= cost {
-            self.state_gas_spent = self.state_gas_spent.saturating_add(cost);
+            self.state_gas_spent = self.state_gas_spent.saturating_add(cost as i64);
             self.reservoir -= cost;
             return true;
         }
@@ -134,10 +138,27 @@ impl GasTracker {
 
         let success = self.record_regular_cost(spill);
         if success {
-            self.state_gas_spent = self.state_gas_spent.saturating_add(cost);
+            self.state_gas_spent = self.state_gas_spent.saturating_add(cost as i64);
             self.reservoir = 0;
         }
         success
+    }
+
+    /// Refills the reservoir with state gas that is returned by 0→x→0 storage
+    /// restoration (EIP-8037 issue #2).
+    ///
+    /// Per the spec, when a storage slot is restored to its original zero value
+    /// within the same transaction, the state gas charged for the initial 0→x
+    /// transition is directly restored to the reservoir rather than routed
+    /// through the capped refund counter.
+    ///
+    /// `state_gas_spent` is decremented by the same amount and may become
+    /// negative if the matching 0→x charge was made by a parent frame. The
+    /// parent's total is reconciled on frame return.
+    #[inline]
+    pub fn refill_reservoir(&mut self, amount: u64) {
+        self.reservoir = self.reservoir.saturating_add(amount);
+        self.state_gas_spent = self.state_gas_spent.saturating_sub(amount as i64);
     }
 
     /// Records a refund value.

--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -336,8 +336,11 @@ impl GasParams {
             table[GasId::code_deposit_state_gas().as_usize()] = CPSB;
             table[GasId::create_state_gas().as_usize()] = 112 * CPSB;
 
-            // SSTORE refund for 0→X→0 restoration: state gas + regular gas
-            table[GasId::sstore_set_refund().as_usize()] = 32 * CPSB + 2800;
+            // SSTORE refund for 0→X→0 restoration: regular gas only.
+            // Under EIP-8037, the state gas portion (32 * CPSB) is restored
+            // directly to the reservoir via `GasParams::sstore_state_gas_refill`
+            // rather than routed through the capped refund counter.
+            table[GasId::sstore_set_refund().as_usize()] = 2800;
 
             // EIP-7702 parameter updates under EIP-8037
             // Total per auth charged pessimistically:
@@ -681,6 +684,21 @@ impl GasParams {
             && vals.is_original_eq_present()
             && vals.is_original_zero()
         {
+            self.get(GasId::sstore_set_state_gas())
+        } else {
+            0
+        }
+    }
+
+    /// State gas to refill the reservoir on 0→x→0 storage restoration (EIP-8037).
+    ///
+    /// When a storage slot is restored to its original zero value within the
+    /// same transaction, the state gas originally charged for the 0→x
+    /// transition is returned directly to the reservoir (not via the capped
+    /// refund counter). Returns 0 in any other case.
+    #[inline]
+    pub fn sstore_state_gas_refill(&self, vals: &SStoreResult) -> u64 {
+        if !vals.is_new_eq_present() && vals.is_original_eq_new() && vals.is_original_zero() {
             self.get(GasId::sstore_set_state_gas())
         } else {
             0

--- a/crates/ee-tests/src/eip8037.rs
+++ b/crates/ee-tests/src/eip8037.rs
@@ -1383,7 +1383,13 @@ fn test_eip8037_nested_call_create_sstore() {
 
 // ---- Category 6: Interactions ----
 
-/// 6.1 SSTORE 0→1 (state gas), then 1→0 (refund). Refund does NOT undo state gas.
+/// 6.1 SSTORE 0→1 (state gas), then 1→0 restoration.
+///
+/// EIP-8037 issue #2: 0→x→0 storage restoration directly refills the reservoir
+/// with the state gas originally charged for the 0→x transition, rather than
+/// routing it through the capped refund counter. The state gas net-out means
+/// `state_gas_spent == 0` after the full set+clear cycle, and no net state
+/// gas shows up in `total_gas_spent`.
 #[test]
 fn test_eip8037_sstore_set_then_clear_refund() {
     let bytecode = sstore_set_then_clear_bytecode();
@@ -1392,7 +1398,6 @@ fn test_eip8037_sstore_set_then_clear_refund() {
     let baseline_result = baseline
         .transact_one(TxEnv::builder_for_bench().gas_price(0).build_fill())
         .unwrap();
-    let baseline_gas = baseline_result.tx_gas_used();
 
     let mut evm = state_gas_evm(bytecode, u64::MAX);
     let result = evm
@@ -1400,13 +1405,13 @@ fn test_eip8037_sstore_set_then_clear_refund() {
         .unwrap();
 
     assert!(result.is_success());
-    // State gas increases spent by exactly STATE_GAS_SSTORE_SET.
-    assert_eq!(result.gas().state_gas_spent(), STATE_GAS_SSTORE_SET);
-    let spent_delta = result.gas().total_gas_spent() - baseline_result.gas().total_gas_spent();
-    assert_eq!(spent_delta, STATE_GAS_SSTORE_SET);
-    // Refund does NOT undo state gas — gas_used is higher than baseline.
-    assert!(result.tx_gas_used() > baseline_gas);
-    assert!(result.gas().total_gas_spent() > baseline_result.gas().total_gas_spent());
+    // State gas originally charged for 0→1 is refilled by the 1→0 restoration.
+    assert_eq!(result.gas().state_gas_spent(), 0);
+    // Total gas spent matches baseline — reservoir ends where it started.
+    assert_eq!(
+        result.gas().total_gas_spent(),
+        baseline_result.gas().total_gas_spent()
+    );
     compare_or_save_eip8037_testdata(
         "test_eip8037_sstore_set_then_clear_refund.json",
         &(baseline_result, result),

--- a/crates/ee-tests/src/eip8037.rs
+++ b/crates/ee-tests/src/eip8037.rs
@@ -2046,3 +2046,138 @@ fn test_eip8037_parent_sstore_after_child_revert() {
         &(baseline_result, result),
     );
 }
+
+// ---- EIP-8037 issue #2: 0→x→0 storage reservoir refill ----
+
+/// EIP-8037 issue #2 — same frame: 0→1→0 restoration refills the reservoir
+/// with the state gas originally charged on 0→1 (via `refill_reservoir`)
+/// rather than routing it through the capped refund counter.
+///
+/// Compared against a set-only variant (0→1 with no clear): the set-then-clear
+/// variant must end with `state_gas_spent == 0`, while the set-only variant
+/// retains the full `STATE_GAS_SSTORE_SET` charge.
+#[test]
+fn test_eip8037_sstore_refill_same_frame() {
+    let mut evm = state_gas_evm(sstore_set_then_clear_bytecode(), u64::MAX);
+    let restored = evm
+        .transact_one(TxEnv::builder_for_bench().gas_price(0).build_fill())
+        .unwrap();
+
+    let mut evm = state_gas_evm(sstore_bytecode(0, 1), u64::MAX);
+    let set_only = evm
+        .transact_one(TxEnv::builder_for_bench().gas_price(0).build_fill())
+        .unwrap();
+
+    assert!(restored.is_success());
+    assert!(set_only.is_success());
+
+    // The refill nets state gas back to zero for the 0→1→0 round-trip.
+    assert_eq!(restored.gas().state_gas_spent(), 0);
+    // Without the clear, the full state gas stays spent.
+    assert_eq!(set_only.gas().state_gas_spent(), STATE_GAS_SSTORE_SET);
+}
+
+/// Parent SSTORE(0,1), CREATE a child, DELEGATECALL the child which SSTORE(0,0).
+///
+/// DELEGATECALL runs the child's code in the parent's storage context, so the
+/// child's SSTORE clears the slot the parent set. Used to exercise the
+/// cross-frame 0→x→0 case.
+fn sstore_parent_then_delegatecall_clear_bytecode() -> Bytecode {
+    // Child runtime: SSTORE(0, 0); STOP
+    let child_runtime: [u8; 6] = [
+        opcode::PUSH1,
+        0,
+        opcode::PUSH1,
+        0,
+        opcode::SSTORE,
+        opcode::STOP,
+    ];
+
+    // Init code: MSTORE8 each byte of child_runtime, then RETURN(0, len).
+    let mut init_code = Vec::new();
+    for (i, &byte) in child_runtime.iter().enumerate() {
+        init_code.push(opcode::PUSH1);
+        init_code.push(byte);
+        init_code.push(opcode::PUSH1);
+        init_code.push(i as u8);
+        init_code.push(opcode::MSTORE8);
+    }
+    init_code.push(opcode::PUSH1);
+    init_code.push(child_runtime.len() as u8);
+    init_code.push(opcode::PUSH1);
+    init_code.push(0);
+    init_code.push(opcode::RETURN);
+
+    let mut bytecode = Vec::new();
+
+    // Parent: SSTORE(0, 1) — state gas charged on the parent frame.
+    bytecode.push(opcode::PUSH1);
+    bytecode.push(1);
+    bytecode.push(opcode::PUSH1);
+    bytecode.push(0);
+    bytecode.push(opcode::SSTORE);
+
+    // MSTORE8 init_code into memory.
+    for (i, &byte) in init_code.iter().enumerate() {
+        bytecode.push(opcode::PUSH1);
+        bytecode.push(byte);
+        bytecode.push(opcode::PUSH1);
+        bytecode.push(i as u8);
+        bytecode.push(opcode::MSTORE8);
+    }
+
+    // CREATE(value=0, offset=0, length=init_code.len())
+    bytecode.push(opcode::PUSH1);
+    bytecode.push(init_code.len() as u8);
+    bytecode.push(opcode::PUSH1);
+    bytecode.push(0);
+    bytecode.push(opcode::PUSH1);
+    bytecode.push(0);
+    bytecode.push(opcode::CREATE);
+    // Stack: [child_addr]
+
+    // DELEGATECALL args (retLen, retOff, argsLen, argsOff, addr, gas).
+    for _ in 0..4 {
+        bytecode.push(opcode::PUSH1);
+        bytecode.push(0);
+    }
+    // Stack: [child_addr, 0, 0, 0, 0]
+    bytecode.push(opcode::SWAP4);
+    // Stack: [0, 0, 0, 0, child_addr]
+    bytecode.push(opcode::GAS);
+    // Stack: [0, 0, 0, 0, child_addr, gas]
+    bytecode.push(opcode::DELEGATECALL);
+    bytecode.push(opcode::POP);
+    bytecode.push(opcode::STOP);
+
+    Bytecode::new_legacy(bytecode.into())
+}
+
+/// EIP-8037 issue #2 — cross frame: parent charges state gas on SSTORE(0,1),
+/// then DELEGATECALLs a child that does SSTORE(0,0). Because DELEGATECALL
+/// shares the caller's storage, the child performs the 0→1→0 restoration
+/// and calls `refill_reservoir` inside its own frame, driving the child's
+/// `state_gas_spent` to `-STATE_GAS_SSTORE_SET`. On frame return, the
+/// parent's +STATE_GAS_SSTORE_SET and the child's negative net out via the
+/// i64 accumulation in `handle_reservoir_remaining_gas`.
+///
+/// After the call, only the parent's CREATE + code-deposit state gas
+/// remains; the SSTORE round-trip leaves no net state gas.
+#[test]
+fn test_eip8037_sstore_refill_cross_frame() {
+    const CHILD_RUNTIME_LEN: u64 = 6;
+
+    let bytecode = sstore_parent_then_delegatecall_clear_bytecode();
+
+    let mut evm = state_gas_evm(bytecode, u64::MAX);
+    let result = evm
+        .transact_one(TxEnv::builder_for_bench().gas_price(0).build_fill())
+        .unwrap();
+
+    assert!(result.is_success());
+
+    // Parent charged STATE_GAS_SSTORE_SET on 0→1; the child's DELEGATECALL
+    // refills it on 1→0. Only the CREATE + code-deposit state gas remains.
+    let expected_state_gas = STATE_GAS_CREATE + STATE_GAS_CODE_DEPOSIT * CHILD_RUNTIME_LEN;
+    assert_eq!(result.gas().state_gas_spent(), expected_state_gas);
+}

--- a/crates/ee-tests/src/revm_tests.rs
+++ b/crates/ee-tests/src/revm_tests.rs
@@ -742,19 +742,17 @@ fn test_custom_opcode_transaction() {
     let mut instructions = EthInstructions::new_mainnet_with_spec(SpecId::CANCUN);
     instructions.insert_instruction(
         DOUBLE,
-        Instruction::new(
-            |ctx: InstructionContext<'_, _, EthInterpreter>| {
-                let Ok(val) = ctx.interpreter.stack.pop() else {
-                    ctx.interpreter.halt_underflow();
-                    return;
-                };
-                if !ctx.interpreter.stack.push(val.wrapping_mul(U256::from(2))) {
-                    ctx.interpreter
-                        .halt(revm::interpreter::InstructionResult::StackOverflow);
-                }
-            },
-            3, // static gas cost (same as ADD)
-        ),
+        Instruction::new(|ctx: InstructionContext<'_, _, EthInterpreter>| {
+            let Ok(val) = ctx.interpreter.stack.pop() else {
+                ctx.interpreter.halt_underflow();
+                return;
+            };
+            if !ctx.interpreter.stack.push(val.wrapping_mul(U256::from(2))) {
+                ctx.interpreter
+                    .halt(revm::interpreter::InstructionResult::StackOverflow);
+            }
+        }),
+        3, // static gas cost (same as ADD)
     );
 
     let mut evm = Evm::new(ctx, instructions, EthPrecompiles::new(SpecId::CANCUN));

--- a/crates/ee-tests/tests/eip8037_testdata/test_eip8037_sstore_set_then_clear_refund.json
+++ b/crates/ee-tests/tests/eip8037_testdata/test_eip8037_sstore_set_then_clear_refund.json
@@ -3,7 +3,7 @@
     "Success": {
       "gas": {
         "floor_gas": 21000,
-        "gas_refunded": 5222,
+        "gas_refunded": 2800,
         "gas_spent": 26112,
         "state_gas_spent": 0
       },
@@ -18,9 +18,9 @@
     "Success": {
       "gas": {
         "floor_gas": 21000,
-        "gas_refunded": 40368,
-        "gas_spent": 226112,
-        "state_gas_spent": 200000
+        "gas_refunded": 2800,
+        "gas_spent": 26112,
+        "state_gas_spent": 0
       },
       "logs": [],
       "output": {

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -553,7 +553,15 @@ pub fn handle_reservoir_remaining_gas(
         // Parent may have already charged state gas (e.g., new_account + create) before
         // creating the child frame. Child starts with state_gas_spent=0, so we must add
         // rather than overwrite to preserve the parent's prior charges.
-        parent_gas.set_state_gas_spent(parent_gas.state_gas_spent() + child_gas.state_gas_spent());
+        //
+        // `child.state_gas_spent()` can be negative (EIP-8037 issue #2) when the
+        // child did more 0→x→0 restorations than 0→x creations; the negative
+        // contribution is the parent's matching charge flowing back out.
+        parent_gas.set_state_gas_spent(
+            parent_gas
+                .state_gas_spent()
+                .saturating_add(child_gas.state_gas_spent()),
+        );
     } else {
         // On revert or halt: state changes are undone, so ALL state gas returns
         // to the parent's reservoir.
@@ -563,7 +571,17 @@ pub fn handle_reservoir_remaining_gas(
         // This replaces (not adds to) the parent's reservoir because the child started with
         // the parent's reservoir value (REVM doesn't zero it before the call), so the child's
         // total already includes the parent's original reservoir.
-        parent_gas.set_reservoir(child_gas.state_gas_spent() + child_gas.reservoir());
+        //
+        // `child.state_gas_spent()` can be negative when the child refilled the
+        // reservoir past what it itself charged (0→x→0 restoration on a slot
+        // the parent had set). The net `state_gas_spent + reservoir` cannot
+        // legitimately go below zero — the parent had already consumed the
+        // extra reservoir via its own 0→x charge, so the child's reservoir is
+        // correspondingly higher — but we saturate defensively.
+        let combined = (child_gas.state_gas_spent())
+            .saturating_add_unsigned(child_gas.reservoir())
+            .max(0) as u64;
+        parent_gas.set_reservoir(combined);
     }
 }
 

--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -395,8 +395,12 @@ pub trait Handler {
             gas.set_state_gas_spent(state_gas_spent);
         } else {
             // State changes rolled back, so no execution state gas was consumed.
+            // `state_gas_spent` can be negative (EIP-8037 issue #2) if the top
+            // frame refilled more than it charged; clamp to zero for reservoir
+            // recovery since the combined value cannot go below zero.
             gas.set_state_gas_spent(0);
-            gas.set_reservoir(reservoir + state_gas_spent);
+            let combined = state_gas_spent.saturating_add_unsigned(reservoir).max(0) as u64;
+            gas.set_reservoir(combined);
         }
 
         Ok(())

--- a/crates/handler/src/post_execution.rs
+++ b/crates/handler/src/post_execution.rs
@@ -10,8 +10,11 @@ use primitives::{hardfork::SpecId, U256};
 
 /// Builds a [`ResultGas`] from the execution [`Gas`] struct and [`InitialAndFloorGas`].
 pub fn build_result_gas(gas: &Gas, init_and_floor_gas: InitialAndFloorGas) -> ResultGas {
-    let state_gas = gas
-        .state_gas_spent()
+    // `state_gas_spent` is tracked as i64 to allow a child frame's count to go
+    // negative on 0→x→0 restoration; at the top level, post-reconciliation it
+    // is expected to be >= 0 and is clamped defensively before combining with
+    // intrinsic state gas.
+    let state_gas = (gas.state_gas_spent().max(0) as u64)
         .saturating_add(init_and_floor_gas.initial_state_gas)
         .saturating_sub(init_and_floor_gas.eip7702_reservoir_refund);
 

--- a/crates/handler/src/precompile_provider.rs
+++ b/crates/handler/src/precompile_provider.rs
@@ -97,7 +97,7 @@ pub fn precompile_output_to_interpreter_result(
     };
 
     // set state gas, reservoir is already set in the Gas constructor
-    result.gas.set_state_gas_spent(output.state_gas_used);
+    result.gas.set_state_gas_spent(output.state_gas_used as i64);
     result.gas.record_refund(output.gas_refunded);
 
     // spend used gas.

--- a/crates/inspector/src/eip3155.rs
+++ b/crates/inspector/src/eip3155.rs
@@ -256,7 +256,10 @@ where
         self.mem_size = interp.memory.size();
         self.gas = interp.gas.remaining();
         self.reservoir = interp.gas.reservoir();
-        self.state_gas = interp.gas.state_gas_spent();
+        // Clamp to 0: EIP-8037 allows state_gas_spent to briefly go negative
+        // within a child frame (0→x→0 restoration); the tracer exposes it as a
+        // u64 counter.
+        self.state_gas = interp.gas.state_gas_spent().max(0) as u64;
         self.refunded = interp.gas.refunded();
     }
 

--- a/crates/inspector/src/gas.rs
+++ b/crates/inspector/src/gas.rs
@@ -7,7 +7,7 @@ use interpreter::{CallOutcome, CreateOutcome, Gas};
 pub struct GasInspector {
     gas_remaining: u64,
     last_gas_cost: u64,
-    state_gas_spent: u64,
+    state_gas_spent: i64,
     reservoir: u64,
 }
 
@@ -31,8 +31,12 @@ impl GasInspector {
     }
 
     /// Returns the state gas spent.
+    ///
+    /// Can be negative within a call frame (EIP-8037 issue #2): a child that
+    /// restores a slot set by its parent via 0→x→0 goes negative until the
+    /// frame returns and the parent's charge is reconciled.
     #[inline]
-    pub fn state_gas_spent(&self) -> u64 {
+    pub fn state_gas_spent(&self) -> i64 {
         self.state_gas_spent
     }
 

--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -160,7 +160,7 @@ where
                 let result_gas = ResultGas::default()
                     .with_total_gas_spent(gas.total_gas_spent())
                     .with_refunded(gas.refunded() as u64)
-                    .with_state_gas_spent(gas.state_gas_spent());
+                    .with_state_gas_spent(gas.state_gas_spent().max(0) as u64);
                 self.execution_result(evm, exec_result, result_gas)
             }) {
             out @ Ok(_) => out,

--- a/crates/interpreter/src/gas.rs
+++ b/crates/interpreter/src/gas.rs
@@ -153,15 +153,27 @@ impl Gas {
     }
 
     /// Returns total state gas spent so far.
+    ///
+    /// Can be negative within a call frame when 0→x→0 storage restoration
+    /// refills more state gas than this frame charged (see
+    /// [`GasTracker::refill_reservoir`]).
     #[inline]
-    pub const fn state_gas_spent(&self) -> u64 {
+    pub const fn state_gas_spent(&self) -> i64 {
         self.tracker.state_gas_spent()
     }
 
     /// Sets the total state gas spent (used when propagating from child frame).
     #[inline]
-    pub fn set_state_gas_spent(&mut self, val: u64) {
+    pub fn set_state_gas_spent(&mut self, val: i64) {
         self.tracker.set_state_gas_spent(val);
+    }
+
+    /// Refills the reservoir with state gas returned by 0→x→0 storage restoration.
+    ///
+    /// See [`GasTracker::refill_reservoir`].
+    #[inline]
+    pub fn refill_reservoir(&mut self, amount: u64) {
+        self.tracker.refill_reservoir(amount);
     }
 
     /// Erases a gas cost from remaining (returns gas from child frame).
@@ -406,6 +418,35 @@ mod tests {
         // On OOG, state_gas_spent is NOT incremented and reservoir is unchanged
         assert_eq!(gas.state_gas_spent(), 0);
         assert_eq!(gas.reservoir(), 20);
+    }
+
+    /// Refill reservoir restores state gas in-place (EIP-8037 0→x→0 restoration).
+    ///
+    /// The refill decrements `state_gas_spent` and may drive it negative if the
+    /// matching charge was made by a parent frame.
+    #[test]
+    fn test_refill_reservoir() {
+        // Simple case: charge then refill within the same frame.
+        let mut gas = Gas::new_with_regular_gas_and_reservoir(1000, 500);
+        assert!(gas.record_state_cost(200));
+        assert_eq!(
+            (gas.reservoir(), gas.remaining(), gas.state_gas_spent()),
+            (300, 1000, 200)
+        );
+        gas.refill_reservoir(200);
+        assert_eq!(
+            (gas.reservoir(), gas.remaining(), gas.state_gas_spent()),
+            (500, 1000, 0)
+        );
+
+        // Child-frame case: refill without a prior charge makes state_gas_spent
+        // negative. The parent's matching +charge is reconciled on return.
+        let mut gas = Gas::new_with_regular_gas_and_reservoir(1000, 100);
+        gas.refill_reservoir(300);
+        assert_eq!(
+            (gas.reservoir(), gas.remaining(), gas.state_gas_spent()),
+            (400, 1000, -300)
+        );
     }
 
     /// A.3: State gas with zero regular remaining but non-zero reservoir.

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -269,6 +269,18 @@ pub fn sstore<WIRE: InterpreterTypes, H: Host + ?Sized>(context: InstructionCont
             context.interpreter,
             context.host.gas_params().sstore_state_gas(&state_load.data)
         );
+
+        // EIP-8037 issue #2: 0→x→0 storage restoration refills the reservoir
+        // directly rather than routing the state gas through the capped refund
+        // counter. The regular-gas portion of the restoration still flows
+        // through `sstore_refund` below.
+        let refill = context
+            .host
+            .gas_params()
+            .sstore_state_gas_refill(&state_load.data);
+        if refill > 0 {
+            context.interpreter.gas.refill_reservoir(refill);
+        }
     }
 
     // refund


### PR DESCRIPTION
## Summary

Implements [EIP-8037 spec review issue #2](https://github.com/misilva73/evm-gas-repricings/blob/main/reports/eip-8037/spec_review_state_gas_accounting.md): when a storage slot is restored to its original zero value within the same transaction (`0 → x → 0`), the state gas originally charged for the `0 → x` transition is returned **directly to the reservoir** rather than routed through the capped (`spent / 5`) refund counter. This preserves the invariant that state gas consumption tracks actual state creation.

Because the matching `0 → x` charge may live on a parent frame, a child frame's `state_gas_spent` can legitimately go **negative** until it returns and the parent reconciles. `state_gas_spent` is therefore now tracked as `i64`.

## Changes

- `GasTracker.state_gas_spent`: `u64` → `i64`.
- New `GasTracker::refill_reservoir(amount)` (mirrored on `Gas`): adds to `reservoir`, subtracts from `state_gas_spent`.
- New `GasParams::sstore_state_gas_refill`: returns `32 × CPSB` only on `0 → x → 0`, else `0`.
- SSTORE instruction calls `refill_reservoir` when EIP-8037 is enabled and the restoration condition matches.
- EIP-8037 gas table: `sstore_set_refund` drops from `32 × CPSB + 2800` to `2800`. The state portion now flows through the reservoir, not the refund counter.
- `handle_reservoir_remaining_gas` (frame.rs):
  - success: `saturating_add` of the i64 net-outs the parent's matching charge.
  - revert/halt: `state_gas_spent + reservoir` computed as i64, clamped to 0.
- Top-frame reconciliation (`handler.rs`) and `build_result_gas` (`post_execution.rs`) clamp to 0 before the public `u64` surface.
- Precompile + inspector (`eip3155`, `gas`, `handler`) plumbing updated for the i64 switch.

## Test plan

- [x] `cargo test -p revm-ee-tests` — 49 passed.
- [x] `cargo test -p revm-interpreter` (gas tests incl. new `test_refill_reservoir`) — pass.
- [x] `cargo test --workspace --lib` — all green.
- [x] `cargo clippy --workspace --all-targets` — clean.
- [x] `test_eip8037_sstore_set_then_clear_refund` updated: `state_gas_spent == 0` after `0 → 1 → 0`, total gas spent matches baseline. Golden JSON regenerated.
- [x] Consider adding an integration test for the cross-frame `0 → x → 0` case (parent sets `0 → x`, DELEGATECALL child clears to `0`, expect parent's `state_gas_spent == 0` on return).