### PR TITLE
feat(database): add State::has_bal helper

### DIFF
--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -234,6 +234,12 @@ impl<DB: Database> State<DB> {
         self.bal_state.bal = bal;
     }
 
+    /// Returns whether the state has a BAL configured.
+    #[inline]
+    pub const fn has_bal(&self) -> bool {
+        self.bal_state.bal.is_some()
+    }
+
     /// Gets storage value of address at index.
     #[inline]
     fn storage(&mut self, address: Address, index: StorageKey) -> Result<StorageValue, DB::Error> {
@@ -497,6 +503,15 @@ mod tests {
         AccountRevert, AccountStatus, BundleAccount, RevertToSlot,
     };
     use primitives::{keccak256, BLOCK_HASH_HISTORY, U256};
+    #[test]
+    fn has_bal_helper() {
+        let state = State::builder().build();
+        assert!(!state.has_bal());
+
+        let state = State::builder().with_bal(Arc::new(Bal::new())).build();
+        assert!(state.has_bal());
+    }
+
     #[test]
     fn block_hash_cache() {
         let mut state = State::builder().build();


### PR DESCRIPTION
## Summary
- add `State::has_bal()` to expose whether a BAL is configured on the state
- add a unit test covering states with and without a BAL

## Why
Callers currently need to reach into `bal_state` to answer this simple question. This keeps the check on the `State` API.

## Validation
- `cargo test -p revm-database`
