### PR TITLE
chore: audit #[allow] attributes

### DIFF
--- a/bins/revme/src/cmd.rs
+++ b/bins/revme/src/cmd.rs
@@ -8,7 +8,6 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 #[command(infer_subcommands = true)]
-#[allow(clippy::large_enum_variant)]
 pub enum MainCmd {
     /// Execute Ethereum state tests.
     Statetest(statetest::Cmd),

--- a/bins/revme/src/cmd/blockchaintest.rs
+++ b/bins/revme/src/cmd/blockchaintest.rs
@@ -314,7 +314,7 @@ fn validate_post_state(
     debug_info: &DebugInfo,
     print_env_on_error: bool,
 ) -> Result<(), TestExecutionError> {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn make_failure(
         state: &mut State<EmptyDB>,
         debug_info: &DebugInfo,

--- a/crates/context/interface/src/context.rs
+++ b/crates/context/interface/src/context.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::type_complexity)]
+#![expect(clippy::type_complexity)]
 //! Context trait and related types.
 pub use crate::journaled_state::StateLoad;
 use crate::{

--- a/crates/context/interface/src/local.rs
+++ b/crates/context/interface/src/local.rs
@@ -133,7 +133,7 @@ impl<T> FrameStack<T> {
 }
 
 /// A potentially initialized frame. Used when initializing a new frame in the main loop.
-#[allow(missing_debug_implementations)]
+#[expect(missing_debug_implementations)]
 pub struct OutFrame<'a, T> {
     ptr: *mut T,
     init: bool,
@@ -200,7 +200,7 @@ impl<'a, T> OutFrame<'a, T> {
 }
 
 /// Used to guarantee that a frame is initialized before use.
-#[allow(missing_debug_implementations)]
+#[expect(missing_debug_implementations)]
 pub struct FrameToken(bool);
 
 impl FrameToken {

--- a/crates/context/src/journal.rs
+++ b/crates/context/src/journal.rs
@@ -235,7 +235,7 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
     }
 
     #[inline]
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     fn caller_accounting_journal_entry(
         &mut self,
         address: Address,
@@ -259,7 +259,7 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
 
     /// Increments the nonce of the account.
     #[inline]
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     fn nonce_bump_journal_entry(&mut self, address: Address) {
         self.inner.nonce_bump_journal_entry(address)
     }

--- a/crates/ee-tests/src/eip8037.rs
+++ b/crates/ee-tests/src/eip8037.rs
@@ -273,7 +273,7 @@ fn sstore_multi_then_revert_bytecode() -> Bytecode {
 }
 
 /// Bytecode that performs a CALL with value to a specific address.
-#[allow(clippy::vec_init_then_push)]
+#[expect(clippy::vec_init_then_push)]
 fn call_with_value_bytecode(target: [u8; 20], value: U256) -> Bytecode {
     // CALL(gas, addr, value, argsOffset, argsSize, retOffset, retSize)
     let mut bytecode = Vec::new();
@@ -457,7 +457,7 @@ fn sstore_then_invalid_bytecode() -> Bytecode {
 }
 
 /// Bytecode: CALL to identity precompile (0x04) with no args, then STOP.
-#[allow(clippy::vec_init_then_push)]
+#[expect(clippy::vec_init_then_push)]
 fn call_precompile_bytecode() -> Bytecode {
     let mut bytecode = Vec::new();
     bytecode.push(opcode::PUSH1);
@@ -1846,7 +1846,7 @@ fn test_eip8037_reservoir_refill_halt_vs_revert_difference() {
 
 /// Bytecode: CALL(gas, addr, value=0, 0, 0, 0, 0); POP; STOP
 /// CALL without value transfer to given address.
-#[allow(clippy::vec_init_then_push)]
+#[expect(clippy::vec_init_then_push)]
 fn call_no_value_bytecode(target: [u8; 20]) -> Bytecode {
     let mut bytecode = Vec::new();
     bytecode.push(opcode::PUSH1);

--- a/crates/ee-tests/src/revm_tests.rs
+++ b/crates/ee-tests/src/revm_tests.rs
@@ -501,7 +501,7 @@ fn test_eip7708_selfdestruct_to_self() {
 }
 
 /// Bytecode that performs a CALL with value to a specific address
-#[allow(clippy::vec_init_then_push)]
+#[expect(clippy::vec_init_then_push)]
 fn call_with_value_bytecode(target: [u8; 20], value: U256) -> Bytecode {
     // CALL(gas, addr, value, argsOffset, argsSize, retOffset, retSize)
     let mut bytecode = Vec::new();
@@ -593,7 +593,6 @@ fn test_eip7708_call_with_value() {
 }
 
 /// Bytecode that creates a contract with initial value
-#[allow(clippy::vec_init_then_push)]
 fn create_with_value_bytecode(init_code: &[u8], value: U256) -> Bytecode {
     // CREATE(value, offset, length)
     let mut bytecode = Vec::new();

--- a/crates/handler/src/evm.rs
+++ b/crates/handler/src/evm.rs
@@ -40,7 +40,7 @@ pub trait EvmTr {
     type Frame: FrameTr;
 
     /// Returns a tuple of references to the context, the frame and the instructions.
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     fn all(
         &self,
     ) -> (
@@ -51,7 +51,7 @@ pub trait EvmTr {
     );
 
     /// Returns a tuple of mutable references to the context, the frame and the instructions.
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     fn all_mut(
         &mut self,
     ) -> (

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -99,7 +99,7 @@ pub type ContextTrDbError<CTX> = <<CTX as ContextTr>::Db as Database>::Error;
 
 impl EthFrame<EthInterpreter> {
     /// Clear and initialize a frame.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     #[inline(always)]
     pub fn clear(
         &mut self,

--- a/crates/inspector/src/gas.rs
+++ b/crates/inspector/src/gas.rs
@@ -2,7 +2,6 @@
 use interpreter::{CallOutcome, CreateOutcome, Gas};
 
 /// Helper that keeps track of gas.
-#[allow(dead_code)]
 #[derive(Clone, Copy, Debug)]
 pub struct GasInspector {
     gas_remaining: u64,

--- a/crates/inspector/src/traits.rs
+++ b/crates/inspector/src/traits.rs
@@ -32,7 +32,7 @@ pub trait InspectorEvmTr:
     /// Returns a tuple of mutable references to the context, the inspector, the frame and the instructions.
     ///
     /// This is one of two functions that need to be implemented for Evm. Second one is `all_mut`.
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     fn all_inspector(
         &self,
     ) -> (
@@ -46,7 +46,7 @@ pub trait InspectorEvmTr:
     /// Returns a tuple of mutable references to the context, the inspector, the frame and the instructions.
     ///
     /// This is one of two functions that need to be implemented for Evm. Second one is `all`.
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     fn all_mut_inspector(
         &mut self,
     ) -> (

--- a/crates/interpreter/src/instructions/i256.rs
+++ b/crates/interpreter/src/instructions/i256.rs
@@ -10,7 +10,6 @@ pub enum Sign {
     Minus = -1,
     /// Zero value sign  
     Zero = 0,
-    #[allow(dead_code)] // "constructed" with `mem::transmute` in `i256_sign` below
     /// Positive value sign
     Plus = 1,
 }

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -90,7 +90,6 @@ impl<EXT: Default> Interpreter<EthInterpreter<EXT>> {
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn new_inner(
         stack: Stack,
         memory: SharedMemory,
@@ -113,7 +112,7 @@ impl<EXT: Default> Interpreter<EthInterpreter<EXT>> {
     }
 
     /// Clears and reinitializes the interpreter with new parameters.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     #[inline(always)]
     pub fn clear(
         &mut self,

--- a/crates/precompile/bench/main.rs
+++ b/crates/precompile/bench/main.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)]
+#![expect(missing_docs)]
 //! Benchmarks for the crypto precompiles
 
 pub mod blake2;

--- a/crates/precompile/src/bls12_381.rs
+++ b/crates/precompile/src/bls12_381.rs
@@ -2,7 +2,7 @@
 //! For more details check modules for each precompile.
 use crate::Precompile;
 
-#[allow(dead_code)]
+#[cfg_attr(feature = "blst", expect(dead_code))]
 pub(crate) mod arkworks;
 
 cfg_if::cfg_if! {

--- a/crates/precompile/src/bn254.rs
+++ b/crates/precompile/src/bn254.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use std::vec::Vec;
 
-#[allow(dead_code)]
+#[cfg_attr(feature = "bn", expect(dead_code))]
 pub mod arkworks;
 
 cfg_if::cfg_if! {

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -8,7 +8,13 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc as std;
 
-#[allow(unreachable_code)]
+#[cfg_attr(
+    all(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        target_feature = "avx2"
+    ),
+    expect(unreachable_code)
+)]
 pub mod blake2;
 pub mod bls12_381;
 pub mod bls12_381_const;

--- a/crates/primitives/src/hardfork.rs
+++ b/crates/primitives/src/hardfork.rs
@@ -1,6 +1,6 @@
 //! Ethereum hardfork specification IDs.
 
-#![allow(non_camel_case_types)]
+#![expect(non_camel_case_types)]
 
 use core::str::FromStr;
 pub use std::string::{String, ToString};

--- a/crates/state/src/account_info.rs
+++ b/crates/state/src/account_info.rs
@@ -340,7 +340,7 @@ mod tests {
             "Ordering should be equal after ignoring code in Ord"
         );
 
-        #[allow(clippy::mutable_key_type)] // Not observable
+        #[expect(clippy::mutable_key_type)] // Not observable
         let mut set = BTreeSet::new();
         assert!(set.insert(account1.clone()), "Inserted account1");
         assert!(

--- a/examples/cheatcode_inspector/src/main.rs
+++ b/examples/cheatcode_inspector/src/main.rs
@@ -237,14 +237,13 @@ impl JournalTr for Backend {
         self.journaled_state.finalize()
     }
 
-    #[allow(deprecated)]
     fn caller_accounting_journal_entry(
         &mut self,
         address: Address,
         old_balance: U256,
         bump_nonce: bool,
     ) {
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         self.journaled_state
             .caller_accounting_journal_entry(address, old_balance, bump_nonce)
     }
@@ -257,9 +256,8 @@ impl JournalTr for Backend {
         self.journaled_state.balance_incr(address, balance)
     }
 
-    #[allow(deprecated)]
     fn nonce_bump_journal_entry(&mut self, address: Address) {
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         self.journaled_state.nonce_bump_journal_entry(address)
     }
 


### PR DESCRIPTION
Closes #3582.

Audited every `#[allow(...)]` in the workspace. For each one, picked one of three actions:

1. Convert to `#[expect(...)]` if the lint still fires. That way, when the underlying issue eventually goes away, the compiler will tell us the suppression is no longer needed.
2. Remove if the lint already does not fire (the `allow` was already obsolete).
3. Wrap in `#[cfg_attr(<cond>, expect(<lint>))]` when the lint only fires under a specific feature/target combination, so the expectation activates exactly where the warning is produced.

## Removed obsolete allows

These were no longer doing anything:

* `Sign::Plus` `dead_code` (pub enum variants don't trigger `dead_code`).
* `Interpreter::new_inner` `clippy::too_many_arguments` (under threshold now).
* `MainCmd` `clippy::large_enum_variant`.
* `create_with_value_bytecode` `clippy::vec_init_then_push`.
* `GasInspector` `dead_code` (all four fields are read by getters).
* Outer `allow(deprecated)` on `cheatcode_inspector`'s `JournalTr` impl methods. `#[deprecated]` on a trait method warns callers, not implementers, so only the inner statement attribute on the actual deprecated call is meaningful. Switching to `#[expect(...)]` correctly flagged the outer one as unfulfilled.

## Cfg-scoped expects

Three cases where the lint only fires under a specific compilation condition. Wrapped the `expect` in `cfg_attr` so the expectation activates only under the configs that produce the warning:

| Where | Condition |
|---|---|
| `precompile/src/lib.rs` (`mod blake2`) | `any(target_arch = "x86", target_arch = "x86_64")` and `target_feature = "avx2"`. The portable fallback is unreachable after the AVX2 fast path's `return`. |
| `precompile/src/bls12_381.rs` (`mod arkworks`) | `feature = "blst"`. The arkworks backend is unused when blst is selected. |
| `precompile/src/bn254.rs` (`mod arkworks`) | `feature = "bn"`. Same pattern. |

## Verification

```
cargo clippy --workspace --all-targets
cargo clippy --workspace --all-targets --all-features
cargo clippy --workspace --all-targets --no-default-features
cargo check --target riscv64imac-unknown-none-elf --no-default-features
RUSTFLAGS='-C target-feature=+avx2' cargo clippy --target x86_64-apple-darwin -p revm-precompile --no-default-features
```

All clean. There are 18 pre-existing `dead_code` warnings in `blake2/avx2.rs` under the unusual `x86_64 + no avx2 + no std` config, but they exist on `main` too and are out of scope for this audit.