### PR TITLE
chore: update alloy-eip7928 to newer version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-eip7928"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1031f4cbbf83817c1c8c63bd2f561f9ac7fd790c81534ed8741eb5bd9b896770"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
 name = "alloy-eips"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,7 +154,7 @@ dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-eip7928",
+ "alloy-eip7928 0.3.3",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
@@ -3885,7 +3898,7 @@ dependencies = [
 name = "revm-state"
 version = "11.0.1"
 dependencies = [
- "alloy-eip7928",
+ "alloy-eip7928 0.4.0",
  "bitflags",
  "nonmax",
  "revm-bytecode",
@@ -3898,7 +3911,7 @@ dependencies = [
 name = "revm-statetest-types"
 version = "17.0.1"
 dependencies = [
- "alloy-eip7928",
+ "alloy-eip7928 0.4.0",
  "k256",
  "revm-context",
  "revm-context-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "0.2
 # alloy
 alloy-eip2930 = { version = "0.2.3", default-features = false }
 alloy-eip7702 = { version = "0.6.3", default-features = false }
-alloy-eip7928 = { version = "0.3.0", default-features = false }
+alloy-eip7928 = { version = "0.4.0", default-features = false }
 alloy-primitives = { version = "1.5.2", default-features = false }
 
 # alloy in examples, revme or feature flagged.

--- a/crates/database/interface/src/bal.rs
+++ b/crates/database/interface/src/bal.rs
@@ -6,7 +6,7 @@ use core::{
 };
 use primitives::{Address, StorageKey, StorageValue, B256};
 use state::{
-    bal::{alloy::AlloyBal, Bal, BalError},
+    bal::{alloy::AlloyBal, Bal, BalError, BlockAccessIndex},
     Account, AccountId, AccountInfo, Bytecode, EvmState,
 };
 use std::sync::Arc;
@@ -24,7 +24,7 @@ pub struct BalState {
     pub bal_builder: Option<Bal>,
     /// BAL index, used by bal to fetch appropriate values and used by bal_builder on commit
     /// to submit changes.
-    pub bal_index: u64,
+    pub bal_index: BlockAccessIndex,
 }
 
 impl BalState {
@@ -34,21 +34,21 @@ impl BalState {
         Self::default()
     }
 
-    /// Reset BAL index.
+    /// Reset BAL index to pre-execution.
     #[inline]
     pub const fn reset_bal_index(&mut self) {
-        self.bal_index = 0;
+        self.bal_index = BlockAccessIndex::PRE_EXECUTION;
     }
 
     /// Bump BAL index.
     #[inline]
     pub const fn bump_bal_index(&mut self) {
-        self.bal_index += 1;
+        self.bal_index.increment();
     }
 
     /// Get BAL index.
     #[inline]
-    pub const fn bal_index(&self) -> u64 {
+    pub const fn bal_index(&self) -> BlockAccessIndex {
         self.bal_index
     }
 

--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -11,7 +11,7 @@ use database_interface::{
 };
 use primitives::{hash_map, Address, AddressMap, HashMap, StorageKey, StorageValue, B256};
 use state::{
-    bal::{alloy::AlloyBal, Bal},
+    bal::{alloy::AlloyBal, Bal, BlockAccessIndex},
     Account, AccountId, AccountInfo,
 };
 use std::{boxed::Box, sync::Arc};
@@ -218,7 +218,7 @@ impl<DB: Database> State<DB> {
 
     /// Set BAL index.
     #[inline]
-    pub const fn set_bal_index(&mut self, index: u64) {
+    pub const fn set_bal_index(&mut self, index: BlockAccessIndex) {
         self.bal_state.bal_index = index;
     }
 

--- a/crates/state/src/bal.rs
+++ b/crates/state/src/bal.rs
@@ -5,7 +5,7 @@
 //!
 //! ## Key Types
 //!
-//! - **`BalIndex`**: Block access index (0 for pre-execution, 1..n for transactions, n+1 for post-execution)
+//! - [`BlockAccessIndex`]: block access index
 //! - **`Bal`**: Main BAL structure containing a map of accounts
 //! - **`BalWrites<T>`**: Array of (index, value) pairs representing sequential writes to a state item
 //! - **`AccountBal`**: Complete BAL structure for an account (balance, nonce, code, and storage)
@@ -17,14 +17,12 @@ pub mod alloy;
 pub mod writes;
 
 pub use account::{AccountBal, AccountInfoBal, StorageBal};
+pub use alloy_eip7928::BlockAccessIndex;
 pub use writes::BalWrites;
 
 use crate::{Account, AccountId, AccountInfo};
 use alloy_eip7928::BlockAccessList as AlloyBal;
 use primitives::{Address, AddressIndexMap, StorageKey, StorageValue};
-
-/// Block access index (0 for pre-execution, 1..n for transactions, n+1 for post-execution)
-pub type BalIndex = u64;
 
 /// BAL structure.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -131,7 +129,12 @@ impl Bal {
 
     #[inline]
     /// Extend BAL with account.
-    pub fn update_account(&mut self, bal_index: BalIndex, address: Address, account: &Account) {
+    pub fn update_account(
+        &mut self,
+        bal_index: BlockAccessIndex,
+        address: Address,
+        account: &Account,
+    ) {
         let bal_account = self.accounts.entry(address).or_default();
         bal_account.update(bal_index, account);
     }
@@ -140,7 +143,7 @@ impl Bal {
     pub fn populate_account_info(
         &self,
         account_id: AccountId,
-        bal_index: BalIndex,
+        bal_index: BlockAccessIndex,
         account: &mut AccountInfo,
     ) -> Result<bool, BalError> {
         let Some((_, bal_account)) = self.accounts.get_index(account_id.get()) else {
@@ -158,7 +161,7 @@ impl Bal {
     pub fn populate_storage_slot_by_account_id(
         &self,
         account_id: AccountId,
-        bal_index: BalIndex,
+        bal_index: BlockAccessIndex,
         key: StorageKey,
         value: &mut StorageValue,
     ) -> Result<(), BalError> {
@@ -178,7 +181,7 @@ impl Bal {
     pub fn populate_storage_slot(
         &self,
         account_address: Address,
-        bal_index: BalIndex,
+        bal_index: BlockAccessIndex,
         key: StorageKey,
         value: &mut StorageValue,
     ) -> Result<(), BalError> {
@@ -199,7 +202,7 @@ impl Bal {
         &self,
         account_id: AccountId,
         key: StorageKey,
-        bal_index: BalIndex,
+        bal_index: BlockAccessIndex,
     ) -> Result<StorageValue, BalError> {
         let Some((address, bal_account)) = self.accounts.get_index(account_id.get()) else {
             return Err(BalError::InvalidAccountId { account_id });
@@ -290,6 +293,10 @@ mod tests {
         (bytecode.hash_slow(), bytecode)
     }
 
+    const fn idx(index: u64) -> BlockAccessIndex {
+        BlockAccessIndex::new(index)
+    }
+
     #[test]
     fn into_alloy_bal_canonicalizes_eip_7928_ordering() {
         let low_address = Address::with_last_byte(1);
@@ -298,13 +305,13 @@ mod tests {
         let unordered_account = AccountBal {
             account_info: AccountInfoBal {
                 nonce: BalWrites {
-                    writes: vec![(9, 90), (4, 40)],
+                    writes: vec![(idx(9), 90), (idx(4), 40)],
                 },
                 balance: BalWrites {
-                    writes: vec![(5, U256::from(50)), (2, U256::from(20))],
+                    writes: vec![(idx(5), U256::from(50)), (idx(2), U256::from(20))],
                 },
                 code: BalWrites {
-                    writes: vec![(7, code(7)), (3, code(3))],
+                    writes: vec![(idx(7), code(7)), (idx(3), code(3))],
                 },
             },
             storage: StorageBal {
@@ -312,14 +319,14 @@ mod tests {
                     (
                         U256::from(4),
                         BalWrites {
-                            writes: vec![(8, U256::from(80)), (6, U256::from(60))],
+                            writes: vec![(idx(8), U256::from(80)), (idx(6), U256::from(60))],
                         },
                     ),
                     (U256::from(1), BalWrites { writes: vec![] }),
                     (
                         U256::from(2),
                         BalWrites {
-                            writes: vec![(3, U256::from(30)), (1, U256::from(10))],
+                            writes: vec![(idx(3), U256::from(30)), (idx(1), U256::from(10))],
                         },
                     ),
                     (U256::from(3), BalWrites { writes: vec![] }),
@@ -357,7 +364,7 @@ mod tests {
                 .iter()
                 .map(|change| change.block_access_index)
                 .collect::<Vec<_>>(),
-            vec![1, 3]
+            vec![idx(1), idx(3)]
         );
         assert_eq!(
             account.storage_changes[1]
@@ -365,7 +372,7 @@ mod tests {
                 .iter()
                 .map(|change| change.block_access_index)
                 .collect::<Vec<_>>(),
-            vec![6, 8]
+            vec![idx(6), idx(8)]
         );
         assert_eq!(
             account
@@ -373,7 +380,7 @@ mod tests {
                 .iter()
                 .map(|change| change.block_access_index)
                 .collect::<Vec<_>>(),
-            vec![2, 5]
+            vec![idx(2), idx(5)]
         );
         assert_eq!(
             account
@@ -381,7 +388,7 @@ mod tests {
                 .iter()
                 .map(|change| change.block_access_index)
                 .collect::<Vec<_>>(),
-            vec![4, 9]
+            vec![idx(4), idx(9)]
         );
         assert_eq!(
             account
@@ -389,7 +396,7 @@ mod tests {
                 .iter()
                 .map(|change| change.block_access_index)
                 .collect::<Vec<_>>(),
-            vec![3, 7]
+            vec![idx(3), idx(7)]
         );
     }
 }

--- a/crates/state/src/bal/account.rs
+++ b/crates/state/src/bal/account.rs
@@ -1,7 +1,7 @@
 //! BAL builder module
 
 use crate::{
-    bal::{writes::BalWrites, BalError, BalIndex},
+    bal::{writes::BalWrites, BalError, BlockAccessIndex},
     Account, AccountInfo, EvmStorage,
 };
 use alloy_eip7928::{
@@ -43,13 +43,17 @@ impl DerefMut for AccountBal {
 
 impl AccountBal {
     /// Populate account from BAL. Return true if account info got changed
-    pub fn populate_account_info(&self, bal_index: BalIndex, account: &mut AccountInfo) -> bool {
+    pub fn populate_account_info(
+        &self,
+        bal_index: BlockAccessIndex,
+        account: &mut AccountInfo,
+    ) -> bool {
         self.account_info.populate_account_info(bal_index, account)
     }
 
     /// Extend account from another account.
     #[inline]
-    pub fn update(&mut self, bal_index: BalIndex, account: &Account) {
+    pub fn update(&mut self, bal_index: BlockAccessIndex, account: &Account) {
         if account.is_selfdestructed_locally() {
             let empty_info = AccountInfo::default();
             self.account_info
@@ -177,7 +181,11 @@ pub struct AccountInfoBal {
 
 impl AccountInfoBal {
     /// Populate account info from BAL. Return true if account info got changed
-    pub fn populate_account_info(&self, bal_index: BalIndex, account: &mut AccountInfo) -> bool {
+    pub fn populate_account_info(
+        &self,
+        bal_index: BlockAccessIndex,
+        account: &mut AccountInfo,
+    ) -> bool {
         let mut changed = false;
         if let Some(nonce) = self.nonce.get(bal_index) {
             account.nonce = nonce;
@@ -197,7 +205,12 @@ impl AccountInfoBal {
 
     /// Extend account info from another account info.
     #[inline]
-    pub fn update(&mut self, index: BalIndex, original: &AccountInfo, present: &AccountInfo) {
+    pub fn update(
+        &mut self,
+        index: BlockAccessIndex,
+        original: &AccountInfo,
+        present: &AccountInfo,
+    ) {
         self.nonce.update(index, &original.nonce, present.nonce);
         self.balance
             .update(index, &original.balance, present.balance);
@@ -221,13 +234,18 @@ impl AccountInfoBal {
 
     /// Update account balance in BAL.
     #[inline]
-    pub fn balance_update(&mut self, bal_index: BalIndex, original_balance: &U256, balance: U256) {
+    pub fn balance_update(
+        &mut self,
+        bal_index: BlockAccessIndex,
+        original_balance: &U256,
+        balance: U256,
+    ) {
         self.balance.update(bal_index, original_balance, balance);
     }
 
     /// Update account nonce in BAL.
     #[inline]
-    pub fn nonce_update(&mut self, bal_index: BalIndex, original_nonce: &u64, nonce: u64) {
+    pub fn nonce_update(&mut self, bal_index: BlockAccessIndex, original_nonce: &u64, nonce: u64) {
         self.nonce.update(bal_index, original_nonce, nonce);
     }
 
@@ -235,7 +253,7 @@ impl AccountInfoBal {
     #[inline]
     pub fn code_update(
         &mut self,
-        bal_index: BalIndex,
+        bal_index: BlockAccessIndex,
         original_code_hash: &B256,
         code_hash: B256,
         code: Bytecode,
@@ -260,7 +278,7 @@ impl StorageBal {
         &self,
         address: &Address,
         key: StorageKey,
-        bal_index: BalIndex,
+        bal_index: BlockAccessIndex,
     ) -> Result<Option<StorageValue>, BalError> {
         Ok(self.get_bal_writes(address, key)?.get(bal_index))
     }
@@ -297,7 +315,7 @@ impl StorageBal {
 
     /// Update storage from [`EvmStorage`].
     #[inline]
-    pub fn update(&mut self, bal_index: BalIndex, storage: &EvmStorage) {
+    pub fn update(&mut self, bal_index: BlockAccessIndex, storage: &EvmStorage) {
         for (key, value) in storage {
             self.storage.entry(*key).or_default().update(
                 bal_index,
@@ -311,7 +329,7 @@ impl StorageBal {
     ///
     /// All accessed slots are recorded as written to zero since selfdestruct wipes storage.
     #[inline]
-    pub fn update_selfdestruct(&mut self, bal_index: BalIndex, storage: &EvmStorage) {
+    pub fn update_selfdestruct(&mut self, bal_index: BlockAccessIndex, storage: &EvmStorage) {
         for (key, value) in storage {
             self.storage.entry(*key).or_default().update(
                 bal_index,

--- a/crates/state/src/bal/writes.rs
+++ b/crates/state/src/bal/writes.rs
@@ -1,6 +1,6 @@
 //! BAL containing writes.
 
-use crate::bal::BalIndex;
+use crate::bal::BlockAccessIndex;
 use std::vec::Vec;
 
 /// Use to store values
@@ -9,20 +9,20 @@ use std::vec::Vec;
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BalWrites<T: PartialEq + Clone> {
-    /// List of writes with BalIndex.
-    pub writes: Vec<(BalIndex, T)>,
+    /// List of writes with [`BlockAccessIndex`].
+    pub writes: Vec<(BlockAccessIndex, T)>,
 }
 
 impl<T: PartialEq + Clone> BalWrites<T> {
     /// Create a new BalWrites.
-    pub fn new(mut writes: Vec<(BalIndex, T)>) -> Self {
+    pub fn new(mut writes: Vec<(BlockAccessIndex, T)>) -> Self {
         writes.sort_by_key(|(index, _)| *index);
         Self { writes }
     }
 
     /// Linear search is used for small number of writes. It is faster than binary search.
     #[inline(never)]
-    pub fn get_linear_search(&self, bal_index: BalIndex) -> Option<T> {
+    pub fn get_linear_search(&self, bal_index: BlockAccessIndex) -> Option<T> {
         let mut last_item = None;
         for (index, item) in self.writes.iter() {
             // if index is greater than bal_index we return the last item.
@@ -35,7 +35,7 @@ impl<T: PartialEq + Clone> BalWrites<T> {
     }
 
     /// Get value from BAL.
-    pub fn get(&self, bal_index: BalIndex) -> Option<T> {
+    pub fn get(&self, bal_index: BlockAccessIndex) -> Option<T> {
         if self.writes.len() < 5 {
             return self.get_linear_search(bal_index);
         }
@@ -69,7 +69,7 @@ impl<T: PartialEq + Clone> BalWrites<T> {
     ///
     /// No checks for original value is done. This is useful when we know that value is different.
     #[inline]
-    pub fn force_update(&mut self, index: BalIndex, value: T) {
+    pub fn force_update(&mut self, index: BlockAccessIndex, value: T) {
         if let Some(last) = self.writes.last_mut() {
             if index == last.0 {
                 last.1 = value;
@@ -81,20 +81,20 @@ impl<T: PartialEq + Clone> BalWrites<T> {
 
     /// Insert a value into the builder.
     ///
-    /// If BalIndex is same as last it will override the value.
-    pub fn update(&mut self, index: BalIndex, original_value: &T, value: T) {
+    /// If [`BlockAccessIndex`] is same as last it will override the value.
+    pub fn update(&mut self, index: BlockAccessIndex, original_value: &T, value: T) {
         self.update_with_key(index, original_value, value, |i| i);
     }
 
     /// Insert a value into the builder.
     ///
-    /// If BalIndex is same as last it will override the value.
+    /// If [`BlockAccessIndex`] is same as last it will override the value.
     ///
     /// Assumes that index is always greater than last one and that Writes are updated in proper order.
     #[inline]
     pub fn update_with_key<K: PartialEq, F>(
         &mut self,
-        index: BalIndex,
+        index: BlockAccessIndex,
         original_subvalue: &K,
         value: T,
         f: F,
@@ -140,38 +140,42 @@ impl<T: PartialEq + Clone> BalWrites<T> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_get() {
-        let bal_writes = BalWrites::new(vec![(0, 1), (1, 2), (2, 3)]);
-        assert_eq!(bal_writes.get(0), None);
-        assert_eq!(bal_writes.get(1), Some(1));
-        assert_eq!(bal_writes.get(2), Some(2));
-        assert_eq!(bal_writes.get(3), Some(3));
-        assert_eq!(bal_writes.get(4), Some(3));
+    const fn idx(index: u64) -> BlockAccessIndex {
+        BlockAccessIndex::new(index)
     }
 
-    fn get_binary_search(threshold: BalIndex) {
+    #[test]
+    fn test_get() {
+        let bal_writes = BalWrites::new(vec![(idx(0), 1), (idx(1), 2), (idx(2), 3)]);
+        assert_eq!(bal_writes.get(idx(0)), None);
+        assert_eq!(bal_writes.get(idx(1)), Some(1));
+        assert_eq!(bal_writes.get(idx(2)), Some(2));
+        assert_eq!(bal_writes.get(idx(3)), Some(3));
+        assert_eq!(bal_writes.get(idx(4)), Some(3));
+    }
+
+    fn get_binary_search(threshold: u64) {
         // Construct test data up to (threshold - 1), skipping one key to simulate a gap.
         let entries: Vec<_> = (0..threshold - 1)
-            .map(|i| (i, i + 1))
-            .chain(std::iter::once((threshold, threshold + 1)))
+            .map(|i| (idx(i), i + 1))
+            .chain(std::iter::once((idx(threshold), threshold + 1)))
             .collect();
 
         let bal_writes = BalWrites::new(entries);
 
         // Case 1: lookup before any entries
-        assert_eq!(bal_writes.get(0), None);
+        assert_eq!(bal_writes.get(idx(0)), None);
 
         // Case 2: lookups for existing keys before the gap
         for i in 1..threshold - 1 {
-            assert_eq!(bal_writes.get(i), Some(i));
+            assert_eq!(bal_writes.get(idx(i)), Some(i));
         }
 
         // Case 3: lookup at the skipped key — should return the previous value
-        assert_eq!(bal_writes.get(threshold), Some(threshold - 1));
+        assert_eq!(bal_writes.get(idx(threshold)), Some(threshold - 1));
 
         // Case 4: lookup after the skipped key — should return the next valid value
-        assert_eq!(bal_writes.get(threshold + 1), Some(threshold + 1));
+        assert_eq!(bal_writes.get(idx(threshold + 1)), Some(threshold + 1));
     }
 
     #[test]


### PR DESCRIPTION
The main effect of that is moving from `type BalIndex = u64` to a newtype `BlockAccessIndex`.