### PR TITLE
fix(state): canonicalize BAL alloy ordering

### DIFF
--- a/crates/state/src/bal.rs
+++ b/crates/state/src/bal.rs
@@ -64,7 +64,7 @@ impl Bal {
 
         // Sort accounts by address before printing
         let mut sorted_accounts: Vec<_> = self.accounts.iter().collect();
-        sorted_accounts.sort_by_key(|(address, _)| *address);
+        sorted_accounts.sort_unstable_by_key(|(address, _)| *address);
 
         for (idx, (address, account)) in sorted_accounts.into_iter().enumerate() {
             println!("Account #{idx} - Address: {address:?}");
@@ -210,14 +210,21 @@ impl Bal {
         Ok(storage_value)
     }
 
-    /// Consume Bal and create [`AlloyBal`]
+    /// Consume `Bal` and create a canonical EIP-7928 [`AlloyBal`].
+    ///
+    /// The returned access list is ordered deterministically: accounts are
+    /// sorted lexicographically by address, and each account's nested reads and
+    /// changes are sorted by [`AccountBal::into_alloy_account`].
+    ///
+    /// This matches the EIP-7928 ordering requirements:
+    /// <https://eips.ethereum.org/EIPS/eip-7928#ordering-uniqueness-and-determinism>.
     pub fn into_alloy_bal(self) -> AlloyBal {
         let mut alloy_bal = AlloyBal::from_iter(
             self.accounts
                 .into_iter()
                 .map(|(address, account)| account.into_alloy_account(address)),
         );
-        alloy_bal.sort_by_key(|a| a.address);
+        alloy_bal.sort_unstable_by_key(|a| a.address);
         alloy_bal
     }
 }
@@ -242,3 +249,119 @@ impl core::fmt::Display for BalError {
 }
 
 impl core::error::Error for BalError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytecode::Bytecode;
+    use primitives::{B256, U256};
+    use std::collections::BTreeMap;
+
+    fn code(byte: u8) -> (B256, Bytecode) {
+        let bytecode = Bytecode::new_raw(vec![byte].into());
+        (bytecode.hash_slow(), bytecode)
+    }
+
+    #[test]
+    fn into_alloy_bal_canonicalizes_eip_7928_ordering() {
+        let low_address = Address::with_last_byte(1);
+        let high_address = Address::with_last_byte(2);
+
+        let unordered_account = AccountBal {
+            account_info: AccountInfoBal {
+                nonce: BalWrites {
+                    writes: vec![(9, 90), (4, 40)],
+                },
+                balance: BalWrites {
+                    writes: vec![(5, U256::from(50)), (2, U256::from(20))],
+                },
+                code: BalWrites {
+                    writes: vec![(7, code(7)), (3, code(3))],
+                },
+            },
+            storage: StorageBal {
+                storage: BTreeMap::from([
+                    (
+                        U256::from(4),
+                        BalWrites {
+                            writes: vec![(8, U256::from(80)), (6, U256::from(60))],
+                        },
+                    ),
+                    (U256::from(1), BalWrites { writes: vec![] }),
+                    (
+                        U256::from(2),
+                        BalWrites {
+                            writes: vec![(3, U256::from(30)), (1, U256::from(10))],
+                        },
+                    ),
+                    (U256::from(3), BalWrites { writes: vec![] }),
+                ]),
+            },
+        };
+
+        let alloy_bal = Bal::from_iter([
+            (high_address, AccountBal::default()),
+            (low_address, unordered_account),
+        ])
+        .into_alloy_bal();
+
+        assert_eq!(
+            alloy_bal
+                .iter()
+                .map(|account| account.address)
+                .collect::<Vec<_>>(),
+            vec![low_address, high_address]
+        );
+
+        let account = &alloy_bal[0];
+        assert_eq!(account.storage_reads, vec![U256::from(1), U256::from(3)]);
+        assert_eq!(
+            account
+                .storage_changes
+                .iter()
+                .map(|slot| slot.slot)
+                .collect::<Vec<_>>(),
+            vec![U256::from(2), U256::from(4)]
+        );
+        assert_eq!(
+            account.storage_changes[0]
+                .changes
+                .iter()
+                .map(|change| change.block_access_index)
+                .collect::<Vec<_>>(),
+            vec![1, 3]
+        );
+        assert_eq!(
+            account.storage_changes[1]
+                .changes
+                .iter()
+                .map(|change| change.block_access_index)
+                .collect::<Vec<_>>(),
+            vec![6, 8]
+        );
+        assert_eq!(
+            account
+                .balance_changes
+                .iter()
+                .map(|change| change.block_access_index)
+                .collect::<Vec<_>>(),
+            vec![2, 5]
+        );
+        assert_eq!(
+            account
+                .nonce_changes
+                .iter()
+                .map(|change| change.block_access_index)
+                .collect::<Vec<_>>(),
+            vec![4, 9]
+        );
+        assert_eq!(
+            account
+                .code_changes
+                .iter()
+                .map(|change| change.block_access_index)
+                .collect::<Vec<_>>(),
+            vec![3, 7]
+        );
+    }
+}

