### PR TITLE
refactor(gas): rename InitialAndFloorGas.initial_total_gas to regular_gas

### DIFF
--- a/crates/context/interface/src/cfg/gas.rs
+++ b/crates/context/interface/src/cfg/gas.rs
@@ -263,63 +263,89 @@ pub const INITCODE_WORD_COST: u64 = 2;
 /// Gas stipend provided to the recipient of a CALL with value transfer.
 pub const CALL_STIPEND: u64 = 2300;
 
-/// Init and floor gas from transaction
+/// Init and floor gas from transaction.
+///
+/// Tracks the intrinsic gas split into regular and state-gas portions
+/// (EIP-8037). Use [`Self::total_gas`] for the combined amount,
+/// [`Self::add_regular_gas`] / [`Self::add_state_gas`] to accumulate into
+/// the respective portion.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InitialAndFloorGas {
-    /// Initial gas for transaction.
-    pub initial_total_gas: u64,
-    /// State gas component of initial_gas (subset of initial_total_gas).
-    /// Under EIP-8037, this includes:
+    /// Regular (non-state) portion of the initial intrinsic gas.
+    ///
+    /// Under EIP-8037 this is the part constrained by `TX_MAX_GAS_LIMIT`;
+    /// state gas uses its own reservoir and is not subject to that cap.
+    pub regular_gas: u64,
+    /// State-gas portion of the initial intrinsic gas (EIP-8037).
+    ///
+    /// Includes:
     /// - EIP-7702 auth list state gas (per-auth account creation + metadata costs)
     /// - For CREATE transactions: `create_state_gas` (account creation + contract metadata)
     /// - For CALL transactions: 0 (state gas is unpredictable at validation time)
-    pub initial_state_gas: u64,
+    pub state_gas: u64,
     /// If transaction is a Call and Prague is enabled
     /// floor_gas is at least amount of gas that is going to be spent.
     pub floor_gas: u64,
     /// EIP-7702 state gas refund for existing authorities.
-    /// Added to the reservoir after initial_state_gas is deducted.
+    /// Added to the reservoir after `state_gas` is deducted.
     /// In the Python spec, set_delegation adds this back to state_gas_reservoir
