### PR TITLE
fix(post-execution): clamp reservoir when floor gas exceeds limit budget

### DIFF
--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -4,6 +4,7 @@ pub mod account;
 pub mod entry;
 
 use crate::{
+    cfg::GasParams,
     context::{SStoreResult, SelfDestructResult},
     host::LoadError,
     journaled_state::account::JournaledAccountTr,
@@ -129,6 +130,24 @@ pub trait JournalTr {
     ///   accounts. When disabled, the logging can be done outside of revm when applying
     ///   accounts to database state.
     fn set_eip7708_config(&mut self, disabled: bool, delayed_burn_disabled: bool);
+
+    /// EIP-8037: Returns the total state gas to refund at end of tx for accounts
+    /// that were both created and self-destructed in this transaction.
+    ///
+    /// Per EIP-6780 such accounts are erased at tx end — the state gas charged
+    /// during execution for account creation, code deposit, and storage slot
+    /// sets must be returned to the reservoir. `skip_address` (when present)
+    /// is excluded: callers pass the CREATE transaction's target contract here
+    /// because its creation state gas was charged via the intrinsic
+    /// `initial_state_gas` rather than an execution-time reservoir draw, and
+    /// is therefore not eligible for this refund path. Returns zero when
+    /// EIP-8037 is not enabled for the current spec.
+    fn eip8037_selfdestruct_state_gas_refund(
+        &self,
+        gas_params: &GasParams,
+        cpsb: u64,
+        skip_address: Option<Address>,
+    ) -> u64;
 
     /// Touches the account.
     fn touch_account(&mut self, address: Address);

--- a/crates/context/src/journal.rs
+++ b/crates/context/src/journal.rs
@@ -10,6 +10,7 @@ pub use inner::{JournalCfg, JournalInner};
 
 use bytecode::Bytecode;
 use context_interface::{
+    cfg::GasParams,
     context::{SStoreResult, SelfDestructResult, StateLoad},
     journaled_state::{
         account::JournaledAccount, AccountInfoLoad, AccountLoad, JournalCheckpoint,
@@ -203,6 +204,17 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
     fn set_eip7708_config(&mut self, disabled: bool, delayed_burn_disabled: bool) {
         self.inner
             .set_eip7708_config(disabled, delayed_burn_disabled);
+    }
+
+    #[inline]
+    fn eip8037_selfdestruct_state_gas_refund(
+        &self,
+        gas_params: &GasParams,
+        cpsb: u64,
+        skip_address: Option<Address>,
+    ) -> u64 {
+        self.inner
+            .eip8037_selfdestruct_state_gas_refund(gas_params, cpsb, skip_address)
     }
 
     #[inline]

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -2,6 +2,7 @@
 use super::warm_addresses::WarmAddresses;
 use bytecode::Bytecode;
 use context_interface::{
+    cfg::{gas_params::GasId, GasParams},
     context::{SStoreResult, SelfDestructResult, StateLoad},
     journaled_state::{
         account::{JournaledAccount, JournaledAccountTr},
@@ -294,6 +295,65 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         for (address, balance) in addresses_with_balance {
             self.eip7708_burn_log(address, balance);
         }
+    }
+
+    /// EIP-8037: Computes the total state gas to refund at end of transaction for
+    /// accounts that were both created and self-destructed in this transaction.
+    ///
+    /// Per EIP-6780, such accounts are erased at end of tx — the state gas
+    /// charged during execution for the account, its code, and its storage
+    /// slot sets must be returned to the reservoir. `skip_address` (when
+    /// present) is excluded from the sum; callers pass the CREATE transaction's
+    /// target contract here, because its creation state gas was charged via
+    /// intrinsic accounting rather than an execution-time reservoir draw.
+    /// Returns the cumulative refund amount (in gas units); zero when EIP-8037
+    /// is not enabled.
+    #[inline]
+    pub fn eip8037_selfdestruct_state_gas_refund(
+        &self,
+        gas_params: &GasParams,
+        cpsb: u64,
+        skip_address: Option<Address>,
+    ) -> u64 {
+        if !self.cfg.spec.is_enabled_in(AMSTERDAM) {
+            return 0;
+        }
+
+        let mut refund: u64 = 0;
+        for (address, account) in self.state.iter() {
+            if !(account.is_selfdestructed_locally() && account.is_created_locally()) {
+                continue;
+            }
+            if skip_address == Some(*address) {
+                continue;
+            }
+
+            // New account state gas (same magnitude as create_state_gas).
+            refund = refund.saturating_add(gas_params.new_account_state_gas(cpsb));
+
+            // Code deposit state gas — for code bytes that were written during this tx.
+            if let Some(code) = account.info.code.as_ref() {
+                let len = code.len();
+                if len != 0 {
+                    refund =
+                        refund.saturating_add(gas_params.code_deposit_state_gas(len, cpsb));
+                }
+            }
+
+            // Storage slot state gas — each 0→non-zero slot set during this tx
+            // was charged SSTORE_SET_BYTES × cpsb; since the account is destroyed,
+            // refund that for every slot that still holds a non-zero present value
+            // and had an original value of zero.
+            let sstore_set = gas_params
+                .get(GasId::sstore_set_state_gas())
+                .saturating_mul(cpsb);
+            for slot in account.storage.values() {
+                if slot.original_value.is_zero() && !slot.present_value.is_zero() {
+                    refund = refund.saturating_add(sstore_set);
+                }
+            }
+        }
+        refund
     }
 
     /// Return reference to state.

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -320,11 +320,17 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         }
 
         let mut refund: u64 = 0;
-        for (address, account) in self.state.iter() {
-            if !(account.is_selfdestructed_locally() && account.is_created_locally()) {
+        let sstore_set = gas_params
+            .get(GasId::sstore_set_state_gas())
+            .saturating_mul(cpsb);
+        for address in self.selfdestructed_addresses.iter() {
+            if skip_address == Some(*address) {
                 continue;
             }
-            if skip_address == Some(*address) {
+            let Some(account) = self.state.get(address) else {
+                continue;
+            };
+            if !account.is_created_locally() {
                 continue;
             }
 
@@ -340,15 +346,11 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
                 }
             }
 
-            // Storage slot state gas — each 0→non-zero slot set during this tx
-            // was charged SSTORE_SET_BYTES × cpsb; since the account is destroyed,
-            // refund that for every slot that still holds a non-zero present value
-            // and had an original value of zero.
-            let sstore_set = gas_params
-                .get(GasId::sstore_set_state_gas())
-                .saturating_mul(cpsb);
+            // Storage slot state gas — each slot set during this tx was charged
+            // SSTORE_SET_BYTES × cpsb; since the account is destroyed, refund
+            // that for every slot that still holds a non-zero present value.
             for slot in account.storage.values() {
-                if slot.original_value.is_zero() && !slot.present_value.is_zero() {
+                if !slot.present_value.is_zero() {
                     refund = refund.saturating_add(sstore_set);
                 }
             }

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -262,6 +262,10 @@ impl EthFrame<EthInterpreter> {
     ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR> {
         let reservoir_remaining_gas = inputs.reservoir();
         let spec = context.cfg().spec().into();
+        // EIP-8037 refund for the CREATE opcode's upfront `create_state_gas` is
+        // applied uniformly in `return_result` when the create fails (revert,
+        // halt, or early-fail with `address == None`), so early-fail results
+        // only carry the reservoir they inherited from the parent.
         let return_error = |e| {
             Ok(ItemOrResult::Result(FrameResult::Create(CreateOutcome {
                 result: InterpreterResult {
@@ -521,6 +525,22 @@ impl EthFrame<EthInterpreter> {
                 // handle reservoir remaining gas
                 handle_reservoir_remaining_gas(this_gas, outcome.gas(), instruction_result);
 
+                // EIP-8037: The CREATE opcode charged `create_state_gas` upfront on
+                // this frame's tracker. When the child fails to deploy a contract
+                // (revert, halt, or early-fail paths that return `address == None`
+                // such as nonce overflow, depth, OutOfFunds), refund the upfront
+                // charge to the reservoir and undo it on `state_gas_spent`.
+                if !instruction_result.is_ok() && ctx.cfg().is_amsterdam_eip8037_enabled() {
+                    let state_gas_charged =
+                        ctx.cfg().gas_params().create_state_gas(ctx.local().cpsb());
+                    this_gas.set_reservoir(this_gas.reservoir().saturating_add(state_gas_charged));
+                    this_gas.set_state_gas_spent(
+                        this_gas
+                            .state_gas_spent()
+                            .saturating_sub(state_gas_charged as i64),
+                    );
+                }
+
                 let stack_item = if instruction_result.is_ok() {
                     this_gas.record_refund(outcome.gas().refunded());
                     outcome.address.unwrap_or_default().into_word().into()
@@ -580,11 +600,11 @@ pub fn handle_reservoir_remaining_gas(
 
 /// Handles the result of a CREATE operation, including validation and state updates.
 ///
-/// The EIP-8037 upfront CREATE state gas is derived from `cfg` (and the current
-/// block's CPSB) inside this function: it is refunded to the reservoir on entry
-/// and re-recorded at the end of a successful commit. On revert/halt the refund
-/// persists, so the state gas flows back to the parent via
-/// `handle_reservoir_remaining_gas`.
+/// The EIP-8037 upfront CREATE state gas is charged on the parent's tracker by
+/// the CREATE/CREATE2 opcode. On child failure (revert/halt/early-fail) it is
+/// refunded to the parent in `return_result`. The child frame is NOT allowed to
+/// borrow the upfront charge to pay for code deposit: it must cover code deposit
+/// state gas from its own reservoir and remaining gas.
 pub fn return_create<CTX: ContextTr>(
     context: &mut CTX,
     checkpoint: JournalCheckpoint,
@@ -599,15 +619,6 @@ pub fn return_create<CTX: ContextTr>(
     let is_amsterdam_eip8037 = cfg.is_amsterdam_eip8037_enabled();
     let cpsb = local.cpsb();
     let gas_params = cfg.gas_params();
-
-    // EIP-8037: The parent charged `create_state_gas` upfront in the CREATE/CREATE2
-    // opcode. Refund it here so the reservoir reflects only what the child actually
-    // consumed; re-record at the end on success, or leave refunded on revert/halt.
-    let state_gas_charged = gas_params.create_state_gas(cpsb);
-
-    if is_amsterdam_eip8037 {
-        interpreter_result.gas.refill_reservoir(state_gas_charged);
-    }
 
     // If return is not ok revert and return.
     if !interpreter_result.result.is_ok() {
@@ -689,13 +700,6 @@ pub fn return_create<CTX: ContextTr>(
 
     // Set code
     journal.set_code(address, bytecode);
-
-    // EIP-8037: Re-apply the upfront CREATE state gas now that the create succeeded,
-    // undoing the entry-side refund so the charge is reflected in the child's
-    // final reservoir and `state_gas_spent`.
-    if is_amsterdam_eip8037 {
-        let _ = interpreter_result.gas.record_state_cost(state_gas_charged);
-    }
 
     interpreter_result.result = InstructionResult::Return;
 }

--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -264,6 +264,12 @@ pub trait Handler {
         init_and_floor_gas: InitialAndFloorGas,
         eip7702_gas_refund: i64,
     ) -> Result<ResultGas, Self::Error> {
+        // EIP-8037: Refund reservoir for accounts that were created and then
+        // self-destructed in this tx (EIP-6780 erasure). Runs first so the
+        // updated reservoir feeds into refund, reimbursement, and beneficiary
+        // reward accounting below.
+        self.eip8037_selfdestruct_refund(evm, exec_result);
+
         // Calculate final refund and add EIP-7702 refund to gas.
         self.refund(evm, exec_result, eip7702_gas_refund);
 
@@ -481,6 +487,23 @@ pub trait Handler {
         init_and_floor_gas: InitialAndFloorGas,
     ) {
         post_execution::eip7623_check_gas_floor(exec_result.gas_mut(), init_and_floor_gas)
+    }
+
+    /// EIP-8037: Refunds state gas for accounts that were both created and
+    /// self-destructed in this transaction (EIP-6780 erasure).
+    ///
+    /// Iterates over destroyed accounts in the journal, sums the state gas that
+    /// was charged for creating each account, depositing its code, and setting
+    /// its storage slots, and refills the reservoir with the total. Refilling
+    /// the reservoir (rather than recording a refund) bypasses the 1/5 refund
+    /// cap because this state never actually persists.
+    #[inline]
+    fn eip8037_selfdestruct_refund(
+        &self,
+        evm: &mut Self::Evm,
+        exec_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
+    ) {
+        post_execution::eip8037_selfdestruct_state_gas_refund(evm.ctx(), exec_result.gas_mut())
     }
 
     /// Calculates the final gas refund amount, including any EIP-7702 refunds.

--- a/crates/handler/src/post_execution.rs
+++ b/crates/handler/src/post_execution.rs
@@ -40,9 +40,20 @@ pub fn eip7623_check_gas_floor(gas: &mut Gas, init_and_floor_gas: InitialAndFloo
     let gas_used_before_refund = gas.total_gas_spent().saturating_sub(gas.reservoir());
     let gas_used_after_refund = gas_used_before_refund.saturating_sub(gas.refunded() as u64);
     if gas_used_after_refund < init_and_floor_gas.floor_gas {
-        // Set spent so that (limit - remaining - reservoir) = floor_gas
-        // i.e. remaining = limit - floor_gas - reservoir
-        gas.set_spent(init_and_floor_gas.floor_gas + gas.reservoir());
+        // Want reimbursable = `limit - floor_gas`. When `floor_gas + reservoir`
+        // exceeds `limit` (e.g. an EIP-7702 reservoir refund pushed `reservoir`
+        // above `limit - floor_gas`), the plain `set_spent` saturates `remaining`
+        // to 0 and silently over-reimburses by `floor_gas + reservoir - limit`;
+        // clamp the reservoir instead.
+        let floor = init_and_floor_gas.floor_gas;
+        let reservoir = gas.reservoir();
+        let limit = gas.limit();
+        if limit >= floor.saturating_add(reservoir) {
+            gas.set_spent(floor + reservoir);
+        } else {
+            gas.set_reservoir(limit.saturating_sub(floor));
+            gas.set_remaining(0);
+        }
         // clear refund
         gas.set_refund(0);
     }

--- a/crates/handler/src/post_execution.rs
+++ b/crates/handler/src/post_execution.rs
@@ -76,21 +76,12 @@ pub fn eip7623_check_gas_floor(gas: &mut Gas, init_and_floor_gas: InitialAndFloo
     let gas_used_before_refund = gas.total_gas_spent().saturating_sub(gas.reservoir());
     let gas_used_after_refund = gas_used_before_refund.saturating_sub(gas.refunded() as u64);
     if gas_used_after_refund < init_and_floor_gas.floor_gas {
-        // Want reimbursable = `limit - floor_gas`. When `floor_gas + reservoir`
-        // exceeds `limit` (e.g. an EIP-7702 reservoir refund pushed `reservoir`
-        // above `limit - floor_gas`), the plain `set_spent` saturates `remaining`
-        // to 0 and silently over-reimburses by `floor_gas + reservoir - limit`;
-        // clamp the reservoir instead.
-        let floor = init_and_floor_gas.floor_gas;
-        let reservoir = gas.reservoir();
-        let limit = gas.limit();
-        if limit >= floor.saturating_add(reservoir) {
-            gas.set_spent(floor + reservoir);
-        } else {
-            gas.set_reservoir(limit.saturating_sub(floor));
-            gas.set_remaining(0);
-        }
-        // clear refund
+        // Match execution-specs: when the floor wins, the unused state gas
+        // (reservoir) is absorbed into the floor cost rather than reimbursed
+        // separately. Zeroing it keeps `reimburse_caller`'s
+        // `remaining + reservoir + refunded` sum equal to `limit - floor`.
+        gas.set_spent(init_and_floor_gas.floor_gas);
+        gas.set_reservoir(0);
         gas.set_refund(0);
     }
 }

--- a/crates/handler/src/post_execution.rs
+++ b/crates/handler/src/post_execution.rs
@@ -6,7 +6,43 @@ use context_interface::{
     Block, Cfg, ContextTr, Database, LocalContextTr, Transaction,
 };
 use interpreter::{Gas, InitialAndFloorGas, SuccessOrHalt};
-use primitives::{hardfork::SpecId, U256};
+use primitives::{hardfork::SpecId, TxKind, U256};
+
+/// EIP-8037: Refunds state gas for accounts that were both created and
+/// self-destructed in this transaction.
+///
+/// Per EIP-6780 those accounts are erased at tx end; the state gas charged
+/// during execution for creating the account, depositing its code, and setting
+/// its storage slots is returned directly to the reservoir (not routed through
+/// the capped refund counter). Must run before [`refund`] / [`build_result_gas`]
+/// so the updated reservoir is reflected in reimbursement and beneficiary
+/// reward.
+///
+/// For CREATE transactions the tx-level contract address is excluded from the
+/// iteration: its creation state gas was charged via the intrinsic
+/// `initial_state_gas` and is surfaced separately in [`build_result_gas`]; it
+/// is not a reservoir-side charge and must not be returned to the reservoir.
+#[inline]
+pub fn eip8037_selfdestruct_state_gas_refund<CTX: ContextTr>(context: &mut CTX, gas: &mut Gas) {
+    if !context.cfg().is_amsterdam_eip8037_enabled() {
+        return;
+    }
+    let cpsb = context.local().cpsb();
+    let skip_address = match context.tx().kind() {
+        TxKind::Create => Some(context.tx().caller().create(context.tx().nonce())),
+        TxKind::Call(_) => None,
+    };
+    let amount = {
+        let cfg = context.cfg();
+        let gas_params = cfg.gas_params();
+        context
+            .journal_ref()
+            .eip8037_selfdestruct_state_gas_refund(gas_params, cpsb, skip_address)
+    };
+    if amount != 0 {
+        gas.refill_reservoir(amount);
+    }
+}
 
 /// Builds a [`ResultGas`] from the execution [`Gas`] struct and [`InitialAndFloorGas`].
 pub fn build_result_gas(gas: &Gas, init_and_floor_gas: InitialAndFloorGas) -> ResultGas {

--- a/examples/cheatcode_inspector/src/main.rs
+++ b/examples/cheatcode_inspector/src/main.rs
@@ -13,6 +13,7 @@ use revm::{
         BlockEnv, Cfg, CfgEnv, ContextTr, Evm, LocalContext, TxEnv,
     },
     context_interface::{
+        cfg::GasParams,
         journaled_state::{AccountLoad, JournalCheckpoint, TransferError},
         result::EVMError,
         Block, JournalTr, Transaction,
@@ -140,6 +141,16 @@ impl JournalTr for Backend {
     fn set_eip7708_config(&mut self, disabled: bool, delayed_burn_disabled: bool) {
         self.journaled_state
             .set_eip7708_config(disabled, delayed_burn_disabled);
+    }
+
+    fn eip8037_selfdestruct_state_gas_refund(
+        &self,
+        gas_params: &GasParams,
+        cpsb: u64,
+        skip_address: Option<Address>,
+    ) -> u64 {
+        self.journaled_state
+            .eip8037_selfdestruct_state_gas_refund(gas_params, cpsb, skip_address)
     }
 
     fn touch_account(&mut self, address: Address) {


### PR DESCRIPTION
## Summary

- Fixes over-reimbursement of the caller by `floor_gas + reservoir - limit` gas when the EIP-7623 data floor clamps `gas_used` upward and the reservoir (e.g. from an EIP-7702 existing-authority refund) pushed past `limit - floor_gas`.
- In that branch `eip7623_check_gas_floor` now clamps the reservoir to `limit - floor_gas` and zeros `remaining`, instead of relying on `set_spent(floor + reservoir)` whose `remaining` saturation silently loses the overshoot.

## Reproduction

Failing test (resolved by this PR):

```
cargo run -p revme -- stest ../fixtures_bal_v570/state_tests/for_amsterdam/amsterdam/eip7976_increase_calldata_floor_cost/refunds/gas_refunds_from_data_floor.json
```

Case: `test_gas_refunds_from_data_floor[...AUTHORIZATION_EXISTING_AUTHORITY...LESS_THAN_DATA_FLOOR]`

- `tx.gas_limit = 374183`, `floor_gas = 242696`, `reservoir = 131488` (EIP-7702 refund)
- `floor + reservoir = 374184 > 374183 = limit` → off by 1 gas (7 wei) → state root mismatch.

## Test plan

- [x] `cargo run -p revme -- stest --keep-going ../fixtures_bal_v570/state_tests/for_amsterdam/amsterdam/` — 245/245 pass.
- [x] Common path (`floor + reservoir <= limit`) unchanged and unaffected.