### PR TITLE
chore: backport v107 release notes from branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
 
+# v107
+date: 17.04.2026
+
+Maintanance release, utility changes.
+
+* `revm-state`: 11.0.0 -> 11.0.1 (✓ API compatible changes)
+* `revm-context-interface`: 17.0.0 -> 17.0.1 (✓ API compatible changes)
+* `revm-interpreter`: 35.0.0 -> 35.0.1 (✓ API compatible changes)
+* `revm-precompile`: 33.0.0 -> 34.0.0 (✓ API compatible changes)
+* `revm-handler`: 18.0.0 -> 19.0.0 (✓ API compatible changes)
+* `revm-inspector`: 18.0.0 -> 19.0.0 (✓ API compatible changes)
+* `revm-database-interface`: 11.0.0 -> 11.0.1
+* `revm-context`: 16.0.0 -> 16.0.1
+* `revm-database`: 13.0.0 -> 13.0.1
+* `revm-statetest-types`: 17.0.0 -> 17.0.1
+* `revm`: 37.0.0 -> 38.0.0
+* `revme`: 14.0.0 -> 15.0.0
+* `op-revm`: 18.0.0 -> 19.0.0
+
 # v106
 date 10.04.2026
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3683,7 +3683,7 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "37.0.0"
+version = "38.0.0"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3717,7 +3717,7 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "16.0.0"
+version = "16.0.1"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3733,7 +3733,7 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "17.0.0"
+version = "17.0.1"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3747,7 +3747,7 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "alloy-eips",
  "alloy-provider",
@@ -3763,7 +3763,7 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "auto_impl",
  "either",
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "alloy-signer",
  "alloy-signer-local",
@@ -3806,7 +3806,7 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "18.0.0"
+version = "19.0.0"
 dependencies = [
  "auto_impl",
  "either",
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "35.0.0"
+version = "35.0.1"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3835,7 +3835,7 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "33.0.0"
+version = "34.0.0"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3874,7 +3874,7 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "alloy-eip7928",
  "bitflags",
@@ -3886,7 +3886,7 @@ dependencies = [
 
 [[package]]
 name = "revm-statetest-types"
-version = "17.0.0"
+version = "17.0.1"
 dependencies = [
  "alloy-eip7928",
  "k256",
@@ -3902,7 +3902,7 @@ dependencies = [
 
 [[package]]
 name = "revme"
-version = "14.0.0"
+version = "15.0.0"
 dependencies = [
  "alloy-rlp",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,19 +41,19 @@ default-members = ["crates/revm"]
 
 [workspace.dependencies]
 # revm
-revm = { path = "crates/revm", version = "37.0.0", default-features = false }
+revm = { path = "crates/revm", version = "38.0.0", default-features = false }
 primitives = { path = "crates/primitives", package = "revm-primitives", version = "23.0.0", default-features = false }
 bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "10.0.0", default-features = false }
-database = { path = "crates/database", package = "revm-database", version = "13.0.0", default-features = false }
-database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "11.0.0", default-features = false }
-state = { path = "crates/state", package = "revm-state", version = "11.0.0", default-features = false }
-interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "35.0.0", default-features = false }
-inspector = { path = "crates/inspector", package = "revm-inspector", version = "18.0.0", default-features = false }
-precompile = { path = "crates/precompile", package = "revm-precompile", version = "33.0.0", default-features = false }
-statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "17.0.0", default-features = false }
-context = { path = "crates/context", package = "revm-context", version = "16.0.0", default-features = false }
-context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "17.0.0", default-features = false }
-handler = { path = "crates/handler", package = "revm-handler", version = "18.0.0", default-features = false }
+database = { path = "crates/database", package = "revm-database", version = "13.0.1", default-features = false }
+database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "11.0.1", default-features = false }
+state = { path = "crates/state", package = "revm-state", version = "11.0.1", default-features = false }
+interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "35.0.1", default-features = false }
+inspector = { path = "crates/inspector", package = "revm-inspector", version = "19.0.0", default-features = false }
+precompile = { path = "crates/precompile", package = "revm-precompile", version = "34.0.0", default-features = false }
+statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "17.0.1", default-features = false }
+context = { path = "crates/context", package = "revm-context", version = "16.0.1", default-features = false }
+context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "17.0.1", default-features = false }
+handler = { path = "crates/handler", package = "revm-handler", version = "18.1.0", default-features = false }
 ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "0.2.0", default-features = false }
 
 # alloy

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,4 +1,11 @@
 
