### PR TITLE
refactor(eip8037): defer state-gas to frame return via NewStateTracker

### DIFF
--- a/crates/context/interface/src/cfg.rs
+++ b/crates/context/interface/src/cfg.rs
@@ -2,8 +2,10 @@
 
 pub mod gas;
 pub mod gas_params;
+pub mod new_state_tracker;
 
 pub use gas_params::{GasId, GasParams};
+pub use new_state_tracker::NewStateTracker;
 
 use auto_impl::auto_impl;
 use core::{fmt::Debug, hash::Hash};

--- a/crates/context/interface/src/cfg/new_state_tracker.rs
+++ b/crates/context/interface/src/cfg/new_state_tracker.rs
@@ -1,0 +1,106 @@
+//! Per-frame state-gas accumulator (EIP-8037).
+//!
+//! State-creating opcodes (SSTORE 0→x, CREATE/CREATE2, CALL with value to an
+//! empty account, SELFDESTRUCT, code deposit) bump the counters here instead
+//! of charging the reservoir directly. At frame return the totals are
+//! reconciled with the gas tracker:
+//!
+//! * **ok**: `state_gas_refunded` is added back to the reservoir first, then
+//!   `state_gas` is charged from it (spilling into regular gas if the
+//!   reservoir is exhausted, which can OOG the call).
+//! * **revert / halt**: the counters are dropped — state work didn't happen.
+//!
+//! Hardcoded gas amounts use the Glamsterdam EIP-8037 defaults
+//! (`bytes_per_unit × CPSB_GLAMSTERDAM`). A future change should derive these
+//! from the active `GasParams` and `cpsb` at frame init.
+
+use primitives::eip8037::{
+    CODE_DEPOSIT_PER_BYTE, CPSB_GLAMSTERDAM, NEW_ACCOUNT_BYTES, SSTORE_SET_BYTES,
+};
+
+/// State gas charged for SSTORE 0→x.
+pub const SSTORE_SET_STATE_GAS: u64 = SSTORE_SET_BYTES * CPSB_GLAMSTERDAM;
+/// State gas charged when a CALL/SELFDESTRUCT materializes a new empty account.
+pub const NEW_ACCOUNT_STATE_GAS: u64 = NEW_ACCOUNT_BYTES * CPSB_GLAMSTERDAM;
+/// State gas charged upfront on CREATE/CREATE2 for the new account + metadata.
+pub const CREATE_STATE_GAS: u64 = NEW_ACCOUNT_BYTES * CPSB_GLAMSTERDAM;
+/// State gas charged per byte of deployed code on a successful contract creation.
+pub const CODE_DEPOSIT_STATE_GAS_PER_BYTE: u64 = CODE_DEPOSIT_PER_BYTE * CPSB_GLAMSTERDAM;
+
+/// Accumulates state gas charged and refunded within a single call frame.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct NewStateTracker {
+    /// Cumulative state gas charged in this frame (SSTORE 0→x, account
+    /// creation, code deposit, etc.).
+    pub state_gas: u64,
+    /// Cumulative state gas refunded in this frame (SSTORE x→0 restoration
+    /// against an originally-zero slot).
+    pub state_gas_refunded: u64,
+}
+
+impl NewStateTracker {
+    /// Creates an empty tracker.
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            state_gas: 0,
+            state_gas_refunded: 0,
+        }
+    }
+
+    /// Records SSTORE 0→x.
+    #[inline]
+    pub const fn add_storage(&mut self) {
+        self.state_gas = self.state_gas.saturating_add(SSTORE_SET_STATE_GAS);
+    }
+
+    /// Records SSTORE x→0 against an originally-zero slot.
+    #[inline]
+    pub const fn remove_storage(&mut self) {
+        self.state_gas_refunded = self.state_gas_refunded.saturating_add(SSTORE_SET_STATE_GAS);
+    }
+
+    /// Records CREATE / CREATE2 new account.
+    #[inline]
+    pub const fn add_create_account(&mut self) {
+        self.state_gas = self.state_gas.saturating_add(CREATE_STATE_GAS);
+    }
+
+    /// Removes a previously-counted CREATE account (failed CREATE refund).
+    #[inline]
+    pub const fn remove_create_account(&mut self) {
+        self.state_gas = self.state_gas.saturating_sub(CREATE_STATE_GAS);
+    }
+
+    /// Records CALL-with-value-to-empty / SELFDESTRUCT-to-empty.
+    #[inline]
+    pub const fn add_call_account(&mut self) {
+        self.state_gas = self.state_gas.saturating_add(NEW_ACCOUNT_STATE_GAS);
+    }
+
+    /// Records `bytes` deposited as code on contract creation success.
+    #[inline]
+    pub const fn add_code_deposit_bytes(&mut self, bytes: u64) {
+        self.state_gas = self
+            .state_gas
+            .saturating_add(bytes.saturating_mul(CODE_DEPOSIT_STATE_GAS_PER_BYTE));
+    }
+
+    /// Merges another tracker's counts into this one. Used when a successful
+    /// child frame's counters are absorbed by the parent.
+    #[inline]
+    pub const fn merge(&mut self, other: &NewStateTracker) {
+        self.state_gas = self.state_gas.saturating_add(other.state_gas);
+        self.state_gas_refunded = self
+            .state_gas_refunded
+            .saturating_add(other.state_gas_refunded);
+    }
+
+    /// Resets both counters to zero.
+    #[inline]
+    pub const fn clear(&mut self) {
+        self.state_gas = 0;
+        self.state_gas_refunded = 0;
+    }
+}

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -2,7 +2,7 @@ use crate::{
     evm::FrameTr, item_or_result::FrameInitOrResult, precompile_provider::PrecompileProvider,
     CallFrame, CreateFrame, FrameData, FrameResult, ItemOrResult,
 };
