### PR TITLE
refactor(primitives): add SpecId::NEXT, drop num_enum dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,7 +3008,6 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3857,7 +3856,6 @@ name = "revm-primitives"
 version = "23.0.0"
 dependencies = [
  "alloy-primitives",
- "num_enum",
  "once_cell",
  "serde",
 ]

--- a/crates/interpreter/src/instructions.rs
+++ b/crates/interpreter/src/instructions.rs
@@ -87,7 +87,7 @@ pub const fn gas_table() -> GasTable {
 
 /// Create a gas table with applied spec changes to static gas cost.
 #[inline]
-pub fn gas_table_spec(spec: SpecId) -> GasTable {
+pub const fn gas_table_spec(spec: SpecId) -> GasTable {
     use bytecode::opcode::*;
     use SpecId::*;
     let mut table = gas_table();

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -26,7 +26,6 @@ alloy-primitives = { workspace = true, features = [
 ] }
 
 # mics
-num_enum = { version = "0.7", default-features = false }
 once_cell = { version = "1.21", default-features = false, features = [
     "alloc",
     "race",
@@ -37,7 +36,7 @@ serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
 [features]
 default = ["std"]
-std = ["alloy-primitives/std", "serde?/std", "num_enum/std", "once_cell/std"]
+std = ["alloy-primitives/std", "serde?/std", "once_cell/std"]
 serde = ["dep:serde", "alloy-primitives/serde"]
 map-foldhash = ["alloy-primitives/map-foldhash"]
 

--- a/crates/primitives/src/hardfork.rs
+++ b/crates/primitives/src/hardfork.rs
@@ -1,5 +1,6 @@
+//! Ethereum hardfork specification IDs.
+
 #![allow(non_camel_case_types)]
-#![allow(missing_docs)]
 
 use core::str::FromStr;
 pub use std::string::{String, ToString};

--- a/crates/primitives/src/hardfork.rs
+++ b/crates/primitives/src/hardfork.rs
@@ -1,17 +1,15 @@
 #![allow(non_camel_case_types)]
-// enumn has missing docs. Should be replaced in the future https://github.com/bluealloy/revm/issues/2402
 #![allow(missing_docs)]
 
 use core::str::FromStr;
-pub use num_enum::TryFromPrimitive;
 pub use std::string::{String, ToString};
 pub use SpecId::*;
 
-/// Specification IDs and their activation block
+/// Specification IDs and their activation block.
 ///
 /// Information was obtained from the [Ethereum Execution Specifications](https://github.com/ethereum/execution-specs).
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, TryFromPrimitive)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SpecId {
     /// Frontier hard fork
@@ -81,16 +79,45 @@ pub enum SpecId {
 }
 
 impl SpecId {
+    /// The latest known spec. This may refer to a highly experimental hard fork
+    /// that is not yet finalized or deployed on any network.
+    ///
+    /// **Warning**: This value will change between minor versions as new hard forks are added.
+    /// Do not rely on it for stable behavior.
+    #[doc(alias = "MAX")]
+    pub const NEXT: Self = Self::AMSTERDAM;
+
     /// Returns the [`SpecId`] for the given [`u8`].
     #[inline]
-    pub fn try_from_u8(spec_id: u8) -> Option<Self> {
-        Self::try_from(spec_id).ok()
+    pub const fn try_from_u8(spec_id: u8) -> Option<Self> {
+        if spec_id <= Self::NEXT as u8 {
+            // SAFETY: `spec_id` is within the valid range.
+            Some(unsafe { core::mem::transmute::<u8, Self>(spec_id) })
+        } else {
+            None
+        }
     }
 
     /// Returns `true` if the given specification ID is enabled in this spec.
     #[inline]
     pub const fn is_enabled_in(self, other: Self) -> bool {
         self as u8 >= other as u8
+    }
+}
+
+impl From<SpecId> for u8 {
+    #[inline]
+    fn from(spec_id: SpecId) -> Self {
+        spec_id as u8
+    }
+}
+
+impl TryFrom<u8> for SpecId {
+    type Error = u8;
+
+    #[inline]
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        Self::try_from_u8(value).ok_or(value)
     }
 }
 


### PR DESCRIPTION
- Add `SpecId::NEXT` const that always points to the max variant, with `doc(alias = "MAX")` and a warning that it may be super experimental / not finalized.
- Remove `TryFromPrimitive` derive and `num_enum` dependency entirely.
- Implement `TryFrom<u8>` for `SpecId` and `From<SpecId>` for `u8` manually using transmute (bounded by `NEXT`).
- Make `try_from_u8` const.