### PR TITLE
perf(interpreter): use arithmetic shift for SIGNEXTEND

### DIFF
--- a/crates/interpreter/src/instructions/arithmetic.rs
+++ b/crates/interpreter/src/instructions/arithmetic.rs
@@ -4,7 +4,6 @@ use crate::{
     InstructionContext as Ictx, InstructionExecResult as Result,
 };
 use context_interface::Host;
-use primitives::U256;
 
 /// Implements the ADD instruction - adds two values from stack.
 pub fn add<IT: ITy, H: ?Sized>(context: Ictx<'_, H, IT>) -> Result {
@@ -96,42 +95,17 @@ pub fn exp<IT: ITy, H: Host + ?Sized>(context: Ictx<'_, H, IT>) -> Result {
 
 /// Implements the `SIGNEXTEND` opcode as defined in the Ethereum Yellow Paper.
 ///
-/// In the yellow paper `SIGNEXTEND` is defined to take two inputs, we will call them
-/// `x` and `y`, and produce one output.
+/// Sign-extends `x` from `(ext + 1)` bytes using arithmetic shift:
+///   `shift = 248 - 8 * ext`
+///   `result = (x << shift) >>s shift`
 ///
-/// The first `t` bits of the output (numbering from the left, starting from 0) are
-/// equal to the `t`-th bit of `y`, where `t` is equal to `256 - 8(x + 1)`.
-///
-/// The remaining bits of the output are equal to the corresponding bits of `y`.
-///
-/// **Note**: If `x >= 32` then the output is equal to `y` since `t <= 0`.
-///
-/// To efficiently implement this algorithm in the case `x < 32` we do the following.
-///
-/// Let `b` be equal to the `t`-th bit of `y` and let `s = 255 - t = 8x + 7`
-/// (this is effectively the same index as `t`, but numbering the bits from the
-/// right instead of the left).
-///
-/// We can create a bit mask which is all zeros up to and including the `t`-th bit,
-/// and all ones afterwards by computing the quantity `2^s - 1`.
-///
-/// We can use this mask to compute the output depending on the value of `b`.
-///
-/// If `b == 1` then the yellow paper says the output should be all ones up to
-/// and including the `t`-th bit, followed by the remaining bits of `y`; this is equal to
-/// `y | !mask` where `|` is the bitwise `OR` and `!` is bitwise negation.
-///
-/// Similarly, if `b == 0` then the yellow paper says the output should start with all zeros,
-/// then end with bits from `b`; this is equal to `y & mask` where `&` is bitwise `AND`.
+/// If `ext >= 31` the value already fills 32 bytes, so `x` is unchanged.
 pub fn signextend<IT: ITy, H: ?Sized>(context: Ictx<'_, H, IT>) -> Result {
     popn_top!([ext], x, context.interpreter);
-    // For 31 we also don't need to do anything.
-    if ext < U256::from(31) {
-        let ext = ext.as_limbs()[0];
-        let bit_index = (8 * ext + 7) as usize;
-        let bit = x.bit(bit_index);
-        let mask = (U256::from(1) << bit_index) - U256::from(1);
-        *x = if bit { *x | !mask } else { *x & mask };
+    // For ext >= 31 the value already fills all 32 bytes; nothing to do.
+    if ext < 31 {
+        let shift = 248 - 8 * ext.as_limbs()[0] as usize;
+        *x = (*x << shift).arithmetic_shr(shift);
     }
     Ok(())
 }


### PR DESCRIPTION
Replace the mask-based SIGNEXTEND implementation with a branchless arithmetic shift approach ported from revmc:

```
shift = 248 - 8 * ext
result = (x << shift) >>s shift
```

Instead of computing a bit mask and branching on the sign bit, this left-shifts the value so the sign bit is at position 255, then arithmetic-right-shifts it back, propagating the sign bit through the upper bytes.