+# v107 tag (revm v38.0.0)
+
+* `Handler::first_frame_input` ([#3578](https://github.com/bluealloy/revm/pull/3578)): `init_and_floor_gas: &InitialAndFloorGas` param replaced by `reservoir: u64`. Compute via `InitialAndFloorGas::initial_gas_and_reservoir(tx_gas_limit, tx_gas_limit_cap, is_eip8037) -> (gas_limit, reservoir)`.
+  * `create_init_frame` and `CreateInputs::new` gained a trailing `reservoir: u64` param.
+* `Handler::validate_against_state_and_deduct_caller` ([#3577](https://github.com/bluealloy/revm/pull/3577)): gained `&mut InitialAndFloorGas` param.
+* `PrecompileOutput::gas_refunded: i64` field re-added ([#3574](https://github.com/bluealloy/revm/pull/3574)). Breaks struct literal constructors.
+
 # v106 tag (revm v37.0.0)
 
 * EIP-8037 state gas support ([#3406](https://github.com/bluealloy/revm/pull/3406)). Gas is now split into regular gas and state gas tracked via a reservoir. State gas draws from the reservoir first and spills into regular gas when exhausted. This affects gas accounting across the entire stack.

--- a/bins/revme/CHANGELOG.md
+++ b/bins/revme/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.0](https://github.com/bluealloy/revm/compare/revme-v14.0.0...revme-v15.0.0) - 2026-04-17
+
+### Other
+
+- updated the following local packages: revm
+
 ## [14.0.0](https://github.com/bluealloy/revm/compare/revme-v13.0.0...revme-v14.0.0) - 2026-04-10
 
 ### Added

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revme"
 description = "Rust Ethereum Virtual Machine Executable"
-version = "14.0.0"
+version = "15.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/context/CHANGELOG.md
+++ b/crates/context/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [16.0.1](https://github.com/bluealloy/revm/compare/revm-context-v16.0.0...revm-context-v16.0.1) - 2026-04-17
+
+### Other
+
+- updated the following local packages: revm-state, revm-context-interface, revm-database-interface
+
 ## [16.0.0](https://github.com/bluealloy/revm/compare/revm-context-v15.0.0...revm-context-v16.0.0) - 2026-04-10
 
 ### Added

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-context"
 description = "Revm context crates"
-version = "16.0.0"
+version = "16.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/context/interface/CHANGELOG.md
+++ b/crates/context/interface/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [17.0.1](https://github.com/bluealloy/revm/compare/revm-context-interface-v17.0.0...revm-context-interface-v17.0.1) - 2026-04-17
+
+### Other
+
+- pass reservoir into `first_frame_input` ([#3578](https://github.com/bluealloy/revm/pull/3578))
+
 ## [17.0.0](https://github.com/bluealloy/revm/compare/revm-context-interface-v16.0.0...revm-context-interface-v17.0.0) - 2026-04-10
 
 ### Added

--- a/crates/context/interface/Cargo.toml
+++ b/crates/context/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-context-interface"
 description = "Revm context interface crates"
-version = "17.0.0"
+version = "17.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/database/CHANGELOG.md
+++ b/crates/database/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [13.0.1](https://github.com/bluealloy/revm/compare/revm-database-v13.0.0...revm-database-v13.0.1) - 2026-04-17
+
+### Other
+
+- updated the following local packages: revm-state, revm-database-interface
+
 ## [13.0.0](https://github.com/bluealloy/revm/compare/revm-database-v12.0.0...revm-database-v13.0.0) - 2026-04-10
 
 ### Added

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-database"
 description = "Revm Database implementations"
-version = "13.0.0"
+version = "13.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/database/interface/CHANGELOG.md
+++ b/crates/database/interface/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.0.1](https://github.com/bluealloy/revm/compare/revm-database-interface-v11.0.0...revm-database-interface-v11.0.1) - 2026-04-17
+
+### Other
+
+- updated the following local packages: revm-state
+
 ## [11.0.0](https://github.com/bluealloy/revm/compare/revm-database-interface-v10.0.0...revm-database-interface-v11.0.0) - 2026-04-10
 
 ### Added

--- a/crates/database/interface/Cargo.toml
+++ b/crates/database/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-database-interface"
 description = "Revm Database interface"
-version = "11.0.0"
+version = "11.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/handler/CHANGELOG.md
+++ b/crates/handler/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [18.1.0](https://github.com/bluealloy/revm/compare/revm-handler-v18.0.0...revm-handler-v18.1.0) - 2026-04-17
+
+### Added
+
+- propagate InitialAndFloorGas to validate_against_state_and_deduct_caller ([#3577](https://github.com/bluealloy/revm/pull/3577))
+
+### Fixed
+
+- re-add PrecompileOutput::gas_refunded ([#3574](https://github.com/bluealloy/revm/pull/3574))
+
+### Other
+
+- pass reservoir into `first_frame_input` ([#3578](https://github.com/bluealloy/revm/pull/3578))
+
 ## [18.0.0](https://github.com/bluealloy/revm/compare/revm-handler-v17.0.0...revm-handler-v18.0.0) - 2026-04-10
 
 ### Added

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-handler"
 description = "Revm handler crates"
-version = "18.0.0"
+version = "18.1.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/inspector/CHANGELOG.md
+++ b/crates/inspector/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [19.0.0](https://github.com/bluealloy/revm/compare/revm-inspector-v18.0.0...revm-inspector-v19.0.0) - 2026-04-17
+
+### Other
+
+- pass reservoir into `first_frame_input` ([#3578](https://github.com/bluealloy/revm/pull/3578))
+
 ## [18.0.0](https://github.com/bluealloy/revm/compare/revm-inspector-v17.0.0...revm-inspector-v18.0.0) - 2026-04-10
 
 ### Added

--- a/crates/inspector/Cargo.toml
+++ b/crates/inspector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-inspector"
 description = "Revm inspector interface"
-version = "18.0.0"
+version = "19.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [35.0.1](https://github.com/bluealloy/revm/compare/revm-interpreter-v35.0.0...revm-interpreter-v35.0.1) - 2026-04-17
+
+### Other
+
+- pass reservoir into `first_frame_input` ([#3578](https://github.com/bluealloy/revm/pull/3578))
+
 ## [35.0.0](https://github.com/bluealloy/revm/compare/revm-interpreter-v34.0.0...revm-interpreter-v35.0.0) - 2026-04-10
 
 ### Added

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-interpreter"
 description = "Revm Interpreter that executes bytecode."
-version = "35.0.0"
+version = "35.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/precompile/CHANGELOG.md
+++ b/crates/precompile/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [34.0.0](https://github.com/bluealloy/revm/compare/revm-precompile-v33.0.0...revm-precompile-v34.0.0) - 2026-04-17
+
+### Fixed
+
+- re-add PrecompileOutput::gas_refunded ([#3574](https://github.com/bluealloy/revm/pull/3574))
+
 ## [33.0.0](https://github.com/bluealloy/revm/compare/revm-precompile-v32.1.0...revm-precompile-v33.0.0) - 2026-04-10
 
 ### Added

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-precompile"
 description = "Revm Precompiles - Ethereum compatible precompiled contracts"
-version = "33.0.0"
+version = "34.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/revm/CHANGELOG.md
+++ b/crates/revm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [38.0.0](https://github.com/bluealloy/revm/compare/revm-v37.0.0...revm-v38.0.0) - 2026-04-17
+
+### Other
+
+- updated the following local packages: revm-state, revm-context-interface, revm-interpreter, revm-precompile, revm-handler, revm-inspector, revm-database-interface, revm-context, revm-database, revm-statetest-types
+
 ## [37.0.0](https://github.com/bluealloy/revm/compare/revm-v36.0.0...revm-v37.0.0) - 2026-04-10
 
 ### Other

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm"
 description = "Revm - Rust Ethereum Virtual Machine"
-version = "37.0.0"
+version = "38.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/state/CHANGELOG.md
+++ b/crates/state/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.0.1](https://github.com/bluealloy/revm/compare/revm-state-v11.0.0...revm-state-v11.0.1) - 2026-04-17
+
+### Fixed
+
+- *(bal)* record storage writes to zero for selfdestructed accounts ([#3573](https://github.com/bluealloy/revm/pull/3573))
+
 ## [11.0.0](https://github.com/bluealloy/revm/compare/revm-state-v10.0.0...revm-state-v11.0.0) - 2026-04-10
 
 ### Other

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-state"
 description = "Revm state types"
-version = "11.0.0"
+version = "11.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/statetest-types/CHANGELOG.md
+++ b/crates/statetest-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [17.0.1](https://github.com/bluealloy/revm/compare/revm-statetest-types-v17.0.0...revm-statetest-types-v17.0.1) - 2026-04-17
+
+### Other
+
+- updated the following local packages: revm-state, revm-context-interface, revm-context, revm-database
+
 ## [17.0.0](https://github.com/bluealloy/revm/compare/revm-statetest-types-v16.0.0...revm-statetest-types-v17.0.0) - 2026-04-10
 
 ### Other

--- a/crates/statetest-types/Cargo.toml
+++ b/crates/statetest-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-statetest-types"
 description = "Statetest types for revme"
-version = "17.0.0"
+version = "17.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
## Summary
- Cherry-picked d62933180 (chore: v107 release prep) onto a fresh branch off origin/main

## Conflict resolution notes
- `crates/op-revm/*` changes from the original commit were dropped — op-revm was removed in 64672d6ef and is no longer part of this workspace.
- `Cargo.toml`: kept the cherry-picked workspace version bumps (revm 38.0.0, revm-database 13.0.1, etc.), omitted the `op-revm` workspace-dep line.
- `Cargo.lock`: removed the `op-revm` package entry.

## Test plan
- [x] `cargo check --workspace` passes
- [ ] CI green