### PR TITLE
chore: enable and fix clippy::missing_const_for_fn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ rust.rust_2018_idioms = { level = "deny", priority = -1 }
 rust.unreachable_pub = "warn"
 rust.unused_must_use = "deny"
 rustdoc.all = "warn"
+clippy.missing_const_for_fn = "warn"
 
 [workspace.metadata.docs.rs]
 all-features = true

--- a/crates/bytecode/src/legacy/jump_map.rs
+++ b/crates/bytecode/src/legacy/jump_map.rs
@@ -158,13 +158,13 @@ impl JumpTable {
 
     /// Gets the bit length of the jump map.
     #[inline]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.bit_len
     }
 
     /// Returns true if the jump map is empty.
     #[inline]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 

--- a/crates/bytecode/src/opcode.rs
+++ b/crates/bytecode/src/opcode.rs
@@ -88,7 +88,7 @@ impl OpCode {
     #[inline]
     #[deprecated = "use new_or_unknown instead"]
     #[doc(hidden)]
-    pub unsafe fn new_unchecked(opcode: u8) -> Self {
+    pub const unsafe fn new_unchecked(opcode: u8) -> Self {
         Self(opcode)
     }
 

--- a/crates/bytecode/src/utils.rs
+++ b/crates/bytecode/src/utils.rs
@@ -6,7 +6,7 @@
 ///
 /// The pointer must point to at least 2 bytes.
 #[inline]
-pub unsafe fn read_i16(ptr: *const u8) -> i16 {
+pub const unsafe fn read_i16(ptr: *const u8) -> i16 {
     read_u16(ptr) as i16
 }
 
@@ -16,7 +16,7 @@ pub unsafe fn read_i16(ptr: *const u8) -> i16 {
 ///
 /// The pointer must point to at least 2 bytes.
 #[inline]
-pub unsafe fn read_u16(ptr: *const u8) -> u16 {
+pub const unsafe fn read_u16(ptr: *const u8) -> u16 {
     u16::from_be_bytes(unsafe { ptr.cast::<[u8; 2]>().read() })
 }
 

--- a/crates/context/interface/src/cfg/gas.rs
+++ b/crates/context/interface/src/cfg/gas.rs
@@ -49,7 +49,7 @@ impl GasTracker {
 
     /// Sets the gas limit.
     #[inline]
-    pub fn set_limit(&mut self, val: u64) {
+    pub const fn set_limit(&mut self, val: u64) {
         self.gas_limit = val;
     }
 
@@ -61,7 +61,7 @@ impl GasTracker {
 
     /// Sets the remaining gas.
     #[inline]
-    pub fn set_remaining(&mut self, val: u64) {
+    pub const fn set_remaining(&mut self, val: u64) {
         self.remaining = val;
     }
 
@@ -73,7 +73,7 @@ impl GasTracker {
 
     /// Sets the reservoir gas.
     #[inline]
-    pub fn set_reservoir(&mut self, val: u64) {
+    pub const fn set_reservoir(&mut self, val: u64) {
         self.reservoir = val;
     }
 
@@ -85,7 +85,7 @@ impl GasTracker {
 
     /// Sets the state gas spent.
     #[inline]
-    pub fn set_state_gas_spent(&mut self, val: u64) {
+    pub const fn set_state_gas_spent(&mut self, val: u64) {
         self.state_gas_spent = val;
     }
 
@@ -97,7 +97,7 @@ impl GasTracker {
 
     /// Sets the refunded gas.
     #[inline]
-    pub fn set_refunded(&mut self, val: i64) {
+    pub const fn set_refunded(&mut self, val: i64) {
         self.refunded = val;
     }
 
@@ -106,7 +106,7 @@ impl GasTracker {
     /// Deducts from `remaining`. Returns `false` if insufficient gas.
     #[inline]
     #[must_use = "In case of not enough gas, the interpreter should halt with an out-of-gas error"]
-    pub fn record_regular_cost(&mut self, cost: u64) -> bool {
+    pub const fn record_regular_cost(&mut self, cost: u64) -> bool {
         if let Some(new_remaining) = self.remaining.checked_sub(cost) {
             self.remaining = new_remaining;
             return true;
@@ -123,7 +123,7 @@ impl GasTracker {
     /// Returns `false` if total remaining gas is insufficient.
     #[inline]
     #[must_use = "In case of not enough gas, the interpreter should halt with an out-of-gas error"]
-    pub fn record_state_cost(&mut self, cost: u64) -> bool {
+    pub const fn record_state_cost(&mut self, cost: u64) -> bool {
         if self.reservoir >= cost {
             self.state_gas_spent = self.state_gas_spent.saturating_add(cost);
             self.reservoir -= cost;
@@ -142,19 +142,19 @@ impl GasTracker {
 
     /// Records a refund value.
     #[inline]
-    pub fn record_refund(&mut self, refund: i64) {
+    pub const fn record_refund(&mut self, refund: i64) {
         self.refunded += refund;
     }
 
     /// Erases a gas cost from remaining (returns gas from child frame).
     #[inline]
-    pub fn erase_cost(&mut self, returned: u64) {
+    pub const fn erase_cost(&mut self, returned: u64) {
         self.remaining += returned;
     }
 
     /// Spends all remaining gas excluding the reservoir.
     #[inline]
-    pub fn spend_all(&mut self) {
+    pub const fn spend_all(&mut self) {
         self.remaining = 0;
     }
 }

--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -373,20 +373,20 @@ impl GasParams {
 
     /// Selfdestruct refund.
     #[inline]
-    pub fn selfdestruct_refund(&self) -> i64 {
+    pub const fn selfdestruct_refund(&self) -> i64 {
         self.get(GasId::selfdestruct_refund()) as i64
     }
 
     /// Selfdestruct cold cost is calculated differently from other cold costs.
     /// and it contains both cold and warm costs.
     #[inline]
-    pub fn selfdestruct_cold_cost(&self) -> u64 {
+    pub const fn selfdestruct_cold_cost(&self) -> u64 {
         self.cold_account_additional_cost() + self.warm_storage_read_cost()
     }
 
     /// Selfdestruct cost.
     #[inline]
-    pub fn selfdestruct_cost(&self, should_charge_topup: bool, is_cold: bool) -> u64 {
+    pub const fn selfdestruct_cost(&self, should_charge_topup: bool, is_cold: bool) -> u64 {
         let mut gas = 0;
 
         // EIP-150: Gas cost changes for IO-heavy operations
@@ -407,51 +407,51 @@ impl GasParams {
 
     /// EXTCODECOPY gas cost
     #[inline]
-    pub fn extcodecopy(&self, len: usize) -> u64 {
+    pub const fn extcodecopy(&self, len: usize) -> u64 {
         self.get(GasId::extcodecopy_per_word())
             .saturating_mul(num_words(len) as u64)
     }
 
     /// MCOPY gas cost
     #[inline]
-    pub fn mcopy_cost(&self, len: usize) -> u64 {
+    pub const fn mcopy_cost(&self, len: usize) -> u64 {
         self.get(GasId::mcopy_per_word())
             .saturating_mul(num_words(len) as u64)
     }
 
     /// Static gas cost for SSTORE opcode
     #[inline]
-    pub fn sstore_static_gas(&self) -> u64 {
+    pub const fn sstore_static_gas(&self) -> u64 {
         self.get(GasId::sstore_static())
     }
 
     /// SSTORE set cost
     #[inline]
-    pub fn sstore_set_without_load_cost(&self) -> u64 {
+    pub const fn sstore_set_without_load_cost(&self) -> u64 {
         self.get(GasId::sstore_set_without_load_cost())
     }
 
     /// SSTORE reset cost
     #[inline]
-    pub fn sstore_reset_without_cold_load_cost(&self) -> u64 {
+    pub const fn sstore_reset_without_cold_load_cost(&self) -> u64 {
         self.get(GasId::sstore_reset_without_cold_load_cost())
     }
 
     /// SSTORE clearing slot refund
     #[inline]
-    pub fn sstore_clearing_slot_refund(&self) -> u64 {
+    pub const fn sstore_clearing_slot_refund(&self) -> u64 {
         self.get(GasId::sstore_clearing_slot_refund())
     }
 
     /// SSTORE set refund. Used in sstore_refund for SSTORE_SET_GAS - SLOAD_GAS.
     #[inline]
-    pub fn sstore_set_refund(&self) -> u64 {
+    pub const fn sstore_set_refund(&self) -> u64 {
         self.get(GasId::sstore_set_refund())
     }
 
     /// SSTORE reset refund. Used in sstore_refund for SSTORE_RESET_GAS - SLOAD_GAS.
     #[inline]
-    pub fn sstore_reset_refund(&self) -> u64 {
+    pub const fn sstore_reset_refund(&self) -> u64 {
         self.get(GasId::sstore_reset_refund())
     }
 
@@ -459,7 +459,12 @@ impl GasParams {
     ///
     /// Dynamic gas cost is gas that needs input from SSTORE operation to be calculated.
     #[inline]
-    pub fn sstore_dynamic_gas(&self, is_istanbul: bool, vals: &SStoreResult, is_cold: bool) -> u64 {
+    pub const fn sstore_dynamic_gas(
+        &self,
+        is_istanbul: bool,
+        vals: &SStoreResult,
+        is_cold: bool,
+    ) -> u64 {
         // frontier logic gets charged for every SSTORE operation if original value is zero.
         // this behaviour is fixed in istanbul fork.
         if !is_istanbul {
@@ -493,7 +498,7 @@ impl GasParams {
 
     /// SSTORE refund calculation.
     #[inline]
-    pub fn sstore_refund(&self, is_istanbul: bool, vals: &SStoreResult) -> i64 {
+    pub const fn sstore_refund(&self, is_istanbul: bool, vals: &SStoreResult) -> i64 {
         // EIP-3529: Reduction in refunds
         let sstore_clearing_slot_refund = self.sstore_clearing_slot_refund() as i64;
 
@@ -555,14 +560,14 @@ impl GasParams {
 
     /// KECCAK256 gas cost per word
     #[inline]
-    pub fn keccak256_cost(&self, len: usize) -> u64 {
+    pub const fn keccak256_cost(&self, len: usize) -> u64 {
         self.get(GasId::keccak256_per_word())
             .saturating_mul(num_words(len) as u64)
     }
 
     /// Memory gas cost
     #[inline]
-    pub fn memory_cost(&self, len: usize) -> u64 {
+    pub const fn memory_cost(&self, len: usize) -> u64 {
         let len = len as u64;
         self.get(GasId::memory_linear_cost())
             .saturating_mul(len)
@@ -574,20 +579,20 @@ impl GasParams {
 
     /// Initcode word cost
     #[inline]
-    pub fn initcode_cost(&self, len: usize) -> u64 {
+    pub const fn initcode_cost(&self, len: usize) -> u64 {
         self.get(GasId::initcode_per_word())
             .saturating_mul(num_words(len) as u64)
     }
 
     /// Create gas cost
     #[inline]
-    pub fn create_cost(&self) -> u64 {
+    pub const fn create_cost(&self) -> u64 {
         self.get(GasId::create())
     }
 
     /// Create2 gas cost.
     #[inline]
-    pub fn create2_cost(&self, len: usize) -> u64 {
+    pub const fn create2_cost(&self, len: usize) -> u64 {
         self.get(GasId::create()).saturating_add(
             self.get(GasId::keccak256_per_word())
                 .saturating_mul(num_words(len) as u64),
@@ -596,43 +601,43 @@ impl GasParams {
 
     /// Call stipend.
     #[inline]
-    pub fn call_stipend(&self) -> u64 {
+    pub const fn call_stipend(&self) -> u64 {
         self.get(GasId::call_stipend())
     }
 
     /// Call stipend reduction. Call stipend is reduced by 1/64 of the gas limit.
     #[inline]
-    pub fn call_stipend_reduction(&self, gas_limit: u64) -> u64 {
+    pub const fn call_stipend_reduction(&self, gas_limit: u64) -> u64 {
         gas_limit - gas_limit / self.get(GasId::call_stipend_reduction())
     }
 
     /// Transfer value cost
     #[inline]
-    pub fn transfer_value_cost(&self) -> u64 {
+    pub const fn transfer_value_cost(&self) -> u64 {
         self.get(GasId::transfer_value_cost())
     }
 
     /// Additional cold cost. Additional cold cost is added to the gas cost if the account is cold loaded.
     #[inline]
-    pub fn cold_account_additional_cost(&self) -> u64 {
+    pub const fn cold_account_additional_cost(&self) -> u64 {
         self.get(GasId::cold_account_additional_cost())
     }
 
     /// Cold storage additional cost.
     #[inline]
-    pub fn cold_storage_additional_cost(&self) -> u64 {
+    pub const fn cold_storage_additional_cost(&self) -> u64 {
         self.get(GasId::cold_storage_additional_cost())
     }
 
     /// Cold storage cost.
     #[inline]
-    pub fn cold_storage_cost(&self) -> u64 {
+    pub const fn cold_storage_cost(&self) -> u64 {
         self.get(GasId::cold_storage_cost())
     }
 
     /// New account cost. New account cost is added to the gas cost if the account is empty.
     #[inline]
-    pub fn new_account_cost(&self, is_spurious_dragon: bool, transfers_value: bool) -> u64 {
+    pub const fn new_account_cost(&self, is_spurious_dragon: bool, transfers_value: bool) -> u64 {
         // EIP-161: State trie clearing (invariant-preserving alternative)
         // Pre-Spurious Dragon: always charge for new account
         // Post-Spurious Dragon: only charge if value is transferred
@@ -644,39 +649,39 @@ impl GasParams {
 
     /// New account cost for selfdestruct.
     #[inline]
-    pub fn new_account_cost_for_selfdestruct(&self) -> u64 {
+    pub const fn new_account_cost_for_selfdestruct(&self) -> u64 {
         self.get(GasId::new_account_cost_for_selfdestruct())
     }
 
     /// Warm storage read cost. Warm storage read cost is added to the gas cost if the account is warm loaded.
     #[inline]
-    pub fn warm_storage_read_cost(&self) -> u64 {
+    pub const fn warm_storage_read_cost(&self) -> u64 {
         self.get(GasId::warm_storage_read_cost())
     }
 
     /// Copy cost
     #[inline]
-    pub fn copy_cost(&self, len: usize) -> u64 {
+    pub const fn copy_cost(&self, len: usize) -> u64 {
         self.copy_per_word_cost(num_words(len))
     }
 
     /// Copy per word cost
     #[inline]
-    pub fn copy_per_word_cost(&self, word_num: usize) -> u64 {
+    pub const fn copy_per_word_cost(&self, word_num: usize) -> u64 {
         self.get(GasId::copy_per_word())
             .saturating_mul(word_num as u64)
     }
 
     /// Code deposit cost, calculated per byte as len * code_deposit_cost.
     #[inline]
-    pub fn code_deposit_cost(&self, len: usize) -> u64 {
+    pub const fn code_deposit_cost(&self, len: usize) -> u64 {
         self.get(GasId::code_deposit_cost())
             .saturating_mul(len as u64)
     }
 
     /// State gas for SSTORE: charges for new slot creation (zero → non-zero).
     #[inline]
-    pub fn sstore_state_gas(&self, vals: &SStoreResult) -> u64 {
+    pub const fn sstore_state_gas(&self, vals: &SStoreResult) -> u64 {
         if vals.new_values_changes_present()
             && vals.is_original_eq_present()
             && vals.is_original_zero()
@@ -689,26 +694,26 @@ impl GasParams {
 
     /// State gas for new account creation.
     #[inline]
-    pub fn new_account_state_gas(&self) -> u64 {
+    pub const fn new_account_state_gas(&self) -> u64 {
         self.get(GasId::new_account_state_gas())
     }
 
     /// State gas per byte for code deposit.
     #[inline]
-    pub fn code_deposit_state_gas(&self, len: usize) -> u64 {
+    pub const fn code_deposit_state_gas(&self, len: usize) -> u64 {
         self.get(GasId::code_deposit_state_gas())
             .saturating_mul(len as u64)
     }
 
     /// State gas for contract metadata creation.
     #[inline]
-    pub fn create_state_gas(&self) -> u64 {
+    pub const fn create_state_gas(&self) -> u64 {
         self.get(GasId::create_state_gas())
     }
 
     /// Used in [GasParams::initial_tx_gas] to calculate the eip7702 per empty account cost.
     #[inline]
-    pub fn tx_eip7702_per_empty_account_cost(&self) -> u64 {
+    pub const fn tx_eip7702_per_empty_account_cost(&self) -> u64 {
         self.get(GasId::tx_eip7702_per_empty_account_cost())
     }
 
@@ -718,7 +723,7 @@ impl GasParams {
     /// to an account that already exists in the trie. By default this is
     /// `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST` (25000 - 12500 = 12500).
     #[inline]
-    pub fn tx_eip7702_auth_refund(&self) -> u64 {
+    pub const fn tx_eip7702_auth_refund(&self) -> u64 {
         self.get(GasId::tx_eip7702_auth_refund())
     }
 
@@ -726,7 +731,7 @@ impl GasParams {
     ///
     /// Used for `initial_state_gas` tracking. Zero before AMSTERDAM.
     #[inline]
-    pub fn tx_eip7702_per_auth_state_gas(&self) -> u64 {
+    pub const fn tx_eip7702_per_auth_state_gas(&self) -> u64 {
         self.get(GasId::tx_eip7702_per_auth_state_gas())
     }
 
@@ -757,18 +762,18 @@ impl GasParams {
 
     /// Used in [GasParams::initial_tx_gas] to calculate the token non zero byte multiplier.
     #[inline]
-    pub fn tx_token_non_zero_byte_multiplier(&self) -> u64 {
+    pub const fn tx_token_non_zero_byte_multiplier(&self) -> u64 {
         self.get(GasId::tx_token_non_zero_byte_multiplier())
     }
 
     /// Used in [GasParams::initial_tx_gas] to calculate the token cost for input data.
     #[inline]
-    pub fn tx_token_cost(&self) -> u64 {
+    pub const fn tx_token_cost(&self) -> u64 {
         self.get(GasId::tx_token_cost())
     }
 
     /// Used in [GasParams::initial_tx_gas] to calculate the floor gas per token.
-    pub fn tx_floor_cost_per_token(&self) -> u64 {
+    pub const fn tx_floor_cost_per_token(&self) -> u64 {
         self.get(GasId::tx_floor_cost_per_token())
     }
 
@@ -776,22 +781,22 @@ impl GasParams {
     ///
     /// Floor gas is introduced in EIP-7623.
     #[inline]
-    pub fn tx_floor_cost(&self, tokens_in_calldata: u64) -> u64 {
+    pub const fn tx_floor_cost(&self, tokens_in_calldata: u64) -> u64 {
         self.tx_floor_cost_per_token() * tokens_in_calldata + self.tx_floor_cost_base_gas()
     }
 
     /// Used in [GasParams::initial_tx_gas] to calculate the floor gas base gas.
-    pub fn tx_floor_cost_base_gas(&self) -> u64 {
+    pub const fn tx_floor_cost_base_gas(&self) -> u64 {
         self.get(GasId::tx_floor_cost_base_gas())
     }
 
     /// Used in [GasParams::initial_tx_gas] to calculate the access list address cost.
-    pub fn tx_access_list_address_cost(&self) -> u64 {
+    pub const fn tx_access_list_address_cost(&self) -> u64 {
         self.get(GasId::tx_access_list_address_cost())
     }
 
     /// Used in [GasParams::initial_tx_gas] to calculate the access list storage key cost.
-    pub fn tx_access_list_storage_key_cost(&self) -> u64 {
+    pub const fn tx_access_list_storage_key_cost(&self) -> u64 {
         self.get(GasId::tx_access_list_storage_key_cost())
     }
 
@@ -813,14 +818,14 @@ impl GasParams {
     /// assert_eq!(cost, 2 * 2400 + 5 * 1900); // 2 * ACCESS_LIST_ADDRESS + 5 * ACCESS_LIST_STORAGE_KEY
     /// ```
     #[inline]
-    pub fn tx_access_list_cost(&self, accounts: u64, storages: u64) -> u64 {
+    pub const fn tx_access_list_cost(&self, accounts: u64, storages: u64) -> u64 {
         accounts
             .saturating_mul(self.tx_access_list_address_cost())
             .saturating_add(storages.saturating_mul(self.tx_access_list_storage_key_cost()))
     }
 
     /// Used in [GasParams::initial_tx_gas] to calculate the base transaction stipend.
-    pub fn tx_base_stipend(&self) -> u64 {
+    pub const fn tx_base_stipend(&self) -> u64 {
         self.get(GasId::tx_base_stipend())
     }
 
@@ -828,13 +833,13 @@ impl GasParams {
     ///
     /// Similar to the [`Self::create_cost`] method but it got activated in different fork,
     #[inline]
-    pub fn tx_create_cost(&self) -> u64 {
+    pub const fn tx_create_cost(&self) -> u64 {
         self.get(GasId::tx_create_cost())
     }
 
     /// Used in [GasParams::initial_tx_gas] to calculate the initcode cost per word of len.
     #[inline]
-    pub fn tx_initcode_cost(&self, len: usize) -> u64 {
+    pub const fn tx_initcode_cost(&self, len: usize) -> u64 {
         self.get(GasId::tx_initcode_cost())
             .saturating_mul(num_words(len) as u64)
     }

--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -335,13 +335,13 @@ pub type JournalLoadErasedError = JournalLoadError<ErasedError>;
 impl<E> JournalLoadError<E> {
     /// Returns true if the error is a database error.
     #[inline]
-    pub fn is_db_error(&self) -> bool {
+    pub const fn is_db_error(&self) -> bool {
         matches!(self, JournalLoadError::DBError(_))
     }
 
     /// Returns true if the error is a cold load skipped.
     #[inline]
-    pub fn is_cold_load_skipped(&self) -> bool {
+    pub const fn is_cold_load_skipped(&self) -> bool {
         matches!(self, JournalLoadError::ColdLoadSkipped)
     }
 
@@ -452,7 +452,7 @@ impl<T> DerefMut for StateLoad<T> {
 impl<T> StateLoad<T> {
     /// Returns a new [`StateLoad`] with the given data and cold load status.
     #[inline]
-    pub fn new(data: T, is_cold: bool) -> Self {
+    pub const fn new(data: T, is_cold: bool) -> Self {
         Self { data, is_cold }
     }
 
@@ -493,7 +493,7 @@ pub struct AccountInfoLoad<'a> {
 impl<'a> AccountInfoLoad<'a> {
     /// Creates new [`AccountInfoLoad`] with the given account info, cold load status and empty status.
     #[inline]
-    pub fn new(account: &'a AccountInfo, is_cold: bool, is_empty: bool) -> Self {
+    pub const fn new(account: &'a AccountInfo, is_cold: bool, is_empty: bool) -> Self {
         Self {
             account: Cow::Borrowed(account),
             is_cold,

--- a/crates/context/interface/src/journaled_state/account.rs
+++ b/crates/context/interface/src/journaled_state/account.rs
@@ -140,7 +140,7 @@ pub struct JournaledAccount<'a, DB, ENTRY: JournalEntryTr = JournalEntry> {
 impl<'a, DB: Database, ENTRY: JournalEntryTr> JournaledAccount<'a, DB, ENTRY> {
     /// Creates new JournaledAccount
     #[inline]
-    pub fn new(
+    pub const fn new(
         address: Address,
         account: &'a mut Account,
         journal_entries: &'a mut Vec<ENTRY>,
@@ -283,7 +283,7 @@ impl<'a, DB: Database, ENTRY: JournalEntryTr> JournaledAccount<'a, DB, ENTRY> {
 
     /// Consumes the journaled account and returns the account.
     #[inline]
-    pub fn into_account(self) -> &'a Account {
+    pub const fn into_account(self) -> &'a Account {
         self.account
     }
 }

--- a/crates/context/interface/src/local.rs
+++ b/crates/context/interface/src/local.rs
@@ -66,7 +66,7 @@ impl<T> FrameStack<T> {
 
     /// Returns the current index of the stack.
     #[inline]
-    pub fn index(&self) -> Option<usize> {
+    pub const fn index(&self) -> Option<usize> {
         self.index
     }
 
@@ -95,7 +95,7 @@ impl<T> FrameStack<T> {
     /// Clears the stack by setting the index to 0.
     /// It does not destroy the stack.
     #[inline]
-    pub fn clear(&mut self) {
+    pub const fn clear(&mut self) {
         self.index = None;
     }
 
@@ -194,7 +194,7 @@ impl<'a, T> OutFrame<'a, T> {
     }
 
     /// Consumes the `OutFrame`, returning a `FrameToken` that indicates the frame has been initialized.
-    pub fn consume(self) -> FrameToken {
+    pub const fn consume(self) -> FrameToken {
         FrameToken(self.init)
     }
 }

--- a/crates/context/interface/src/result.rs
+++ b/crates/context/interface/src/result.rs
@@ -37,7 +37,7 @@ pub type ResultVecAndState<R, S> = ExecResultAndState<Vec<R>, S>;
 
 impl<R, S> ExecResultAndState<R, S> {
     /// Creates new ResultAndState.
-    pub fn new(result: R, state: S) -> Self {
+    pub const fn new(result: R, state: S) -> Self {
         Self { result, state }
     }
 }
@@ -172,25 +172,25 @@ impl ResultGas {
 
     /// Sets the `total_gas_spent` field by mutable reference.
     #[inline]
-    pub fn set_total_gas_spent(&mut self, total_gas_spent: u64) {
+    pub const fn set_total_gas_spent(&mut self, total_gas_spent: u64) {
         self.total_gas_spent = total_gas_spent;
     }
 
     /// Sets the `refunded` field by mutable reference.
     #[inline]
-    pub fn set_refunded(&mut self, refunded: u64) {
+    pub const fn set_refunded(&mut self, refunded: u64) {
         self.refunded = refunded;
     }
 
     /// Sets the `floor_gas` field by mutable reference.
     #[inline]
-    pub fn set_floor_gas(&mut self, floor_gas: u64) {
+    pub const fn set_floor_gas(&mut self, floor_gas: u64) {
         self.floor_gas = floor_gas;
     }
 
     /// Sets the `state_gas_spent` field by mutable reference.
     #[inline]
-    pub fn set_state_gas_spent(&mut self, state_gas_spent: u64) {
+    pub const fn set_state_gas_spent(&mut self, state_gas_spent: u64) {
         self.state_gas_spent = state_gas_spent;
     }
 
@@ -202,7 +202,7 @@ impl ResultGas {
             regular and state gas, this method is no longer valid.
             Use [`ResultGas::set_total_gas_spent`] instead"
     )]
-    pub fn set_spent(&mut self, spent: u64) {
+    pub const fn set_spent(&mut self, spent: u64) {
         self.total_gas_spent = spent;
     }
 
@@ -407,7 +407,7 @@ impl<HaltReasonTy> ExecutionResult<HaltReasonTy> {
     /// 1 indicates success, 0 indicates revert.
     ///
     /// <https://eips.ethereum.org/EIPS/eip-658>
-    pub fn is_success(&self) -> bool {
+    pub const fn is_success(&self) -> bool {
         matches!(self, Self::Success { .. })
     }
 
@@ -447,14 +447,14 @@ impl<HaltReasonTy> ExecutionResult<HaltReasonTy> {
     }
 
     /// Returns true if execution result is a Halt.
-    pub fn is_halt(&self) -> bool {
+    pub const fn is_halt(&self) -> bool {
         matches!(self, Self::Halt { .. })
     }
 
     /// Returns the output data of the execution.
     ///
     /// Returns [`None`] if the execution was halted.
-    pub fn output(&self) -> Option<&Bytes> {
+    pub const fn output(&self) -> Option<&Bytes> {
         match self {
             Self::Success { output, .. } => Some(output.data()),
             Self::Revert { output, .. } => Some(output),
@@ -474,7 +474,7 @@ impl<HaltReasonTy> ExecutionResult<HaltReasonTy> {
     }
 
     /// Returns the logs emitted during execution.
-    pub fn logs(&self) -> &[Log] {
+    pub const fn logs(&self) -> &[Log] {
         match self {
             Self::Success { logs, .. } | Self::Revert { logs, .. } | Self::Halt { logs, .. } => {
                 logs.as_slice()
@@ -492,14 +492,14 @@ impl<HaltReasonTy> ExecutionResult<HaltReasonTy> {
     }
 
     /// Returns the gas accounting information.
-    pub fn gas(&self) -> &ResultGas {
+    pub const fn gas(&self) -> &ResultGas {
         match self {
             Self::Success { gas, .. } | Self::Revert { gas, .. } | Self::Halt { gas, .. } => gas,
         }
     }
 
     /// Returns the gas used needed for the transaction receipt.
-    pub fn tx_gas_used(&self) -> u64 {
+    pub const fn tx_gas_used(&self) -> u64 {
         self.gas().tx_gas_used()
     }
 
@@ -509,7 +509,7 @@ impl<HaltReasonTy> ExecutionResult<HaltReasonTy> {
         since = "32.0.0",
         note = "Use `tx_gas_used()` instead, `gas_used` is ambiguous after EIP-8037 state gas split"
     )]
-    pub fn gas_used(&self) -> u64 {
+    pub const fn gas_used(&self) -> u64 {
         self.tx_gas_used()
     }
 }
@@ -585,7 +585,7 @@ impl Output {
     }
 
     /// Returns the output data of the execution output.
-    pub fn data(&self) -> &Bytes {
+    pub const fn data(&self) -> &Bytes {
         match self {
             Output::Call(data) => data,
             Output::Create(data, _) => data,
@@ -593,7 +593,7 @@ impl Output {
     }
 
     /// Returns the created address, if any.
-    pub fn address(&self) -> Option<&Address> {
+    pub const fn address(&self) -> Option<&Address> {
         match self {
             Output::Call(_) => None,
             Output::Create(_, address) => address.as_ref(),
@@ -1210,7 +1210,7 @@ pub struct TransactionIndexedError<Error> {
 impl<Error> TransactionIndexedError<Error> {
     /// Create a new `TransactionIndexedError` with the given error and transaction index.
     #[must_use]
-    pub fn new(error: Error, transaction_index: usize) -> Self {
+    pub const fn new(error: Error, transaction_index: usize) -> Self {
         Self {
             error,
             transaction_index,
@@ -1218,7 +1218,7 @@ impl<Error> TransactionIndexedError<Error> {
     }
 
     /// Get a reference to the underlying error.
-    pub fn error(&self) -> &Error {
+    pub const fn error(&self) -> &Error {
         &self.error
     }
 

--- a/crates/context/interface/src/transaction/transaction_type.rs
+++ b/crates/context/interface/src/transaction/transaction_type.rs
@@ -21,12 +21,12 @@ pub enum TransactionType {
 
 impl TransactionType {
     /// Returns true if the transaction type is legacy.
-    pub fn is_legacy(&self) -> bool {
+    pub const fn is_legacy(&self) -> bool {
         matches!(self, Self::Legacy)
     }
 
     /// Returns true if the transaction type is custom.
-    pub fn is_custom(&self) -> bool {
+    pub const fn is_custom(&self) -> bool {
         matches!(self, Self::Custom)
     }
 }

--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -165,12 +165,12 @@ impl CfgEnv {
 impl<SPEC> CfgEnv<SPEC> {
     /// Returns the spec for the `CfgEnv`.
     #[inline]
-    pub fn spec(&self) -> &SPEC {
+    pub const fn spec(&self) -> &SPEC {
         &self.spec
     }
 
     /// Consumes `self` and returns a new `CfgEnv` with the specified chain ID.
-    pub fn with_chain_id(mut self, chain_id: u64) -> Self {
+    pub const fn with_chain_id(mut self, chain_id: u64) -> Self {
         self.chain_id = chain_id;
         self
     }
@@ -196,13 +196,13 @@ impl<SPEC> CfgEnv<SPEC> {
     }
 
     /// Enables the transaction's chain ID check.
-    pub fn enable_tx_chain_id_check(mut self) -> Self {
+    pub const fn enable_tx_chain_id_check(mut self) -> Self {
         self.tx_chain_id_check = true;
         self
     }
 
     /// Disables the transaction's chain ID check.
-    pub fn disable_tx_chain_id_check(mut self) -> Self {
+    pub const fn disable_tx_chain_id_check(mut self) -> Self {
         self.tx_chain_id_check = false;
         self
     }
@@ -273,44 +273,44 @@ impl<SPEC> CfgEnv<SPEC> {
     }
 
     /// Sets the blob target
-    pub fn with_max_blobs_per_tx(mut self, max_blobs_per_tx: u64) -> Self {
+    pub const fn with_max_blobs_per_tx(mut self, max_blobs_per_tx: u64) -> Self {
         self.set_max_blobs_per_tx(max_blobs_per_tx);
         self
     }
 
     /// Sets the blob target
-    pub fn set_max_blobs_per_tx(&mut self, max_blobs_per_tx: u64) {
+    pub const fn set_max_blobs_per_tx(&mut self, max_blobs_per_tx: u64) {
         self.max_blobs_per_tx = Some(max_blobs_per_tx);
     }
 
     /// Clears the blob target and max count over hardforks.
-    pub fn clear_max_blobs_per_tx(&mut self) {
+    pub const fn clear_max_blobs_per_tx(&mut self) {
         self.max_blobs_per_tx = None;
     }
 
     /// Sets the disable priority fee check flag.
     #[cfg(feature = "optional_priority_fee_check")]
-    pub fn with_disable_priority_fee_check(mut self, disable: bool) -> Self {
+    pub const fn with_disable_priority_fee_check(mut self, disable: bool) -> Self {
         self.disable_priority_fee_check = disable;
         self
     }
 
     /// Sets the disable fee charge flag.
     #[cfg(feature = "optional_fee_charge")]
-    pub fn with_disable_fee_charge(mut self, disable: bool) -> Self {
+    pub const fn with_disable_fee_charge(mut self, disable: bool) -> Self {
         self.disable_fee_charge = disable;
         self
     }
 
     /// Sets the disable eip7623 flag.
     #[cfg(feature = "optional_eip7623")]
-    pub fn with_disable_eip7623(mut self, disable: bool) -> Self {
+    pub const fn with_disable_eip7623(mut self, disable: bool) -> Self {
         self.disable_eip7623 = disable;
         self
     }
 
     /// Sets the enable EIP-8037 (Amsterdam) state creation gas cost flag.
-    pub fn with_enable_amsterdam_eip8037(mut self, enable: bool) -> Self {
+    pub const fn with_enable_amsterdam_eip8037(mut self, enable: bool) -> Self {
         self.enable_amsterdam_eip8037 = enable;
         self
     }

--- a/crates/context/src/journal.rs
+++ b/crates/context/src/journal.rs
@@ -66,7 +66,7 @@ impl<DB, ENTRY: JournalEntryTr> Journal<DB, ENTRY> {
     /// Creates a new JournaledState by copying state data from a JournalInit and provided database.
     /// This allows reusing the state, logs, and other data from a previous execution context while
     /// connecting it to a different database backend.
-    pub fn new_with_inner(database: DB, inner: JournalInner<ENTRY>) -> Self {
+    pub const fn new_with_inner(database: DB, inner: JournalInner<ENTRY>) -> Self {
         Self { database, inner }
     }
 

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -298,19 +298,19 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
 
     /// Return reference to state.
     #[inline]
-    pub fn state(&mut self) -> &mut EvmState {
+    pub const fn state(&mut self) -> &mut EvmState {
         &mut self.state
     }
 
     /// Sets SpecId.
     #[inline]
-    pub fn set_spec_id(&mut self, spec: SpecId) {
+    pub const fn set_spec_id(&mut self, spec: SpecId) {
         self.cfg.spec = spec;
     }
 
     /// Sets EIP-7708 configuration flags.
     #[inline]
-    pub fn set_eip7708_config(&mut self, disabled: bool, delayed_burn_disabled: bool) {
+    pub const fn set_eip7708_config(&mut self, disabled: bool, delayed_burn_disabled: bool) {
         self.cfg.eip7708_disabled = disabled;
         self.cfg.eip7708_delayed_burn_disabled = delayed_burn_disabled;
     }
@@ -574,7 +574,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
 
     /// Makes a checkpoint that in case of Revert can bring back state to this point.
     #[inline]
-    pub fn checkpoint(&mut self) -> JournalCheckpoint {
+    pub const fn checkpoint(&mut self) -> JournalCheckpoint {
         let checkpoint = JournalCheckpoint {
             log_i: self.logs.len(),
             journal_i: self.journal.len(),
@@ -586,7 +586,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
 
     /// Commits the checkpoint.
     #[inline]
-    pub fn checkpoint_commit(&mut self) {
+    pub const fn checkpoint_commit(&mut self) {
         self.depth = self.depth.saturating_sub(1);
     }
 

--- a/crates/context/src/journal/warm_addresses.rs
+++ b/crates/context/src/journal/warm_addresses.rs
@@ -54,13 +54,13 @@ impl WarmAddresses {
 
     /// Returns the precompile addresses.
     #[inline]
-    pub fn precompiles(&self) -> &AddressSet {
+    pub const fn precompiles(&self) -> &AddressSet {
         &self.precompile_set
     }
 
     /// Returns the coinbase address.
     #[inline]
-    pub fn coinbase(&self) -> Option<Address> {
+    pub const fn coinbase(&self) -> Option<Address> {
         self.coinbase
     }
 
@@ -83,7 +83,7 @@ impl WarmAddresses {
 
     /// Set the coinbase address.
     #[inline]
-    pub fn set_coinbase(&mut self, address: Address) {
+    pub const fn set_coinbase(&mut self, address: Address) {
         self.coinbase = Some(address);
     }
 
@@ -95,13 +95,13 @@ impl WarmAddresses {
 
     /// Returns the access list.
     #[inline]
-    pub fn access_list(&self) -> &AddressMap<HashSet<StorageKey>> {
+    pub const fn access_list(&self) -> &AddressMap<HashSet<StorageKey>> {
         &self.access_list
     }
 
     /// Clear the coinbase address.
     #[inline]
-    pub fn clear_coinbase(&mut self) {
+    pub const fn clear_coinbase(&mut self) {
         self.coinbase = None;
     }
 

--- a/crates/context/src/tx.rs
+++ b/crates/context/src/tx.rs
@@ -132,7 +132,7 @@ impl TxEnv {
 
     /// Derives tx type from transaction fields and sets it to `tx_type`.
     /// Returns error in case some fields were not set correctly.
-    pub fn derive_tx_type(&mut self) -> Result<(), DeriveTxTypeError> {
+    pub const fn derive_tx_type(&mut self) -> Result<(), DeriveTxTypeError> {
         if !self.access_list.0.is_empty() {
             self.tx_type = TransactionType::Eip2930 as u8;
         }
@@ -282,65 +282,65 @@ impl TxEnvBuilder {
     }
 
     /// Set the transaction type
-    pub fn tx_type(mut self, tx_type: Option<u8>) -> Self {
+    pub const fn tx_type(mut self, tx_type: Option<u8>) -> Self {
         self.tx_type = tx_type;
         self
     }
 
     /// Get the transaction type
-    pub fn get_tx_type(&self) -> Option<u8> {
+    pub const fn get_tx_type(&self) -> Option<u8> {
         self.tx_type
     }
 
     /// Set the caller address
-    pub fn caller(mut self, caller: Address) -> Self {
+    pub const fn caller(mut self, caller: Address) -> Self {
         self.caller = caller;
         self
     }
 
     /// Set the gas limit
-    pub fn gas_limit(mut self, gas_limit: u64) -> Self {
+    pub const fn gas_limit(mut self, gas_limit: u64) -> Self {
         self.gas_limit = gas_limit;
         self
     }
 
     /// Set the max fee per gas.
-    pub fn max_fee_per_gas(mut self, max_fee_per_gas: u128) -> Self {
+    pub const fn max_fee_per_gas(mut self, max_fee_per_gas: u128) -> Self {
         self.gas_price = max_fee_per_gas;
         self
     }
 
     /// Set the gas price
-    pub fn gas_price(mut self, gas_price: u128) -> Self {
+    pub const fn gas_price(mut self, gas_price: u128) -> Self {
         self.gas_price = gas_price;
         self
     }
 
     /// Set the transaction kind
-    pub fn kind(mut self, kind: TxKind) -> Self {
+    pub const fn kind(mut self, kind: TxKind) -> Self {
         self.kind = kind;
         self
     }
 
     /// Set the transaction kind to call
-    pub fn call(mut self, target: Address) -> Self {
+    pub const fn call(mut self, target: Address) -> Self {
         self.kind = TxKind::Call(target);
         self
     }
 
     /// Set the transaction kind to create
-    pub fn create(mut self) -> Self {
+    pub const fn create(mut self) -> Self {
         self.kind = TxKind::Create;
         self
     }
 
     /// Set the transaction kind to create
-    pub fn to(self, target: Address) -> Self {
+    pub const fn to(self, target: Address) -> Self {
         self.call(target)
     }
 
     /// Set the transaction value
-    pub fn value(mut self, value: U256) -> Self {
+    pub const fn value(mut self, value: U256) -> Self {
         self.value = value;
         self
     }
@@ -352,13 +352,13 @@ impl TxEnvBuilder {
     }
 
     /// Set the transaction nonce
-    pub fn nonce(mut self, nonce: u64) -> Self {
+    pub const fn nonce(mut self, nonce: u64) -> Self {
         self.nonce = nonce;
         self
     }
 
     /// Set the chain ID
-    pub fn chain_id(mut self, chain_id: Option<u64>) -> Self {
+    pub const fn chain_id(mut self, chain_id: Option<u64>) -> Self {
         self.chain_id = chain_id;
         self
     }
@@ -370,7 +370,7 @@ impl TxEnvBuilder {
     }
 
     /// Set the gas priority fee
-    pub fn gas_priority_fee(mut self, gas_priority_fee: Option<u128>) -> Self {
+    pub const fn gas_priority_fee(mut self, gas_priority_fee: Option<u128>) -> Self {
         self.gas_priority_fee = gas_priority_fee;
         self
     }
@@ -382,7 +382,7 @@ impl TxEnvBuilder {
     }
 
     /// Set the max fee per blob gas
-    pub fn max_fee_per_blob_gas(mut self, max_fee_per_blob_gas: u128) -> Self {
+    pub const fn max_fee_per_blob_gas(mut self, max_fee_per_blob_gas: u128) -> Self {
         self.max_fee_per_blob_gas = max_fee_per_blob_gas;
         self
     }

--- a/crates/database/interface/src/async_db.rs
+++ b/crates/database/interface/src/async_db.rs
@@ -130,7 +130,7 @@ impl<T> WrapDatabaseAsync<T> {
     /// Refer to [tokio::runtime::Builder] on how to create a runtime if you are in synchronous world.
     ///
     /// If you are already using something like [tokio::main], call [`WrapDatabaseAsync::new`] instead.
-    pub fn with_runtime(db: T, runtime: Runtime) -> Self {
+    pub const fn with_runtime(db: T, runtime: Runtime) -> Self {
         let rt = HandleOrRuntime::Runtime(runtime);
         Self { db, rt }
     }
@@ -141,7 +141,7 @@ impl<T> WrapDatabaseAsync<T> {
     /// to obtain a handle.
     ///
     /// If you are already in asynchronous world, like [tokio::main], use [`WrapDatabaseAsync::new`] instead.
-    pub fn with_handle(db: T, handle: Handle) -> Self {
+    pub const fn with_handle(db: T, handle: Handle) -> Self {
         let rt = HandleOrRuntime::Handle(handle);
         Self { db, rt }
     }

--- a/crates/database/interface/src/bal.rs
+++ b/crates/database/interface/src/bal.rs
@@ -36,19 +36,19 @@ impl BalState {
 
     /// Reset BAL index.
     #[inline]
-    pub fn reset_bal_index(&mut self) {
+    pub const fn reset_bal_index(&mut self) {
         self.bal_index = 0;
     }
 
     /// Bump BAL index.
     #[inline]
-    pub fn bump_bal_index(&mut self) {
+    pub const fn bump_bal_index(&mut self) {
         self.bal_index += 1;
     }
 
     /// Get BAL index.
     #[inline]
-    pub fn bal_index(&self) -> u64 {
+    pub const fn bal_index(&self) -> u64 {
         self.bal_index
     }
 
@@ -80,7 +80,7 @@ impl BalState {
 
     /// Take BAL builder.
     #[inline]
-    pub fn take_built_bal(&mut self) -> Option<Bal> {
+    pub const fn take_built_bal(&mut self) -> Option<Bal> {
         self.reset_bal_index();
         self.bal_builder.take()
     }
@@ -271,14 +271,14 @@ impl<DB> BalDatabase<DB> {
 
     /// Reset BAL index.
     #[inline]
-    pub fn reset_bal_index(mut self) -> Self {
+    pub const fn reset_bal_index(mut self) -> Self {
         self.bal_state.reset_bal_index();
         self
     }
 
     /// Bump BAL index.
     #[inline]
-    pub fn bump_bal_index(&mut self) {
+    pub const fn bump_bal_index(&mut self) {
         self.bal_state.bump_bal_index();
     }
 }

--- a/crates/database/interface/src/empty_db.rs
+++ b/crates/database/interface/src/empty_db.rs
@@ -47,7 +47,7 @@ impl<E> Eq for EmptyDBTyped<E> {}
 
 impl<E> EmptyDBTyped<E> {
     /// Create a new empty database.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             _phantom: PhantomData,
         }

--- a/crates/database/src/alloydb.rs
+++ b/crates/database/src/alloydb.rs
@@ -74,7 +74,7 @@ impl<N: Network, P: Provider<N>> AlloyDB<N, P> {
     }
 
     /// Sets the block number on which the queries will be based on.
-    pub fn set_block_number(&mut self, block_number: BlockId) {
+    pub const fn set_block_number(&mut self, block_number: BlockId) {
         self.block_number = block_number;
     }
 }

--- a/crates/database/src/in_memory_db.rs
+++ b/crates/database/src/in_memory_db.rs
@@ -476,7 +476,7 @@ impl DbAccount {
 
     /// Updates the account state.
     #[inline(always)]
-    pub fn update_account_state(&mut self, account_state: AccountState) {
+    pub const fn update_account_state(&mut self, account_state: AccountState) {
         self.account_state = account_state;
     }
 }
@@ -516,7 +516,7 @@ pub enum AccountState {
 
 impl AccountState {
     /// Returns `true` if EVM cleared storage of this account
-    pub fn is_storage_cleared(&self) -> bool {
+    pub const fn is_storage_cleared(&self) -> bool {
         matches!(self, AccountState::StorageCleared)
     }
 }

--- a/crates/database/src/states/account_status.rs
+++ b/crates/database/src/states/account_status.rs
@@ -38,7 +38,7 @@ pub enum AccountStatus {
 
 impl AccountStatus {
     /// Account is not modified and just loaded from database.
-    pub fn is_not_modified(&self) -> bool {
+    pub const fn is_not_modified(&self) -> bool {
         matches!(
             self,
             Self::LoadedNotExisting | Self::Loaded | Self::LoadedEmptyEIP161
@@ -47,7 +47,7 @@ impl AccountStatus {
 
     /// Account was destroyed by calling SELFDESTRUCT.
     /// This means that full account and storage are inside memory.
-    pub fn was_destroyed(&self) -> bool {
+    pub const fn was_destroyed(&self) -> bool {
         matches!(
             self,
             Self::Destroyed | Self::DestroyedChanged | Self::DestroyedAgain
@@ -55,7 +55,7 @@ impl AccountStatus {
     }
 
     /// This means storage is known, it can be newly created or storage got destroyed.
-    pub fn is_storage_known(&self) -> bool {
+    pub const fn is_storage_known(&self) -> bool {
         matches!(
             self,
             Self::LoadedNotExisting
@@ -69,12 +69,12 @@ impl AccountStatus {
     /// Account is modified but not destroyed.
     /// This means that some storage values can be found in both
     /// memory and database.
-    pub fn is_modified_and_not_destroyed(&self) -> bool {
+    pub const fn is_modified_and_not_destroyed(&self) -> bool {
         matches!(self, Self::Changed | Self::InMemoryChange)
     }
 
     /// Returns the next account status on creation.
-    pub fn on_created(&self) -> Self {
+    pub const fn on_created(&self) -> Self {
         match self {
             // If account was destroyed previously just copy new info to it.
             Self::DestroyedAgain
@@ -96,7 +96,7 @@ impl AccountStatus {
     }
 
     /// Returns the next account status on touched empty account post state clear EIP (EIP-161).
-    pub fn on_touched_empty_post_eip161(&self) -> Self {
+    pub const fn on_touched_empty_post_eip161(&self) -> Self {
         match self {
             // Account can be touched but not existing. The status should remain the same.
             Self::LoadedNotExisting => Self::LoadedNotExisting,
@@ -110,7 +110,7 @@ impl AccountStatus {
     }
 
     /// Returns the next account status on change.
-    pub fn on_changed(&self, had_no_nonce_and_code: bool) -> Self {
+    pub const fn on_changed(&self, had_no_nonce_and_code: bool) -> Self {
         match self {
             // If the account was loaded as not existing, promote it to changed.
             // This account was likely created by a balance transfer.
@@ -143,7 +143,7 @@ impl AccountStatus {
     }
 
     /// Returns the next account status on selfdestruct.
-    pub fn on_selfdestructed(&self) -> Self {
+    pub const fn on_selfdestructed(&self) -> Self {
         match self {
             // Non existing account can't be destroyed.
             Self::LoadedNotExisting => Self::LoadedNotExisting,

--- a/crates/database/src/states/bundle_account.rs
+++ b/crates/database/src/states/bundle_account.rs
@@ -34,7 +34,7 @@ pub struct BundleAccount {
 
 impl BundleAccount {
     /// Create new BundleAccount.
-    pub fn new(
+    pub const fn new(
         original_info: Option<AccountInfo>,
         present_info: Option<AccountInfo>,
         storage: StorageWithOriginalValues,
@@ -75,7 +75,7 @@ impl BundleAccount {
     }
 
     /// Was this account destroyed.
-    pub fn was_destroyed(&self) -> bool {
+    pub const fn was_destroyed(&self) -> bool {
         self.status.was_destroyed()
     }
 

--- a/crates/database/src/states/bundle_state.rs
+++ b/crates/database/src/states/bundle_state.rs
@@ -49,7 +49,7 @@ pub enum OriginalValuesKnown {
 }
 impl OriginalValuesKnown {
     /// Original value is not known for sure.
-    pub fn is_not_known(&self) -> bool {
+    pub const fn is_not_known(&self) -> bool {
         matches!(self, Self::No)
     }
 }
@@ -320,58 +320,58 @@ impl BundleBuilder {
     }
 
     /// Getter for `states` field
-    pub fn get_states(&self) -> &AddressSet {
+    pub const fn get_states(&self) -> &AddressSet {
         &self.states
     }
 
     /// Mutable getter for `states` field
-    pub fn get_states_mut(&mut self) -> &mut AddressSet {
+    pub const fn get_states_mut(&mut self) -> &mut AddressSet {
         &mut self.states
     }
 
     /// Mutable getter for `state_original` field
-    pub fn get_state_original_mut(&mut self) -> &mut AddressMap<AccountInfo> {
+    pub const fn get_state_original_mut(&mut self) -> &mut AddressMap<AccountInfo> {
         &mut self.state_original
     }
 
     /// Mutable getter for `state_present` field
-    pub fn get_state_present_mut(&mut self) -> &mut AddressMap<AccountInfo> {
+    pub const fn get_state_present_mut(&mut self) -> &mut AddressMap<AccountInfo> {
         &mut self.state_present
     }
 
     /// Mutable getter for `state_storage` field
-    pub fn get_state_storage_mut(
+    pub const fn get_state_storage_mut(
         &mut self,
     ) -> &mut AddressMap<StorageKeyMap<(StorageValue, StorageValue)>> {
         &mut self.state_storage
     }
 
     /// Mutable getter for `reverts` field
-    pub fn get_reverts_mut(&mut self) -> &mut BTreeSet<(u64, Address)> {
+    pub const fn get_reverts_mut(&mut self) -> &mut BTreeSet<(u64, Address)> {
         &mut self.reverts
     }
 
     /// Mutable getter for `revert_range` field
-    pub fn get_revert_range_mut(&mut self) -> &mut RangeInclusive<u64> {
+    pub const fn get_revert_range_mut(&mut self) -> &mut RangeInclusive<u64> {
         &mut self.revert_range
     }
 
     /// Mutable getter for `revert_account` field
-    pub fn get_revert_account_mut(
+    pub const fn get_revert_account_mut(
         &mut self,
     ) -> &mut HashMap<(u64, Address), Option<Option<AccountInfo>>> {
         &mut self.revert_account
     }
 
     /// Mutable getter for `revert_storage` field
-    pub fn get_revert_storage_mut(
+    pub const fn get_revert_storage_mut(
         &mut self,
     ) -> &mut HashMap<(u64, Address), Vec<(StorageKey, StorageValue)>> {
         &mut self.revert_storage
     }
 
     /// Mutable getter for `contracts` field
-    pub fn get_contracts_mut(&mut self) -> &mut B256Map<Bytecode> {
+    pub const fn get_contracts_mut(&mut self) -> &mut B256Map<Bytecode> {
         &mut self.contracts
     }
 }
@@ -387,7 +387,7 @@ pub enum BundleRetention {
 
 impl BundleRetention {
     /// Returns `true` if reverts should be retained.
-    pub fn includes_reverts(&self) -> bool {
+    pub const fn includes_reverts(&self) -> bool {
         matches!(self, Self::Reverts)
     }
 }
@@ -513,7 +513,7 @@ impl BundleState {
     }
 
     /// Returns reference to the state.
-    pub fn state(&self) -> &AddressMap<BundleAccount> {
+    pub const fn state(&self) -> &AddressMap<BundleAccount> {
         &self.state
     }
 

--- a/crates/database/src/states/cache_account.rs
+++ b/crates/database/src/states/cache_account.rs
@@ -40,7 +40,7 @@ impl From<&BundleAccount> for CacheAccount {
 
 impl CacheAccount {
     /// Creates new account that is loaded from database.
-    pub fn new_loaded(info: AccountInfo, storage: PlainStorage) -> Self {
+    pub const fn new_loaded(info: AccountInfo, storage: PlainStorage) -> Self {
         Self {
             account: Some(PlainAccount { info, storage }),
             status: AccountStatus::Loaded,
@@ -56,7 +56,7 @@ impl CacheAccount {
     }
 
     /// Loaded not existing account.
-    pub fn new_loaded_not_existing() -> Self {
+    pub const fn new_loaded_not_existing() -> Self {
         Self {
             account: None,
             status: AccountStatus::LoadedNotExisting,
@@ -64,7 +64,7 @@ impl CacheAccount {
     }
 
     /// Creates new account that is newly created.
-    pub fn new_newly_created(info: AccountInfo, storage: PlainStorage) -> Self {
+    pub const fn new_newly_created(info: AccountInfo, storage: PlainStorage) -> Self {
         Self {
             account: Some(PlainAccount { info, storage }),
             status: AccountStatus::InMemoryChange,
@@ -72,7 +72,7 @@ impl CacheAccount {
     }
 
     /// Creates account that is destroyed.
-    pub fn new_destroyed() -> Self {
+    pub const fn new_destroyed() -> Self {
         Self {
             account: None,
             status: AccountStatus::Destroyed,
@@ -80,7 +80,7 @@ impl CacheAccount {
     }
 
     /// Creates changed account.
-    pub fn new_changed(info: AccountInfo, storage: PlainStorage) -> Self {
+    pub const fn new_changed(info: AccountInfo, storage: PlainStorage) -> Self {
         Self {
             account: Some(PlainAccount { info, storage }),
             status: AccountStatus::Changed,
@@ -88,7 +88,7 @@ impl CacheAccount {
     }
 
     /// Returns true if account is some.
-    pub fn is_some(&self) -> bool {
+    pub const fn is_some(&self) -> bool {
         matches!(
             self.status,
             AccountStatus::Changed

--- a/crates/database/src/states/plain_account.rs
+++ b/crates/database/src/states/plain_account.rs
@@ -47,7 +47,7 @@ impl From<EvmStorageSlot> for StorageSlot {
 
 impl StorageSlot {
     /// Creates a new _unchanged_ `StorageSlot` for the given value.
-    pub fn new(original: StorageValue) -> Self {
+    pub const fn new(original: StorageValue) -> Self {
         Self {
             previous_or_original_value: original,
             present_value: original,
@@ -55,7 +55,7 @@ impl StorageSlot {
     }
 
     /// Creates a new _changed_ `StorageSlot`.
-    pub fn new_changed(
+    pub const fn new_changed(
         previous_or_original_value: StorageValue,
         present_value: StorageValue,
     ) -> Self {
@@ -71,12 +71,12 @@ impl StorageSlot {
     }
 
     /// Returns the original value of the storage slot.
-    pub fn original_value(&self) -> StorageValue {
+    pub const fn original_value(&self) -> StorageValue {
         self.previous_or_original_value
     }
 
     /// Returns the current value of the storage slot.
-    pub fn present_value(&self) -> StorageValue {
+    pub const fn present_value(&self) -> StorageValue {
         self.present_value
     }
 }

--- a/crates/database/src/states/reverts.rs
+++ b/crates/database/src/states/reverts.rs
@@ -31,7 +31,7 @@ impl DerefMut for Reverts {
 
 impl Reverts {
     /// Creates new reverts.
-    pub fn new(reverts: Vec<Vec<(Address, AccountRevert)>>) -> Self {
+    pub const fn new(reverts: Vec<Vec<(Address, AccountRevert)>>) -> Self {
         Self(reverts)
     }
 
@@ -325,7 +325,7 @@ pub enum RevertToSlot {
 
 impl RevertToSlot {
     /// Returns the previous value to set on revert.
-    pub fn to_previous_value(self) -> StorageValue {
+    pub const fn to_previous_value(self) -> StorageValue {
         match self {
             RevertToSlot::Some(value) => value,
             RevertToSlot::Destroyed => StorageValue::ZERO,

--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -200,7 +200,7 @@ impl<DB: Database> State<DB> {
 
     /// Takes build bal from bal state.
     #[inline]
-    pub fn take_built_bal(&mut self) -> Option<Bal> {
+    pub const fn take_built_bal(&mut self) -> Option<Bal> {
         self.bal_state.take_built_bal()
     }
 
@@ -212,19 +212,19 @@ impl<DB: Database> State<DB> {
 
     /// Bump BAL index.
     #[inline]
-    pub fn bump_bal_index(&mut self) {
+    pub const fn bump_bal_index(&mut self) {
         self.bal_state.bump_bal_index();
     }
 
     /// Set BAL index.
     #[inline]
-    pub fn set_bal_index(&mut self, index: u64) {
+    pub const fn set_bal_index(&mut self, index: u64) {
         self.bal_state.bal_index = index;
     }
 
     /// Reset BAL index.
     #[inline]
-    pub fn reset_bal_index(&mut self) {
+    pub const fn reset_bal_index(&mut self) {
         self.bal_state.reset_bal_index();
     }
 

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -84,12 +84,12 @@ impl EthFrame<EthInterpreter> {
     }
 
     /// Returns true if the frame has finished execution.
-    pub fn is_finished(&self) -> bool {
+    pub const fn is_finished(&self) -> bool {
         self.is_finished
     }
 
     /// Sets the finished state of the frame.
-    pub fn set_finished(&mut self, finished: bool) {
+    pub const fn set_finished(&mut self, finished: bool) {
         self.is_finished = finished;
     }
 }
@@ -541,7 +541,7 @@ impl EthFrame<EthInterpreter> {
 
 /// Handles the remaining gas of the parent frame.
 #[inline]
-pub fn handle_reservoir_remaining_gas(
+pub const fn handle_reservoir_remaining_gas(
     parent_gas: &mut Gas,
     child_gas: &Gas,
     result: InstructionResult,

--- a/crates/handler/src/frame_data.rs
+++ b/crates/handler/src/frame_data.rs
@@ -80,7 +80,7 @@ impl FrameResult {
 
     /// Returns reference to gas.
     #[inline]
-    pub fn gas(&self) -> &Gas {
+    pub const fn gas(&self) -> &Gas {
         match self {
             FrameResult::Call(outcome) => &outcome.result.gas,
             FrameResult::Create(outcome) => &outcome.result.gas,
@@ -89,7 +89,7 @@ impl FrameResult {
 
     /// Returns mutable reference to interpreter result.
     #[inline]
-    pub fn gas_mut(&mut self) -> &mut Gas {
+    pub const fn gas_mut(&mut self) -> &mut Gas {
         match self {
             FrameResult::Call(outcome) => &mut outcome.result.gas,
             FrameResult::Create(outcome) => &mut outcome.result.gas,
@@ -98,7 +98,7 @@ impl FrameResult {
 
     /// Returns reference to interpreter result.
     #[inline]
-    pub fn interpreter_result(&self) -> &InterpreterResult {
+    pub const fn interpreter_result(&self) -> &InterpreterResult {
         match self {
             FrameResult::Call(outcome) => &outcome.result,
             FrameResult::Create(outcome) => &outcome.result,
@@ -107,7 +107,7 @@ impl FrameResult {
 
     /// Returns mutable reference to interpreter result.
     #[inline]
-    pub fn interpreter_result_mut(&mut self) -> &mut InterpreterResult {
+    pub const fn interpreter_result_mut(&mut self) -> &mut InterpreterResult {
         match self {
             FrameResult::Call(outcome) => &mut outcome.result,
             FrameResult::Create(outcome) => &mut outcome.result,
@@ -116,36 +116,36 @@ impl FrameResult {
 
     /// Return Instruction result.
     #[inline]
-    pub fn instruction_result(&self) -> InstructionResult {
+    pub const fn instruction_result(&self) -> InstructionResult {
         self.interpreter_result().result
     }
 }
 
 impl FrameData {
     /// Creates a new create frame data.
-    pub fn new_create(created_address: Address) -> Self {
+    pub const fn new_create(created_address: Address) -> Self {
         Self::Create(CreateFrame { created_address })
     }
 
     /// Creates a new call frame data.
-    pub fn new_call(return_memory_range: Range<usize>) -> Self {
+    pub const fn new_call(return_memory_range: Range<usize>) -> Self {
         Self::Call(CallFrame {
             return_memory_range,
         })
     }
 
     /// Returns true if frame is call frame.
-    pub fn is_call(&self) -> bool {
+    pub const fn is_call(&self) -> bool {
         matches!(self, Self::Call { .. })
     }
 
     /// Returns true if frame is create frame.
-    pub fn is_create(&self) -> bool {
+    pub const fn is_create(&self) -> bool {
         matches!(self, Self::Create { .. })
     }
 
     /// Returns created address if frame is create otherwise returns None.
-    pub fn created_address(&self) -> Option<Address> {
+    pub const fn created_address(&self) -> Option<Address> {
         match self {
             Self::Create(create_frame) => Some(create_frame.created_address),
             _ => None,

--- a/crates/handler/src/item_or_result.rs
+++ b/crates/handler/src/item_or_result.rs
@@ -37,12 +37,12 @@ impl<ITEM, RES> ItemOrResult<ITEM, RES> {
 
 impl<ITEM, RES> ItemOrResult<ITEM, RES> {
     /// Returns true if this is a result variant.
-    pub fn is_result(&self) -> bool {
+    pub const fn is_result(&self) -> bool {
         matches!(self, ItemOrResult::Result(_))
     }
 
     /// Returns true if this is an item variant.
-    pub fn is_item(&self) -> bool {
+    pub const fn is_item(&self) -> bool {
         matches!(self, ItemOrResult::Item(_))
     }
 }

--- a/crates/handler/src/post_execution.rs
+++ b/crates/handler/src/post_execution.rs
@@ -30,7 +30,7 @@ pub fn build_result_gas(gas: &Gas, init_and_floor_gas: InitialAndFloorGas) -> Re
 ///
 /// Per EIP-8037, gas used before refund is `tx.gas - gas_left - state_gas_reservoir`.
 /// The floor applies to this combined total, not just regular gas.
-pub fn eip7623_check_gas_floor(gas: &mut Gas, init_and_floor_gas: InitialAndFloorGas) {
+pub const fn eip7623_check_gas_floor(gas: &mut Gas, init_and_floor_gas: InitialAndFloorGas) {
     // EIP-7623: Increase calldata cost
     // EIP-8037: tx_gas_used_before_refund = tx.gas - gas_left - reservoir
     // The floor must apply to this combined value, not just (limit - remaining).

--- a/crates/handler/src/precompile_provider.rs
+++ b/crates/handler/src/precompile_provider.rs
@@ -52,7 +52,7 @@ impl EthPrecompiles {
     }
 
     /// Returns addresses of the precompiles.
-    pub fn warm_addresses(&self) -> &AddressSet {
+    pub const fn warm_addresses(&self) -> &AddressSet {
         self.precompiles.addresses_set()
     }
 

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -25,7 +25,7 @@ pub fn validate_env<CTX: ContextTr, ERROR: From<InvalidHeader> + From<InvalidTra
 
 /// Validate legacy transaction gas price against basefee.
 #[inline]
-pub fn validate_legacy_gas_price(
+pub const fn validate_legacy_gas_price(
     gas_price: u128,
     base_fee: Option<u128>,
 ) -> Result<(), InvalidTransaction> {

--- a/crates/inspector/src/count_inspector.rs
+++ b/crates/inspector/src/count_inspector.rs
@@ -52,12 +52,12 @@ impl CountInspector {
     }
 
     /// Get the count for a specific opcode.
-    pub fn get_count(&self, opcode: u8) -> u64 {
+    pub const fn get_count(&self, opcode: u8) -> u64 {
         self.opcode_counts[opcode as usize]
     }
 
     /// Get a reference to all opcode counts.
-    pub fn opcode_counts(&self) -> &[u64; 256] {
+    pub const fn opcode_counts(&self) -> &[u64; 256] {
         &self.opcode_counts
     }
 
@@ -75,7 +75,7 @@ impl CountInspector {
     }
 
     /// Clear all counts.
-    pub fn clear(&mut self) {
+    pub const fn clear(&mut self) {
         self.opcode_counts = [0; 256];
         self.initialize_interp_count = 0;
         self.step_count = 0;
@@ -89,47 +89,47 @@ impl CountInspector {
     }
 
     /// Get the count of initialize_interp calls.
-    pub fn initialize_interp_count(&self) -> u64 {
+    pub const fn initialize_interp_count(&self) -> u64 {
         self.initialize_interp_count
     }
 
     /// Get the count of step calls.
-    pub fn step_count(&self) -> u64 {
+    pub const fn step_count(&self) -> u64 {
         self.step_count
     }
 
     /// Get the count of step_end calls.
-    pub fn step_end_count(&self) -> u64 {
+    pub const fn step_end_count(&self) -> u64 {
         self.step_end_count
     }
 
     /// Get the count of log calls.
-    pub fn log_count(&self) -> u64 {
+    pub const fn log_count(&self) -> u64 {
         self.log_count
     }
 
     /// Get the count of call calls.
-    pub fn call_count(&self) -> u64 {
+    pub const fn call_count(&self) -> u64 {
         self.call_count
     }
 
     /// Get the count of call_end calls.
-    pub fn call_end_count(&self) -> u64 {
+    pub const fn call_end_count(&self) -> u64 {
         self.call_end_count
     }
 
     /// Get the count of create calls.
-    pub fn create_count(&self) -> u64 {
+    pub const fn create_count(&self) -> u64 {
         self.create_count
     }
 
     /// Get the count of create_end calls.
-    pub fn create_end_count(&self) -> u64 {
+    pub const fn create_end_count(&self) -> u64 {
         self.create_end_count
     }
 
     /// Get the count of selfdestruct calls.
-    pub fn selfdestruct_count(&self) -> u64 {
+    pub const fn selfdestruct_count(&self) -> u64 {
         self.selfdestruct_count
     }
 }

--- a/crates/inspector/src/eip3155.rs
+++ b/crates/inspector/src/eip3155.rs
@@ -161,13 +161,13 @@ impl TracerEip3155 {
     }
 
     /// Don't include a summary at the end of the trace
-    pub fn without_summary(mut self) -> Self {
+    pub const fn without_summary(mut self) -> Self {
         self.print_summary = false;
         self
     }
 
     /// Include a memory field for each step. This significantly increases processing time and output size.
-    pub fn with_memory(mut self) -> Self {
+    pub const fn with_memory(mut self) -> Self {
         self.include_memory = true;
         self
     }

--- a/crates/inspector/src/gas.rs
+++ b/crates/inspector/src/gas.rs
@@ -20,30 +20,30 @@ impl Default for GasInspector {
 impl GasInspector {
     /// Returns the remaining gas.
     #[inline]
-    pub fn gas_remaining(&self) -> u64 {
+    pub const fn gas_remaining(&self) -> u64 {
         self.gas_remaining
     }
 
     /// Returns the last gas cost.
     #[inline]
-    pub fn last_gas_cost(&self) -> u64 {
+    pub const fn last_gas_cost(&self) -> u64 {
         self.last_gas_cost
     }
 
     /// Returns the state gas spent.
     #[inline]
-    pub fn state_gas_spent(&self) -> u64 {
+    pub const fn state_gas_spent(&self) -> u64 {
         self.state_gas_spent
     }
 
     /// Returns the reservoir gas.
     #[inline]
-    pub fn reservoir(&self) -> u64 {
+    pub const fn reservoir(&self) -> u64 {
         self.reservoir
     }
 
     /// Create a new gas inspector.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             gas_remaining: 0,
             last_gas_cost: 0,
@@ -54,7 +54,7 @@ impl GasInspector {
 
     /// Sets remaining gas to gas limit.
     #[inline]
-    pub fn initialize_interp(&mut self, gas: &Gas) {
+    pub const fn initialize_interp(&mut self, gas: &Gas) {
         self.gas_remaining = gas.limit();
         self.state_gas_spent = gas.state_gas_spent();
         self.reservoir = gas.reservoir();
@@ -62,7 +62,7 @@ impl GasInspector {
 
     /// Sets the remaining gas.
     #[inline]
-    pub fn step(&mut self, gas: &Gas) {
+    pub const fn step(&mut self, gas: &Gas) {
         self.gas_remaining = gas.remaining();
         self.state_gas_spent = gas.state_gas_spent();
         self.reservoir = gas.reservoir();
@@ -70,7 +70,7 @@ impl GasInspector {
 
     /// calculate last gas cost and remaining gas.
     #[inline]
-    pub fn step_end(&mut self, gas: &Gas) {
+    pub const fn step_end(&mut self, gas: &Gas) {
         let remaining = gas.remaining();
         self.last_gas_cost = self.gas_remaining.saturating_sub(remaining);
         self.gas_remaining = remaining;
@@ -80,7 +80,7 @@ impl GasInspector {
 
     /// Spend all gas if call failed.
     #[inline]
-    pub fn call_end(&mut self, outcome: &mut CallOutcome) {
+    pub const fn call_end(&mut self, outcome: &mut CallOutcome) {
         if outcome.result.result.is_error() {
             outcome.result.gas.spend_all();
             self.gas_remaining = 0;
@@ -91,7 +91,7 @@ impl GasInspector {
 
     /// Spend all gas if create failed.
     #[inline]
-    pub fn create_end(&mut self, outcome: &mut CreateOutcome) {
+    pub const fn create_end(&mut self, outcome: &mut CreateOutcome) {
         if outcome.result.result.is_error() {
             outcome.result.gas.spend_all();
             self.gas_remaining = 0;

--- a/crates/inspector/src/test_inspector.rs
+++ b/crates/inspector/src/test_inspector.rs
@@ -102,7 +102,7 @@ impl TestInspector {
     }
 
     /// Get the total step count.
-    pub fn get_step_count(&self) -> usize {
+    pub const fn get_step_count(&self) -> usize {
         self.step_count
     }
 }

--- a/crates/interpreter/src/gas.rs
+++ b/crates/interpreter/src/gas.rs
@@ -82,13 +82,13 @@ impl Gas {
 
     /// Returns the memory gas.
     #[inline]
-    pub fn memory(&self) -> &MemoryGas {
+    pub const fn memory(&self) -> &MemoryGas {
         &self.memory
     }
 
     /// Returns the memory gas.
     #[inline]
-    pub fn memory_mut(&mut self) -> &mut MemoryGas {
+    pub const fn memory_mut(&mut self) -> &mut MemoryGas {
         &mut self.memory
     }
 
@@ -148,7 +148,7 @@ impl Gas {
 
     /// Sets the state gas reservoir (used when propagating from child frame).
     #[inline]
-    pub fn set_reservoir(&mut self, val: u64) {
+    pub const fn set_reservoir(&mut self, val: u64) {
         self.tracker.set_reservoir(val);
     }
 
@@ -160,13 +160,13 @@ impl Gas {
 
     /// Sets the total state gas spent (used when propagating from child frame).
     #[inline]
-    pub fn set_state_gas_spent(&mut self, val: u64) {
+    pub const fn set_state_gas_spent(&mut self, val: u64) {
         self.tracker.set_state_gas_spent(val);
     }
 
     /// Erases a gas cost from remaining (returns gas from child frame).
     #[inline]
-    pub fn erase_cost(&mut self, returned: u64) {
+    pub const fn erase_cost(&mut self, returned: u64) {
         self.tracker.erase_cost(returned);
     }
 
@@ -177,7 +177,7 @@ impl Gas {
     ///
     /// Note that this does not affect the reservoir.
     #[inline]
-    pub fn spend_all(&mut self) {
+    pub const fn spend_all(&mut self) {
         self.tracker.spend_all();
     }
 
@@ -186,7 +186,7 @@ impl Gas {
     /// `refund` can be negative but `self.refunded` should always be positive
     /// at the end of transact.
     #[inline]
-    pub fn record_refund(&mut self, refund: i64) {
+    pub const fn record_refund(&mut self, refund: i64) {
         self.tracker.record_refund(refund);
     }
 
@@ -206,19 +206,19 @@ impl Gas {
 
     /// Set a refund value. This overrides the current refund value.
     #[inline]
-    pub fn set_refund(&mut self, refund: i64) {
+    pub const fn set_refund(&mut self, refund: i64) {
         self.tracker.set_refunded(refund);
     }
 
     /// Set a remaining value. This overrides the current remaining value.
     #[inline]
-    pub fn set_remaining(&mut self, remaining: u64) {
+    pub const fn set_remaining(&mut self, remaining: u64) {
         self.tracker.set_remaining(remaining);
     }
 
     /// Set a spent value. This overrides the current spent value.
     #[inline]
-    pub fn set_spent(&mut self, spent: u64) {
+    pub const fn set_spent(&mut self, spent: u64) {
         self.tracker
             .set_remaining(self.tracker.limit().saturating_sub(spent));
     }
@@ -233,7 +233,7 @@ impl Gas {
     #[inline]
     #[must_use = "prefer using `gas!` instead to return an out-of-gas error on failure"]
     #[deprecated(since = "32.0.0", note = "use record_regular_cost instead")]
-    pub fn record_cost(&mut self, cost: u64) -> bool {
+    pub const fn record_cost(&mut self, cost: u64) -> bool {
         self.record_regular_cost(cost)
     }
 
@@ -244,7 +244,7 @@ impl Gas {
     /// without consequence if the caller handles it.
     #[inline(always)]
     #[must_use = "In case of not enough gas, the interpreter should halt with an out-of-gas error"]
-    pub fn record_cost_unsafe(&mut self, cost: u64) -> bool {
+    pub const fn record_cost_unsafe(&mut self, cost: u64) -> bool {
         let remaining = self.tracker.remaining();
         let oog = remaining < cost;
         self.tracker.set_remaining(remaining.wrapping_sub(cost));
@@ -260,7 +260,7 @@ impl Gas {
     /// Returns `false` if total remaining gas is insufficient.
     #[inline]
     #[must_use = "In case of not enough gas, the interpreter should halt with an out-of-gas error"]
-    pub fn record_state_cost(&mut self, cost: u64) -> bool {
+    pub const fn record_state_cost(&mut self, cost: u64) -> bool {
         self.tracker.record_state_cost(cost)
     }
 
@@ -269,7 +269,7 @@ impl Gas {
     /// Used for forwarding gas to child frames.
     #[inline]
     #[must_use = "In case of not enough gas, the interpreter should halt with an out-of-gas error"]
-    pub fn record_regular_cost(&mut self, cost: u64) -> bool {
+    pub const fn record_regular_cost(&mut self, cost: u64) -> bool {
         self.tracker.record_regular_cost(cost)
     }
 }
@@ -312,7 +312,11 @@ impl MemoryGas {
     ///
     /// Returns the difference between the new and old expansion cost.
     #[inline]
-    pub fn set_words_num(&mut self, words_num: usize, mut expansion_cost: u64) -> Option<u64> {
+    pub const fn set_words_num(
+        &mut self,
+        words_num: usize,
+        mut expansion_cost: u64,
+    ) -> Option<u64> {
         self.words_num = words_num;
         core::mem::swap(&mut self.expansion_cost, &mut expansion_cost);
         self.expansion_cost.checked_sub(expansion_cost)

--- a/crates/interpreter/src/instructions.rs
+++ b/crates/interpreter/src/instructions.rs
@@ -87,7 +87,7 @@ pub const fn gas_table() -> GasTable {
 
 /// Create a gas table with applied spec changes to static gas cost.
 #[inline]
-pub fn gas_table_spec(spec: SpecId) -> GasTable {
+pub const fn gas_table_spec(spec: SpecId) -> GasTable {
     use bytecode::opcode::*;
     use SpecId::*;
     let mut table = gas_table();

--- a/crates/interpreter/src/instructions/control.rs
+++ b/crates/interpreter/src/instructions/control.rs
@@ -43,7 +43,10 @@ fn jump_inner<WIRE: InterpreterTypes>(interpreter: &mut Interpreter<WIRE>, targe
 /// Implements the JUMPDEST instruction.
 ///
 /// Marks a valid destination for jump operations.
-pub fn jumpdest<WIRE: InterpreterTypes, H: ?Sized>(_context: InstructionContext<'_, H, WIRE>) {}
+pub const fn jumpdest<WIRE: InterpreterTypes, H: ?Sized>(
+    _context: InstructionContext<'_, H, WIRE>,
+) {
+}
 
 /// Implements the PC instruction.
 ///

--- a/crates/interpreter/src/instructions/i256.rs
+++ b/crates/interpreter/src/instructions/i256.rs
@@ -55,7 +55,7 @@ pub fn i256_sign_compl(val: &mut U256) -> Sign {
 }
 
 #[inline]
-fn u256_remove_sign(val: &mut U256) {
+const fn u256_remove_sign(val: &mut U256) {
     // SAFETY: U256 does not have any padding bytes
     unsafe {
         val.as_limbs_mut()[3] &= FLIPH_BITMASK_U64;
@@ -64,13 +64,13 @@ fn u256_remove_sign(val: &mut U256) {
 
 /// Computes the two's complement of a U256 value in place.
 #[inline]
-pub fn two_compl_mut(op: &mut U256) {
+pub const fn two_compl_mut(op: &mut U256) {
     *op = two_compl(*op);
 }
 
 /// Computes the two's complement of a U256 value.
 #[inline]
-pub fn two_compl(op: U256) -> U256 {
+pub const fn two_compl(op: U256) -> U256 {
     op.wrapping_neg()
 }
 

--- a/crates/interpreter/src/instructions/stack.rs
+++ b/crates/interpreter/src/instructions/stack.rs
@@ -114,7 +114,7 @@ pub fn exchange<WIRE: InterpreterTypes, H: ?Sized>(context: InstructionContext<'
     }
 }
 
-fn decode_single(x: usize) -> Option<usize> {
+const fn decode_single(x: usize) -> Option<usize> {
     if x <= 90 || x >= 128 {
         Some((x + 145) % 256)
     } else {
@@ -122,7 +122,7 @@ fn decode_single(x: usize) -> Option<usize> {
     }
 }
 
-fn decode_pair(x: usize) -> Option<(usize, usize)> {
+const fn decode_pair(x: usize) -> Option<(usize, usize)> {
     if x > 81 && x < 128 {
         return None;
     }

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -382,7 +382,7 @@ pub struct InterpreterResult {
 
 impl InterpreterResult {
     /// Returns a new `InterpreterResult` with the given values.
-    pub fn new(result: InstructionResult, output: Bytes, gas: Gas) -> Self {
+    pub const fn new(result: InstructionResult, output: Bytes, gas: Gas) -> Self {
         Self {
             result,
             output,

--- a/crates/interpreter/src/interpreter/ext_bytecode.rs
+++ b/crates/interpreter/src/interpreter/ext_bytecode.rs
@@ -80,7 +80,7 @@ impl ExtBytecode {
 
     /// Returns the bytecode hash.
     #[inline]
-    pub fn hash(&mut self) -> Option<B256> {
+    pub const fn hash(&mut self) -> Option<B256> {
         self.bytecode_hash
     }
 

--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -147,7 +147,7 @@ impl SharedMemory {
 
     /// Creates a new invalid memory instance.
     #[inline]
-    pub fn invalid() -> Self {
+    pub const fn invalid() -> Self {
         Self {
             buffer: None,
             my_checkpoint: 0,
@@ -158,7 +158,7 @@ impl SharedMemory {
     }
 
     /// Creates a new memory instance with a given shared buffer.
-    pub fn new_with_buffer(buffer: Rc<RefCell<Vec<u8>>>) -> Self {
+    pub const fn new_with_buffer(buffer: Rc<RefCell<Vec<u8>>>) -> Self {
         Self {
             buffer: Some(buffer),
             my_checkpoint: 0,
@@ -195,7 +195,7 @@ impl SharedMemory {
 
     /// Sets the memory limit in bytes.
     #[inline]
-    pub fn set_memory_limit(&mut self, limit: u64) {
+    pub const fn set_memory_limit(&mut self, limit: u64) {
         #[cfg(feature = "memory_limit")]
         {
             self.memory_limit = limit;

--- a/crates/interpreter/src/interpreter/stack.rs
+++ b/crates/interpreter/src/interpreter/stack.rs
@@ -114,31 +114,31 @@ impl Stack {
 
     /// Instantiate a new invalid Stack.
     #[inline]
-    pub fn invalid() -> Self {
+    pub const fn invalid() -> Self {
         Self { data: Vec::new() }
     }
 
     /// Returns the length of the stack in words.
     #[inline]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.data.len()
     }
 
     /// Returns whether the stack is empty.
     #[inline]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.data.is_empty()
     }
 
     /// Returns a reference to the underlying data buffer.
     #[inline]
-    pub fn data(&self) -> &Vec<U256> {
+    pub const fn data(&self) -> &Vec<U256> {
         &self.data
     }
 
     /// Returns a mutable reference to the underlying data buffer.
     #[inline]
-    pub fn data_mut(&mut self) -> &mut Vec<U256> {
+    pub const fn data_mut(&mut self) -> &mut Vec<U256> {
         &mut self.data
     }
 

--- a/crates/interpreter/src/interpreter_action.rs
+++ b/crates/interpreter/src/interpreter_action.rs
@@ -90,25 +90,25 @@ pub enum InterpreterAction {
 impl InterpreterAction {
     /// Returns `true` if action is call.
     #[inline]
-    pub fn is_call(&self) -> bool {
+    pub const fn is_call(&self) -> bool {
         matches!(self, InterpreterAction::NewFrame(FrameInput::Call(..)))
     }
 
     /// Returns `true` if action is create.
     #[inline]
-    pub fn is_create(&self) -> bool {
+    pub const fn is_create(&self) -> bool {
         matches!(self, InterpreterAction::NewFrame(FrameInput::Create(..)))
     }
 
     /// Returns `true` if action is return.
     #[inline]
-    pub fn is_return(&self) -> bool {
+    pub const fn is_return(&self) -> bool {
         matches!(self, InterpreterAction::Return { .. })
     }
 
     /// Returns [`Gas`] if action is return.
     #[inline]
-    pub fn gas_mut(&mut self) -> Option<&mut Gas> {
+    pub const fn gas_mut(&mut self) -> Option<&mut Gas> {
         match self {
             InterpreterAction::Return(result) => Some(&mut result.gas),
             _ => None,
@@ -130,7 +130,7 @@ impl InterpreterAction {
     ///
     /// Else it returns [None].
     #[inline]
-    pub fn instruction_result(&self) -> Option<InstructionResult> {
+    pub const fn instruction_result(&self) -> Option<InstructionResult> {
         match self {
             InterpreterAction::Return(result) => Some(result.result),
             _ => None,
@@ -139,25 +139,25 @@ impl InterpreterAction {
 
     /// Create new frame action with the given frame input.
     #[inline]
-    pub fn new_frame(frame_input: FrameInput) -> Self {
+    pub const fn new_frame(frame_input: FrameInput) -> Self {
         Self::NewFrame(frame_input)
     }
 
     /// Create new halt action with the given result and gas.
     #[inline]
-    pub fn new_halt(result: InstructionResult, gas: Gas) -> Self {
+    pub const fn new_halt(result: InstructionResult, gas: Gas) -> Self {
         Self::Return(InterpreterResult::new(result, Bytes::new(), gas))
     }
 
     /// Create new return action with the given result, output and gas.
     #[inline]
-    pub fn new_return(result: InstructionResult, output: Bytes, gas: Gas) -> Self {
+    pub const fn new_return(result: InstructionResult, output: Bytes, gas: Gas) -> Self {
         Self::Return(InterpreterResult::new(result, output, gas))
     }
 
     /// Create new stop action.
     #[inline]
-    pub fn new_stop() -> Self {
+    pub const fn new_stop() -> Self {
         Self::Return(InterpreterResult::new(
             InstructionResult::Stop,
             Bytes::new(),

--- a/crates/interpreter/src/interpreter_action/call_inputs.rs
+++ b/crates/interpreter/src/interpreter_action/call_inputs.rs
@@ -235,22 +235,22 @@ pub enum CallScheme {
 
 impl CallScheme {
     /// Returns true if it is `CALL`.
-    pub fn is_call(&self) -> bool {
+    pub const fn is_call(&self) -> bool {
         matches!(self, Self::Call)
     }
 
     /// Returns true if it is `CALLCODE`.
-    pub fn is_call_code(&self) -> bool {
+    pub const fn is_call_code(&self) -> bool {
         matches!(self, Self::CallCode)
     }
 
     /// Returns true if it is `DELEGATECALL`.
-    pub fn is_delegate_call(&self) -> bool {
+    pub const fn is_delegate_call(&self) -> bool {
         matches!(self, Self::DelegateCall)
     }
 
     /// Returns true if it is `STATICCALL`.
-    pub fn is_static_call(&self) -> bool {
+    pub const fn is_static_call(&self) -> bool {
         matches!(self, Self::StaticCall)
     }
 }

--- a/crates/interpreter/src/interpreter_action/call_outcome.rs
+++ b/crates/interpreter/src/interpreter_action/call_outcome.rs
@@ -36,7 +36,7 @@ impl CallOutcome {
     ///
     /// * `result` - The result of the interpreter's execution.
     /// * `memory_offset` - The range in memory indicating where the output data is stored.
-    pub fn new(result: InterpreterResult, memory_offset: Range<usize>) -> Self {
+    pub const fn new(result: InterpreterResult, memory_offset: Range<usize>) -> Self {
         Self {
             result,
             memory_offset,
@@ -65,7 +65,7 @@ impl CallOutcome {
     /// # Returns
     ///
     /// A reference to the [`InstructionResult`].
-    pub fn instruction_result(&self) -> &InstructionResult {
+    pub const fn instruction_result(&self) -> &InstructionResult {
         &self.result.result
     }
 
@@ -76,7 +76,7 @@ impl CallOutcome {
     /// # Returns
     ///
     /// An instance of [`Gas`] representing the gas usage.
-    pub fn gas(&self) -> Gas {
+    pub const fn gas(&self) -> Gas {
         self.result.gas
     }
 
@@ -87,7 +87,7 @@ impl CallOutcome {
     /// # Returns
     ///
     /// A reference to the output data as [`Bytes`].
-    pub fn output(&self) -> &Bytes {
+    pub const fn output(&self) -> &Bytes {
         &self.result.output
     }
 
@@ -98,7 +98,7 @@ impl CallOutcome {
     /// # Returns
     ///
     /// The starting index of the memory offset as [`usize`].
-    pub fn memory_start(&self) -> usize {
+    pub const fn memory_start(&self) -> usize {
         self.memory_offset.start
     }
 

--- a/crates/interpreter/src/interpreter_action/create_inputs.rs
+++ b/crates/interpreter/src/interpreter_action/create_inputs.rs
@@ -26,7 +26,7 @@ pub struct CreateInputs {
 
 impl CreateInputs {
     /// Creates a new `CreateInputs` instance.
-    pub fn new(
+    pub const fn new(
         caller: Address,
         scheme: CreateScheme,
         value: U256,
@@ -59,44 +59,44 @@ impl CreateInputs {
     }
 
     /// Returns the caller address of the EVM.
-    pub fn caller(&self) -> Address {
+    pub const fn caller(&self) -> Address {
         self.caller
     }
 
     /// Returns the create scheme of the EVM.
-    pub fn scheme(&self) -> CreateScheme {
+    pub const fn scheme(&self) -> CreateScheme {
         self.scheme
     }
 
     /// Returns the value to transfer.
-    pub fn value(&self) -> U256 {
+    pub const fn value(&self) -> U256 {
         self.value
     }
 
     /// Returns the init code of the contract.
-    pub fn init_code(&self) -> &Bytes {
+    pub const fn init_code(&self) -> &Bytes {
         &self.init_code
     }
 
     /// Returns the gas limit of the call.
-    pub fn gas_limit(&self) -> u64 {
+    pub const fn gas_limit(&self) -> u64 {
         self.gas_limit
     }
 
     /// Set call
-    pub fn set_call(&mut self, caller: Address) {
+    pub const fn set_call(&mut self, caller: Address) {
         self.caller = caller;
         self.cached_address = OnceCell::new();
     }
 
     /// Set scheme
-    pub fn set_scheme(&mut self, scheme: CreateScheme) {
+    pub const fn set_scheme(&mut self, scheme: CreateScheme) {
         self.scheme = scheme;
         self.cached_address = OnceCell::new();
     }
 
     /// Set value
-    pub fn set_value(&mut self, value: U256) {
+    pub const fn set_value(&mut self, value: U256) {
         self.value = value;
     }
 
@@ -107,17 +107,17 @@ impl CreateInputs {
     }
 
     /// Set gas limit
-    pub fn set_gas_limit(&mut self, gas_limit: u64) {
+    pub const fn set_gas_limit(&mut self, gas_limit: u64) {
         self.gas_limit = gas_limit;
     }
 
     /// Returns the state gas reservoir (EIP-8037).
-    pub fn reservoir(&self) -> u64 {
+    pub const fn reservoir(&self) -> u64 {
         self.reservoir
     }
 
     /// Set the state gas reservoir (EIP-8037).
-    pub fn set_reservoir(&mut self, reservoir: u64) {
+    pub const fn set_reservoir(&mut self, reservoir: u64) {
         self.reservoir = reservoir;
     }
 }

--- a/crates/interpreter/src/interpreter_action/create_outcome.rs
+++ b/crates/interpreter/src/interpreter_action/create_outcome.rs
@@ -26,7 +26,7 @@ impl CreateOutcome {
     /// # Returns
     ///
     /// A new [`CreateOutcome`] instance.
-    pub fn new(result: InterpreterResult, address: Option<Address>) -> Self {
+    pub const fn new(result: InterpreterResult, address: Option<Address>) -> Self {
         Self { result, address }
     }
 
@@ -54,7 +54,7 @@ impl CreateOutcome {
     /// # Returns
     ///
     /// A reference to the [`InstructionResult`].
-    pub fn instruction_result(&self) -> &InstructionResult {
+    pub const fn instruction_result(&self) -> &InstructionResult {
         &self.result.result
     }
 
@@ -68,7 +68,7 @@ impl CreateOutcome {
     /// # Returns
     ///
     /// A reference to the output [`Bytes`].
-    pub fn output(&self) -> &Bytes {
+    pub const fn output(&self) -> &Bytes {
         &self.result.output
     }
 
@@ -82,7 +82,7 @@ impl CreateOutcome {
     /// # Returns
     ///
     /// A reference to the [`Gas`] details.
-    pub fn gas(&self) -> &Gas {
+    pub const fn gas(&self) -> &Gas {
         &self.result.gas
     }
 }

--- a/crates/precompile/src/blake2.rs
+++ b/crates/precompile/src/blake2.rs
@@ -102,7 +102,7 @@ pub mod algo {
     #[inline(always)]
     #[allow(clippy::many_single_char_names)]
     /// G function: <https://tools.ietf.org/html/rfc7693#section-3.1>
-    fn g(v: &mut [u64; 16], a: usize, b: usize, c: usize, d: usize, x: u64, y: u64) {
+    const fn g(v: &mut [u64; 16], a: usize, b: usize, c: usize, d: usize, x: u64, y: u64) {
         let mut va = v[a];
         let mut vb = v[b];
         let mut vc = v[c];
@@ -173,7 +173,7 @@ pub mod algo {
     }
 
     #[inline(always)]
-    fn round(v: &mut [u64; 16], m: &[u64; 16], r: usize) {
+    const fn round(v: &mut [u64; 16], m: &[u64; 16], r: usize) {
         // Message word selection permutation for this round.
         let s = &SIGMA[r % 10];
         // g1
@@ -514,12 +514,12 @@ mod avx2 {
     }
 
     #[inline(always)]
-    pub(crate) fn count_low(count: Count) -> Word {
+    pub(crate) const fn count_low(count: Count) -> Word {
         count as Word
     }
 
     #[inline(always)]
-    pub(crate) fn count_high(count: Count) -> Word {
+    pub(crate) const fn count_high(count: Count) -> Word {
         (count >> Word::BITS as usize) as Word
     }
 

--- a/crates/precompile/src/interface.rs
+++ b/crates/precompile/src/interface.rs
@@ -45,7 +45,7 @@ pub struct EthPrecompileOutput {
 
 impl EthPrecompileOutput {
     /// Returns new precompile output with the given gas used and output bytes.
-    pub fn new(gas_used: u64, bytes: Bytes) -> Self {
+    pub const fn new(gas_used: u64, bytes: Bytes) -> Self {
         Self { gas_used, bytes }
     }
 }
@@ -64,19 +64,19 @@ pub enum PrecompileStatus {
 impl PrecompileStatus {
     /// Returns `true` if the precompile execution was successful or reverted.
     #[inline]
-    pub fn is_success_or_revert(&self) -> bool {
+    pub const fn is_success_or_revert(&self) -> bool {
         matches!(self, PrecompileStatus::Success | PrecompileStatus::Revert)
     }
 
     /// Returns `true` if the precompile execution was reverted or halted.
     #[inline]
-    pub fn is_revert_or_halt(&self) -> bool {
+    pub const fn is_revert_or_halt(&self) -> bool {
         matches!(self, PrecompileStatus::Revert | PrecompileStatus::Halt(_))
     }
 
     /// Returns the halt reason if the precompile halted, `None` otherwise.
     #[inline]
-    pub fn halt_reason(&self) -> Option<&PrecompileHalt> {
+    pub const fn halt_reason(&self) -> Option<&PrecompileHalt> {
         match &self {
             PrecompileStatus::Halt(reason) => Some(reason),
             _ => None,
@@ -85,19 +85,19 @@ impl PrecompileStatus {
 
     /// Returns `true` if the precompile execution was successful.
     #[inline]
-    pub fn is_success(&self) -> bool {
+    pub const fn is_success(&self) -> bool {
         matches!(self, PrecompileStatus::Success)
     }
 
     /// Returns `true` if the precompile reverted.
     #[inline]
-    pub fn is_revert(&self) -> bool {
+    pub const fn is_revert(&self) -> bool {
         matches!(self, PrecompileStatus::Revert)
     }
 
     /// Returns `true` if the precompile halted.
     #[inline]
-    pub fn is_halt(&self) -> bool {
+    pub const fn is_halt(&self) -> bool {
         matches!(self, PrecompileStatus::Halt(_))
     }
 }
@@ -131,7 +131,7 @@ impl PrecompileOutput {
         }
     }
     /// Returns a new successful precompile output.
-    pub fn new(gas_used: u64, bytes: Bytes, reservoir: u64) -> Self {
+    pub const fn new(gas_used: u64, bytes: Bytes, reservoir: u64) -> Self {
         Self {
             status: PrecompileStatus::Success,
             gas_used,
@@ -143,7 +143,7 @@ impl PrecompileOutput {
     }
 
     /// Returns a new halted precompile output with the given halt reason.
-    pub fn halt(reason: PrecompileHalt, reservoir: u64) -> Self {
+    pub const fn halt(reason: PrecompileHalt, reservoir: u64) -> Self {
         Self {
             status: PrecompileStatus::Halt(reason),
             gas_used: 0,
@@ -155,7 +155,7 @@ impl PrecompileOutput {
     }
 
     /// Returns a new reverted precompile output.
-    pub fn revert(gas_used: u64, bytes: Bytes, reservoir: u64) -> Self {
+    pub const fn revert(gas_used: u64, bytes: Bytes, reservoir: u64) -> Self {
         Self {
             status: PrecompileStatus::Revert,
             gas_used,
@@ -167,29 +167,29 @@ impl PrecompileOutput {
     }
 
     /// Returns `true` if the precompile execution was successful.
-    pub fn is_success(&self) -> bool {
+    pub const fn is_success(&self) -> bool {
         matches!(self.status, PrecompileStatus::Success)
     }
 
     /// Returns `true` if the precompile execution was successful.
     #[deprecated(note = "use `is_success` instead")]
-    pub fn is_ok(&self) -> bool {
+    pub const fn is_ok(&self) -> bool {
         self.is_success()
     }
 
     /// Returns `true` if the precompile reverted.
-    pub fn is_revert(&self) -> bool {
+    pub const fn is_revert(&self) -> bool {
         matches!(self.status, PrecompileStatus::Revert)
     }
 
     /// Returns `true` if the precompile halted.
-    pub fn is_halt(&self) -> bool {
+    pub const fn is_halt(&self) -> bool {
         matches!(self.status, PrecompileStatus::Halt(_))
     }
 
     /// Returns the halt reason if the precompile halted, `None` otherwise.
     #[inline]
-    pub fn halt_reason(&self) -> Option<&PrecompileHalt> {
+    pub const fn halt_reason(&self) -> Option<&PrecompileHalt> {
         self.status.halt_reason()
     }
 }
@@ -475,7 +475,7 @@ impl PrecompileHalt {
     }
 
     /// Returns `true` if the halt reason is out of gas.
-    pub fn is_oog(&self) -> bool {
+    pub const fn is_oog(&self) -> bool {
         matches!(self, Self::OutOfGas)
     }
 }
@@ -543,7 +543,7 @@ pub enum PrecompileError {
 
 impl PrecompileError {
     /// Returns `true` if the error is `Fatal` or `FatalAny`.
-    pub fn is_fatal(&self) -> bool {
+    pub const fn is_fatal(&self) -> bool {
         true
     }
 }

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -69,13 +69,13 @@ use std::vec::Vec;
 
 /// Calculate the linear cost of a precompile.
 #[inline]
-pub fn calc_linear_cost(len: usize, base: u64, word: u64) -> u64 {
+pub const fn calc_linear_cost(len: usize, base: u64, word: u64) -> u64 {
     (len as u64).div_ceil(32) * word + base
 }
 
 /// Calculate the linear cost of a precompile.
 #[deprecated(note = "please use `calc_linear_cost` instead")]
-pub fn calc_linear_cost_u32(len: usize, base: u64, word: u64) -> u64 {
+pub const fn calc_linear_cost_u32(len: usize, base: u64, word: u64) -> u64 {
     calc_linear_cost(len, base, word)
 }
 
@@ -133,7 +133,7 @@ impl Precompiles {
     }
 
     /// Returns inner HashMap of precompiles.
-    pub fn inner(&self) -> &AddressMap<Precompile> {
+    pub const fn inner(&self) -> &AddressMap<Precompile> {
         &self.inner
     }
 
@@ -270,7 +270,7 @@ impl Precompiles {
     }
 
     /// Returns the precompiles addresses as a set.
-    pub fn addresses_set(&self) -> &AddressSet {
+    pub const fn addresses_set(&self) -> &AddressSet {
         &self.addresses
     }
 
@@ -371,13 +371,13 @@ impl Precompile {
 
     /// Returns reference to precompile identifier.
     #[inline]
-    pub fn id(&self) -> &PrecompileId {
+    pub const fn id(&self) -> &PrecompileId {
         &self.id
     }
 
     /// Returns reference to address.
     #[inline]
-    pub fn address(&self) -> &Address {
+    pub const fn address(&self) -> &Address {
         &self.address
     }
 

--- a/crates/precompile/src/modexp.rs
+++ b/crates/precompile/src/modexp.rs
@@ -52,11 +52,11 @@ pub(crate) fn modexp(base: &[u8], exponent: &[u8], modulus: &[u8]) -> Vec<u8> {
             }
         }
 
-        fn as_ptr(&self) -> *const gmp::mpz_t {
+        const fn as_ptr(&self) -> *const gmp::mpz_t {
             &self.0
         }
 
-        fn as_mut_ptr(&mut self) -> *mut gmp::mpz_t {
+        const fn as_mut_ptr(&mut self) -> *mut gmp::mpz_t {
             &mut self.0
         }
 

--- a/crates/primitives/src/hints_util.rs
+++ b/crates/primitives/src/hints_util.rs
@@ -7,11 +7,11 @@
 /// Cold path function.
 #[inline(always)]
 #[cold]
-pub fn cold_path() {}
+pub const fn cold_path() {}
 
 /// Returns `b` but mark `false` path as cold
 #[inline(always)]
-pub fn likely(b: bool) -> bool {
+pub const fn likely(b: bool) -> bool {
     if b {
         true
     } else {
@@ -22,7 +22,7 @@ pub fn likely(b: bool) -> bool {
 
 /// Returns `b` but mark `true` path as cold
 #[inline(always)]
-pub fn unlikely(b: bool) -> bool {
+pub const fn unlikely(b: bool) -> bool {
     if b {
         cold_path();
         true

--- a/crates/state/src/account_info.rs
+++ b/crates/state/src/account_info.rs
@@ -81,7 +81,7 @@ impl Ord for AccountInfo {
 impl AccountInfo {
     /// Creates a new [`AccountInfo`] with the given fields.
     #[inline]
-    pub fn new(balance: U256, nonce: u64, code_hash: B256, code: Bytecode) -> Self {
+    pub const fn new(balance: U256, nonce: u64, code_hash: B256, code: Bytecode) -> Self {
         Self {
             balance,
             nonce,
@@ -134,27 +134,27 @@ impl AccountInfo {
     }
 
     /// Creates a new [`AccountInfo`] with the given balance.
-    pub fn with_balance(mut self, balance: U256) -> Self {
+    pub const fn with_balance(mut self, balance: U256) -> Self {
         self.balance = balance;
         self
     }
 
     /// Creates a new [`AccountInfo`] with the given nonce.
-    pub fn with_nonce(mut self, nonce: u64) -> Self {
+    pub const fn with_nonce(mut self, nonce: u64) -> Self {
         self.nonce = nonce;
         self
     }
 
     /// Sets the [`AccountInfo`] `balance`.
     #[inline]
-    pub fn set_balance(&mut self, balance: U256) -> &mut Self {
+    pub const fn set_balance(&mut self, balance: U256) -> &mut Self {
         self.balance = balance;
         self
     }
 
     /// Sets the [`AccountInfo`] `nonce`.
     #[inline]
-    pub fn set_nonce(&mut self, nonce: u64) -> &mut Self {
+    pub const fn set_nonce(&mut self, nonce: u64) -> &mut Self {
         self.nonce = nonce;
         self
     }
@@ -204,7 +204,7 @@ impl AccountInfo {
     ///
     /// [`without_code`][Self::without_code] will modify and return the same instance.
     #[inline]
-    pub fn copy_without_code(&self) -> Self {
+    pub const fn copy_without_code(&self) -> Self {
         Self {
             balance: self.balance,
             nonce: self.nonce,
@@ -259,7 +259,7 @@ impl AccountInfo {
     ///
     /// If account does not have code, it returns `KECCAK_EMPTY` hash.
     #[inline]
-    pub fn code_hash(&self) -> B256 {
+    pub const fn code_hash(&self) -> B256 {
         self.code_hash
     }
 
@@ -273,7 +273,7 @@ impl AccountInfo {
     ///
     /// Code will be set to [None].
     #[inline]
-    pub fn take_bytecode(&mut self) -> Option<Bytecode> {
+    pub const fn take_bytecode(&mut self) -> Option<Bytecode> {
         self.code.take()
     }
 

--- a/crates/state/src/bal/writes.rs
+++ b/crates/state/src/bal/writes.rs
@@ -57,7 +57,7 @@ impl<T: PartialEq + Clone> BalWrites<T> {
     }
 
     /// Returns true if the builder is empty.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.writes.is_empty()
     }
 

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -106,7 +106,7 @@ impl Account {
 
     /// Is account marked for self destruct.
     #[inline]
-    pub fn is_selfdestructed(&self) -> bool {
+    pub const fn is_selfdestructed(&self) -> bool {
         self.status.contains(AccountStatus::SelfDestructed)
     }
 
@@ -124,7 +124,7 @@ impl Account {
 
     /// If account status is marked as touched.
     #[inline]
-    pub fn is_touched(&self) -> bool {
+    pub const fn is_touched(&self) -> bool {
         self.status.contains(AccountStatus::Touched)
     }
 
@@ -148,7 +148,7 @@ impl Account {
 
     /// Is account warm for given transaction id.
     #[inline]
-    pub fn is_cold_transaction_id(&self, transaction_id: usize) -> bool {
+    pub const fn is_cold_transaction_id(&self, transaction_id: usize) -> bool {
         self.transaction_id != transaction_id || self.status.contains(AccountStatus::Cold)
     }
 
@@ -163,13 +163,13 @@ impl Account {
 
     /// Is account locally created
     #[inline]
-    pub fn is_created_locally(&self) -> bool {
+    pub const fn is_created_locally(&self) -> bool {
         self.status.contains(AccountStatus::CreatedLocal)
     }
 
     /// Is account locally selfdestructed
     #[inline]
-    pub fn is_selfdestructed_locally(&self) -> bool {
+    pub const fn is_selfdestructed_locally(&self) -> bool {
         self.status.contains(AccountStatus::SelfDestructedLocal)
     }
 
@@ -225,17 +225,17 @@ impl Account {
     ///
     /// This is needed for pre spurious dragon hardforks where
     /// existing and empty were two separate states.
-    pub fn is_loaded_as_not_existing(&self) -> bool {
+    pub const fn is_loaded_as_not_existing(&self) -> bool {
         self.status.contains(AccountStatus::LoadedAsNotExisting)
     }
 
     /// Is account loaded as not existing from database and not touched.
-    pub fn is_loaded_as_not_existing_not_touched(&self) -> bool {
+    pub const fn is_loaded_as_not_existing_not_touched(&self) -> bool {
         self.is_loaded_as_not_existing() && !self.is_touched()
     }
 
     /// Is account newly created in this transaction.
-    pub fn is_created(&self) -> bool {
+    pub const fn is_created(&self) -> bool {
         self.status.contains(AccountStatus::Created)
     }
 
@@ -422,7 +422,7 @@ bitflags! {
 impl AccountStatus {
     /// Returns true if the account status is touched.
     #[inline]
-    pub fn is_touched(&self) -> bool {
+    pub const fn is_touched(&self) -> bool {
         self.contains(AccountStatus::Touched)
     }
 }
@@ -449,7 +449,7 @@ pub struct EvmStorageSlot {
 
 impl EvmStorageSlot {
     /// Creates a new _unchanged_ `EvmStorageSlot` for the given value.
-    pub fn new(original: StorageValue, transaction_id: usize) -> Self {
+    pub const fn new(original: StorageValue, transaction_id: usize) -> Self {
         Self {
             original_value: original,
             present_value: original,
@@ -459,7 +459,7 @@ impl EvmStorageSlot {
     }
 
     /// Creates a new _changed_ `EvmStorageSlot`.
-    pub fn new_changed(
+    pub const fn new_changed(
         original_value: StorageValue,
         present_value: StorageValue,
         transaction_id: usize,
@@ -478,25 +478,25 @@ impl EvmStorageSlot {
 
     /// Returns the original value of the storage slot.
     #[inline]
-    pub fn original_value(&self) -> StorageValue {
+    pub const fn original_value(&self) -> StorageValue {
         self.original_value
     }
 
     /// Returns the current value of the storage slot.
     #[inline]
-    pub fn present_value(&self) -> StorageValue {
+    pub const fn present_value(&self) -> StorageValue {
         self.present_value
     }
 
     /// Marks the storage slot as cold. Does not change transaction_id.
     #[inline]
-    pub fn mark_cold(&mut self) {
+    pub const fn mark_cold(&mut self) {
         self.is_cold = true;
     }
 
     /// Is storage slot cold for given transaction id.
     #[inline]
-    pub fn is_cold_transaction_id(&self, transaction_id: usize) -> bool {
+    pub const fn is_cold_transaction_id(&self, transaction_id: usize) -> bool {
         self.transaction_id != transaction_id || self.is_cold
     }
 
@@ -505,7 +505,7 @@ impl EvmStorageSlot {
     ///
     /// Returns false if old transition_id is different from given id or in case they are same return `Self::is_cold` value.
     #[inline]
-    pub fn mark_warm_with_transaction_id(&mut self, transaction_id: usize) -> bool {
+    pub const fn mark_warm_with_transaction_id(&mut self, transaction_id: usize) -> bool {
         let is_cold = self.is_cold_transaction_id(transaction_id);
         if is_cold {
             // if slot is cold original value should be reset to present value.

--- a/examples/block_traces/src/main.rs
+++ b/examples/block_traces/src/main.rs
@@ -27,7 +27,7 @@ struct FlushWriter {
 }
 
 impl FlushWriter {
-    fn new(writer: Arc<Mutex<BufWriter<std::fs::File>>>) -> Self {
+    const fn new(writer: Arc<Mutex<BufWriter<std::fs::File>>>) -> Self {
         Self { writer }
     }
 }

--- a/examples/erc20_gas/src/handler.rs
+++ b/examples/erc20_gas/src/handler.rs
@@ -22,7 +22,7 @@ pub struct Erc20MainnetHandler<EVM, ERROR, FRAME> {
 
 impl<CTX, ERROR, FRAME> Erc20MainnetHandler<CTX, ERROR, FRAME> {
     /// Creates a new ERC20 gas payment handler
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             _phantom: core::marker::PhantomData,
         }


### PR DESCRIPTION
Enable the `clippy::missing_const_for_fn` lint as a workspace-level warning and fix all existing violations across 62 files.

This adds `const` to functions that can be evaluated at compile time, enabling more compile-time computation and catching future regressions.