-use context::{result::FromStringError, LocalContextTr};
+use context::result::FromStringError;
 use context_interface::{
     context::{take_error, ContextError},
     journaled_state::{account::JournaledAccountTr, JournalCheckpoint, JournalTr},
@@ -22,7 +22,7 @@ use interpreter::{
 use primitives::{
     constants::CALL_STACK_LIMIT,
     hardfork::SpecId::{self, HOMESTEAD, LONDON, SPURIOUS_DRAGON},
-    keccak256, Address, Bytes, U256,
+    keccak256, Bytes, U256,
 };
 use state::Bytecode;
 use std::{borrow::ToOwned, boxed::Box, vec::Vec};
@@ -413,38 +413,97 @@ impl EthFrame<EthInterpreter> {
             InterpreterAction::Return(result) => result,
         };
 
-        // Handle return from frame
-        let result = match &self.data {
-            FrameData::Call(frame) => {
-                // return_call
-                // Revert changes or not.
-                if interpreter_result.result.is_ok() {
-                    context.journal_mut().checkpoint_commit();
-                } else {
-                    context.journal_mut().checkpoint_revert(self.checkpoint);
-                }
-                ItemOrResult::Result(FrameResult::Call(CallOutcome::new(
-                    interpreter_result,
-                    frame.return_memory_range.clone(),
-                )))
-            }
-            FrameData::Create(frame) => {
-                return_create(
-                    context,
-                    self.checkpoint,
-                    &mut interpreter_result,
-                    frame.created_address,
-                );
+        // For Create frames, run validation + bump new_state for code deposit.
+        // This may set interpreter_result.result to a failure variant.
+        let create_address = match &self.data {
+            FrameData::Create(frame) => Some(frame.created_address),
+            FrameData::Call(_) => None,
+        };
+        if create_address.is_some() {
+            return_create(context, &mut self.interpreter, &mut interpreter_result);
+        }
 
-                ItemOrResult::Result(FrameResult::Create(CreateOutcome::new(
-                    interpreter_result,
-                    Some(frame.created_address),
-                )))
+        // Apply per-frame state-gas reconciliation (EIP-8037, deferred model).
+        // - on ok: refund first (grows reservoir), then charge (may OOG)
+        // - on revert/halt: drop the counters (state work undone, no charge)
+        let new_state = self.interpreter.new_state;
+        self.interpreter.new_state.clear();
+        if interpreter_result.result.is_ok() {
+            interpreter_result
+                .gas
+                .refill_reservoir(new_state.state_gas_refunded);
+            if !interpreter_result.gas.record_state_cost(new_state.state_gas) {
+                interpreter_result.result = InstructionResult::OutOfGas;
             }
+        }
+
+        // Commit or revert the journal based on the final result; for a
+        // successful CREATE, also persist the deployed bytecode.
+        if interpreter_result.result.is_ok() {
+            context.journal_mut().checkpoint_commit();
+            if let Some(address) = create_address {
+                let bytecode = Bytecode::new_legacy(interpreter_result.output.clone());
+                context.journal_mut().set_code(address, bytecode);
+                interpreter_result.result = InstructionResult::Return;
+            }
+        } else {
+            context.journal_mut().checkpoint_revert(self.checkpoint);
+        }
+
+        let result = match &self.data {
+            FrameData::Call(frame) => ItemOrResult::Result(FrameResult::Call(CallOutcome::new(
+                interpreter_result,
+                frame.return_memory_range.clone(),
+            ))),
+            FrameData::Create(frame) => ItemOrResult::Result(FrameResult::Create(
+                CreateOutcome::new(interpreter_result, Some(frame.created_address)),
+            )),
         };
 
         Ok(result)
     }
+
+    /*
+
+    10:5 regular:reservoir
+
+    1:6 sstore 1 regular 6 state.
+
+    call1 10:5 state_created:0 state_refunded:0
+    add 9:5 state_created:0 state_refunded:0
+    call2 9:5 state_created:0 state_refunded:0
+    sstore 8:5 state_created:6 state_refunded:0
+    call2 return ok 7:0 state_created:6 state_refunded:0
+    call1 7:0 state_created:6 state_refunded:0
+    call3 7:0 state_created:0 state_refunded:0
+    sstore 6:0 state_created:6 state_refunded:0
+
+        call3 ok 1:0 state_created:6 state_refunded:0
+        call1 1:0 state_created:12 state_refunded:0
+
+        call3 halts: 6:0 state_created:0 state_refunded:0
+        call1 6:0 state_created:6 state_refunded:0
+
+        call3 reverts: 6:0 state_created:6 state_refunded:0
+        call1 6:0 state_created:6 state_refunded:0
+
+    call1 1:0 state_created:12 state_refunded:0
+
+        case call1 return ok: Expectation two sstores were created 12 gas should be spent.
+        call1 1:0
+
+        case call1 return halt: Expectation two sstores were created 12 gas should be returned.
+        call1 0:5 (use previous parent gas value)
+
+        case call1 return revert: Expectation two sstores were created 12 gas should be returned.
+        call1 1:12 reservoir gets increased by 12.
+
+
+
+    Rules:
+    * Inside one frame
+
+    */
 
     /// Processes a frame result and updates the interpreter state accordingly.
     pub fn return_result<CTX: ContextTr, ERROR: From<ContextTrDbError<CTX>> + FromStringError>(
@@ -516,36 +575,37 @@ impl EthFrame<EthInterpreter> {
                     "Fatal external error in insert_eofcreate_outcome"
                 );
 
-                let this_gas = &mut interpreter.gas;
-                // Refund unused gas for success and revert cases.
-                if instruction_result.is_ok_or_revert() {
-                    this_gas.erase_cost(outcome.gas().remaining());
+                {
+                    let this_gas = &mut interpreter.gas;
+                    // Refund unused gas for success and revert cases.
+                    if instruction_result.is_ok_or_revert() {
+                        this_gas.erase_cost(outcome.gas().remaining());
+                    }
+
+                    // handle reservoir remaining gas
+                    handle_reservoir_remaining_gas(
+                        instruction_result.is_ok(),
+                        this_gas,
+                        outcome.gas(),
+                    );
+
+                    if instruction_result.is_ok() {
+                        this_gas.record_refund(outcome.gas().refunded());
+                    }
                 }
 
-                // handle reservoir remaining gas
-                handle_reservoir_remaining_gas(instruction_result.is_ok(), this_gas, outcome.gas());
-
-                // EIP-8037: The CREATE opcode charged `create_state_gas` upfront on
-                // this frame's tracker. When the child fails to deploy a contract
-                // (revert, halt, or early-fail paths that return `address == None`
-                // such as nonce overflow, depth, OutOfFunds), refund the upfront
-                // charge to the reservoir and undo it on `state_gas_spent`.
-                // The nonce-overflow path reports `InstructionResult::Return` (ok)
-                // with `address == None`, so gate on address rather than the result.
-                //
-                // Use `refill_reservoir` so that this refund is counted in
-                // `refill_amount` and gets unwound if the parent itself
-                // reverts/halts (matching 0→x→0 storage restoration).
+                // EIP-8037 (deferred model): the CREATE opcode bumped this
+                // frame's `new_state.add_create_account()` for the upfront
+                // create_state_gas. On child failure (revert/halt/early-fail
+                // paths that return `address == None` — nonce overflow, depth,
+                // OutOfFunds), undo the bump so the parent doesn't end up
+                // charged for a CREATE that didn't deploy.
                 let create_failed = outcome.address.is_none() || !instruction_result.is_ok();
-
                 if create_failed && ctx.cfg().is_amsterdam_eip8037_enabled() {
-                    let state_gas_charged =
-                        ctx.cfg().gas_params().create_state_gas(ctx.local().cpsb());
-                    this_gas.refill_reservoir(state_gas_charged);
+                    interpreter.new_state.remove_create_account();
                 }
 
                 let stack_item = if instruction_result.is_ok() {
-                    this_gas.record_refund(outcome.gas().refunded());
                     outcome.address.unwrap_or_default().into_word().into()
                 } else {
                     U256::ZERO
@@ -561,124 +621,83 @@ impl EthFrame<EthInterpreter> {
 }
 
 /// Handles the remaining gas of the parent frame.
+///
+/// Under the deferred state-gas model (EIP-8037), the child frame applies its
+/// own state-gas to its gas tracker at frame return (`process_next_action`):
+/// on success the charge is committed to `reservoir` / `remaining`, on
+/// revert/halt the per-frame counters are dropped. As a result the child's
+/// reservoir is always "the parent's pre-call value plus the net effect of
+/// successful sub-work" — there's no spill-on-revert distortion to undo here.
 #[inline]
 pub fn handle_reservoir_remaining_gas(is_success: bool, parent_gas: &mut Gas, child_gas: &Gas) {
+    parent_gas.set_reservoir(child_gas.reservoir());
+
     if is_success {
-        // On success: parent takes the child's final reservoir.
-        parent_gas.set_reservoir(child_gas.reservoir());
-        // Accumulate child's state gas into parent's total.
-        // Parent may have already charged state gas (e.g., new_account + create) before
-        // creating the child frame. Child starts with state_gas_spent=0, so we must add
-        // rather than overwrite to preserve the parent's prior charges.
-        //
-        // `child.state_gas_spent()` can be negative (EIP-8037 issue #2) when the
-        // child did more 0→x→0 restorations than 0→x creations; the negative
-        // contribution is the parent's matching charge flowing back out.
+        // Audit totals: accumulate child's contribution into the parent's.
+        // (state_gas_spent / refill_amount on the gas tracker are populated
+        // by the child's process_next_action when state-gas was applied.)
         parent_gas.set_state_gas_spent(
             parent_gas
                 .state_gas_spent()
                 .saturating_add(child_gas.state_gas_spent()),
         );
-        // Propagate child's 0→x→0 refill total so that if the parent
-        // later reverts/halts, the refill contribution can be unwound.
         parent_gas.set_refill_amount(
             parent_gas
                 .refill_amount()
                 .saturating_add(child_gas.refill_amount()),
         );
-    } else {
-        // On revert or halt: child state changes are rolled back. Compute
-        // the gas to add to parent's pre-call reservoir as:
-        //
-        //   excess = max(0, child.reservoir + max(0, child.state_gas_spent)
-        //                  - parent.reservoir - child.refill_amount)
-        //
-        // The intuition:
-        // * `child.reservoir + max(0, child.state_gas_spent)` is the
-        //   "logical refund" if no refills had happened: it adds back the
-        //   child's own state-gas charges (positive `state_gas_spent`) on
-        //   top of whatever reservoir value the child carried out
-        //   (including refunds propagated from deeper halted/reverted
-        //   sub-frames, which reach `child.reservoir` via `set_reservoir`).
-        // * Subtracting `parent.reservoir` (the pre-call value) and the
-        //   in-frame 0→x→0 refill total leaves only the contribution that
-        //   genuinely belongs to the parent on revert/halt — i.e. own
-        //   charges + grandchild propagations.
-        // * The `max(0, ...)` guards against cases where own charges
-        //   spilled into regular gas (irrecoverable) and the refunded
-        //   charges are smaller than the refill the child did against
-        //   parent's prior charges.
-        let logical_refund = child_gas
-            .reservoir()
-            .saturating_add(child_gas.state_gas_spent().max(0) as u64);
-        let baseline = parent_gas
-            .reservoir()
-            .saturating_add(child_gas.refill_amount());
-        let excess = logical_refund.saturating_sub(baseline);
-        parent_gas.set_reservoir(parent_gas.reservoir().saturating_add(excess));
     }
 }
 
-/// Handles the result of a CREATE operation, including validation and state updates.
+/// Validates the deployed bytecode of a successful CREATE/CREATE2 and bumps
+/// the per-frame state-gas counter. Charging state gas and committing the
+/// journal are handled by [`EthFrame::process_next_action`] after this call.
 ///
-/// The EIP-8037 upfront CREATE state gas is charged on the parent's tracker by
-/// the CREATE/CREATE2 opcode. On child failure (revert/halt/early-fail) it is
-/// refunded to the parent in `return_result`. The child frame is NOT allowed to
-/// borrow the upfront charge to pay for code deposit: it must cover code deposit
-/// state gas from its own reservoir and remaining gas.
+/// Sets `interpreter_result.result` to a failure variant (e.g.
+/// `CreateContractSizeLimit`, `OutOfGas`) when validation or gas charges fail;
+/// the caller is responsible for journal revert in that case.
 pub fn return_create<CTX: ContextTr>(
     context: &mut CTX,
-    checkpoint: JournalCheckpoint,
+    interpreter: &mut Interpreter<EthInterpreter>,
     interpreter_result: &mut InterpreterResult,
-    address: Address,
 ) {
-    let (_, _, cfg, journal, _, local) = context.all_mut();
+    let (_, _, cfg, _, _, _) = context.all_mut();
 
     let max_code_size = cfg.max_code_size();
     let is_eip3541_disabled = cfg.is_eip3541_disabled();
     let spec_id = cfg.spec().into();
     let is_amsterdam_eip8037 = cfg.is_amsterdam_eip8037_enabled();
-    let cpsb = local.cpsb();
     let gas_params = cfg.gas_params();
 
-    // If return is not ok revert and return.
+    // If return is not ok, nothing to validate or charge.
     if !interpreter_result.result.is_ok() {
-        journal.checkpoint_revert(checkpoint);
         return;
     }
 
-    // EIP-170: Contract code size limit to 0x6000 (~25kb)
-    // EIP-7954 increased this limit to 0x8000 (~32kb).
-    // This must be checked BEFORE charging state gas for code deposit,
-    // so that oversized code does not incur storage gas costs.
+    // EIP-170 / EIP-7954: code size limit. Checked BEFORE state gas so
+    // oversized code does not incur storage gas costs.
     if spec_id.is_enabled_in(SPURIOUS_DRAGON) && interpreter_result.output.len() > max_code_size {
-        journal.checkpoint_revert(checkpoint);
         interpreter_result.result = InstructionResult::CreateContractSizeLimit;
         return;
     }
 
-    // Host error if present on execution
-    // If ok, check contract creation limit and calculate gas deduction on output len.
-    //
-    // EIP-3541: Reject new contract code starting with the 0xEF byte
+    // EIP-3541: reject new contract code starting with the 0xEF byte.
     if !is_eip3541_disabled
         && spec_id.is_enabled_in(LONDON)
         && interpreter_result.output.first() == Some(&0xEF)
     {
-        journal.checkpoint_revert(checkpoint);
         interpreter_result.result = InstructionResult::CreateContractStartingWithEF;
         return;
     }
 
-    // regular gas for code deposit. It is zero in EIP-8037.
+    // Regular gas for code deposit. Zero under EIP-8037.
     let gas_for_code = gas_params.code_deposit_cost(interpreter_result.output.len());
     if !interpreter_result.gas.record_regular_cost(gas_for_code) {
-        // Record code deposit gas cost and check if we are out of gas.
-        // EIP-2 point 3: If contract creation does not have enough gas to pay for the
-        // final gas fee for adding the contract code to the state, the contract
-        // creation fails (i.e. goes out-of-gas) rather than leaving an empty contract.
+        // EIP-2 point 3: If contract creation does not have enough gas to pay
+        // for the final gas fee for adding the contract code to the state,
+        // the contract creation fails (i.e. goes out-of-gas) rather than
+        // leaving an empty contract.
         if spec_id.is_enabled_in(HOMESTEAD) {
-            journal.checkpoint_revert(checkpoint);
             interpreter_result.result = InstructionResult::OutOfGas;
             return;
         } else {
@@ -686,41 +705,20 @@ pub fn return_create<CTX: ContextTr>(
         }
     }
 
-    // EIP-8037: Hash cost for deployed bytecode (keccak256)
-    // HASH_COST(L) = 6 × ceil(L / 32)
-    // Both CREATE and CREATE2 must pay this cost: it covers hashing the deployed code
-    // to compute the code_hash stored in the account. CREATE2's existing keccak256 charge
-    // (in create2_cost) is for hashing the init code during address derivation, which is
-    // a different hash.
+    // EIP-8037: hash cost for deployed bytecode (keccak256).
+    // HASH_COST(L) = 6 × ceil(L / 32). Both CREATE and CREATE2 pay this — it
+    // covers hashing the deployed code to compute the code_hash stored on the
+    // account (distinct from CREATE2's init-code hash).
     if is_amsterdam_eip8037 {
         let hash_cost = gas_params.keccak256_cost(interpreter_result.output.len());
         if !interpreter_result.gas.record_regular_cost(hash_cost) {
-            journal.checkpoint_revert(checkpoint);
             interpreter_result.result = InstructionResult::OutOfGas;
             return;
         }
-        // State gas for code deposit (EIP-8037).
-        // Charged after size check: only code that passes validation incurs state gas cost.
-        //
-        // Note: This should be last operation before checkpoint commit as spending state before this messes
-        // with refilling of state gas.
-        let state_gas_for_code =
-            gas_params.code_deposit_state_gas(interpreter_result.output.len(), cpsb);
-        if state_gas_for_code > 0 && !interpreter_result.gas.record_state_cost(state_gas_for_code) {
-            journal.checkpoint_revert(checkpoint);
-            interpreter_result.result = InstructionResult::OutOfGas;
-            return;
-        }
+        // State gas for code deposit accumulates on the frame's NewStateTracker;
+        // the actual reservoir charge happens in process_next_action.
+        interpreter
+            .new_state
+            .add_code_deposit_bytes(interpreter_result.output.len() as u64);
     }
-
-    // If we have enough gas we can commit changes.
-    journal.checkpoint_commit();
-
-    // Do analysis of bytecode straight away.
-    let bytecode = Bytecode::new_legacy(interpreter_result.output.clone());
-
-    // Set code
-    journal.set_code(address, bytecode);
-
-    interpreter_result.result = InstructionResult::Return;
 }

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -443,6 +443,7 @@ impl EthFrame<EthInterpreter> {
         // - refunds > charges: refill the reservoir by the difference
         // - on revert/halt: drop the counters (state work undone, no charge)
         let new_state = self.interpreter.new_state;
+
         self.interpreter.new_state.clear();
         if commit {
             if new_state.state_gas >= new_state.state_gas_refunded {
@@ -455,6 +456,13 @@ impl EthFrame<EthInterpreter> {
                 let net_refund = new_state.state_gas_refunded - new_state.state_gas;
                 interpreter_result.gas.refill_reservoir(net_refund);
             }
+        } else {
+            interpreter_result.gas.set_reservoir(
+                interpreter_result
+                    .gas
+                    .reservoir()
+                    .saturating_add(new_state.state_gas),
+            );
         }
 
         if commit {

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -436,18 +436,24 @@ impl EthFrame<EthInterpreter> {
             interpreter_result.result.is_ok()
         };
 
-        // EIP-8037 deferred state-gas reconciliation:
-        // - on commit: refund first (grows reservoir), then charge (may OOG)
-        // - otherwise: drop the counters (state work undone, no charge)
+        // EIP-8037 deferred state-gas reconciliation. Apply only the net
+        // delta between charges and refunds:
+        // - charges > refunds: deduct the difference from the reservoir
+        //   (may spill into regular gas → OOG)
+        // - refunds > charges: refill the reservoir by the difference
+        // - on revert/halt: drop the counters (state work undone, no charge)
         let new_state = self.interpreter.new_state;
         self.interpreter.new_state.clear();
         if commit {
-            interpreter_result
-                .gas
-                .refill_reservoir(new_state.state_gas_refunded);
-            if !interpreter_result.gas.record_state_cost(new_state.state_gas) {
-                interpreter_result.result = InstructionResult::OutOfGas;
-                commit = false;
+            if new_state.state_gas >= new_state.state_gas_refunded {
+                let net_cost = new_state.state_gas - new_state.state_gas_refunded;
+                if !interpreter_result.gas.record_state_cost(net_cost) {
+                    interpreter_result.result = InstructionResult::OutOfGas;
+                    commit = false;
+                }
+            } else {
+                let net_refund = new_state.state_gas_refunded - new_state.state_gas;
+                interpreter_result.gas.refill_reservoir(net_refund);
             }
         }
 

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -630,31 +630,61 @@ impl EthFrame<EthInterpreter> {
 }
 
 /// Handles the remaining gas of the parent frame.
-///
-/// Under the deferred state-gas model (EIP-8037), the child frame applies its
-/// own state-gas to its gas tracker at frame return (`process_next_action`):
-/// on success the charge is committed to `reservoir` / `remaining`, on
-/// revert/halt the per-frame counters are dropped. As a result the child's
-/// reservoir is always "the parent's pre-call value plus the net effect of
-/// successful sub-work" — there's no spill-on-revert distortion to undo here.
 #[inline]
 pub fn handle_reservoir_remaining_gas(is_success: bool, parent_gas: &mut Gas, child_gas: &Gas) {
-    parent_gas.set_reservoir(child_gas.reservoir());
-
     if is_success {
-        // Audit totals: accumulate child's contribution into the parent's.
-        // (state_gas_spent / refill_amount on the gas tracker are populated
-        // by the child's process_next_action when state-gas was applied.)
+        // On success: parent takes the child's final reservoir.
+        parent_gas.set_reservoir(child_gas.reservoir());
+        // Accumulate child's state gas into parent's total.
+        // Parent may have already charged state gas (e.g., new_account + create) before
+        // creating the child frame. Child starts with state_gas_spent=0, so we must add
+        // rather than overwrite to preserve the parent's prior charges.
+        //
+        // `child.state_gas_spent()` can be negative (EIP-8037 issue #2) when the
+        // child did more 0→x→0 restorations than 0→x creations; the negative
+        // contribution is the parent's matching charge flowing back out.
         parent_gas.set_state_gas_spent(
             parent_gas
                 .state_gas_spent()
                 .saturating_add(child_gas.state_gas_spent()),
         );
+        // Propagate child's 0→x→0 refill total so that if the parent
+        // later reverts/halts, the refill contribution can be unwound.
         parent_gas.set_refill_amount(
             parent_gas
                 .refill_amount()
                 .saturating_add(child_gas.refill_amount()),
         );
+    } else {
+        // On revert or halt: child state changes are rolled back. Compute
+        // the gas to add to parent's pre-call reservoir as:
+        //
+        //   excess = max(0, child.reservoir + max(0, child.state_gas_spent)
+        //                  - parent.reservoir - child.refill_amount)
+        //
+        // The intuition:
+        // * `child.reservoir + max(0, child.state_gas_spent)` is the
+        //   "logical refund" if no refills had happened: it adds back the
+        //   child's own state-gas charges (positive `state_gas_spent`) on
+        //   top of whatever reservoir value the child carried out
+        //   (including refunds propagated from deeper halted/reverted
+        //   sub-frames, which reach `child.reservoir` via `set_reservoir`).
+        // * Subtracting `parent.reservoir` (the pre-call value) and the
+        //   in-frame 0→x→0 refill total leaves only the contribution that
+        //   genuinely belongs to the parent on revert/halt — i.e. own
+        //   charges + grandchild propagations.
+        // * The `max(0, ...)` guards against cases where own charges
+        //   spilled into regular gas (irrecoverable) and the refunded
+        //   charges are smaller than the refill the child did against
+        //   parent's prior charges.
+        let logical_refund = child_gas
+            .reservoir()
+            .saturating_add(child_gas.state_gas_spent().max(0) as u64);
+        let baseline = parent_gas
+            .reservoir()
+            .saturating_add(child_gas.refill_amount());
+        let excess = logical_refund.saturating_sub(baseline);
+        parent_gas.set_reservoir(parent_gas.reservoir().saturating_add(excess));
     }
 }
 

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -22,7 +22,7 @@ use interpreter::{
 use primitives::{
     constants::CALL_STACK_LIMIT,
     hardfork::SpecId::{self, HOMESTEAD, LONDON, SPURIOUS_DRAGON},
-    keccak256, Bytes, U256,
+    keccak256, Address, Bytes, U256,
 };
 use state::Bytecode;
 use std::{borrow::ToOwned, boxed::Box, vec::Vec};
@@ -413,51 +413,60 @@ impl EthFrame<EthInterpreter> {
             InterpreterAction::Return(result) => result,
         };
 
-        // For Create frames, run validation + bump new_state for code deposit.
-        // This may set interpreter_result.result to a failure variant.
-        let create_address = match &self.data {
-            FrameData::Create(frame) => Some(frame.created_address),
-            FrameData::Call(_) => None,
+        // Snapshot the relevant frame data so the immutable borrow on
+        // `self.data` does not block mutable access to `self.interpreter`.
+        let (return_memory_range, created_address) = match &self.data {
+            FrameData::Call(f) => (Some(f.return_memory_range.clone()), None),
+            FrameData::Create(f) => (None, Some(f.created_address)),
         };
-        if create_address.is_some() {
-            return_create(context, &mut self.interpreter, &mut interpreter_result);
-        }
 
-        // Apply per-frame state-gas reconciliation (EIP-8037, deferred model).
-        // - on ok: refund first (grows reservoir), then charge (may OOG)
-        // - on revert/halt: drop the counters (state work undone, no charge)
+        // For CREATE / CREATE2: validate, charge code-deposit + hash gas,
+        // bump state-gas for deployed bytes, and (on success) persist the
+        // bytecode. `return_create` is the single owner of create-specific
+        // logic; it returns whether the journal should be committed.
+        // For CALL: commit when the interpreter returned ok.
+        let mut commit = if let Some(address) = created_address {
+            return_create(
+                context,
+                &mut self.interpreter,
+                &mut interpreter_result,
+                address,
+            )
+        } else {
+            interpreter_result.result.is_ok()
+        };
+
+        // EIP-8037 deferred state-gas reconciliation:
+        // - on commit: refund first (grows reservoir), then charge (may OOG)
+        // - otherwise: drop the counters (state work undone, no charge)
         let new_state = self.interpreter.new_state;
         self.interpreter.new_state.clear();
-        if interpreter_result.result.is_ok() {
+        if commit {
             interpreter_result
                 .gas
                 .refill_reservoir(new_state.state_gas_refunded);
             if !interpreter_result.gas.record_state_cost(new_state.state_gas) {
                 interpreter_result.result = InstructionResult::OutOfGas;
+                commit = false;
             }
         }
 
-        // Commit or revert the journal based on the final result; for a
-        // successful CREATE, also persist the deployed bytecode.
-        if interpreter_result.result.is_ok() {
+        if commit {
             context.journal_mut().checkpoint_commit();
-            if let Some(address) = create_address {
-                let bytecode = Bytecode::new_legacy(interpreter_result.output.clone());
-                context.journal_mut().set_code(address, bytecode);
-                interpreter_result.result = InstructionResult::Return;
-            }
         } else {
             context.journal_mut().checkpoint_revert(self.checkpoint);
         }
 
-        let result = match &self.data {
-            FrameData::Call(frame) => ItemOrResult::Result(FrameResult::Call(CallOutcome::new(
+        let result = if let Some(address) = created_address {
+            ItemOrResult::Result(FrameResult::Create(CreateOutcome::new(
                 interpreter_result,
-                frame.return_memory_range.clone(),
-            ))),
-            FrameData::Create(frame) => ItemOrResult::Result(FrameResult::Create(
-                CreateOutcome::new(interpreter_result, Some(frame.created_address)),
-            )),
+                Some(address),
+            )))
+        } else {
+            ItemOrResult::Result(FrameResult::Call(CallOutcome::new(
+                interpreter_result,
+                return_memory_range.expect("Call frame has return memory range"),
+            )))
         };
 
         Ok(result)
@@ -649,19 +658,22 @@ pub fn handle_reservoir_remaining_gas(is_success: bool, parent_gas: &mut Gas, ch
     }
 }
 
-/// Validates the deployed bytecode of a successful CREATE/CREATE2 and bumps
-/// the per-frame state-gas counter. Charging state gas and committing the
-/// journal are handled by [`EthFrame::process_next_action`] after this call.
+/// Validates the deployed bytecode of a successful CREATE/CREATE2, charges
+/// the regular code-deposit + hash gas, bumps the per-frame state-gas
+/// counter for the deployed bytes, and on success persists the bytecode in
+/// the journal.
 ///
-/// Sets `interpreter_result.result` to a failure variant (e.g.
-/// `CreateContractSizeLimit`, `OutOfGas`) when validation or gas charges fail;
-/// the caller is responsible for journal revert in that case.
+/// Returns `true` when the deployment should be committed by the caller and
+/// `false` when the caller should revert the journal checkpoint. State-gas
+/// reconciliation is handled generically in [`EthFrame::process_next_action`]
+/// after this call.
 pub fn return_create<CTX: ContextTr>(
     context: &mut CTX,
     interpreter: &mut Interpreter<EthInterpreter>,
     interpreter_result: &mut InterpreterResult,
-) {
-    let (_, _, cfg, _, _, _) = context.all_mut();
+    address: Address,
+) -> bool {
+    let (_, _, cfg, journal, _, _) = context.all_mut();
 
     let max_code_size = cfg.max_code_size();
     let is_eip3541_disabled = cfg.is_eip3541_disabled();
@@ -671,14 +683,14 @@ pub fn return_create<CTX: ContextTr>(
 
     // If return is not ok, nothing to validate or charge.
     if !interpreter_result.result.is_ok() {
-        return;
+        return false;
     }
 
     // EIP-170 / EIP-7954: code size limit. Checked BEFORE state gas so
     // oversized code does not incur storage gas costs.
     if spec_id.is_enabled_in(SPURIOUS_DRAGON) && interpreter_result.output.len() > max_code_size {
         interpreter_result.result = InstructionResult::CreateContractSizeLimit;
-        return;
+        return false;
     }
 
     // EIP-3541: reject new contract code starting with the 0xEF byte.
@@ -687,7 +699,7 @@ pub fn return_create<CTX: ContextTr>(
         && interpreter_result.output.first() == Some(&0xEF)
     {
         interpreter_result.result = InstructionResult::CreateContractStartingWithEF;
-        return;
+        return false;
     }
 
     // Regular gas for code deposit. Zero under EIP-8037.
@@ -699,7 +711,7 @@ pub fn return_create<CTX: ContextTr>(
         // leaving an empty contract.
         if spec_id.is_enabled_in(HOMESTEAD) {
             interpreter_result.result = InstructionResult::OutOfGas;
-            return;
+            return false;
         } else {
             interpreter_result.output = Bytes::new();
         }
@@ -713,7 +725,7 @@ pub fn return_create<CTX: ContextTr>(
         let hash_cost = gas_params.keccak256_cost(interpreter_result.output.len());
         if !interpreter_result.gas.record_regular_cost(hash_cost) {
             interpreter_result.result = InstructionResult::OutOfGas;
-            return;
+            return false;
         }
         // State gas for code deposit accumulates on the frame's NewStateTracker;
         // the actual reservoir charge happens in process_next_action.
@@ -721,4 +733,10 @@ pub fn return_create<CTX: ContextTr>(
             .new_state
             .add_code_deposit_bytes(interpreter_result.output.len() as u64);
     }
+
+    // Persist the deployed bytecode.
+    let bytecode = Bytecode::new_legacy(interpreter_result.output.clone());
+    journal.set_code(address, bytecode);
+    interpreter_result.result = InstructionResult::Return;
+    true
 }

--- a/crates/interpreter/src/instructions/contract.rs
+++ b/crates/interpreter/src/instructions/contract.rs
@@ -87,16 +87,9 @@ pub fn create<IT: ITy, const IS_CREATE2: bool, H: Host + ?Sized>(
     };
 
     // State gas for account creation + contract metadata (EIP-8037).
-    // Charged upfront on the parent's tracker; `return_create` refunds the same
-    // amount (derived from cfg) on entry and re-records it on a successful commit.
+    // Bumps the per-frame state-gas counter; reconciled at frame return.
     if context.host.is_amsterdam_eip8037_enabled() {
-        state_gas!(
-            context.interpreter,
-            context
-                .host
-                .gas_params()
-                .create_state_gas(context.host.cpsb())
-        );
+        context.interpreter.new_state.add_create_account();
     }
 
     let mut gas_limit = context.interpreter.gas.remaining();

--- a/crates/interpreter/src/instructions/contract/call_helpers.rs
+++ b/crates/interpreter/src/instructions/contract/call_helpers.rs
@@ -75,8 +75,11 @@ pub fn load_acc_and_calc_gas<H: Host + ?Sized>(
     // deduct dynamic gas.
     gas!(interpreter, gas);
 
-    // deduct state gas (EIP-8037) if any.
-    state_gas!(interpreter, state_gas_cost);
+    // EIP-8037: bump per-frame state-gas counter for a CALL that materializes
+    // a new empty account (value transfer to an empty account).
+    if state_gas_cost > 0 {
+        interpreter.new_state.add_call_account();
+    }
 
     let interpreter = &mut context.interpreter;
     let host = &mut context.host;

--- a/crates/interpreter/src/instructions/contract/call_helpers.rs
+++ b/crates/interpreter/src/instructions/contract/call_helpers.rs
@@ -68,7 +68,7 @@ pub fn load_acc_and_calc_gas<H: Host + ?Sized>(
     }
 
     // load account delegated and deduct dynamic gas.
-    let (gas, _state_gas_cost, bytecode, code_hash) =
+    let (gas, state_gas_cost, bytecode, code_hash) =
         load_account_delegated_handle_error(context, to, transfers_value, create_empty_account)?;
     let interpreter = &mut context.interpreter;
 
@@ -76,8 +76,10 @@ pub fn load_acc_and_calc_gas<H: Host + ?Sized>(
     gas!(interpreter, gas);
 
     // EIP-8037: bump per-frame state-gas counter for a CALL that materializes
-    // a new empty account (value transfer to an empty account).
-    if context.host.is_amsterdam_eip8037_enabled() {
+    // a new empty account (value transfer to an empty account). `state_gas_cost`
+    // is non-zero only when EIP-8037 is enabled and the CALL actually creates
+    // a new empty account.
+    if state_gas_cost > 0 {
         interpreter.new_state.add_call_account();
     }
 

--- a/crates/interpreter/src/instructions/contract/call_helpers.rs
+++ b/crates/interpreter/src/instructions/contract/call_helpers.rs
@@ -68,7 +68,7 @@ pub fn load_acc_and_calc_gas<H: Host + ?Sized>(
     }
 
     // load account delegated and deduct dynamic gas.
-    let (gas, state_gas_cost, bytecode, code_hash) =
+    let (gas, _state_gas_cost, bytecode, code_hash) =
         load_account_delegated_handle_error(context, to, transfers_value, create_empty_account)?;
     let interpreter = &mut context.interpreter;
 
@@ -77,7 +77,7 @@ pub fn load_acc_and_calc_gas<H: Host + ?Sized>(
 
     // EIP-8037: bump per-frame state-gas counter for a CALL that materializes
     // a new empty account (value transfer to an empty account).
-    if state_gas_cost > 0 {
+    if context.host.is_amsterdam_eip8037_enabled() {
         interpreter.new_state.add_call_account();
     }
 

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -232,27 +232,19 @@ pub fn sstore<IT: ITy, H: Host + ?Sized>(context: Ictx<'_, H, IT>) -> Result {
         )
     );
 
-    // state gas for new slot creation (EIP-8037)
+    // EIP-8037: bump per-frame state-gas counters. Reconciled at frame return.
     if context.host.is_amsterdam_eip8037_enabled() {
-        let cpsb = context.host.cpsb();
-        state_gas!(
-            context.interpreter,
-            context
-                .host
-                .gas_params()
-                .sstore_state_gas(&state_load.data, cpsb)
-        );
-
-        // EIP-8037 issue #2: 0→x→0 storage restoration refills the reservoir
-        // directly rather than routing the state gas through the capped refund
-        // counter. The regular-gas portion of the restoration still flows
-        // through `sstore_refund` below.
-        let refill = context
-            .host
-            .gas_params()
-            .sstore_state_gas_refill(&state_load.data, cpsb);
-        if refill > 0 {
-            context.interpreter.gas.refill_reservoir(refill);
+        let vals = &state_load.data;
+        // SSTORE 0→x: charge a new-slot.
+        if vals.new_values_changes_present()
+            && vals.is_original_eq_present()
+            && vals.is_original_zero()
+        {
+            context.interpreter.new_state.add_storage();
+        }
+        // SSTORE x→0 against an originally-zero slot: refund.
+        if !vals.is_new_eq_present() && vals.is_original_eq_new() && vals.is_original_zero() {
+            context.interpreter.new_state.remove_storage();
         }
     }
 
@@ -360,15 +352,9 @@ pub fn selfdestruct<IT: ITy, H: Host + ?Sized>(context: Ictx<'_, H, IT>) -> Resu
             .selfdestruct_cost(should_charge_topup, res.is_cold)
     );
 
-    // State gas for new account creation (EIP-8037)
+    // State gas for new account creation (EIP-8037).
     if context.host.is_amsterdam_eip8037_enabled() && should_charge_topup {
-        state_gas!(
-            context.interpreter,
-            context
-                .host
-                .gas_params()
-                .new_account_state_gas(context.host.cpsb())
-        );
+        context.interpreter.new_state.add_call_account();
     }
 
     if !res.previously_destroyed {

--- a/crates/interpreter/src/instructions/macros.rs
+++ b/crates/interpreter/src/instructions/macros.rs
@@ -28,19 +28,6 @@ macro_rules! check {
     };
 }
 
-/// Records a state gas cost (EIP-8037) and fails the instruction if it would exceed the available gas.
-/// State gas only deducts from `remaining` (not `regular_gas_remaining`).
-#[macro_export]
-#[collapse_debuginfo(yes)]
-macro_rules! state_gas {
-    ($interpreter:expr, $gas:expr) => {{
-        if !$interpreter.gas.record_state_cost($gas) {
-            $crate::primitives::hints_util::cold_path();
-            return Err($crate::InstructionResult::OutOfGas);
-        }
-    }};
-}
-
 /// Records a `gas` cost and fails the instruction if it would exceed the available gas.
 #[macro_export]
 #[collapse_debuginfo(yes)]

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -22,7 +22,10 @@ use crate::{
     InstructionExecResult, InstructionResult, InstructionTable, InterpreterAction,
 };
 use bytecode::Bytecode;
-use context_interface::{cfg::GasParams, host::LoadError};
+use context_interface::{
+    cfg::{GasParams, NewStateTracker},
+    host::LoadError,
+};
 use primitives::{hardfork::SpecId, hints_util::cold_path, Bytes};
 
 /// Main interpreter structure that contains all components defined in [`InterpreterTypes`].
@@ -33,6 +36,9 @@ pub struct Interpreter<WIRE: InterpreterTypes = EthInterpreter> {
     pub bytecode: WIRE::Bytecode,
     /// Gas tracking for execution costs.
     pub gas: Gas,
+    /// Per-frame EIP-8037 state-gas accumulator. Reset on every frame entry;
+    /// reconciled with `gas` at frame return (see `EthFrame::process_next_action`).
+    pub new_state: NewStateTracker,
     /// EVM stack for computation.
     pub stack: WIRE::Stack,
     /// Buffer for return data from calls.
@@ -103,6 +109,7 @@ impl<EXT: Default> Interpreter<EthInterpreter<EXT>> {
         Self {
             bytecode,
             gas: Gas::new(gas_limit),
+            new_state: NewStateTracker::new(),
             stack,
             return_data: Default::default(),
             memory,
@@ -128,6 +135,7 @@ impl<EXT: Default> Interpreter<EthInterpreter<EXT>> {
         let Self {
             bytecode: bytecode_ref,
             gas,
+            new_state,
             stack,
             return_data,
             memory: memory_ref,
@@ -137,6 +145,7 @@ impl<EXT: Default> Interpreter<EthInterpreter<EXT>> {
         } = self;
         *bytecode_ref = bytecode;
         *gas = Gas::new_with_regular_gas_and_reservoir(gas_limit, reservoir_remaining_gas);
+        new_state.clear();
         if stack.data().capacity() == 0 {
             *stack = Stack::new();
         } else {


### PR DESCRIPTION
## Summary

Switches EIP-8037 state-gas from immediate charging to a deferred model. State-creating opcodes bump a simple per-frame counter on the `Interpreter` (`new_state`); the totals are reconciled with the gas tracker at frame return inside `EthFrame::process_next_action`.

* **on ok**: `state_gas_refunded` added to the reservoir first, then `state_gas` charged (may OOG → result flipped to `OutOfGas` before journal commit)
* **on revert/halt**: counters dropped — state work didn't happen, no reservoir change

## Notes

- `NewStateTracker` (`crates/context/interface/src/cfg/new_state_tracker.rs`) is intentionally minimal: two `u64` counters and a small set of `add_*` / `remove_*` methods. Uses **hardcoded** Glamsterdam EIP-8037 values (`bytes_per_unit × CPSB_GLAMSTERDAM`) for now — does not read `GasParams` at runtime.
- Migrates the immediate-charge call sites (SSTORE in `host.rs`, SELFDESTRUCT in `host.rs`, CREATE/CREATE2 in `contract.rs`, CALL-with-value in `call_helpers.rs`) to bump `interpreter.new_state.add_*()`. Removes the `state_gas!` macro.
- `return_create` no longer commits/reverts the journal; it validates code, charges regular code-deposit + hash gas, bumps `add_code_deposit_bytes`, and lets `process_next_action` apply state-gas and finalize (`set_code` on success).
- `handle_reservoir_remaining_gas` is simplified — the deferred model removes the spill-on-revert distortion, so the old `logical_refund / baseline / excess` math is no longer needed.
- Parent's `return_result` Create-branch: on child failure → `interpreter.new_state.remove_create_account()` (replaces `refill_reservoir(create_state_gas)`).

## Test plan

- [x] `cargo build --workspace` clean
- [ ] 23 EIP-8037 tests in `revm-ee-tests` currently fail because the test suite overrides `sstore_set_state_gas` etc. via `GasParams` (e.g. `200_000`) but the new `NewStateTracker` ignores those — the numbers it produces are EIP-8037 Glamsterdam defaults (e.g. SSTORE = `32 × 1174 = 37_568`). Need to either update test expectations, switch `NewStateTracker` to read `GasParams`/`cpsb`, or both.
- [ ] Spot-check tracing/inspector output (state_gas no longer goes negative since charges are deferred)