### PR TITLE
perf: move memory_limit check into cold resize path

### DIFF
--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -129,7 +129,7 @@ impl MemoryTr for SharedMemory {
     #[cfg(feature = "memory_limit")]
     #[inline]
     fn limit_reached(&self, new_words: usize) -> bool {
-        self.my_checkpoint.saturating_add(new_words * 32) as u64 > self.memory_limit
+        self.my_checkpoint.saturating_add(new_words.saturating_mul(32)) as u64 > self.memory_limit
     }
 }
 

--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -124,15 +124,12 @@ impl MemoryTr for SharedMemory {
         true
     }
 
-    /// Returns `true` if the `new_size` for the current context memory will
+    /// Returns `true` if the `new_words` for the current context memory will
     /// make the shared buffer length exceed the `memory_limit`.
     #[cfg(feature = "memory_limit")]
     #[inline]
-    fn limit_reached(&self, offset: usize, len: usize) -> bool {
-        self.my_checkpoint
-            .saturating_add(offset)
-            .saturating_add(len) as u64
-            > self.memory_limit
+    fn limit_reached(&self, new_words: usize) -> bool {
+        self.my_checkpoint.saturating_add(new_words * 32) as u64 > self.memory_limit
     }
 }
 
@@ -570,11 +567,6 @@ pub fn resize_memory<Memory: MemoryTr>(
     offset: usize,
     len: usize,
 ) -> Result<(), InstructionResult> {
-    #[cfg(feature = "memory_limit")]
-    if memory.limit_reached(offset, len) {
-        return Err(InstructionResult::MemoryLimitOOG);
-    }
-
     let new_num_words = num_words(offset.saturating_add(len));
     if new_num_words > gas.memory().words_num {
         return resize_memory_cold(gas, memory, gas_table, new_num_words);
@@ -591,6 +583,11 @@ fn resize_memory_cold<Memory: MemoryTr>(
     gas_table: &GasParams,
     new_num_words: usize,
 ) -> Result<(), InstructionResult> {
+    #[cfg(feature = "memory_limit")]
+    if memory.limit_reached(new_num_words) {
+        return Err(InstructionResult::MemoryLimitOOG);
+    }
+
     let cost = gas_table.memory_cost(new_num_words);
     let cost = unsafe {
         gas.memory_mut()
@@ -689,5 +686,31 @@ mod tests {
         assert_eq!(sm1.buffer_ref().len(), 32);
         assert_eq!(sm1.len(), 32);
         assert_eq!(sm1.buffer_ref().get(0..32), Some(&[0_u8; 32] as &[u8]));
+    }
+
+    #[cfg(feature = "memory_limit")]
+    #[test]
+    fn resize_memory_limit() {
+        let gas_table = GasParams::default();
+
+        // Limit of 64 bytes allows 2 words.
+        let mut memory = SharedMemory::new_with_memory_limit(64);
+        let mut gas = crate::Gas::new(100_000);
+
+        // Resize to 1 word (32 bytes) should succeed.
+        assert!(resize_memory(&mut gas, &mut memory, &gas_table, 0, 32).is_ok());
+        assert_eq!(memory.len(), 32);
+
+        // Resize to 2 words (64 bytes) should succeed.
+        assert!(resize_memory(&mut gas, &mut memory, &gas_table, 0, 64).is_ok());
+        assert_eq!(memory.len(), 64);
+
+        // Resize to 3 words (96 bytes) should fail with MemoryLimitOOG.
+        assert_eq!(
+            resize_memory(&mut gas, &mut memory, &gas_table, 0, 96),
+            Err(InstructionResult::MemoryLimitOOG),
+        );
+        // Memory should not have grown.
+        assert_eq!(memory.len(), 64);
     }
 }

--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -129,7 +129,9 @@ impl MemoryTr for SharedMemory {
     #[cfg(feature = "memory_limit")]
     #[inline]
     fn limit_reached(&self, new_words: usize) -> bool {
-        self.my_checkpoint.saturating_add(new_words.saturating_mul(32)) as u64 > self.memory_limit
+        self.my_checkpoint
+            .saturating_add(new_words.saturating_mul(32)) as u64
+            > self.memory_limit
     }
 }
 

--- a/crates/interpreter/src/interpreter_types.rs
+++ b/crates/interpreter/src/interpreter_types.rs
@@ -149,10 +149,10 @@ pub trait MemoryTr {
     /// It checks if the memory allocation fits under gas cap.
     fn resize(&mut self, new_size: usize) -> bool;
 
-    /// Returns `true` if the `new_size` for the current context memory will
+    /// Returns `true` if the `new_words` for the current context memory will
     /// make the shared buffer length exceed the `memory_limit`.
     #[cfg(feature = "memory_limit")]
-    fn limit_reached(&self, offset: usize, len: usize) -> bool;
+    fn limit_reached(&self, new_words: usize) -> bool;
 }
 
 /// Functions needed for Interpreter Stack operations.


### PR DESCRIPTION
Move `limit_reached` from the hot `resize_memory` function into `resize_memory_cold`, keeping the fast path free of the feature-gated branch.

The `MemoryTr::limit_reached` signature is simplified to take `new_words` instead of `(offset, len)` since the caller has already computed it.

Also adds a test exercising the `memory_limit` path through `resize_memory_cold`.