### PR TITLE
perf: no alloc for empty accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,6 +1145,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3771,6 +3782,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
+ "similar-asserts",
 ]
 
 [[package]]
@@ -4452,6 +4464,27 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "similar"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d93e861ede2e497b47833469b8ec9d5c07fa4c78ce7a00f6eb7dd8168b4b3f"
+dependencies = [
+ "bstr",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "similar-asserts"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "997e6ca38e97437973fc9f7f50a50d1274cacd874341a4960fea90067291038c"
+dependencies = [
+ "console",
+ "serde",
+ "similar",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ indicatif = "0.18"
 rstest = "0.26.0"
 thiserror = { version = "2.0", default-features = false }
 walkdir = "2.5"
+similar-asserts = "2.0"
 
 [workspace.package]
 license = "MIT"

--- a/crates/bytecode/src/bytecode/mod.rs
+++ b/crates/bytecode/src/bytecode/mod.rs
@@ -105,22 +105,25 @@ impl Bytecode {
     /// Creates a new legacy analyzed [`Bytecode`] with exactly one STOP opcode.
     #[inline]
     pub fn new() -> Self {
+        Self::default_ref().clone()
+    }
+
+    #[inline]
+    fn default_ref() -> &'static Self {
         static DEFAULT: OnceLock<Bytecode> = OnceLock::new();
-        DEFAULT
-            .get_or_init(|| {
-                Self(Arc::new(BytecodeInner {
-                    kind: BytecodeKind::LegacyAnalyzed,
-                    bytecode: Bytes::from_static(&[opcode::STOP]),
-                    original_len: 0,
-                    jump_table: JumpTable::default(),
-                    hash: {
-                        let hash = OnceLock::new();
-                        let _ = hash.set(KECCAK_EMPTY);
-                        hash
-                    },
-                }))
-            })
-            .clone()
+        DEFAULT.get_or_init(|| {
+            Self(Arc::new(BytecodeInner {
+                kind: BytecodeKind::LegacyAnalyzed,
+                bytecode: Bytes::from_static(&[opcode::STOP]),
+                original_len: 0,
+                jump_table: JumpTable::default(),
+                hash: {
+                    let hash = OnceLock::new();
+                    let _ = hash.set(KECCAK_EMPTY);
+                    hash
+                },
+            }))
+        })
     }
 
     /// Creates a new legacy [`Bytecode`] by analyzing raw bytes.
@@ -351,6 +354,12 @@ impl Bytecode {
         self.0.original_len == 0
     }
 
+    /// Returns `true` if the bytecode is empty and has the default bytecode hash.
+    #[inline]
+    pub fn is_default(&self) -> bool {
+        Arc::ptr_eq(&self.0, &Self::default_ref().0)
+    }
+
     /// Returns an iterator over the opcodes in this bytecode, skipping immediates.
     #[inline]
     pub fn iter_opcodes(&self) -> crate::BytecodeIterator<'_> {
@@ -460,5 +469,19 @@ mod tests {
             bytecode.original_bytes(),
             bytes!("ef01000101010101010101010101010101010101010101")
         );
+    }
+
+    #[test]
+    fn is_default() {
+        assert!(Bytecode::default().is_default());
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn is_default_after_serde() {
+        let bc = Bytecode::default();
+        let json = serde_json::to_string(&bc).unwrap();
+        let deser: Bytecode = serde_json::from_str(&json).unwrap();
+        assert!(deser.is_default());
     }
 }

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -906,8 +906,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
                         account.selfdestruct();
                         account.unmark_selfdestructed_locally();
                     }
-                    // set original info to current info.
-                    *account.original_info = account.info.clone();
+                    account.set_current_info_as_original();
 
                     // unmark locally created
                     account.unmark_created_locally();

--- a/crates/ee-tests/Cargo.toml
+++ b/crates/ee-tests/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 serde.workspace = true
 serde_json = { workspace = true, features = ["preserve_order"] }
 revm = { workspace = true, features = ["serde", "std"] }
+similar-asserts = { workspace = true, features = ["serde"] }
 
 [features]
 default = []

