### PR TITLE
refactor: wrap shared memory buffer

### DIFF
--- a/crates/context/interface/src/lib.rs
+++ b/crates/context/interface/src/lib.rs
@@ -25,5 +25,5 @@ pub use database_interface::{erased_error::ErasedError, DBErrorMarker, Database}
 pub use either;
 pub use host::{DummyHost, Host};
 pub use journaled_state::JournalTr;
-pub use local::{FrameStack, FrameToken, LocalContextTr, OutFrame};
+pub use local::{FrameStack, FrameToken, LocalContextTr, OutFrame, SharedMemoryBuffer};
 pub use transaction::{Transaction, TransactionType};

--- a/crates/context/interface/src/local.rs
+++ b/crates/context/interface/src/local.rs
@@ -1,9 +1,44 @@
 //! Local context trait [`LocalContextTr`] and related types.
 use core::{
-    cell::{Ref, RefCell},
+    cell::{Ref, RefCell, RefMut},
     ops::Range,
 };
-use std::{rc::Rc, string::String, vec::Vec};
+use std::{rc::Rc, string::String, vec, vec::Vec};
+
+trait RefcellExt<T> {
+    fn dbg_borrow(&self) -> Ref<'_, T>;
+    fn dbg_borrow_mut(&self) -> RefMut<'_, T>;
+}
+
+impl<T> RefcellExt<T> for RefCell<T> {
+    #[inline]
+    fn dbg_borrow(&self) -> Ref<'_, T> {
+        match self.try_borrow() {
+            Ok(b) => b,
+            Err(e) => {
+                if cfg!(debug_assertions) {
+                    unreachable!("{e}");
+                } else {
+                    unsafe { core::hint::unreachable_unchecked() }
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn dbg_borrow_mut(&self) -> RefMut<'_, T> {
+        match self.try_borrow_mut() {
+            Ok(b) => b,
+            Err(e) => {
+                if cfg!(debug_assertions) {
+                    unreachable!("{e}");
+                } else {
+                    unsafe { core::hint::unreachable_unchecked() }
+                }
+            }
+        }
+    }
+}
 
 /// Non-empty, item-pooling Vec.
 #[derive(Debug, Clone)]
@@ -211,10 +246,86 @@ impl FrameToken {
     }
 }
 
+/// A shared byte buffer whose spare capacity is always zeroed.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SharedMemoryBuffer(Rc<RefCell<Vec<u8>>>);
+
+impl Default for SharedMemoryBuffer {
+    fn default() -> Self {
+        Self::with_capacity(4 * 1024)
+    }
+}
+
+impl SharedMemoryBuffer {
+    /// Creates a new buffer with zeroed spare capacity.
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        let mut buffer = vec![0; capacity];
+        unsafe { buffer.set_len(0) };
+        Self(Rc::new(RefCell::new(buffer)))
+    }
+
+    /// Returns the buffer length.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.borrow().len()
+    }
+
+    /// Returns `true` if the buffer is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Borrows the initialized bytes.
+    #[inline]
+    pub fn borrow(&self) -> Ref<'_, [u8]> {
+        Ref::map(self.0.dbg_borrow(), Vec::as_slice)
+    }
+
+    /// Mutably borrows the initialized bytes.
+    #[inline]
+    pub fn borrow_mut(&self) -> RefMut<'_, [u8]> {
+        RefMut::map(self.0.dbg_borrow_mut(), Vec::as_mut_slice)
+    }
+
+    /// Resizes the initialized bytes, zeroing any bytes that become spare capacity.
+    #[inline]
+    pub fn resize(&self, new_len: usize) {
+        let buffer = &mut *self.0.dbg_borrow_mut();
+        let len = buffer.len();
+        let cap = buffer.capacity();
+        if new_len > cap {
+            buffer.reserve(new_len - len);
+            let new_cap = buffer.capacity();
+            // SAFETY: `cap..new_cap` is the newly allocated spare capacity and is in bounds.
+            unsafe { buffer.as_mut_ptr().add(cap).write_bytes(0, new_cap - cap) };
+        } else if new_len < len {
+            // SAFETY: `new_len..len` is initialized and in bounds.
+            unsafe {
+                buffer
+                    .as_mut_ptr()
+                    .add(new_len)
+                    .write_bytes(0, len - new_len)
+            };
+        }
+        // SAFETY: `new_len` is at most the capacity. Newly exposed bytes were zeroed either when
+        // allocated or when they previously became spare capacity.
+        unsafe { buffer.set_len(new_len) };
+    }
+
+    /// Clears the initialized bytes, zeroing them first so they become zeroed spare capacity.
+    #[inline]
+    pub fn clear(&self) {
+        self.resize(0);
+    }
+}
+
 /// Local context used for caching initcode from Initcode transactions.
 pub trait LocalContextTr {
     /// Interpreter shared memory buffer. A reused memory buffer for calls.
-    fn shared_memory_buffer(&self) -> &Rc<RefCell<Vec<u8>>>;
+    fn shared_memory_buffer(&self) -> &SharedMemoryBuffer;
 
     /// Slice of the shared memory buffer returns None if range is not valid or buffer can't be borrowed.
     fn shared_memory_buffer_slice(&self, range: Range<usize>) -> Option<Ref<'_, [u8]>> {
@@ -239,6 +350,34 @@ pub trait LocalContextTr {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn assert_spare_capacity_zeroed(buffer: &SharedMemoryBuffer) {
+        let mut vec = buffer.0.borrow_mut();
+        assert!(vec
+            .spare_capacity_mut()
+            .iter_mut()
+            .all(|byte| unsafe { byte.assume_init() } == 0));
+    }
+
+    #[test]
+    fn shared_memory_buffer_zeroes_spare_capacity() {
+        let buffer = SharedMemoryBuffer::with_capacity(4);
+        assert_spare_capacity_zeroed(&buffer);
+
+        buffer.resize(64);
+        buffer.borrow_mut().fill(0xff);
+        buffer.resize(32);
+        assert_eq!(&*buffer.borrow(), &[0xff; 32]);
+        assert_spare_capacity_zeroed(&buffer);
+
+        buffer.resize(128);
+        assert_eq!(&buffer.borrow()[32..128], &[0; 96]);
+        assert_spare_capacity_zeroed(&buffer);
+
+        buffer.clear();
+        assert!(buffer.is_empty());
+        assert_spare_capacity_zeroed(&buffer);
+    }
 
     #[test]
     fn frame_stack() {

--- a/crates/context/interface/src/local.rs
+++ b/crates/context/interface/src/local.rs
@@ -3,7 +3,7 @@ use core::{
     cell::{Ref, RefCell, RefMut},
     ops::Range,
 };
-use std::{rc::Rc, string::String, vec, vec::Vec};
+use std::{rc::Rc, string::String, vec::Vec};
 
 trait RefcellExt<T> {
     fn dbg_borrow(&self) -> Ref<'_, T>;
@@ -246,7 +246,7 @@ impl FrameToken {
     }
 }
 
-/// A shared byte buffer whose spare capacity is always zeroed.
+/// A shared byte buffer.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SharedMemoryBuffer(Rc<RefCell<Vec<u8>>>);
@@ -258,12 +258,10 @@ impl Default for SharedMemoryBuffer {
 }
 
 impl SharedMemoryBuffer {
-    /// Creates a new buffer with zeroed spare capacity.
+    /// Creates a new buffer with the given capacity.
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
-        let mut buffer = vec![0; capacity];
-        unsafe { buffer.set_len(0) };
-        Self(Rc::new(RefCell::new(buffer)))
+        Self(Rc::new(RefCell::new(Vec::with_capacity(capacity))))
     }
 
     /// Returns the buffer length.
@@ -290,35 +288,16 @@ impl SharedMemoryBuffer {
         RefMut::map(self.0.dbg_borrow_mut(), Vec::as_mut_slice)
     }
 
-    /// Resizes the initialized bytes, zeroing any bytes that become spare capacity.
+    /// Resizes the initialized bytes.
     #[inline]
     pub fn resize(&self, new_len: usize) {
-        let buffer = &mut *self.0.dbg_borrow_mut();
-        let len = buffer.len();
-        let cap = buffer.capacity();
-        if new_len > cap {
-            buffer.reserve(new_len - len);
-            let new_cap = buffer.capacity();
-            // SAFETY: `cap..new_cap` is the newly allocated spare capacity and is in bounds.
-            unsafe { buffer.as_mut_ptr().add(cap).write_bytes(0, new_cap - cap) };
-        } else if new_len < len {
-            // SAFETY: `new_len..len` is initialized and in bounds.
-            unsafe {
-                buffer
-                    .as_mut_ptr()
-                    .add(new_len)
-                    .write_bytes(0, len - new_len)
-            };
-        }
-        // SAFETY: `new_len` is at most the capacity. Newly exposed bytes were zeroed either when
-        // allocated or when they previously became spare capacity.
-        unsafe { buffer.set_len(new_len) };
+        self.0.dbg_borrow_mut().resize(new_len, 0);
     }
 
-    /// Clears the initialized bytes, zeroing them first so they become zeroed spare capacity.
+    /// Clears the initialized bytes.
     #[inline]
     pub fn clear(&self) {
-        self.resize(0);
+        self.0.dbg_borrow_mut().clear();
     }
 }
 
@@ -351,32 +330,20 @@ pub trait LocalContextTr {
 mod tests {
     use super::*;
 
-    fn assert_spare_capacity_zeroed(buffer: &SharedMemoryBuffer) {
-        let mut vec = buffer.0.borrow_mut();
-        assert!(vec
-            .spare_capacity_mut()
-            .iter_mut()
-            .all(|byte| unsafe { byte.assume_init() } == 0));
-    }
-
     #[test]
-    fn shared_memory_buffer_zeroes_spare_capacity() {
+    fn shared_memory_buffer_resize() {
         let buffer = SharedMemoryBuffer::with_capacity(4);
-        assert_spare_capacity_zeroed(&buffer);
+        assert!(buffer.is_empty());
 
-        buffer.resize(64);
+        buffer.resize(8);
+        assert_eq!(&*buffer.borrow(), &[0; 8]);
+
         buffer.borrow_mut().fill(0xff);
-        buffer.resize(32);
-        assert_eq!(&*buffer.borrow(), &[0xff; 32]);
-        assert_spare_capacity_zeroed(&buffer);
-
-        buffer.resize(128);
-        assert_eq!(&buffer.borrow()[32..128], &[0; 96]);
-        assert_spare_capacity_zeroed(&buffer);
+        buffer.resize(4);
+        assert_eq!(&*buffer.borrow(), &[0xff; 4]);
 
         buffer.clear();
         assert!(buffer.is_empty());
-        assert_spare_capacity_zeroed(&buffer);
     }
 
     #[test]

--- a/crates/context/src/local.rs
+++ b/crates/context/src/local.rs
@@ -1,13 +1,12 @@
 //! Local context that is filled by execution.
-use context_interface::LocalContextTr;
-use core::cell::RefCell;
-use std::{rc::Rc, string::String, vec::Vec};
+use context_interface::{LocalContextTr, SharedMemoryBuffer};
+use std::string::String;
 
 /// Local context that is filled by execution.
 #[derive(Clone, Debug)]
 pub struct LocalContext {
     /// Interpreter shared memory buffer. A reused memory buffer for calls.
-    pub shared_memory_buffer: Rc<RefCell<Vec<u8>>>,
+    pub shared_memory_buffer: SharedMemoryBuffer,
     /// Optional precompile error message to bubble up.
     pub precompile_error_message: Option<String>,
 }
@@ -15,7 +14,7 @@ pub struct LocalContext {
 impl Default for LocalContext {
     fn default() -> Self {
         Self {
-            shared_memory_buffer: Rc::new(RefCell::new(Vec::with_capacity(1024 * 4))),
+            shared_memory_buffer: SharedMemoryBuffer::with_capacity(1024 * 4),
             precompile_error_message: None,
         }
     }
@@ -24,11 +23,11 @@ impl Default for LocalContext {
 impl LocalContextTr for LocalContext {
     fn clear(&mut self) {
         // Sets len to 0 but it will not shrink to drop the capacity.
-        unsafe { self.shared_memory_buffer.borrow_mut().set_len(0) };
+        self.shared_memory_buffer.clear();
         self.precompile_error_message = None;
     }
 
-    fn shared_memory_buffer(&self) -> &Rc<RefCell<Vec<u8>>> {
+    fn shared_memory_buffer(&self) -> &SharedMemoryBuffer {
         &self.shared_memory_buffer
     }
 

--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -1,37 +1,13 @@
 use super::MemoryTr;
 use crate::InstructionResult;
-use context_interface::cfg::GasParams;
+use context_interface::{cfg::GasParams, SharedMemoryBuffer};
 use core::{
-    cell::{Ref, RefCell, RefMut},
+    cell::{Ref, RefMut},
     cmp::min,
     fmt,
     ops::Range,
 };
 use primitives::{hex, B256, U256};
-use std::{rc::Rc, vec::Vec};
-
-trait RefcellExt<T> {
-    fn dbg_borrow(&self) -> Ref<'_, T>;
-    fn dbg_borrow_mut(&self) -> RefMut<'_, T>;
-}
-
-impl<T> RefcellExt<T> for RefCell<T> {
-    #[inline]
-    fn dbg_borrow(&self) -> Ref<'_, T> {
-        match self.try_borrow() {
-            Ok(b) => b,
-            Err(e) => debug_unreachable!("{e}"),
-        }
-    }
-
-    #[inline]
-    fn dbg_borrow_mut(&self) -> RefMut<'_, T> {
-        match self.try_borrow_mut() {
-            Ok(b) => b,
-            Err(e) => debug_unreachable!("{e}"),
-        }
-    }
-}
 
 /// A sequential memory shared between calls, which uses
 /// a `Vec` for internal representation.
@@ -41,7 +17,7 @@ impl<T> RefcellExt<T> for RefCell<T> {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SharedMemory {
     /// The underlying buffer.
-    buffer: Option<Rc<RefCell<Vec<u8>>>>,
+    buffer: Option<SharedMemoryBuffer>,
     /// Memory checkpoints for each depth.
     /// Invariant: these are always in bounds of `data`.
     my_checkpoint: usize,
@@ -157,7 +133,7 @@ impl SharedMemory {
     }
 
     /// Creates a new memory instance with a given shared buffer.
-    pub const fn new_with_buffer(buffer: Rc<RefCell<Vec<u8>>>) -> Self {
+    pub const fn new_with_buffer(buffer: SharedMemoryBuffer) -> Self {
         Self {
             buffer: Some(buffer),
             my_checkpoint: 0,
@@ -171,7 +147,7 @@ impl SharedMemory {
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            buffer: Some(Rc::new(RefCell::new(Vec::with_capacity(capacity)))),
+            buffer: Some(SharedMemoryBuffer::with_capacity(capacity)),
             my_checkpoint: 0,
             child_checkpoint: None,
             #[cfg(feature = "memory_limit")]
@@ -204,19 +180,19 @@ impl SharedMemory {
     }
 
     #[inline]
-    fn buffer(&self) -> &Rc<RefCell<Vec<u8>>> {
+    fn buffer(&self) -> &SharedMemoryBuffer {
         debug_assert!(self.buffer.is_some(), "cannot use SharedMemory::empty");
         unsafe { self.buffer.as_ref().unwrap_unchecked() }
     }
 
     #[inline]
-    fn buffer_ref(&self) -> Ref<'_, Vec<u8>> {
-        self.buffer().dbg_borrow()
+    fn buffer_ref(&self) -> Ref<'_, [u8]> {
+        self.buffer().borrow()
     }
 
     #[inline]
-    fn buffer_ref_mut(&self) -> RefMut<'_, Vec<u8>> {
-        self.buffer().dbg_borrow_mut()
+    fn buffer_ref_mut(&self) -> RefMut<'_, [u8]> {
+        self.buffer().borrow_mut()
     }
 
     /// Returns a byte slice of the backing buffer, applying `base` to `range`.
@@ -261,9 +237,7 @@ impl SharedMemory {
         let Some(child_checkpoint) = self.child_checkpoint.take() else {
             return;
         };
-        unsafe {
-            self.buffer_ref_mut().set_len(child_checkpoint);
-        }
+        self.buffer().resize(child_checkpoint);
     }
 
     /// Returns the length of the current memory range.
@@ -285,9 +259,7 @@ impl SharedMemory {
     /// Resizes the memory in-place so that `len` is equal to `new_len`.
     #[inline]
     pub fn resize(&mut self, new_size: usize) {
-        self.buffer()
-            .dbg_borrow_mut()
-            .resize(self.my_checkpoint + new_size, 0);
+        self.buffer().resize(self.my_checkpoint + new_size);
     }
 
     /// Returns a byte slice of the memory region at the given offset.
@@ -630,7 +602,7 @@ mod tests {
         assert_eq!(sm1.buffer_ref().len(), 0);
         assert_eq!(sm1.my_checkpoint, 0);
 
-        unsafe { sm1.buffer_ref_mut().set_len(32) };
+        sm1.buffer().resize(32);
         assert_eq!(sm1.len(), 32);
         let mut sm2 = sm1.new_child_context();
 
@@ -638,7 +610,7 @@ mod tests {
         assert_eq!(sm2.my_checkpoint, 32);
         assert_eq!(sm2.len(), 0);
 
-        unsafe { sm2.buffer_ref_mut().set_len(96) };
+        sm2.buffer().resize(96);
         assert_eq!(sm2.len(), 64);
         let mut sm3 = sm2.new_child_context();
 
@@ -646,7 +618,7 @@ mod tests {
         assert_eq!(sm3.my_checkpoint, 96);
         assert_eq!(sm3.len(), 0);
 
-        unsafe { sm3.buffer_ref_mut().set_len(128) };
+        sm3.buffer().resize(128);
         let sm4 = sm3.new_child_context();
         assert_eq!(sm4.buffer_ref().len(), 128);
         assert_eq!(sm4.my_checkpoint, 128);

--- a/crates/interpreter/src/interpreter_action/call_inputs.rs
+++ b/crates/interpreter/src/interpreter_action/call_inputs.rs
@@ -317,28 +317,29 @@ impl CallValue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core::cell::RefCell;
-    use std::rc::Rc;
+    use context_interface::SharedMemoryBuffer;
 
     struct TestLocalContext {
-        buffer: Rc<RefCell<Vec<u8>>>,
+        buffer: SharedMemoryBuffer,
     }
 
     impl TestLocalContext {
         fn new(data: Vec<u8>) -> Self {
-            Self {
-                buffer: Rc::new(RefCell::new(data)),
-            }
+            let len = data.len().next_multiple_of(32);
+            let buffer = SharedMemoryBuffer::with_capacity(len);
+            buffer.resize(len);
+            buffer.borrow_mut()[..data.len()].copy_from_slice(&data);
+            Self { buffer }
         }
     }
 
     impl LocalContextTr for TestLocalContext {
-        fn shared_memory_buffer(&self) -> &Rc<RefCell<Vec<u8>>> {
+        fn shared_memory_buffer(&self) -> &SharedMemoryBuffer {
             &self.buffer
         }
 
         fn clear(&mut self) {
-            self.buffer.borrow_mut().clear();
+            self.buffer.clear();
         }
 
         fn set_precompile_error_context(&mut self, _output: String) {}
@@ -366,7 +367,7 @@ mod tests {
 
     #[test]
     fn as_bytes_local_with_out_of_range_buffer() {
-        let input = CallInput::SharedBuffer(10..20);
+        let input = CallInput::SharedBuffer(40..50);
         let local = TestLocalContext::new(vec![0, 1, 2]);
         let result = input.as_bytes_local(&local);
         // Out of range returns empty via unwrap_or_default on the Option<Ref>
@@ -391,7 +392,7 @@ mod tests {
 
     #[test]
     fn bytes_local_with_out_of_range_buffer() {
-        let input = CallInput::SharedBuffer(5..10);
+        let input = CallInput::SharedBuffer(40..50);
         let local = TestLocalContext::new(vec![0]);
         let result = input.bytes_local(&local);
         assert_eq!(result, Bytes::new());

--- a/crates/interpreter/src/interpreter_action/call_inputs.rs
+++ b/crates/interpreter/src/interpreter_action/call_inputs.rs
@@ -325,10 +325,9 @@ mod tests {
 
     impl TestLocalContext {
         fn new(data: Vec<u8>) -> Self {
-            let len = data.len().next_multiple_of(32);
-            let buffer = SharedMemoryBuffer::with_capacity(len);
-            buffer.resize(len);
-            buffer.borrow_mut()[..data.len()].copy_from_slice(&data);
+            let buffer = SharedMemoryBuffer::with_capacity(data.len());
+            buffer.resize(data.len());
+            buffer.borrow_mut().copy_from_slice(&data);
             Self { buffer }
         }
     }
@@ -367,7 +366,7 @@ mod tests {
 
     #[test]
     fn as_bytes_local_with_out_of_range_buffer() {
-        let input = CallInput::SharedBuffer(40..50);
+        let input = CallInput::SharedBuffer(10..20);
         let local = TestLocalContext::new(vec![0, 1, 2]);
         let result = input.as_bytes_local(&local);
         // Out of range returns empty via unwrap_or_default on the Option<Ref>
@@ -392,7 +391,7 @@ mod tests {
 
     #[test]
     fn bytes_local_with_out_of_range_buffer() {
-        let input = CallInput::SharedBuffer(40..50);
+        let input = CallInput::SharedBuffer(5..10);
         let local = TestLocalContext::new(vec![0]);
         let result = input.bytes_local(&local);
         assert_eq!(result, Bytes::new());


### PR DESCRIPTION
This wraps the shared memory Rc<RefCell<Vec<u8>>> in a SharedMemoryBuffer type so the Rc/RefCell details are kept in one place. LocalContext and SharedMemory now use the wrapper directly, while callers borrow initialized memory through slice-returning APIs.

This is only a cleanup around ownership and borrowing; it keeps normal Vec resizing behavior and avoids changing the buffer allocation/zeroing strategy.

Verified with cargo fmt --all, cargo test -p revm-context-interface --lib, cargo test -p revm-interpreter call_inputs --lib, and cargo check -p revm-context-interface -p revm-context -p revm-interpreter --all-features.
