### PR TITLE
feat: show address or slot in BAL error

### DIFF
--- a/crates/database/interface/src/bal.rs
+++ b/crates/database/interface/src/bal.rs
@@ -102,7 +102,7 @@ impl BalState {
                 bal.accounts
                     .get_full(address)
                     .map(|i| AccountId::new(i.0).expect("too many bals"))
-                    .ok_or(BalError::AccountNotFound)
+                    .ok_or(BalError::AccountNotFound { address: *address })
             })
             .transpose()
     }
@@ -121,34 +121,30 @@ impl BalState {
         let Some(account_id) = self.get_account_id(&address)? else {
             return Ok(false);
         };
-        Ok(self.basic_by_account_id(account_id, basic))
+        self.basic_by_account_id(account_id, basic)
     }
 
     /// Fetch account from database and apply bal changes to it by account id.
-    ///
-    /// Panics if account_id is invalid
     #[inline]
     pub fn basic_by_account_id(
         &self,
         account_id: AccountId,
         basic: &mut Option<AccountInfo>,
-    ) -> bool {
-        if let Some(bal) = &self.bal {
-            let is_none = basic.is_none();
-            let mut bal_basic = core::mem::take(basic).unwrap_or_default();
-            let changed = bal
-                .populate_account_info(account_id, self.bal_index, &mut bal_basic)
-                .expect("Invalid account id");
+    ) -> Result<bool, BalError> {
+        let Some(bal) = &self.bal else {
+            return Ok(false);
+        };
+        let is_none = basic.is_none();
+        let mut bal_basic = core::mem::take(basic).unwrap_or_default();
+        let changed = bal.populate_account_info(account_id, self.bal_index, &mut bal_basic)?;
 
-            // If account was not in DB and BAL has no changes, keep it as None.
-            if !changed && is_none {
-                return true;
-            }
-
-            *basic = Some(bal_basic);
-            return true;
+        // If account was not in DB and BAL has no changes, keep it as None.
+        if !changed && is_none {
+            return Ok(true);
         }
-        false
+
+        *basic = Some(bal_basic);
+        Ok(true)
     }
 
     /// Get storage value from BAL.
@@ -165,20 +161,18 @@ impl BalState {
         };
 
         let Some(bal_account) = bal.accounts.get(account) else {
-            return Err(BalError::AccountNotFound);
+            return Err(BalError::AccountNotFound { address: *account });
         };
 
         Ok(bal_account
             .storage
-            .get_bal_writes(storage_key)?
+            .get_bal_writes(account, storage_key)?
             .get(self.bal_index))
     }
 
     /// Get the storage value by account id.
     ///
     /// Return Err if bal is present but account or storage is not found inside BAL.