--- a/crates/ee-tests/src/lib.rs
+++ b/crates/ee-tests/src/lib.rs
@@ -99,9 +99,17 @@ where
 
     // Compare the output objects directly
     if *output != expected {
-        panic!(
-            "Value does not match testdata.\nExpected:\n{expected_json}\n\nActual:\n{output_json}"
+        similar_asserts::assert_eq!(
+            *output,
+            expected,
+            "value does not match testdata {testdata_file:?}"
         );
+        similar_asserts::assert_eq!(
+            output_json,
+            expected_json,
+            "value does not match testdata {testdata_file:?}"
+        );
+        panic!("output != expected @ {testdata_file:?}");
     }
 }
 

--- a/crates/ee-tests/tests/revm_testdata/test_frame_stack_index.json
+++ b/crates/ee-tests/tests/revm_testdata/test_frame_stack_index.json
@@ -4,8 +4,7 @@
       "floor_gas": 0,
       "gas_refunded": 0,
       "gas_spent": 21000,
-      "intrinsic_gas": 21000,
-      "limit": 1000000000
+      "state_gas_spent": 0
     },
     "logs": [],
     "output": {

--- a/crates/ee-tests/tests/revm_testdata/test_multi_tx_create.json
+++ b/crates/ee-tests/tests/revm_testdata/test_multi_tx_create.json
@@ -5,8 +5,7 @@
         "floor_gas": 0,
         "gas_refunded": 0,
         "gas_spent": 54260,
-        "intrinsic_gas": 53236,
-        "limit": 1000000000
+        "state_gas_spent": 0
       },
       "logs": [],
       "output": {
@@ -24,8 +23,7 @@
         "floor_gas": 0,
         "gas_refunded": 14301,
         "gas_spent": 28603,
-        "intrinsic_gas": 21000,
-        "limit": 1000000000
+        "state_gas_spent": 0
       },
       "logs": [],
       "output": {
@@ -40,8 +38,7 @@
         "floor_gas": 0,
         "gas_refunded": 0,
         "gas_spent": 54260,
-        "intrinsic_gas": 53236,
-        "limit": 1000000000
+        "state_gas_spent": 0
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/tests/revm_testdata/test_multi_tx_create.json
+++ b/crates/ee-tests/tests/revm_testdata/test_multi_tx_create.json
@@ -72,26 +72,7 @@
         "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "nonce": 0
       },
-      "original_info": {
-        "balance": "0x0",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "jump_table": {
-              "bits": 0,
-              "data": [],
-              "head": {
-                "index": 0,
-                "width": 8
-              },
-              "order": "bitvec::order::Lsb0"
-            },
-            "original_len": 0
-          }
-        },
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "nonce": 0
-      },
+      "original_info": null,
       "status": "Touched | LoadedAsNotExisting",
       "storage": {},
       "transaction_id": 2
@@ -117,26 +98,7 @@
         "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "nonce": 0
       },
-      "original_info": {
-        "balance": "0x0",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "jump_table": {
-              "bits": 0,
-              "data": [],
-              "head": {
-                "index": 0,
-                "width": 8
-              },
-              "order": "bitvec::order::Lsb0"
-            },
-            "original_len": 0
-          }
-        },
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "nonce": 0
-      },
+      "original_info": null,
       "status": "Touched | LoadedAsNotExisting",
       "storage": {},
       "transaction_id": 1

--- a/crates/ee-tests/tests/revm_testdata/test_selfdestruct_multi_tx.json
+++ b/crates/ee-tests/tests/revm_testdata/test_selfdestruct_multi_tx.json
@@ -51,26 +51,7 @@
         "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "nonce": 0
       },
-      "original_info": {
-        "balance": "0x0",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "jump_table": {
-              "bits": 0,
-              "data": [],
-              "head": {
-                "index": 0,
-                "width": 8
-              },
-              "order": "bitvec::order::Lsb0"
-            },
-            "original_len": 0
-          }
-        },
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "nonce": 0
-      },
+      "original_info": null,
       "status": "Touched | LoadedAsNotExisting",
       "storage": {},
       "transaction_id": 1
@@ -96,26 +77,7 @@
         "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "nonce": 0
       },