-    /// rather than reducing initial_state_gas, so the refunded gas stays as
+    /// rather than reducing `state_gas`, so the refunded gas stays as
     /// reservoir gas (not regular gas).
     pub eip7702_reservoir_refund: u64,
 }
 
 impl InitialAndFloorGas {
-    /// Create a new InitialAndFloorGas instance.
+    /// Creates a new `InitialAndFloorGas` instance with only regular gas set.
     #[inline]
-    pub const fn new(initial_total_gas: u64, floor_gas: u64) -> Self {
+    pub const fn new(regular_gas: u64, floor_gas: u64) -> Self {
         Self {
-            initial_total_gas,
-            initial_state_gas: 0,
+            regular_gas,
+            state_gas: 0,
             floor_gas,
             eip7702_reservoir_refund: 0,
         }
     }
 
-    /// Create a new InitialAndFloorGas instance with state gas tracking.
+    /// Creates a new `InitialAndFloorGas` instance with both regular and state gas.
+    ///
+    /// `regular_gas` is the non-state portion and `state_gas` is the EIP-8037
+    /// state portion; [`Self::total_gas`] returns their sum.
     #[inline]
-    pub const fn new_with_state_gas(
-        initial_total_gas: u64,
-        initial_state_gas: u64,
-        floor_gas: u64,
-    ) -> Self {
+    pub const fn new_with_state_gas(regular_gas: u64, state_gas: u64, floor_gas: u64) -> Self {
         Self {
-            initial_total_gas,
-            initial_state_gas,
+            regular_gas,
+            state_gas,
             floor_gas,
             eip7702_reservoir_refund: 0,
         }
+    }
+
+    /// Total intrinsic gas: `regular_gas + state_gas`.
+    #[inline]
+    pub const fn total_gas(&self) -> u64 {
+        self.regular_gas.saturating_add(self.state_gas)
+    }
+
+    /// Adds `gas` to the regular-gas portion.
+    #[inline]
+    pub fn add_regular_gas(&mut self, gas: u64) {
+        self.regular_gas = self.regular_gas.saturating_add(gas);
+    }
+
+    /// Adds `gas` to the state-gas portion.
+    #[inline]
+    pub fn add_state_gas(&mut self, gas: u64) {
+        self.state_gas = self.state_gas.saturating_add(gas);
     }
 
     /// Regular (non-state) portion of the initial intrinsic gas.
     ///
-    /// Under EIP-8037, this is the part constrained by `TX_MAX_GAS_LIMIT`;
-    /// state gas uses its own reservoir and is not subject to that cap.
+    /// Retained as a transition alias for pre-rename call sites; equivalent
+    /// to reading [`Self::regular_gas`] directly.
     #[inline]
     pub const fn initial_regular_gas(&self) -> u64 {
-        self.initial_total_gas - self.initial_state_gas
+        self.regular_gas
     }
 
     /// Computes the regular gas budget and reservoir for the initial call frame.
@@ -342,14 +368,14 @@ impl InitialAndFloorGas {
         tx_gas_limit_cap: u64,
         is_eip8037: bool,
     ) -> (u64, u64) {
-        let execution_gas = tx_gas_limit - self.initial_regular_gas();
+        let execution_gas = tx_gas_limit - self.regular_gas;
 
         // System calls pass InitialAndFloorGas with all zeros and should not be
         // subject to the TX_MAX_GAS_LIMIT cap.
-        let regular_gas_cap = if self.initial_total_gas == 0 {
+        let regular_gas_cap = if self.total_gas() == 0 {
             u64::MAX
         } else if is_eip8037 {
-            tx_gas_limit_cap.saturating_sub(self.initial_regular_gas())
+            tx_gas_limit_cap.saturating_sub(self.regular_gas)
         } else {
             tx_gas_limit_cap
         };
@@ -359,11 +385,11 @@ impl InitialAndFloorGas {
 
         // Deduct initial state gas from the reservoir. When the reservoir is
         // insufficient, the deficit is charged from the regular gas budget.
-        if self.initial_state_gas > 0 {
-            if reservoir >= self.initial_state_gas {
-                reservoir -= self.initial_state_gas;
+        if self.state_gas > 0 {
+            if reservoir >= self.state_gas {
+                reservoir -= self.state_gas;
             } else {
-                gas_limit -= self.initial_state_gas - reservoir;
+                gas_limit -= self.state_gas - reservoir;
                 reservoir = 0;
             }
         }

--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -347,7 +347,7 @@ impl GasParams {
             // Refund for existing accounts: PER_EMPTY_ACCOUNT state gas (112 × CPSB)
             table[GasId::tx_eip7702_auth_refund().as_usize()] = 112 * CPSB;
 
-            // State gas per auth for initial_state_gas tracking
+            // State gas per auth for `InitialAndFloorGas::state_gas` tracking
             table[GasId::tx_eip7702_per_auth_state_gas().as_usize()] = (112 + 23) * CPSB;
         }
 
@@ -724,7 +724,7 @@ impl GasParams {
 
     /// EIP-8037: State gas per EIP-7702 authorization (pessimistic).
     ///
-    /// Used for `initial_state_gas` tracking. Zero before AMSTERDAM.
+    /// Used for [`InitialAndFloorGas::state_gas`] tracking. Zero before AMSTERDAM.
     #[inline]
     pub fn tx_eip7702_per_auth_state_gas(&self) -> u64 {
         self.get(GasId::tx_eip7702_per_auth_state_gas())
@@ -735,8 +735,9 @@ impl GasParams {
     /// At validation time, `initial_tx_gas` splits each auth cost into state + regular.
     /// This method is the inverse: it recovers how much of the total refund was state gas.
     ///
-    /// The state gas portion reduces `initial_state_gas` directly (not subject to refund caps).
-    /// The regular gas portion goes through the standard 1/5 refund cap.
+    /// The state gas portion reduces `InitialAndFloorGas::state_gas` directly (not
+    /// subject to refund caps). The regular gas portion goes through the standard
+    /// 1/5 refund cap.
     ///
     /// # Returns
     ///
@@ -842,17 +843,13 @@ impl GasParams {
     /// Initial gas that is deducted for transaction to be included.
     /// Initial gas contains initial stipend gas, gas for access list and input data.
     ///
-    /// Under EIP-8037, state gas is tracked separately in `initial_state_gas` and
-    /// added to `initial_total_gas` at the end. The state gas components are:
+    /// Under EIP-8037, regular and state gas are accumulated into separate
+    /// fields on [`InitialAndFloorGas`]; use [`InitialAndFloorGas::total_gas`]
+    /// for the combined amount. The state gas components are:
     /// - EIP-7702 auth list state gas (per-auth account creation + metadata costs)
     /// - For CREATE transactions: `create_state_gas` (account creation + contract metadata)
     ///
     /// Note: `code_deposit_state_gas` is not included since deployed code size is unknown at validation time.
-    ///
-    /// # Returns
-    ///
-    /// - Intrinsic gas (including state gas for CREATE)
-    /// - Number of tokens in calldata
     pub fn initial_tx_gas(
         &self,
         input: &[u8],
@@ -869,42 +866,38 @@ impl GasParams {
 
         // EIP-7702: Compute auth list costs.
         // Under EIP-8037, tx_eip7702_per_empty_account_cost bundles regular + state gas.
-        // We split them: regular goes in initial_total_gas, state goes in initial_state_gas.
+        // We split them into the respective portions on `gas`.
         let auth_total_cost = authorization_list_num * self.tx_eip7702_per_empty_account_cost();
         let auth_state_gas = authorization_list_num * self.tx_eip7702_per_auth_state_gas();
         let auth_regular_cost = auth_total_cost - auth_state_gas;
 
-        gas.initial_total_gas += tokens_in_calldata * self.tx_token_cost()
-            // before berlin tx_access_list_address_cost will be zero
-            + access_list_accounts * self.tx_access_list_address_cost()
-            // before berlin tx_access_list_storage_key_cost will be zero
-            + access_list_storages * self.tx_access_list_storage_key_cost()
-            + self.tx_base_stipend()
-            // EIP-7702: Only the regular portion of auth list cost
-            + auth_regular_cost;
+        gas.add_regular_gas(
+            tokens_in_calldata * self.tx_token_cost()
+                // before berlin tx_access_list_address_cost will be zero
+                + access_list_accounts * self.tx_access_list_address_cost()
+                // before berlin tx_access_list_storage_key_cost will be zero
+                + access_list_storages * self.tx_access_list_storage_key_cost()
+                + self.tx_base_stipend()
+                // EIP-7702: regular portion of auth list cost
+                + auth_regular_cost,
+        );
 
-        // EIP-8037: Track auth list state gas separately for reservoir handling.
-        // State gas is added to initial_total_gas at the end of this function.
-        gas.initial_state_gas += auth_state_gas;
+        // EIP-8037: auth list state gas portion.
+        gas.add_state_gas(auth_state_gas);
 
         if is_create {
             // EIP-2: Homestead Hard-fork Changes
-            gas.initial_total_gas += self.tx_create_cost();
+            gas.add_regular_gas(self.tx_create_cost());
 
             // EIP-3860: Limit and meter initcode
-            gas.initial_total_gas += self.tx_initcode_cost(input.len());
+            gas.add_regular_gas(self.tx_initcode_cost(input.len()));
 
-            // EIP-8037: State gas for CREATE transactions.
-            // create_state_gas covers both account creation and contract metadata.
-            gas.initial_state_gas += self.create_state_gas();
+            // EIP-8037: state gas for CREATE — account creation + contract metadata.
+            gas.add_state_gas(self.create_state_gas());
         }
 
         // Calculate gas floor for EIP-7623
         gas.floor_gas = self.tx_floor_cost(tokens_in_calldata);
-
-        // EIP-8037: Include state gas in total initial gas.
-        // State gas is a subset of initial_total_gas, deducted before execution starts.
-        gas.initial_total_gas += gas.initial_state_gas;
 
         gas
     }
@@ -1438,21 +1431,21 @@ mod tests {
         let create_gas = gas_params.initial_tx_gas(b"", true, 0, 0, 0);
         let expected_state_gas = gas_params.create_state_gas();
 
-        assert_eq!(create_gas.initial_state_gas, expected_state_gas);
-        assert_eq!(create_gas.initial_state_gas, 131488);
+        assert_eq!(create_gas.state_gas, expected_state_gas);
+        assert_eq!(create_gas.state_gas, 131488);
 
-        // initial_total_gas includes both regular and state gas
+        // total_gas combines regular and state gas
         let create_cost = gas_params.tx_create_cost();
         let initcode_cost = gas_params.tx_initcode_cost(0);
         assert_eq!(
-            create_gas.initial_total_gas,
+            create_gas.total_gas(),
             gas_params.tx_base_stipend() + create_cost + initcode_cost + expected_state_gas
         );
 
         // Test CALL transaction (is_create = false)
         let call_gas = gas_params.initial_tx_gas(b"", false, 0, 0, 0);
-        assert_eq!(call_gas.initial_state_gas, 0);
-        // initial_gas should be unchanged for calls
-        assert_eq!(call_gas.initial_total_gas, gas_params.tx_base_stipend());
+        assert_eq!(call_gas.state_gas, 0);
+        // regular portion carries the base stipend for calls
+        assert_eq!(call_gas.total_gas(), gas_params.tx_base_stipend());
     }
 }

--- a/crates/handler/src/post_execution.rs
+++ b/crates/handler/src/post_execution.rs
@@ -12,7 +12,7 @@ use primitives::{hardfork::SpecId, U256};
 pub fn build_result_gas(gas: &Gas, init_and_floor_gas: InitialAndFloorGas) -> ResultGas {
     let state_gas = gas
         .state_gas_spent()
-        .saturating_add(init_and_floor_gas.initial_state_gas)
+        .saturating_add(init_and_floor_gas.state_gas)
         .saturating_sub(init_and_floor_gas.eip7702_reservoir_refund);
 
     ResultGas::default()

--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -210,7 +210,7 @@ pub fn apply_eip7702_auth_list<
         apply_auth_list::<_, ERROR>(chain_id, refund_per_auth, tx.authorization_list(), journal)?;
 
     // EIP-8037: Split auth list refund into state gas and regular gas portions.
-    // The state gas portion is added to the reservoir after initial_state_gas deduction,
+    // The state gas portion is added to the reservoir after `state_gas` deduction,
     // matching the Python spec where set_delegation adds state refund directly to
     // state_gas_reservoir. This ensures refunded state gas stays as reservoir gas
     // (not regular gas), so it's not consumed on frame halt.

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -250,10 +250,10 @@ pub fn validate_initial_tx_gas(
     }
 
     // Additional check to see if limit is big enough to cover initial gas.
-    if gas.initial_total_gas > tx.gas_limit() {
+    if gas.total_gas() > tx.gas_limit() {
         return Err(InvalidTransaction::CallGasCostMoreThanGasLimit {
             gas_limit: tx.gas_limit(),
-            initial_gas: gas.initial_total_gas,
+            initial_gas: gas.total_gas(),
         });
     }
 
@@ -270,7 +270,7 @@ pub fn validate_initial_tx_gas(
     // Validate that both intrinsic regular gas and floor gas fit within the cap.
     // State gas is excluded — it uses its own reservoir.
     if is_amsterdam_eip8037_enabled && tx.gas_limit() > tx_gas_limit_cap {
-        let min_regular_gas = gas.initial_regular_gas().max(gas.floor_gas);
+        let min_regular_gas = gas.regular_gas.max(gas.floor_gas);
         if min_regular_gas > tx_gas_limit_cap {
             return Err(InvalidTransaction::GasFloorMoreThanGasLimit {
                 gas_floor: min_regular_gas,


### PR DESCRIPTION
## Summary

Refactors `InitialAndFloorGas` to store the regular and state portions of the intrinsic gas as separate fields and derive the total on demand, rather than keeping a pre-merged total plus a state subset. Also adds small accumulator helpers so call sites don't have to touch the fields directly.

### Field change

| Before                      | After               | Meaning                                     |
| --------------------------- | ------------------- | ------------------------------------------- |
| `initial_total_gas: u64`    | `regular_gas: u64`  | Regular (non-state) portion only            |
| `initial_state_gas: u64`    | `state_gas: u64`    | EIP-8037 state-gas portion                  |
| `floor_gas`                 | unchanged           | EIP-7623 floor                              |
| `eip7702_reservoir_refund`  | unchanged           | EIP-7702 state refund for existing auths    |

### New methods

- `total_gas(&self) -> u64` — saturating `regular_gas + state_gas`
- `add_regular_gas(&mut self, gas: u64)` — saturating `+=` on the regular portion
- `add_state_gas(&mut self, gas: u64)` — saturating `+=` on the state portion
- `initial_regular_gas()` retained as a transition alias for pre-rename call sites

### Migration

Downstream code that read `gas.initial_total_gas` should switch to `gas.total_gas()`; direct writes (`gas.initial_total_gas += x`) become `gas.add_regular_gas(x)` (if the increment was regular) or `gas.add_state_gas(x)` (if it was state). `gas.initial_state_gas` becomes `gas.state_gas`.

### Internal callers updated

- `GasParams::initial_tx_gas` — uses `add_regular_gas` / `add_state_gas`; dropped the trailing `initial_total_gas += initial_state_gas` merge.
- `validation.rs` — `total_gas()` for the intrinsic-vs-gas-limit check; `gas.regular_gas` for the EIP-8037 regular cap check.
- `post_execution.rs::build_result_gas` — reads `state_gas`.
- Doc comments in `pre_execution.rs` / `gas_params.rs` updated to the new field names.

## Test plan

- [x] `cargo check --workspace` — clean.
- [x] `cargo test --workspace --lib` — all green, including `test_initial_state_gas_for_create` (updated to use `state_gas` + `total_gas()`) and the handler validation suite.
- [x] `cargo clippy --workspace --all-targets` — no new warnings.