-    ///
-    ///
     #[inline]
     pub fn storage_by_account_id(
         &self,
@@ -189,13 +183,13 @@ impl BalState {
             return Ok(None);
         };
 
-        let Some((_, bal_account)) = bal.accounts.get_index(account_id.get()) else {
-            return Err(BalError::AccountNotFound);
+        let Some((address, bal_account)) = bal.accounts.get_index(account_id.get()) else {
+            return Err(BalError::InvalidAccountId { account_id });
         };
 
         Ok(bal_account
             .storage
-            .get_bal_writes(storage_key)?
+            .get_bal_writes(address, storage_key)?
             .get(self.bal_index))
     }
 
@@ -338,7 +332,7 @@ impl<DB: Database> Database for BalDatabase<DB> {
         let mut account = self.db.basic(address).map_err(EvmDatabaseError::Database)?;
 
         if let Some(account_id) = account_id {
-            self.bal_state.basic_by_account_id(account_id, &mut account);
+            self.bal_state.basic_by_account_id(account_id, &mut account)?;
         }
 
         Ok(account)

--- a/crates/database/interface/src/bal.rs
+++ b/crates/database/interface/src/bal.rs
@@ -332,7 +332,8 @@ impl<DB: Database> Database for BalDatabase<DB> {
         let mut account = self.db.basic(address).map_err(EvmDatabaseError::Database)?;
 
         if let Some(account_id) = account_id {
-            self.bal_state.basic_by_account_id(account_id, &mut account)?;
+            self.bal_state
+                .basic_by_account_id(account_id, &mut account)?;
         }
 
         Ok(account)

--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -293,7 +293,9 @@ impl<DB: Database> Database for State<DB> {
         // will populate account code if there was a bal change to it. If there is no change
         // it will be fetched in code_by_hash.
         if let Some(account_id) = account_id {
-            self.bal_state.basic_by_account_id(account_id, &mut basic);
+            self.bal_state
+                .basic_by_account_id(account_id, &mut basic)
+                .map_err(EvmDatabaseError::Bal)?;
         }
         Ok(basic)
     }
@@ -431,7 +433,9 @@ impl<DB: DatabaseRef> DatabaseRef for State<DB> {
 
         // if it is inside bal, overwrite the account with the bal changes.
         if let Some(account_id) = account_id {
-            self.bal_state.basic_by_account_id(account_id, &mut account);
+            self.bal_state
+                .basic_by_account_id(account_id, &mut account)
+                .map_err(EvmDatabaseError::Bal)?;
         }
         Ok(account)
     }

--- a/crates/state/src/bal.rs
+++ b/crates/state/src/bal.rs
@@ -136,7 +136,7 @@ impl Bal {
         bal_account.update(bal_index, account);
     }
 
-    /// Populate account from BAL. Return true if account info got changed
+    /// Populate account from BAL. Return true if account info got changed.
     pub fn populate_account_info(
         &self,
         account_id: AccountId,
@@ -144,7 +144,7 @@ impl Bal {
         account: &mut AccountInfo,
     ) -> Result<bool, BalError> {
         let Some((_, bal_account)) = self.accounts.get_index(account_id.get()) else {
-            return Err(BalError::AccountNotFound);
+            return Err(BalError::InvalidAccountId { account_id });
         };
         account.account_id = Some(account_id);
 
@@ -162,11 +162,11 @@ impl Bal {
         key: StorageKey,
         value: &mut StorageValue,
     ) -> Result<(), BalError> {
-        let Some((_, bal_account)) = self.accounts.get_index(account_id.get()) else {
-            return Err(BalError::AccountNotFound);
+        let Some((address, bal_account)) = self.accounts.get_index(account_id.get()) else {
+            return Err(BalError::InvalidAccountId { account_id });
         };
 
-        if let Some(bal_value) = bal_account.storage.get(key, bal_index)? {
+        if let Some(bal_value) = bal_account.storage.get(address, key, bal_index)? {
             *value = bal_value;
         };
 
@@ -183,10 +183,12 @@ impl Bal {
         value: &mut StorageValue,
     ) -> Result<(), BalError> {
         let Some(bal_account) = self.accounts.get(&account_address) else {
-            return Err(BalError::AccountNotFound);
+            return Err(BalError::AccountNotFound {
+                address: account_address,
+            });
         };
 
-        if let Some(bal_value) = bal_account.storage.get(key, bal_index)? {
+        if let Some(bal_value) = bal_account.storage.get(&account_address, key, bal_index)? {
             *value = bal_value;
         };
         Ok(())
@@ -199,12 +201,15 @@ impl Bal {
         key: StorageKey,
         bal_index: BalIndex,
     ) -> Result<StorageValue, BalError> {
-        let Some((_, bal_account)) = self.accounts.get_index(account_id.get()) else {
-            return Err(BalError::AccountNotFound);
+        let Some((address, bal_account)) = self.accounts.get_index(account_id.get()) else {
+            return Err(BalError::InvalidAccountId { account_id });
         };
 
-        let Some(storage_value) = bal_account.storage.get(key, bal_index)? else {
-            return Err(BalError::SlotNotFound);
+        let Some(storage_value) = bal_account.storage.get(address, key, bal_index)? else {
+            return Err(BalError::SlotNotFound {
+                address: *address,
+                slot: key,
+            });
         };
 
         Ok(storage_value)
@@ -233,17 +238,40 @@ impl Bal {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BalError {
-    /// Account not found in BAL.
-    AccountNotFound,
-    /// Slot not found in BAL.
-    SlotNotFound,
+    /// Account not found in BAL by address.
+    AccountNotFound {
+        /// Address that was not found.
+        address: Address,
+    },
+    /// Account id does not point at a valid entry in the BAL accounts map.
+    ///
+    /// Signals that a stale or mismatched id was supplied — the id is expected to come
+    /// from a prior BAL lookup against the same BAL.
+    InvalidAccountId {
+        /// Account id that was supplied.
+        account_id: AccountId,
+    },
+    /// Slot not found in BAL for a given account.
+    SlotNotFound {
+        /// Address of the account whose slot was missing.
+        address: Address,
+        /// Storage slot that was not found.
+        slot: StorageKey,
+    },
 }
 
 impl core::fmt::Display for BalError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::AccountNotFound => write!(f, "Account not found in BAL"),
-            Self::SlotNotFound => write!(f, "Slot not found in BAL"),
+            Self::AccountNotFound { address } => {
+                write!(f, "Account {address} not found in BAL")
+            }
+            Self::InvalidAccountId { account_id } => {
+                write!(f, "Invalid BAL account id {}", account_id.get())
+            }
+            Self::SlotNotFound { address, slot } => {
+                write!(f, "Slot {slot:#x} not found in BAL for account {address}")
+            }
         }
     }
 }

--- a/crates/state/src/bal/account.rs
+++ b/crates/state/src/bal/account.rs
@@ -274,7 +274,7 @@ impl StorageBal {
         address: &Address,
         key: StorageKey,
     ) -> Result<&BalWrites<StorageValue>, BalError> {
-        self.storage.get(&key).ok_or_else(|| BalError::SlotNotFound {
+        self.storage.get(&key).ok_or(BalError::SlotNotFound {
             address: *address,
             slot: key,
         })

--- a/crates/state/src/bal/account.rs
+++ b/crates/state/src/bal/account.rs
@@ -258,16 +258,26 @@ impl StorageBal {
     #[inline]
     pub fn get(
         &self,
+        address: &Address,
         key: StorageKey,
         bal_index: BalIndex,
     ) -> Result<Option<StorageValue>, BalError> {
-        Ok(self.get_bal_writes(key)?.get(bal_index))
+        Ok(self.get_bal_writes(address, key)?.get(bal_index))
     }
 
     /// Get storage writes from the builder.
+    ///
+    /// `address` is only needed in case of an error to propagate the address.
     #[inline]
-    pub fn get_bal_writes(&self, key: StorageKey) -> Result<&BalWrites<StorageValue>, BalError> {
-        self.storage.get(&key).ok_or(BalError::SlotNotFound)
+    pub fn get_bal_writes(
+        &self,
+        address: &Address,
+        key: StorageKey,
+    ) -> Result<&BalWrites<StorageValue>, BalError> {
+        self.storage.get(&key).ok_or_else(|| BalError::SlotNotFound {
+            address: *address,
+            slot: key,
+        })
     }
 
     /// Extend storage from another storage.


### PR DESCRIPTION
When an item, either the address or a slot, is not found in the BAL it's useful to know what item is missing exactly.

This changest plumbs this info into the error.

We had to introduce a new error variant into the BalError enum because otherwise there is no way to report the address.