-      "original_info": {
-        "balance": "0x0",
-        "code": {
-          "LegacyAnalyzed": {
-            "bytecode": "0x00",
-            "jump_table": {
-              "bits": 0,
-              "data": [],
-              "head": {
-                "index": 0,
-                "width": 8
-              },
-              "order": "bitvec::order::Lsb0"
-            },
-            "original_len": 0
-          }
-        },
-        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        "nonce": 0
-      },
+      "original_info": null,
       "status": "Touched | LoadedAsNotExisting",
       "storage": {},
       "transaction_id": 0

--- a/crates/ee-tests/tests/revm_testdata/test_selfdestruct_multi_tx.json
+++ b/crates/ee-tests/tests/revm_testdata/test_selfdestruct_multi_tx.json
@@ -5,8 +5,7 @@
         "floor_gas": 0,
         "gas_refunded": 24000,
         "gas_spent": 53603,
-        "intrinsic_gas": 21000,
-        "limit": 1000000000
+        "state_gas_spent": 0
       },
       "logs": [],
       "output": {
@@ -21,8 +20,7 @@
         "floor_gas": 0,
         "gas_refunded": 0,
         "gas_spent": 21000,
-        "intrinsic_gas": 21000,
-        "limit": 1000000000
+        "state_gas_spent": 0
       },
       "logs": [],
       "output": {

--- a/crates/state/src/account_info.rs
+++ b/crates/state/src/account_info.rs
@@ -3,7 +3,7 @@ use core::{
     cmp::Ordering,
     hash::{Hash, Hasher},
 };
-use primitives::{OnceLock, B256, KECCAK_EMPTY, U256};
+use primitives::{B256, KECCAK_EMPTY, U256};
 
 /// Account information that contains balance, nonce, code hash and code
 ///
@@ -33,21 +33,20 @@ pub struct AccountInfo {
 }
 
 impl Default for AccountInfo {
+    #[inline]
     fn default() -> Self {
-        static DEFAULT: OnceLock<AccountInfo> = OnceLock::new();
-        DEFAULT
-            .get_or_init(|| Self {
-                balance: U256::ZERO,
-                code_hash: KECCAK_EMPTY,
-                account_id: None,
-                nonce: 0,
-                code: Some(Bytecode::default()),
-            })
-            .clone()
+        Self {
+            balance: U256::ZERO,
+            code_hash: KECCAK_EMPTY,
+            account_id: None,
+            nonce: 0,
+            code: Some(Bytecode::default()),
+        }
     }
 }
 
 impl PartialEq for AccountInfo {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.balance == other.balance
             && self.nonce == other.nonce
@@ -56,6 +55,7 @@ impl PartialEq for AccountInfo {
 }
 
 impl Hash for AccountInfo {
+    #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.balance.hash(state);
         self.nonce.hash(state);
@@ -64,12 +64,14 @@ impl Hash for AccountInfo {
 }
 
 impl PartialOrd for AccountInfo {
+    #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl Ord for AccountInfo {
+    #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
         self.balance
             .cmp(&other.balance)
@@ -96,6 +98,7 @@ impl AccountInfo {
     /// # Note
     ///
     /// As code hash is calculated with [`Bytecode::hash_slow`] there will be performance penalty if used frequently.
+    #[inline]
     pub fn with_code(self, code: Bytecode) -> Self {
         Self {
             code_hash: code.hash_slow(),
@@ -110,6 +113,7 @@ impl AccountInfo {
     ///
     /// Resets code to `None`. Not guaranteed to maintain invariant `code` and `code_hash`. See
     /// also [Self::with_code_and_hash].
+    #[inline]
     pub fn with_code_hash(self, code_hash: B256) -> Self {
         Self {
             code_hash,
@@ -124,6 +128,7 @@ impl AccountInfo {
     ///
     /// In debug mode panics if [`Bytecode::hash_slow`] called on `code` is not equivalent to
     /// `code_hash`. See also [`Self::with_code`].
+    #[inline]
     pub fn with_code_and_hash(self, code: Bytecode, code_hash: B256) -> Self {
         debug_assert_eq!(code.hash_slow(), code_hash);
         Self {
@@ -134,12 +139,14 @@ impl AccountInfo {
     }
 
     /// Creates a new [`AccountInfo`] with the given balance.
+    #[inline]
     pub fn with_balance(mut self, balance: U256) -> Self {
         self.balance = balance;
         self
     }
 
     /// Creates a new [`AccountInfo`] with the given nonce.
+    #[inline]
     pub fn with_nonce(mut self, nonce: u64) -> Self {
         self.nonce = nonce;
         self
@@ -226,6 +233,7 @@ impl AccountInfo {
     ///
     /// [`copy_without_code`][Self::copy_without_code]
     /// will copy the non-code fields and return a new [`AccountInfo`] instance.
+    #[inline]
     pub fn without_code(mut self) -> Self {
         self.take_bytecode();
         self
@@ -241,6 +249,12 @@ impl AccountInfo {
     pub fn is_empty(&self) -> bool {
         let code_empty = self.is_empty_code_hash() || self.code_hash.is_zero();
         code_empty && self.balance.is_zero() && self.nonce == 0
+    }
+
+    /// Optimization hint.
+    #[inline]
+    pub(crate) fn is_default(&self) -> bool {
+        self.is_empty() && self.code.as_ref().is_some_and(Bytecode::is_default)
     }
 
     /// Returns `true` if the account is not empty.
@@ -305,9 +319,7 @@ impl AccountInfo {
 
 #[cfg(test)]
 mod tests {
-    use crate::AccountInfo;
-    use bytecode::Bytecode;
-    use core::cmp::Ordering;
+    use super::*;
     use std::collections::BTreeSet;
 
     #[test]
@@ -346,5 +358,19 @@ mod tests {
         let mut accounts = [account2, account1];
         accounts.sort();
         assert_eq!(accounts[0], accounts[1], "Sorted vec treats them as equal");
+    }
+
+    #[test]
+    fn is_default() {
+        assert!(AccountInfo::default().is_default())
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn is_default_after_serde() {
+        let info = AccountInfo::default();
+        let json = serde_json::to_string(&info).unwrap();
+        let deser: AccountInfo = serde_json::from_str(&json).unwrap();
+        assert!(deser.is_default());
     }
 }

--- a/crates/state/src/bal/account.rs
+++ b/crates/state/src/bal/account.rs
@@ -53,7 +53,7 @@ impl AccountBal {
         if account.is_selfdestructed_locally() {
             let empty_info = AccountInfo::default();
             self.account_info
-                .update(bal_index, &account.original_info, &empty_info);
+                .update(bal_index, &account.original_info(), &empty_info);
             // Selfdestruct wipes all storage to zero, record writes accordingly.
             self.storage
                 .update_selfdestruct(bal_index, &account.storage);
@@ -61,7 +61,7 @@ impl AccountBal {
         }
 
         self.account_info
-            .update(bal_index, &account.original_info, &account.info);
+            .update(bal_index, &account.original_info(), &account.info);
 
         self.storage.update(bal_index, &account.storage);
     }

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -17,7 +17,7 @@ pub use primitives;
 pub use types::{EvmState, EvmStorage, TransientStorage};
 
 use bitflags::bitflags;
-use primitives::{hardfork::SpecId, HashMap, OnceLock, StorageKey, StorageValue, U256};
+use primitives::{hardfork::SpecId, HashMap, StorageKey, StorageValue, U256};
 use std::boxed::Box;
 
 /// The main account type used inside Revm. It is stored inside Journal and contains all the information about the account.
@@ -38,7 +38,12 @@ pub struct Account {
     /// Balance, nonce, and code
     pub info: AccountInfo,
     /// Original account info used by BAL, changed only on cold load by BAL.
-    pub original_info: Box<AccountInfo>,
+    /// `None` means `Default::default()`, to avoid allocations.
+    #[cfg_attr(
+        feature = "serde",
+        serde(serialize_with = "serde_impl::serialize_original")
+    )]
+    original_info: Option<Box<AccountInfo>>,
     /// Transaction id, used to track when account was touched/loaded into journal.
     pub transaction_id: usize,
     /// Storage cache
@@ -49,19 +54,13 @@ pub struct Account {
 
 impl Account {
     /// Creates new account and mark it as non existing.
+    #[inline]
     pub fn new_not_existing(transaction_id: usize) -> Self {
-        static DEFAULT: OnceLock<Account> = OnceLock::new();
-        let mut account = DEFAULT
-            .get_or_init(|| Self {
-                info: AccountInfo::default(),
-                storage: HashMap::default(),
-                transaction_id: 0,
-                status: AccountStatus::LoadedAsNotExisting,
-                original_info: Box::new(AccountInfo::default()),
-            })
-            .clone();
-        account.transaction_id = transaction_id;
-        account
+        Self {
+            transaction_id,
+            status: AccountStatus::LoadedAsNotExisting,
+            ..Default::default()
+        }
     }
 
     /// Make changes to the caller account.
@@ -90,6 +89,30 @@ impl Account {
         } else {
             self.is_loaded_as_not_existing_not_touched()
         }
+    }
+
+    /// Returns the original account info.
+    #[inline]
+    pub fn original_info(&self) -> AccountInfo {
+        self.original_info.as_deref().cloned().unwrap_or_default()
+    }
+
+    /// Returns a mutable reference to the original account info.
+    #[inline]
+    pub fn original_info_mut(&mut self) -> &mut AccountInfo {
+        self.original_info.get_or_insert_default()
+    }
+
+    /// Clones the current info into the original info.
+    pub fn set_current_info_as_original(&mut self) {
+        if self.info.is_default() {
+            self.original_info = None;
+            return;
+        }
+        self.original_info
+            .get_or_insert_default()
+            .as_mut()
+            .clone_from(&self.info);
     }
 
     /// Marks the account as self destructed.
@@ -308,13 +331,17 @@ impl Account {
 
 impl From<AccountInfo> for Account {
     fn from(info: AccountInfo) -> Self {
-        let original_info = Box::new(info.clone());
+        let original_info = if info.is_default() {
+            None
+        } else {
+            Some(Box::new(info.clone()))
+        };
         Self {
             info,
-            storage: HashMap::default(),
-            transaction_id: 0,
-            status: AccountStatus::empty(),
             original_info,
+            transaction_id: 0,
+            storage: HashMap::default(),
+            status: AccountStatus::empty(),
         }
     }
 }
@@ -324,7 +351,19 @@ mod serde_impl {
     use super::*;
     use serde::{Deserialize, Serialize};
 
-    #[derive(Serialize, Deserialize)]
+    pub(super) fn serialize_original<S: serde::Serializer>(
+        original_info: &Option<Box<AccountInfo>>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let x = if let Some(original_info) = original_info {
+            original_info.as_ref()
+        } else {
+            &AccountInfo::default()
+        };
+        x.serialize(serializer)
+    }
+
+    #[derive(Deserialize)]
     struct AccountSerde {
         info: AccountInfo,
         original_info: Option<AccountInfo>,
@@ -348,10 +387,15 @@ mod serde_impl {
 
             // If original info is not present, use info as original info
             let original_info = original_info.unwrap_or_else(|| info.clone());
+            let original_info = if original_info.is_default() {
+                None
+            } else {
+                Some(Box::new(original_info))
+            };
 
             Ok(Account {
                 info,
-                original_info: Box::new(original_info),
+                original_info,
                 storage,
                 transaction_id,
                 status,
@@ -646,6 +690,30 @@ mod tests {
         let serialized = serde_json::to_string(&account).unwrap();
         let deserialized: Account = serde_json::from_str(&serialized).unwrap();
         assert_eq!(account, deserialized);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_account_original_info_none_roundtrip() {
+        // Account with original_info = None (default optimization).
+        let account = Account::new_not_existing(2);
+        assert!(account.original_info.is_none());
+        let serialized = serde_json::to_string(&account).unwrap();
+        let deserialized: Account = serde_json::from_str(&serialized).unwrap();
+        assert!(
+            deserialized.original_info.is_none(),
+            "should be None after roundtrip: {:?}",
+            deserialized.original_info
+        );
+        assert_eq!(account, deserialized);
+
+        // Also test via serde_json::Value roundtrip with sort (what ee-tests does).
+        let mut value: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+        value.sort_all_objects();
+        let pretty = serde_json::to_string_pretty(&value).unwrap();
+        let deserialized2: Account = serde_json::from_str(&pretty).unwrap();
+        assert!(deserialized2.original_info.is_none());
+        assert_eq!(account, deserialized2);
     }
 
     #[test]

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -32,24 +32,32 @@ use std::boxed::Box;
 ///     * Database needs to load account and tie to with BAL writes
 /// If CompiledBal is not present, use loaded values
 ///     * Account is already up to date (uses present flow).
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Account {
     /// Balance, nonce, and code
     pub info: AccountInfo,
-    /// Original account info used by BAL, changed only on cold load by BAL.
-    /// `None` means `Default::default()`, to avoid allocations.
-    #[cfg_attr(
-        feature = "serde",
-        serde(serialize_with = "serde_impl::serialize_original")
-    )]
-    original_info: Option<Box<AccountInfo>>,
     /// Transaction id, used to track when account was touched/loaded into journal.
     pub transaction_id: usize,
     /// Storage cache
     pub storage: EvmStorage,
     /// Account status flags
     pub status: AccountStatus,
+
+    /// Original account info used by BAL, changed only on cold load by BAL.
+    /// `None` means `Default::default()`, to avoid allocations.
+    original_info: Option<Box<AccountInfo>>,
+}
+
+impl PartialEq for Account {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.info == other.info
+            && self.transaction_id == other.transaction_id
+            && self.storage == other.storage
+            && self.status == other.status
+            && self.original_info() == other.original_info()
+    }
 }
 
 impl Account {
@@ -105,8 +113,7 @@ impl Account {
 
     /// Clones the current info into the original info.
     pub fn set_current_info_as_original(&mut self) {
-        if self.info.is_default() {
-            self.original_info = None;
+        if self.original_info.is_none() && self.info.is_default() {
             return;
         }
         self.original_info
@@ -349,24 +356,32 @@ impl From<AccountInfo> for Account {
 #[cfg(feature = "serde")]
 mod serde_impl {
     use super::*;
-    use serde::{Deserialize, Serialize};
+    use serde::Deserialize;
 
-    pub(super) fn serialize_original<S: serde::Serializer>(
-        original_info: &Option<Box<AccountInfo>>,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error> {
-        let x = if let Some(original_info) = original_info {
-            original_info.as_ref()
-        } else {
-            &AccountInfo::default()
-        };
-        x.serialize(serializer)
+    /// Distinguishes missing field (old format) from explicit `null` (new format).
+    #[derive(Default)]
+    enum MaybeOriginalInfo {
+        /// Field was missing from JSON (old format).
+        #[default]
+        Missing,
+        /// Present in JSON: `null` means default, `Some` is the value.
+        Present(Option<AccountInfo>),
+    }
+
+    impl<'de> Deserialize<'de> for MaybeOriginalInfo {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            Option::<AccountInfo>::deserialize(deserializer).map(MaybeOriginalInfo::Present)
+        }
     }
 
     #[derive(Deserialize)]
     struct AccountSerde {
         info: AccountInfo,
-        original_info: Option<AccountInfo>,
+        #[serde(default)]
+        original_info: MaybeOriginalInfo,
         storage: EvmStorage,
         transaction_id: usize,
         status: AccountStatus,
@@ -385,12 +400,13 @@ mod serde_impl {
                 status,
             } = Deserialize::deserialize(deserializer)?;
 
-            // If original info is not present, use info as original info
-            let original_info = original_info.unwrap_or_else(|| info.clone());
-            let original_info = if original_info.is_default() {
-                None
-            } else {
-                Some(Box::new(original_info))
+            let original_info = match original_info {
+                // Old format: field missing → use info as original.
+                MaybeOriginalInfo::Missing => Some(Box::new(info.clone())),
+                // New format: null → None (default).
+                MaybeOriginalInfo::Present(None) => None,
+                // New format: explicit value.
+                MaybeOriginalInfo::Present(Some(oi)) => Some(Box::new(oi)),
             };
 
             Ok(Account {
@@ -695,37 +711,45 @@ mod tests {
     #[test]
     #[cfg(feature = "serde")]
     fn test_account_original_info_none_roundtrip() {
-        // Account with original_info = None (default optimization).
         let account = Account::new_not_existing(2);
         assert!(account.original_info.is_none());
         let serialized = serde_json::to_string(&account).unwrap();
         let deserialized: Account = serde_json::from_str(&serialized).unwrap();
-        assert!(
-            deserialized.original_info.is_none(),
-            "should be None after roundtrip: {:?}",
-            deserialized.original_info
-        );
+        assert!(deserialized.original_info.is_none());
         assert_eq!(account, deserialized);
-
-        // Also test via serde_json::Value roundtrip with sort (what ee-tests does).
-        let mut value: serde_json::Value = serde_json::from_str(&serialized).unwrap();
-        value.sort_all_objects();
-        let pretty = serde_json::to_string_pretty(&value).unwrap();
-        let deserialized2: Account = serde_json::from_str(&pretty).unwrap();
-        assert!(deserialized2.original_info.is_none());
-        assert_eq!(account, deserialized2);
     }
 
     #[test]
     #[cfg(feature = "serde")]
-    fn test_account_serialize_deserialize_without_original_info() {
-        let deserialize_without_original_info = r#"
-        {"info":{"balance":"0x0","nonce":0,"code_hash":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","storage_id":null,"code":{"LegacyAnalyzed":{"bytecode":"0x00","original_len":0,"jump_table":{"order":"bitvec::order::Lsb0","head":{"width":8,"index":0},"bits":0,"data":[]}}}},"transaction_id":0,"storage":{},"status":"SelfDestructed"}"#;
+    fn test_account_deserialize_original_info_missing_null_present() {
+        let code = r#"{"LegacyAnalyzed":{"bytecode":"0x00","original_len":0,"jump_table":{"order":"bitvec::order::Lsb0","head":{"width":8,"index":0},"bits":0,"data":[]}}}"#;
+        let info = format!(
+            r#"{{"balance":"0x2386f26fc10000","nonce":1,"code_hash":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","code":{code}}}"#
+        );
 
-        let account = Account::default().with_selfdestruct_mark();
-        let deserialized: Account =
-            serde_json::from_str(deserialize_without_original_info).unwrap();
-        assert_eq!(account, deserialized);
+        // Missing field (old format): original_info = Some(info.clone()).
+        let json =
+            format!(r#"{{"info":{info},"transaction_id":0,"storage":{{}},"status":"Touched"}}"#);
+        let acct: Account = serde_json::from_str(&json).unwrap();
+        assert!(acct.original_info.is_some());
+        assert_eq!(acct.original_info(), acct.info);
+
+        // Null (new format): original_info = None (default).
+        let json = format!(
+            r#"{{"info":{info},"original_info":null,"transaction_id":0,"storage":{{}},"status":"Touched"}}"#
+        );
+        let acct: Account = serde_json::from_str(&json).unwrap();
+        assert!(acct.original_info.is_none());
+
+        // Present value.
+        let original = r#"{"balance":"0x0","nonce":0,"code_hash":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","code":null}"#;
+        let json = format!(
+            r#"{{"info":{info},"original_info":{original},"transaction_id":0,"storage":{{}},"status":"Touched"}}"#
+        );
+        let acct: Account = serde_json::from_str(&json).unwrap();
+        assert!(acct.original_info.is_some());
+        assert_eq!(acct.original_info().nonce, 0);
+        assert_eq!(acct.original_info().balance, U256::ZERO);
     }
 
     #[test]

--- a/examples/custom_precompile_journal/src/precompile_provider.rs
+++ b/examples/custom_precompile_journal/src/precompile_provider.rs
@@ -37,7 +37,7 @@ impl CustomPrecompileProvider {
 
     fn renew(&mut self) {
         // Include our custom precompile address along with standard ones
-        self.addresses.clone_from(&mut self.inner.warm_addresses());
+        self.addresses.clone_from(self.inner.warm_addresses());
         self.addresses.insert(CUSTOM_PRECOMPILE_ADDRESS);
     }
 }


### PR DESCRIPTION
Avoids allocating a `Box<AccountInfo>` for `original_info` when the account is default/empty by using `Option<Box<AccountInfo>>` where `None` represents the default.

Key changes:

- `Account::original_info` is now `Option<Box<AccountInfo>>` — `None` means `Default::default()`
- `Bytecode::is_default()` works after serde roundtrip by returning the static default from deserialization when `original_len == 0`
- `AccountInfo::is_default()` optimization hint using `Bytecode::is_default()`
- Custom `PartialEq` for `Account` that normalizes `None` vs `Some(default)` via `original_info()` getter
- Backwards-compatible serde: missing field (old format) clones current info, `null` (new format) means `None`/default, present value is used directly

Closes https://github.com/bluealloy/revm/issues/3585.