### PR TITLE
refactor(precompile): use static OnceLock array for Precompiles init

### DIFF
--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -436,8 +436,8 @@ impl PrecompileSpecId {
     }
 
     /// Returns the appropriate precompile Spec for the primitive [SpecId].
-    pub const fn from_spec_id(spec_id: primitives::hardfork::SpecId) -> Self {
-        use primitives::hardfork::SpecId::*;
+    pub const fn from_spec_id(spec_id: SpecId) -> Self {
+        use SpecId::*;
         match spec_id {
             FRONTIER | FRONTIER_THAWING | HOMESTEAD | DAO_FORK | TANGERINE | SPURIOUS_DRAGON => {
                 Self::HOMESTEAD

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -65,7 +65,6 @@ use primitives::{
     hardfork::SpecId, short_address, Address, AddressMap, AddressSet, HashMap, OnceLock,
     SHORT_ADDRESS_CAP,
 };
-use std::vec::Vec;
 
 /// Calculate the linear cost of a precompile.
 #[inline]
@@ -87,9 +86,7 @@ pub struct Precompiles {
     /// Addresses of precompiles.
     addresses: AddressSet,
     /// Optimized addresses filter.
-    optimized_access: Vec<Option<Precompile>>,
-    /// `true` if all precompiles are short addresses.
-    all_short_addresses: bool,
+    optimized_access: Box<[Option<Precompile>; SHORT_ADDRESS_CAP]>,
 }
 
 impl Default for Precompiles {
@@ -97,80 +94,16 @@ impl Default for Precompiles {
         Self {
             inner: HashMap::default(),
             addresses: AddressSet::default(),
-            optimized_access: vec![None; SHORT_ADDRESS_CAP],
-            all_short_addresses: true,
+            optimized_access: Box::new([const { None }; SHORT_ADDRESS_CAP]),
         }
     }
-}
-
-fn init_precompiles(spec: PrecompileSpecId) -> Precompiles {
-    use PrecompileSpecId::*;
-
-    let mut precompiles = Precompiles::default();
-
-    // Homestead
-    precompiles.extend([
-        secp256k1::ECRECOVER,
-        hash::SHA256,
-        hash::RIPEMD160,
-        identity::FUN,
-    ]);
-
-    if spec.is_enabled_in(BYZANTIUM) {
-        // EIP-198: Big integer modular exponentiation.
-        precompiles.extend([modexp::BYZANTIUM]);
-        // EIP-196: Precompiled contracts for addition and scalar multiplication on the elliptic curve alt_bn128.
-        // EIP-197: Precompiled contracts for optimal ate pairing check on the elliptic curve alt_bn128.
-        precompiles.extend([
-            bn254::add::BYZANTIUM,
-            bn254::mul::BYZANTIUM,
-            bn254::pair::BYZANTIUM,
-        ]);
-    }
-
-    if spec.is_enabled_in(ISTANBUL) {
-        // EIP-1108: Reduce alt_bn128 precompile gas costs.
-        precompiles.extend([
-            bn254::add::ISTANBUL,
-            bn254::mul::ISTANBUL,
-            bn254::pair::ISTANBUL,
-        ]);
-        // EIP-152: Add BLAKE2 compression function `F` precompile.
-        precompiles.extend([blake2::FUN]);
-    }
-
-    if spec.is_enabled_in(BERLIN) {
-        // EIP-2565: ModExp Gas Cost.
-        precompiles.extend([modexp::BERLIN]);
-    }
-
-    if spec.is_enabled_in(CANCUN) {
-        // EIP-4844: Shard Blob Transactions.
-        precompiles.extend([kzg_point_evaluation::POINT_EVALUATION]);
-    }
-
-    if spec.is_enabled_in(PRAGUE) {
-        // EIP-2537: Precompile for BLS12-381 curve operations.
-        precompiles.extend(bls12_381::precompiles());
-    }
-
-    if spec.is_enabled_in(OSAKA) {
-        // EIP-7823: Set upper bounds for MODEXP.
-        // EIP-7883: ModExp Gas Cost Increase.
-        precompiles.extend([modexp::OSAKA, secp256r1::P256VERIFY_OSAKA]);
-    }
-
-    precompiles
 }
 
 impl Precompiles {
     /// Returns the precompiles for the given spec.
     pub fn new(spec: PrecompileSpecId) -> &'static Self {
-        static INSTANCES: [OnceLock<Precompiles>; PrecompileSpecId::NEXT as usize + 1] = {
-            #[allow(clippy::declare_interior_mutable_const)]
-            const NEW: OnceLock<Precompiles> = OnceLock::new();
-            [NEW; PrecompileSpecId::NEXT as usize + 1]
-        };
+        static INSTANCES: [OnceLock<Precompiles>; PrecompileSpecId::NEXT as usize + 1] =
+            [const { OnceLock::new() }; PrecompileSpecId::NEXT as usize + 1];
         INSTANCES[spec as usize].get_or_init(|| init_precompiles(spec))
     }
 
@@ -283,8 +216,6 @@ impl Precompiles {
             let address = *item.address();
             if let Some(short_idx) = short_address(&address) {
                 self.optimized_access[short_idx] = Some(item.clone());
-            } else {
-                self.all_short_addresses = false;
             }
             self.addresses.insert(address);
             self.inner.insert(address, item);
@@ -324,6 +255,66 @@ impl Precompiles {
         precompiles.extend(inner.into_iter().map(|p| p.1));
         precompiles
     }
+}
+
+fn init_precompiles(spec: PrecompileSpecId) -> Precompiles {
+    use PrecompileSpecId::*;
+
+    let mut precompiles = Precompiles::default();
+
+    // Homestead
+    precompiles.extend([
+        secp256k1::ECRECOVER,
+        hash::SHA256,
+        hash::RIPEMD160,
+        identity::FUN,
+    ]);
+
+    if spec.is_enabled_in(BYZANTIUM) {
+        // EIP-196: Precompiled contracts for addition and scalar multiplication on the elliptic curve alt_bn128.
+        // EIP-197: Precompiled contracts for optimal ate pairing check on the elliptic curve alt_bn128.
+        // EIP-198: Big integer modular exponentiation.
+        precompiles.extend([
+            modexp::BYZANTIUM,
+            bn254::add::BYZANTIUM,
+            bn254::mul::BYZANTIUM,
+            bn254::pair::BYZANTIUM,
+        ]);
+    }
+
+    if spec.is_enabled_in(ISTANBUL) {
+        // EIP-152: Add BLAKE2 compression function `F` precompile.
+        // EIP-1108: Reduce alt_bn128 precompile gas costs.
+        precompiles.extend([
+            bn254::add::ISTANBUL,
+            bn254::mul::ISTANBUL,
+            bn254::pair::ISTANBUL,
+            blake2::FUN,
+        ]);
+    }
+
+    if spec.is_enabled_in(BERLIN) {
+        // EIP-2565: ModExp Gas Cost.
+        precompiles.extend([modexp::BERLIN]);
+    }
+
+    if spec.is_enabled_in(CANCUN) {
+        // EIP-4844: Shard Blob Transactions.
+        precompiles.extend([kzg_point_evaluation::POINT_EVALUATION]);
+    }
+
+    if spec.is_enabled_in(PRAGUE) {
+        // EIP-2537: Precompile for BLS12-381 curve operations.
+        precompiles.extend(bls12_381::precompiles());
+    }
+
+    if spec.is_enabled_in(OSAKA) {
+        // EIP-7823: Set upper bounds for MODEXP.
+        // EIP-7883: ModExp Gas Cost Increase.
+        precompiles.extend([modexp::OSAKA, secp256r1::P256VERIFY_OSAKA]);
+    }
+
+    precompiles
 }
 
 /// Precompile wrapper for simple eth function that provides complex interface on execution.
@@ -392,7 +383,7 @@ impl Precompile {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum PrecompileSpecId {
     /// Frontier spec.
-    HOMESTEAD = 0,
+    HOMESTEAD,
     /// Byzantium spec introduced
     /// * [EIP-198](https://eips.ethereum.org/EIPS/eip-198) a EIP-198: Big integer modular exponentiation (at 0x05 address).
     /// * [EIP-196](https://eips.ethereum.org/EIPS/eip-196) a bn_add (at 0x06 address) and bn_mul (at 0x07 address) precompile

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -112,11 +112,6 @@ impl Precompiles {
         Self::new(PrecompileSpecId::HOMESTEAD)
     }
 
-    /// Returns inner HashMap of precompiles.
-    pub const fn inner(&self) -> &AddressMap<Precompile> {
-        &self.inner
-    }
-
     /// Returns precompiles for Byzantium spec.
     pub fn byzantium() -> &'static Self {
         Self::new(PrecompileSpecId::BYZANTIUM)
@@ -155,6 +150,12 @@ impl Precompiles {
         Self::new(PrecompileSpecId::NEXT)
     }
 
+    /// Returns inner HashMap of precompiles.
+    #[inline]
+    pub const fn inner(&self) -> &AddressMap<Precompile> {
+        &self.inner
+    }
+
     /// Returns an iterator over the precompiles addresses.
     #[inline]
     pub fn addresses(&self) -> impl ExactSizeIterator<Item = &Address> {
@@ -189,16 +190,19 @@ impl Precompiles {
     }
 
     /// Is the precompiles list empty.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
 
     /// Returns the number of precompiles.
+    #[inline]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
     /// Returns the precompiles addresses as a set.
+    #[inline]
     pub const fn addresses_set(&self) -> &AddressSet {
         &self.addresses
     }
@@ -206,7 +210,6 @@ impl Precompiles {
     /// Extends the precompiles with the given precompiles.
     ///
     /// Other precompiles with overwrite existing precompiles.
-    #[inline]
     pub fn extend(&mut self, other: impl IntoIterator<Item = Precompile>) {
         let iter = other.into_iter();
         let (lower, _) = iter.size_hint();

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -426,7 +426,11 @@ impl From<SpecId> for PrecompileSpecId {
 }
 
 impl PrecompileSpecId {
-    /// The latest known precompile spec.
+    /// The latest known precompile spec. This may refer to a highly experimental hard fork
+    /// that is not yet finalized or deployed on any network.
+    ///
+    /// **Warning**: This value will change between minor versions as new hard forks are added.
+    /// Do not rely on it for stable behavior.
     #[doc(alias = "MAX")]
     pub const NEXT: Self = Self::OSAKA;
 

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -103,33 +103,80 @@ impl Default for Precompiles {
     }
 }
 
+fn init_precompiles(spec: PrecompileSpecId) -> Precompiles {
+    use PrecompileSpecId::*;
+
+    let mut precompiles = Precompiles::default();
+
+    // Homestead
+    precompiles.extend([
+        secp256k1::ECRECOVER,
+        hash::SHA256,
+        hash::RIPEMD160,
+        identity::FUN,
+    ]);
+
+    if spec.is_enabled_in(BYZANTIUM) {
+        // EIP-198: Big integer modular exponentiation.
+        precompiles.extend([modexp::BYZANTIUM]);
+        // EIP-196: Precompiled contracts for addition and scalar multiplication on the elliptic curve alt_bn128.
+        // EIP-197: Precompiled contracts for optimal ate pairing check on the elliptic curve alt_bn128.
+        precompiles.extend([
+            bn254::add::BYZANTIUM,
+            bn254::mul::BYZANTIUM,
+            bn254::pair::BYZANTIUM,
+        ]);
+    }
+
+    if spec.is_enabled_in(ISTANBUL) {
+        // EIP-1108: Reduce alt_bn128 precompile gas costs.
+        precompiles.extend([
+            bn254::add::ISTANBUL,
+            bn254::mul::ISTANBUL,
+            bn254::pair::ISTANBUL,
+        ]);
+        // EIP-152: Add BLAKE2 compression function `F` precompile.
+        precompiles.extend([blake2::FUN]);
+    }
+
+    if spec.is_enabled_in(BERLIN) {
+        // EIP-2565: ModExp Gas Cost.
+        precompiles.extend([modexp::BERLIN]);
+    }
+
+    if spec.is_enabled_in(CANCUN) {
+        // EIP-4844: Shard Blob Transactions.
+        precompiles.extend([kzg_point_evaluation::POINT_EVALUATION]);
+    }
+
+    if spec.is_enabled_in(PRAGUE) {
+        // EIP-2537: Precompile for BLS12-381 curve operations.
+        precompiles.extend(bls12_381::precompiles());
+    }
+
+    if spec.is_enabled_in(OSAKA) {
+        // EIP-7823: Set upper bounds for MODEXP.
+        // EIP-7883: ModExp Gas Cost Increase.
+        precompiles.extend([modexp::OSAKA, secp256r1::P256VERIFY_OSAKA]);
+    }
+
+    precompiles
+}
+
 impl Precompiles {
     /// Returns the precompiles for the given spec.
     pub fn new(spec: PrecompileSpecId) -> &'static Self {
-        match spec {
-            PrecompileSpecId::HOMESTEAD => Self::homestead(),
-            PrecompileSpecId::BYZANTIUM => Self::byzantium(),
-            PrecompileSpecId::ISTANBUL => Self::istanbul(),
-            PrecompileSpecId::BERLIN => Self::berlin(),
-            PrecompileSpecId::CANCUN => Self::cancun(),
-            PrecompileSpecId::PRAGUE => Self::prague(),
-            PrecompileSpecId::OSAKA => Self::osaka(),
-        }
+        static INSTANCES: [OnceLock<Precompiles>; PrecompileSpecId::NEXT as usize + 1] = {
+            #[allow(clippy::declare_interior_mutable_const)]
+            const NEW: OnceLock<Precompiles> = OnceLock::new();
+            [NEW; PrecompileSpecId::NEXT as usize + 1]
+        };
+        INSTANCES[spec as usize].get_or_init(|| init_precompiles(spec))
     }
 
     /// Returns precompiles for Homestead spec.
     pub fn homestead() -> &'static Self {
-        static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
-        INSTANCE.get_or_init(|| {
-            let mut precompiles = Precompiles::default();
-            precompiles.extend([
-                secp256k1::ECRECOVER,
-                hash::SHA256,
-                hash::RIPEMD160,
-                identity::FUN,
-            ]);
-            precompiles
-        })
+        Self::new(PrecompileSpecId::HOMESTEAD)
     }
 
     /// Returns inner HashMap of precompiles.
@@ -139,50 +186,17 @@ impl Precompiles {
 
     /// Returns precompiles for Byzantium spec.
     pub fn byzantium() -> &'static Self {
-        static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
-        INSTANCE.get_or_init(|| {
-            let mut precompiles = Self::homestead().clone();
-            precompiles.extend([
-                // EIP-198: Big integer modular exponentiation.
-                modexp::BYZANTIUM,
-                // EIP-196: Precompiled contracts for addition and scalar multiplication on the elliptic curve alt_bn128.
-                // EIP-197: Precompiled contracts for optimal ate pairing check on the elliptic curve alt_bn128.
-                bn254::add::BYZANTIUM,
-                bn254::mul::BYZANTIUM,
-                bn254::pair::BYZANTIUM,
-            ]);
-            precompiles
-        })
+        Self::new(PrecompileSpecId::BYZANTIUM)
     }
 
     /// Returns precompiles for Istanbul spec.
     pub fn istanbul() -> &'static Self {
-        static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
-        INSTANCE.get_or_init(|| {
-            let mut precompiles = Self::byzantium().clone();
-            precompiles.extend([
-                // EIP-1108: Reduce alt_bn128 precompile gas costs.
-                bn254::add::ISTANBUL,
-                bn254::mul::ISTANBUL,
-                bn254::pair::ISTANBUL,
-                // EIP-152: Add BLAKE2 compression function `F` precompile.
-                blake2::FUN,
-            ]);
-            precompiles
-        })
+        Self::new(PrecompileSpecId::ISTANBUL)
     }
 
     /// Returns precompiles for Berlin spec.
     pub fn berlin() -> &'static Self {
-        static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
-        INSTANCE.get_or_init(|| {
-            let mut precompiles = Self::istanbul().clone();
-            precompiles.extend([
-                // EIP-2565: ModExp Gas Cost.
-                modexp::BERLIN,
-            ]);
-            precompiles
-        })
+        Self::new(PrecompileSpecId::BERLIN)
     }
 
     /// Returns precompiles for Cancun spec.
@@ -190,40 +204,22 @@ impl Precompiles {
     /// If the `c-kzg` feature is not enabled KZG Point Evaluation precompile will not be included,
     /// effectively making this the same as Berlin.
     pub fn cancun() -> &'static Self {
-        static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
-        INSTANCE.get_or_init(|| {
-            let mut precompiles = Self::berlin().clone();
-            precompiles.extend([
-                // EIP-4844: Shard Blob Transactions
-                kzg_point_evaluation::POINT_EVALUATION,
-            ]);
-            precompiles
-        })
+        Self::new(PrecompileSpecId::CANCUN)
     }
 
     /// Returns precompiles for Prague spec.
     pub fn prague() -> &'static Self {
-        static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
-        INSTANCE.get_or_init(|| {
-            let mut precompiles = Self::cancun().clone();
-            precompiles.extend(bls12_381::precompiles());
-            precompiles
-        })
+        Self::new(PrecompileSpecId::PRAGUE)
     }
 
     /// Returns precompiles for Osaka spec.
     pub fn osaka() -> &'static Self {
-        static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
-        INSTANCE.get_or_init(|| {
-            let mut precompiles = Self::prague().clone();
-            precompiles.extend([modexp::OSAKA, secp256r1::P256VERIFY_OSAKA]);
-            precompiles
-        })
+        Self::new(PrecompileSpecId::OSAKA)
     }
 
     /// Returns the precompiles for the latest spec.
     pub fn latest() -> &'static Self {
-        Self::osaka()
+        Self::new(PrecompileSpecId::NEXT)
     }
 
     /// Returns an iterator over the precompiles addresses.
@@ -392,10 +388,11 @@ impl Precompile {
 }
 
 /// Ethereum hardfork spec ids. Represents the specs where precompiles had a change.
+#[repr(u8)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum PrecompileSpecId {
     /// Frontier spec.
-    HOMESTEAD,
+    HOMESTEAD = 0,
     /// Byzantium spec introduced
     /// * [EIP-198](https://eips.ethereum.org/EIPS/eip-198) a EIP-198: Big integer modular exponentiation (at 0x05 address).
     /// * [EIP-196](https://eips.ethereum.org/EIPS/eip-196) a bn_add (at 0x06 address) and bn_mul (at 0x07 address) precompile
@@ -434,6 +431,16 @@ impl From<SpecId> for PrecompileSpecId {
 }
 
 impl PrecompileSpecId {
+    /// The latest known precompile spec.
+    #[doc(alias = "MAX")]
+    pub const NEXT: Self = Self::OSAKA;
+
+    /// Returns `true` if the given specification ID is enabled in this spec.
+    #[inline]
+    pub const fn is_enabled_in(self, other: Self) -> bool {
+        self as u8 >= other as u8
+    }
+
     /// Returns the appropriate precompile Spec for the primitive [SpecId].
     pub const fn from_spec_id(spec_id: primitives::hardfork::SpecId) -> Self {
         use primitives::hardfork::SpecId::*;

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -65,6 +65,7 @@ use primitives::{
     hardfork::SpecId, short_address, Address, AddressMap, AddressSet, HashMap, OnceLock,
     SHORT_ADDRESS_CAP,
 };
+use std::boxed::Box;
 
 /// Calculate the linear cost of a precompile.
 #[inline]

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -63,8 +63,9 @@ pub const SHORT_ADDRESS_CAP: usize = 300;
 /// and last two bytes are less than [`SHORT_ADDRESS_CAP`].
 #[inline]
 pub fn short_address(address: &Address) -> Option<usize> {
-    if address[..18].iter().all(|b| *b == 0) {
-        let short_address = u16::from_be_bytes([address[18], address[19]]) as usize;
+    let (zeros, value) = address.split_at(18);
+    if zeros.iter().all(|b| *b == 0) {
+        let short_address = u16::from_be_bytes([value[0], value[1]]) as usize;
         if short_address < SHORT_ADDRESS_CAP {
             return Some(short_address);
         }


### PR DESCRIPTION
Replaces per-spec `static OnceLock` instances with a single `static [OnceLock<Precompiles>; PrecompileSpecId::NEXT as usize + 1]` array indexed by `PrecompileSpecId`.

Adds `PrecompileSpecId::NEXT` and `is_enabled_in()`, and introduces a standalone `init_precompiles()` function that builds precompiles incrementally using `if spec.is_enabled_in(X)` guards, similar to `gas_table_spec`.