### PR TITLE
chore(deps): bump alloy-eip7928 to 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-eip7928"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1031f4cbbf83817c1c8c63bd2f561f9ac7fd790c81534ed8741eb5bd9b896770"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
 name = "alloy-eips"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,7 +154,7 @@ dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-eip7928",
+ "alloy-eip7928 0.3.3",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
@@ -3885,7 +3898,7 @@ dependencies = [
 name = "revm-state"
 version = "11.0.1"
 dependencies = [
- "alloy-eip7928",
+ "alloy-eip7928 0.4.0",
  "bitflags",
  "nonmax",
  "revm-bytecode",
@@ -3898,7 +3911,7 @@ dependencies = [
 name = "revm-statetest-types"
 version = "17.0.1"
 dependencies = [
- "alloy-eip7928",
+ "alloy-eip7928 0.4.0",
  "k256",
  "revm-context",
  "revm-context-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "0.2
 # alloy
 alloy-eip2930 = { version = "0.2.3", default-features = false }
 alloy-eip7702 = { version = "0.6.3", default-features = false }
-alloy-eip7928 = { version = "0.3.0", default-features = false }
+alloy-eip7928 = { version = "0.4.0", default-features = false }
 alloy-primitives = { version = "1.5.2", default-features = false }
 
 # alloy in examples, revme or feature flagged.

--- a/crates/state/src/bal.rs
+++ b/crates/state/src/bal.rs
@@ -327,7 +327,7 @@ mod tests {
             account.storage_changes[0]
                 .changes
                 .iter()
-                .map(|change| change.block_access_index)
+                .map(|change| change.block_access_index.get())
                 .collect::<Vec<_>>(),
             vec![1, 3]
         );
@@ -335,7 +335,7 @@ mod tests {
             account.storage_changes[1]
                 .changes
                 .iter()
-                .map(|change| change.block_access_index)
+                .map(|change| change.block_access_index.get())
                 .collect::<Vec<_>>(),
             vec![6, 8]
         );
@@ -343,7 +343,7 @@ mod tests {
             account
                 .balance_changes
                 .iter()
-                .map(|change| change.block_access_index)
+                .map(|change| change.block_access_index.get())
                 .collect::<Vec<_>>(),
             vec![2, 5]
         );
@@ -351,7 +351,7 @@ mod tests {
             account
                 .nonce_changes
                 .iter()
-                .map(|change| change.block_access_index)
+                .map(|change| change.block_access_index.get())
                 .collect::<Vec<_>>(),
             vec![4, 9]
         );
@@ -359,7 +359,7 @@ mod tests {
             account
                 .code_changes
                 .iter()
-                .map(|change| change.block_access_index)
+                .map(|change| change.block_access_index.get())
                 .collect::<Vec<_>>(),
             vec![3, 7]
         );

--- a/crates/state/src/bal/account.rs
+++ b/crates/state/src/bal/account.rs
@@ -6,8 +6,9 @@ use crate::{
 };
 use alloy_eip7928::{
     AccountChanges as AlloyAccountChanges, BalanceChange as AlloyBalanceChange,
-    CodeChange as AlloyCodeChange, NonceChange as AlloyNonceChange,
-    SlotChanges as AlloySlotChanges, StorageChange as AlloyStorageChange,
+    BlockAccessIndex as AlloyBlockAccessIndex, CodeChange as AlloyCodeChange,
+    NonceChange as AlloyNonceChange, SlotChanges as AlloySlotChanges,
+    StorageChange as AlloyStorageChange,
 };
 use bytecode::{Bytecode, BytecodeDecodeError};
 use core::ops::{Deref, DerefMut};
@@ -117,7 +118,9 @@ impl AccountBal {
                 let mut changes = value
                     .writes
                     .into_iter()
-                    .map(|(index, value)| AlloyStorageChange::new(index, value))
+                    .map(|(index, value)| {
+                        AlloyStorageChange::new(AlloyBlockAccessIndex::new(index), value)
+                    })
                     .collect::<Vec<_>>();
                 changes.sort_unstable_by_key(|change| change.block_access_index);
 
@@ -130,7 +133,7 @@ impl AccountBal {
             .balance
             .writes
             .into_iter()
-            .map(|(index, value)| AlloyBalanceChange::new(index, value))
+            .map(|(index, value)| AlloyBalanceChange::new(AlloyBlockAccessIndex::new(index), value))
             .collect::<Vec<_>>();
         balance_changes.sort_unstable_by_key(|change| change.block_access_index);
 
@@ -139,7 +142,7 @@ impl AccountBal {
             .nonce
             .writes
             .into_iter()
-            .map(|(index, value)| AlloyNonceChange::new(index, value))
+            .map(|(index, value)| AlloyNonceChange::new(AlloyBlockAccessIndex::new(index), value))
             .collect::<Vec<_>>();
         nonce_changes.sort_unstable_by_key(|change| change.block_access_index);
 
@@ -148,7 +151,9 @@ impl AccountBal {
             .code
             .writes
             .into_iter()
-            .map(|(index, (_, value))| AlloyCodeChange::new(index, value.original_bytes()))
+            .map(|(index, (_, value))| {
+                AlloyCodeChange::new(AlloyBlockAccessIndex::new(index), value.original_bytes())
+            })
             .collect::<Vec<_>>();
         code_changes.sort_unstable_by_key(|change| change.block_access_index);
 

--- a/crates/state/src/bal/alloy.rs
+++ b/crates/state/src/bal/alloy.rs
@@ -2,8 +2,8 @@
 
 // Re-export Alloy BAL types.
 pub use alloy_eip7928::{
-    BalanceChange as AlloyBalanceChange, BlockAccessList as AlloyBal,
-    CodeChange as AlloyCodeChange, NonceChange as AlloyNonceChange,
+    BalanceChange as AlloyBalanceChange, BlockAccessIndex as AlloyBlockAccessIndex,
+    BlockAccessList as AlloyBal, CodeChange as AlloyCodeChange, NonceChange as AlloyNonceChange,
     StorageChange as AlloyStorageChange,
 };
 
@@ -32,7 +32,7 @@ impl From<Vec<AlloyBalanceChange>> for BalWrites<U256> {
         Self {
             writes: value
                 .into_iter()
-                .map(|change| (change.block_access_index, change.post_balance))
+                .map(|change| (change.block_access_index.get(), change.post_balance))
                 .collect(),
         }
     }
@@ -43,7 +43,7 @@ impl From<Vec<AlloyNonceChange>> for BalWrites<u64> {
         Self {
             writes: value
                 .into_iter()
-                .map(|change| (change.block_access_index, change.new_nonce))
+                .map(|change| (change.block_access_index.get(), change.new_nonce))
                 .collect(),
         }
     }
@@ -54,7 +54,7 @@ impl From<Vec<AlloyStorageChange>> for BalWrites<U256> {
         Self {
             writes: value
                 .into_iter()
-                .map(|change| (change.block_access_index, change.new_value))
+                .map(|change| (change.block_access_index.get(), change.new_value))
                 .collect(),
         }
     }
@@ -71,7 +71,7 @@ impl TryFrom<Vec<AlloyCodeChange>> for BalWrites<(B256, Bytecode)> {
                     // convert bytes to bytecode.
                     Bytecode::new_raw_checked(change.new_code).map(|bytecode| {
                         let hash = bytecode.hash_slow();
-                        (change.block_access_index, (hash, bytecode))
+                        (change.block_access_index.get(), (hash, bytecode))
                     })
                 })
                 .collect::<Result<Vec<_>, Self::Error>>()?,


### PR DESCRIPTION
## Summary
- bump the workspace `alloy-eip7928` dependency to `0.4.0`
- adapt BAL conversions to the new `BlockAccessIndex` newtype at the alloy boundary
- update BAL ordering assertions to compare raw index values

## Validation
- `cargo fmt --all`
- `cargo test -p revm-state --features std,serde`
- `cargo test -p revm-statetest-types`
- `cargo check --workspace --all-targets`