### PR TITLE
perf: avoid cloning precompiles on warmup

### DIFF
--- a/crates/bytecode/src/bytecode/mod.rs
+++ b/crates/bytecode/src/bytecode/mod.rs
@@ -105,8 +105,8 @@ impl Bytecode {
     /// Creates a new legacy analyzed [`Bytecode`] with exactly one STOP opcode.
     #[inline]
     pub fn new() -> Self {
-        static DEFAULT_BYTECODE: OnceLock<Bytecode> = OnceLock::new();
-        DEFAULT_BYTECODE
+        static DEFAULT: OnceLock<Bytecode> = OnceLock::new();
+        DEFAULT
             .get_or_init(|| {
                 Self(Arc::new(BytecodeInner {
                     kind: BytecodeKind::LegacyAnalyzed,

--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -111,7 +111,7 @@ pub trait JournalTr {
     fn warm_coinbase_account(&mut self, address: Address);
 
     /// Warms the precompiles.
-    fn warm_precompiles(&mut self, addresses: AddressSet);
+    fn warm_precompiles(&mut self, addresses: &AddressSet);
 
     /// Returns the addresses of the precompiles.
     fn precompile_addresses(&self) -> &AddressSet;

--- a/crates/context/src/journal.rs
+++ b/crates/context/src/journal.rs
@@ -106,10 +106,12 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
         }
     }
 
+    #[inline]
     fn db(&self) -> &Self::Database {
         &self.database
     }
 
+    #[inline]
     fn db_mut(&mut self) -> &mut Self::Database {
         &mut self.database
     }
@@ -173,11 +175,13 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
         self.inner.warm_addresses.set_access_list(access_list);
     }
 
+    #[inline]
     fn warm_coinbase_account(&mut self, address: Address) {
         self.inner.warm_addresses.set_coinbase(address);
     }
 
-    fn warm_precompiles(&mut self, precompiles: AddressSet) {
+    #[inline]
+    fn warm_precompiles(&mut self, precompiles: &AddressSet) {
         self.inner
             .warm_addresses
             .set_precompile_addresses(precompiles);

--- a/crates/context/src/journal/warm_addresses.rs
+++ b/crates/context/src/journal/warm_addresses.rs
@@ -65,8 +65,7 @@ impl WarmAddresses {
     }
 
     /// Set the precompile addresses and short addresses.
-    #[inline]
-    pub fn set_precompile_addresses(&mut self, addresses: AddressSet) {
+    pub fn set_precompile_addresses(&mut self, addresses: &AddressSet) {
         self.precompile_short_addresses.fill(false);
 
         let mut all_short_addresses = true;
@@ -79,7 +78,7 @@ impl WarmAddresses {
         }
 
         self.precompile_all_short_addresses = all_short_addresses;
-        self.precompile_set = addresses;
+        self.precompile_set.clone_from(addresses);
     }
 
     /// Set the coinbase address.
@@ -114,7 +113,6 @@ impl WarmAddresses {
     }
 
     /// Returns true if the address is warm loaded.
-    #[inline]
     pub fn is_warm(&self, address: &Address) -> bool {
         // check if it is coinbase
         if Some(*address) == self.coinbase {
@@ -161,7 +159,6 @@ impl WarmAddresses {
     }
 
     /// Checks if the address is cold loaded and returns an error if it is and skip_cold_load is true.
-    #[inline(never)]
     pub fn check_is_cold<E>(
         &self,
         address: &Address,
@@ -231,7 +228,7 @@ mod tests {
         precompiles.insert(short_addr1);
         precompiles.insert(short_addr2);
 
-        warm_addresses.set_precompile_addresses(precompiles.clone());
+        warm_addresses.set_precompile_addresses(&precompiles);
 
         // Verify storage
         assert_eq!(warm_addresses.precompile_set, precompiles);
@@ -271,7 +268,7 @@ mod tests {
         precompiles.insert(regular_addr);
         precompiles.insert(boundary_addr);
 
-        warm_addresses.set_precompile_addresses(precompiles.clone());
+        warm_addresses.set_precompile_addresses(&precompiles);
 
         // Verify storage
         assert_eq!(warm_addresses.precompile_set, precompiles);
@@ -299,7 +296,7 @@ mod tests {
         precompiles.insert(short_addr);
         precompiles.insert(regular_addr);
 
-        warm_addresses.set_precompile_addresses(precompiles);
+        warm_addresses.set_precompile_addresses(&precompiles);
 
         // Both types should be warm
         assert!(warm_addresses.is_warm(&short_addr));
@@ -324,7 +321,7 @@ mod tests {
         let mut precompiles = HashSet::default();
         precompiles.insert(boundary_addr);
 
-        warm_addresses.set_precompile_addresses(precompiles);
+        warm_addresses.set_precompile_addresses(&precompiles);
 
         assert!(warm_addresses.is_warm(&boundary_addr));
         assert!(warm_addresses.precompile_short_addresses[SHORT_ADDRESS_CAP - 1]);

--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -36,7 +36,7 @@ pub fn load_accounts<
         // When precompiles addresses are changed we reset the warmed hashmap to those new addresses.
         context
             .journal_mut()
-            .warm_precompiles(precompiles.warm_addresses().collect());
+            .warm_precompiles(precompiles.warm_addresses());
     }
 
     // Load coinbase

--- a/crates/handler/src/precompile_provider.rs
+++ b/crates/handler/src/precompile_provider.rs
@@ -3,11 +3,8 @@ use context::{Cfg, LocalContextTr};
 use context_interface::{ContextTr, JournalTr};
 use interpreter::{CallInputs, Gas, InstructionResult, InterpreterResult};
 use precompile::{PrecompileOutput, PrecompileSpecId, PrecompileStatus, Precompiles};
-use primitives::{hardfork::SpecId, Address, Bytes};
-use std::{
-    boxed::Box,
-    string::{String, ToString},
-};
+use primitives::{hardfork::SpecId, Address, AddressSet, Bytes};
+use std::string::{String, ToString};
 
 /// Provider for precompiled contracts in the EVM.
 #[auto_impl(&mut, Box)]
@@ -28,10 +25,12 @@ pub trait PrecompileProvider<CTX: ContextTr> {
     ) -> Result<Option<Self::Output>, String>;
 
     /// Get the warm addresses.
-    fn warm_addresses(&self) -> Box<impl Iterator<Item = Address>>;
+    fn warm_addresses(&self) -> &AddressSet;
 
     /// Check if the address is a precompile.
-    fn contains(&self, address: &Address) -> bool;
+    fn contains(&self, address: &Address) -> bool {
+        self.warm_addresses().contains(address)
+    }
 }
 
 /// The [`PrecompileProvider`] for ethereum precompiles.
@@ -53,8 +52,8 @@ impl EthPrecompiles {
     }
 
     /// Returns addresses of the precompiles.
-    pub fn warm_addresses(&self) -> Box<impl Iterator<Item = Address>> {
-        Box::new(self.precompiles.addresses().cloned())
+    pub fn warm_addresses(&self) -> &AddressSet {
+        self.precompiles.addresses_set()
     }
 
     /// Returns whether the address is a precompile.
@@ -169,7 +168,7 @@ impl<CTX: ContextTr> PrecompileProvider<CTX> for EthPrecompiles {
         Ok(Some(result))
     }
 
-    fn warm_addresses(&self) -> Box<impl Iterator<Item = Address>> {
+    fn warm_addresses(&self) -> &AddressSet {
         Self::warm_addresses(self)
     }
 

--- a/examples/cheatcode_inspector/src/main.rs
+++ b/examples/cheatcode_inspector/src/main.rs
@@ -125,7 +125,7 @@ impl JournalTr for Backend {
         self.journaled_state.warm_coinbase_account(address)
     }
 
-    fn warm_precompiles(&mut self, addresses: AddressSet) {
+    fn warm_precompiles(&mut self, addresses: &AddressSet) {
         self.journaled_state.warm_precompiles(addresses)
     }
 

--- a/examples/custom_precompile_journal/src/precompile_provider.rs
+++ b/examples/custom_precompile_journal/src/precompile_provider.rs
@@ -6,9 +6,9 @@ use revm::{
     handler::{precompile_output_to_interpreter_result, EthPrecompiles, PrecompileProvider},
     interpreter::{CallInputs, InterpreterResult},
     precompile::{EthPrecompileOutput, EthPrecompileResult, PrecompileHalt, PrecompileOutput},
-    primitives::{address, hardfork::SpecId, Address, Bytes, Log, B256, U256},
+    primitives::{address, hardfork::SpecId, Address, AddressSet, Bytes, Log, B256, U256},
 };
-use std::{boxed::Box, string::String};
+use std::string::String;
 
 // Define our custom precompile address
 pub const CUSTOM_PRECOMPILE_ADDRESS: Address = address!("0000000000000000000000000000000000000100");
@@ -20,15 +20,25 @@ const STORAGE_KEY: U256 = U256::ZERO;
 #[derive(Debug, Clone)]
 pub struct CustomPrecompileProvider {
     inner: EthPrecompiles,
+    addresses: AddressSet,
     spec: SpecId,
 }
 
 impl CustomPrecompileProvider {
     pub fn new_with_spec(spec: SpecId) -> Self {
-        Self {
+        let mut this = Self {
             inner: EthPrecompiles::new(spec),
+            addresses: AddressSet::default(),
             spec,
-        }
+        };
+        this.renew();
+        this
+    }
+
+    fn renew(&mut self) {
+        // Include our custom precompile address along with standard ones
+        self.addresses.clone_from(&mut self.inner.warm_addresses());
+        self.addresses.insert(CUSTOM_PRECOMPILE_ADDRESS);
     }
 }
 
@@ -43,8 +53,8 @@ where
             return false;
         }
         self.spec = spec;
-        // Create a new inner provider with the new spec
         self.inner = EthPrecompiles::new(spec);
+        self.renew();
         true
     }
 
@@ -62,15 +72,8 @@ where
         self.inner.run(context, inputs)
     }
 
-    fn warm_addresses(&self) -> Box<impl Iterator<Item = Address>> {
-        // Include our custom precompile address along with standard ones
-        let mut addresses = vec![CUSTOM_PRECOMPILE_ADDRESS];
-        addresses.extend(self.inner.warm_addresses());
-        Box::new(addresses.into_iter())
-    }
-
-    fn contains(&self, address: &Address) -> bool {
-        *address == CUSTOM_PRECOMPILE_ADDRESS || self.inner.contains(address)
+    fn warm_addresses(&self) -> &AddressSet {
+        &self.addresses
     }
 }
 


### PR DESCRIPTION
Removes the Box + collect in `.warm_precompiles(precompiles.warm_addresses().collect());`.
`Precompiles` already stores the addresses as a separate set so we can use that directly.