--- a/crates/state/src/bal/account.rs
+++ b/crates/state/src/bal/account.rs
@@ -95,7 +95,16 @@ impl AccountBal {
         ))
     }
 
-    /// Consumes AccountBal and converts it into [`AlloyAccountChanges`].
+    /// Consumes `AccountBal` and converts it into canonical EIP-7928
+    /// [`AlloyAccountChanges`].
+    ///
+    /// The returned account changes are ordered deterministically: storage reads
+    /// and storage changes are sorted lexicographically by slot key, changes
+    /// within each storage slot are sorted by block access index, and balance,
+    /// nonce, and code changes are sorted by block access index.
+    ///
+    /// This matches the EIP-7928 ordering requirements:
+    /// <https://eips.ethereum.org/EIPS/eip-7928#ordering-uniqueness-and-determinism>.
     #[inline]
     pub fn into_alloy_account(self, address: Address) -> AlloyAccountChanges {
         let storage_len = self.storage.storage.len();
@@ -105,42 +114,51 @@ impl AccountBal {
             if value.writes.is_empty() {
                 storage_reads.push(key);
             } else {
-                storage_changes.push(AlloySlotChanges::new(
-                    key,
-                    value
-                        .writes
-                        .into_iter()
-                        .map(|(index, value)| AlloyStorageChange::new(index, value))
-                        .collect(),
-                ));
+                let mut changes = value
+                    .writes
+                    .into_iter()
+                    .map(|(index, value)| AlloyStorageChange::new(index, value))
+                    .collect::<Vec<_>>();
+                changes.sort_unstable_by_key(|change| change.block_access_index);
+
+                storage_changes.push(AlloySlotChanges::new(key, changes));
             }
         }
+
+        let mut balance_changes = self
+            .account_info
+            .balance
+            .writes
+            .into_iter()
+            .map(|(index, value)| AlloyBalanceChange::new(index, value))
+            .collect::<Vec<_>>();
+        balance_changes.sort_unstable_by_key(|change| change.block_access_index);
+
+        let mut nonce_changes = self
+            .account_info
+            .nonce
+            .writes
+            .into_iter()
+            .map(|(index, value)| AlloyNonceChange::new(index, value))
+            .collect::<Vec<_>>();
+        nonce_changes.sort_unstable_by_key(|change| change.block_access_index);
+
+        let mut code_changes = self
+            .account_info
+            .code
+            .writes
+            .into_iter()
+            .map(|(index, (_, value))| AlloyCodeChange::new(index, value.original_bytes()))
+            .collect::<Vec<_>>();
+        code_changes.sort_unstable_by_key(|change| change.block_access_index);
 
         AlloyAccountChanges {
             address,
             storage_changes,
             storage_reads,
-            balance_changes: self
-                .account_info
-                .balance
-                .writes
-                .into_iter()
-                .map(|(index, value)| AlloyBalanceChange::new(index, value))
-                .collect(),
-            nonce_changes: self
-                .account_info
-                .nonce
-                .writes
-                .into_iter()
-                .map(|(index, value)| AlloyNonceChange::new(index, value))
-                .collect(),
-            code_changes: self
-                .account_info
-                .code
-                .writes
-                .into_iter()
-                .map(|(index, (_, value))| AlloyCodeChange::new(index, value.original_bytes()))
-                .collect(),
+            balance_changes,
+            nonce_changes,
+            code_changes,
         }
     }
 }


### PR DESCRIPTION
## Summary

- canonicalize EIP-7928 ordering when converting internal BAL state to Alloy BAL types
- sort nested storage, balance, nonce, and code changes by block access index during export
- document the EIP-7928 ordering requirement on the conversion functions and add a regression test

## Root Cause

`into_alloy_bal` sorted accounts by address, but delegated nested vectors were emitted in their existing internal order. That was only EIP-compliant when every internal `BalWrites` happened to already be sorted.

## Validation

- `cargo test -p revm-state`
