### PR TITLE
refactor(gas): simplify log2floor

### DIFF
--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -903,13 +903,7 @@ impl GasParams {
 
 #[inline]
 pub(crate) fn log2floor(value: U256) -> u64 {
-    for i in (0..4).rev() {
-        let limb = value.as_limbs()[i];
-        if limb != 0 {
-            return i as u64 * 64 + 63 - limb.leading_zeros() as u64;
-        }
-    }
-    0
+    255u64.saturating_sub(value.leading_zeros() as u64)
 }
 
 /// Gas identifier that maps onto index in gas table.

--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -902,7 +902,7 @@ impl GasParams {
 }
 
 #[inline]
-pub(crate) fn log2floor(value: U256) -> u64 {
+pub(crate) const fn log2floor(value: U256) -> u64 {
     255u64.saturating_sub(value.leading_zeros() as u64)
 }
 


### PR DESCRIPTION
Simplifies the `log2floor` helper by using `U256::leading_zeros()` directly instead of manually scanning limbs. Zero preserves the existing `0` behavior via saturating subtraction.

```text
floor(log2(x)) = bit_len(x) - 1 = (256 - leading_zeros(x)) - 1 = 255 - leading_zeros(x)
```
