### PR TITLE
fix(inspector): use build_result_gas in inspect_run_system_call

### DIFF
--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -1,9 +1,8 @@
 use crate::{Inspector, InspectorEvmTr, JournalExt};
-use context::{
-    result::{ExecutionResult, ResultGas},
-    Cfg, ContextTr, JournalEntry, JournalTr, Transaction,
+use context::{result::ExecutionResult, Cfg, ContextTr, JournalEntry, JournalTr, Transaction};
+use handler::{
+    evm::FrameTr, post_execution::build_result_gas, EvmTr, FrameResult, Handler, ItemOrResult,
 };
-use handler::{evm::FrameTr, EvmTr, FrameResult, Handler, ItemOrResult};
 use interpreter::{
     instructions::{GasTable, InstructionTable},
     interpreter_types::{Jumps, LoopControl},
@@ -158,10 +157,7 @@ where
             .and_then(|exec_result| {
                 // System calls have no intrinsic gas; build ResultGas from frame result.
                 let gas = exec_result.gas();
-                let result_gas = ResultGas::default()
-                    .with_total_gas_spent(gas.total_gas_spent())
-                    .with_refunded(gas.refunded() as u64)
-                    .with_state_gas_spent(gas.state_gas_spent());
+                let result_gas = build_result_gas(gas, init_and_floor_gas);
                 self.execution_result(evm, exec_result, result_gas)
             }) {
             out @ Ok(_) => out,

--- a/crates/inspector/src/inspector_tests.rs
+++ b/crates/inspector/src/inspector_tests.rs
@@ -628,4 +628,148 @@ mod tests {
 
         assert!(evm.inspector.get_step_count() > 0);
     }
+
+    /// Regression test for inspector vs non-inspector divergence in
+    /// `run_system_call`'s `ResultGas` construction.
+    ///
+    /// The non-inspect path uses `build_result_gas`, which subtracts the gas
+    /// reservoir from `limit - remaining`. The inspect path used to construct
+    /// `ResultGas` inline via `gas.total_gas_spent()` (which is just
+    /// `limit - remaining`), so when a system call left `reservoir > 0` the
+    /// two paths reported different `total_gas_spent`.
+    ///
+    /// To force `reservoir > 0` in the top-level system frame we run a
+    /// scenario where the system contract calls a child that consumes state
+    /// gas (SSTORE on a fresh slot under AMSTERDAM) and then REVERT. On
+    /// revert the parent's reservoir is set to `child.state_gas_spent +
+    /// child.reservoir` (see `frame::handle_reservoir_remaining_gas`), which
+    /// is non-zero and triggers the divergence.
+    #[test]
+    fn test_system_call_gas_consistency_with_reservoir() {
+        use database::{CacheDB, EmptyDB};
+        use handler::SystemCallEvm;
+        use primitives::hardfork::SpecId;
+
+        let child_addr = address!("0x000000000000000000000000000000000000c0de");
+
+        // PUSH1 0x42 PUSH1 0x00 SSTORE PUSH0 PUSH0 REVERT
+        // Charges sstore_set_state_gas (32 * 1174 = 37568 under AMSTERDAM) and
+        // then reverts so the parent inherits that state gas as reservoir.
+        let child_code = Bytes::from(vec![
+            opcode::PUSH1,
+            0x42,
+            opcode::PUSH1,
+            0x00,
+            opcode::SSTORE,
+            opcode::PUSH0,
+            opcode::PUSH0,
+            opcode::REVERT,
+        ]);
+
+        // System contract: CALL child, ignore return value, STOP.
+        let system_code = Bytes::from(vec![
+            opcode::PUSH1,
+            0x00, // retSize
+            opcode::PUSH1,
+            0x00, // retOffset
+            opcode::PUSH1,
+            0x00, // argsSize
+            opcode::PUSH1,
+            0x00, // argsOffset
+            opcode::PUSH1,
+            0x00, // value
+            opcode::PUSH20,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0xc0,
+            0xde, // child_addr
+            opcode::PUSH4,
+            0x00,
+            0xFF,
+            0xFF,
+            0xFF, // gas to forward
+            opcode::CALL,
+            opcode::POP,
+            opcode::STOP,
+        ]);
+
+        let make_db = || {
+            let mut db = CacheDB::<EmptyDB>::default();
+            db.insert_account_info(
+                BENCH_TARGET,
+                AccountInfo {
+                    balance: U256::ZERO,
+                    nonce: 0,
+                    code_hash: primitives::keccak256(&system_code),
+                    code: Some(Bytecode::new_raw(system_code.clone())),
+                    ..Default::default()
+                },
+            );
+            db.insert_account_info(
+                child_addr,
+                AccountInfo {
+                    balance: U256::ZERO,
+                    nonce: 0,
+                    code_hash: primitives::keccak256(&child_code),
+                    code: Some(Bytecode::new_raw(child_code.clone())),
+                    ..Default::default()
+                },
+            );
+            db
+        };
+
+        let make_ctx = || {
+            Context::mainnet()
+                .modify_cfg_chained(|c| c.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM))
+                .with_db(make_db())
+        };
+
+        // Non-inspect path.
+        let mut evm_plain = make_ctx().build_mainnet();
+        let result_plain = evm_plain
+            .system_call_one(BENCH_TARGET, Bytes::default())
+            .expect("non-inspect system call must succeed");
+
+        // Inspect path.
+        let mut evm_inspect = make_ctx().build_mainnet_with_inspector(TestInspector::new());
+        let result_inspect = evm_inspect
+            .inspect_one_system_call(BENCH_TARGET, Bytes::default())
+            .expect("inspect system call must succeed");
+
+        assert!(result_plain.is_success(), "non-inspect must succeed");
+        assert!(result_inspect.is_success(), "inspect must succeed");
+
+        let plain_total = result_plain.gas().total_gas_spent();
+        let inspect_total = result_inspect.gas().total_gas_spent();
+
+        // Both paths must report identical gas — observability must not depend
+        // on whether an inspector is attached.
+        assert_eq!(
+            plain_total, inspect_total,
+            "system_call total_gas_spent must match between inspect and non-inspect paths",
+        );
+
+        // Sanity check: state_gas_spent should also agree.
+        assert_eq!(
+            result_plain.gas().state_gas_spent(),
+            result_inspect.gas().state_gas_spent(),
+            "system_call state_gas_spent must match between inspect and non-inspect paths",
+        );
+    }
 }


### PR DESCRIPTION
The inspect path constructed `ResultGas` inline from `gas.total_gas_spent()` (`limit - remaining`), while the non-inspect path used `build_result_gas`, which also subtracts the reservoir. When a system call left `reservoir > 0` (e.g. a child frame consuming state gas then reverting), the two paths reported different `total_gas_spent`, making observability depend on whether an inspector was attached.

Switch the inspect path to `build_result_gas` so both paths produce identical `ResultGas`. Add a regression test that triggers `reservoir > 0` via SSTORE + REVERT in a child under AMSTERDAM and asserts gas reporting matches between `system_call_one` and `inspect_one_system_call`.