### PR TITLE
fix(precompile): tighten cfg on blake2 avx2 module

### DIFF
--- a/crates/precompile/src/blake2/mod.rs
+++ b/crates/precompile/src/blake2/mod.rs
@@ -9,7 +9,10 @@ use crate::{
     PrecompileHalt, PrecompileId,
 };
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    any(target_feature = "avx2", feature = "std")
+))]
 mod avx2;
 mod portable;
 


### PR DESCRIPTION
Closes #3612.

Tightens the cfg on the `mod avx2;` declaration in `blake2/mod.rs` so the module is only included when at least one of its call sites is active.

## Before

```rust
#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
mod avx2;
```

Under `x86_64 + no target_feature = "avx2" + no feature = "std"`, the module was included but neither call site to `avx2::compress` was enabled, leaving every helper inside `avx2.rs` as dead code (18 warnings: `DEGREE`, `BLOCKBYTES`, `loadu`, `storeu`, `add`, `xor`, `set4`, `rot32`, `rot24`, etc.).

## After

```rust
#[cfg(all(
    any(target_arch = "x86", target_arch = "x86_64"),
    any(target_feature = "avx2", feature = "std")
))]
mod avx2;
```

The two call sites in `compress()` require:

1. `target_feature = "avx2"` (compile-time fast path), or
2. `feature = "std"` with `is_x86_feature_detected!("avx2")` (runtime detection).

Both are subsumed by the new cfg, so wherever the module is referenced it is also included. The function logic is unchanged.

## Verification

```
cargo clippy --workspace --all-targets
cargo clippy --workspace --all-targets --all-features
cargo clippy --workspace --all-targets --no-default-features
cargo check --target riscv64imac-unknown-none-elf --no-default-features
cargo clippy --target x86_64-apple-darwin -p revm-precompile --no-default-features
RUSTFLAGS='-C target-feature=+avx2' cargo clippy --target x86_64-apple-darwin -p revm-precompile
RUSTFLAGS='-C target-feature=+avx2' cargo clippy --target x86_64-apple-darwin -p revm-precompile --no-default-features
cargo nextest run -p revm-precompile
```

All clean. The 18 warnings under `x86_64 + no avx2 + no std` are gone, the AVX2 fast path still compiles under `x86_64 + avx2`, and all 51 precompile tests pass.