### PR TITLE
perf(interpreter): optimize MLOAD/MSTORE with direct u256 memory ops

### DIFF
--- a/crates/interpreter/src/instructions/memory.rs
+++ b/crates/interpreter/src/instructions/memory.rs
@@ -12,8 +12,7 @@ pub fn mload<WIRE: InterpreterTypes, H: Host + ?Sized>(context: InstructionConte
     popn_top!([], top, context.interpreter);
     let offset = as_usize_or_fail!(context.interpreter, top);
     resize_memory!(context.interpreter, context.host.gas_params(), offset, 32);
-    *top =
-        U256::try_from_be_slice(context.interpreter.memory.slice_len(offset, 32).as_ref()).unwrap()
+    *top = context.interpreter.memory.get_u256(offset)
 }
 
 /// Implements the MSTORE instruction.
@@ -23,10 +22,7 @@ pub fn mstore<WIRE: InterpreterTypes, H: Host + ?Sized>(context: InstructionCont
     popn!([offset, value], context.interpreter);
     let offset = as_usize_or_fail!(context.interpreter, offset);
     resize_memory!(context.interpreter, context.host.gas_params(), offset, 32);
-    context
-        .interpreter
-        .memory
-        .set(offset, &value.to_be_bytes::<32>());
+    context.interpreter.memory.set_u256(offset, value);
 }
 
 /// Implements the MSTORE8 instruction.

--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -6,6 +6,7 @@ use core::{
     cmp::min,
     fmt,
     ops::Range,
+    ptr,
 };
 use primitives::{hex, B256, U256};
 use std::{rc::Rc, vec::Vec};
@@ -87,6 +88,34 @@ impl MemoryTr for SharedMemory {
 
     fn slice(&self, range: Range<usize>) -> Ref<'_, [u8]> {
         self.slice_range(range)
+    }
+
+    #[inline]
+    fn get_u256(&self, offset: usize) -> U256 {
+        let buffer = self.buffer_ref();
+        let start = self.my_checkpoint + offset;
+        assert!(start + 32 <= buffer.len(), "get_u256 out of bounds");
+        let ptr = unsafe { buffer.as_ptr().add(start) };
+        let limb3 = u64::from_be(unsafe { ptr::read_unaligned(ptr.cast::<u64>()) });
+        let limb2 = u64::from_be(unsafe { ptr::read_unaligned(ptr.add(8).cast::<u64>()) });
+        let limb1 = u64::from_be(unsafe { ptr::read_unaligned(ptr.add(16).cast::<u64>()) });
+        let limb0 = u64::from_be(unsafe { ptr::read_unaligned(ptr.add(24).cast::<u64>()) });
+        U256::from_limbs([limb0, limb1, limb2, limb3])
+    }
+
+    #[inline]
+    fn set_u256(&mut self, offset: usize, value: U256) {
+        let limbs = value.as_limbs();
+        let mut buffer = self.buffer_ref_mut();
+        let start = self.my_checkpoint + offset;
+        assert!(start + 32 <= buffer.len(), "set_u256 out of bounds");
+        let ptr = unsafe { buffer.as_mut_ptr().add(start) };
+        unsafe {
+            ptr::write_unaligned(ptr.cast::<u64>(), limbs[3].to_be());
+            ptr::write_unaligned(ptr.add(8).cast::<u64>(), limbs[2].to_be());
+            ptr::write_unaligned(ptr.add(16).cast::<u64>(), limbs[1].to_be());
+            ptr::write_unaligned(ptr.add(24).cast::<u64>(), limbs[0].to_be());
+        }
     }
 
     fn local_memory_offset(&self) -> usize {
@@ -385,7 +414,7 @@ impl SharedMemory {
     /// Panics on out of bounds.
     #[inline]
     pub fn get_u256(&self, offset: usize) -> U256 {
-        self.get_word(offset).into()
+        <Self as MemoryTr>::get_u256(self, offset)
     }
 
     /// Sets the `byte` at the given `index`.
@@ -418,7 +447,7 @@ impl SharedMemory {
     #[inline]
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn set_u256(&mut self, offset: usize, value: U256) {
-        self.set(offset, &value.to_be_bytes::<32>());
+        <Self as MemoryTr>::set_u256(self, offset, value)
     }
 
     /// Set memory region at given `offset`.
@@ -689,5 +718,22 @@ mod tests {
         assert_eq!(sm1.buffer_ref().len(), 32);
         assert_eq!(sm1.len(), 32);
         assert_eq!(sm1.buffer_ref().get(0..32), Some(&[0_u8; 32] as &[u8]));
+    }
+
+    #[test]
+    fn get_set_u256_roundtrip_preserves_be_layout() {
+        let mut sm = SharedMemory::new();
+        sm.resize(64);
+
+        let value = U256::from_limbs([
+            0x8899_aabb_ccdd_eeff,
+            0x0011_2233_4455_6677,
+            0x0123_4567_89ab_cdef,
+            0xfedc_ba98_7654_3210,
+        ]);
+        sm.set_u256(8, value);
+
+        assert_eq!(sm.get_u256(8), value);
+        assert_eq!(&*sm.slice_len(8, 32), &value.to_be_bytes::<32>());
     }
 }

--- a/crates/interpreter/src/interpreter_types.rs
+++ b/crates/interpreter/src/interpreter_types.rs
@@ -142,6 +142,16 @@ pub trait MemoryTr {
         self.slice(offset..offset + len)
     }
 
+    /// Returns a 32-byte EVM word from memory.
+    fn get_u256(&self, offset: usize) -> U256 {
+        U256::try_from_be_slice(self.slice_len(offset, 32).as_ref()).unwrap()
+    }
+
+    /// Sets a 32-byte EVM word in memory.
+    fn set_u256(&mut self, offset: usize, value: U256) {
+        self.set(offset, &value.to_be_bytes::<32>())
+    }
+
     /// Resizes memory to new size
     ///
     /// # Note


### PR DESCRIPTION
Porting one of the optimizations from the batch. This one focuses on mstore and mload.