### PR TITLE
fix(precompile): halt with PrecompileOOG when precompile over-spends gas

### DIFF
--- a/crates/handler/src/precompile_provider.rs
+++ b/crates/handler/src/precompile_provider.rs
@@ -101,7 +101,12 @@ pub fn precompile_output_to_interpreter_result(
 
     // spend used gas.
     if output.status.is_success_or_revert() {
-        let _ = result.gas.record_regular_cost(output.gas_used);
+        if !result.gas.record_regular_cost(output.gas_used) {
+            result.gas.spend_all();
+            result.output = Bytes::new();
+            result.result = InstructionResult::PrecompileOOG;
+            return result;
+        }
     } else {
         result.gas.spend_all();
     }
@@ -174,5 +179,133 @@ impl<CTX: ContextTr> PrecompileProvider<CTX> for EthPrecompiles {
 
     fn contains(&self, address: &Address) -> bool {
         Self::contains(self, address)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{instructions::EthInstructions, ExecuteEvm, MainContext};
+    use context::{Context, Evm, FrameStack, TxEnv};
+    use context_interface::result::{ExecutionResult, HaltReason, OutOfGasError};
+    use database::InMemoryDB;
+    use interpreter::interpreter::EthInterpreter;
+    use primitives::{address, hardfork::SpecId, TxKind, U256};
+    use state::AccountInfo;
+
+    /// Test-only address that hosts an over-spending precompile.
+    const OVERSPEND_PRECOMPILE: Address = address!("0000000000000000000000000000000000000100");
+
+    /// Custom precompile provider that drives the bug path: it returns a
+    /// `PrecompileOutput` with `status = Success` and `gas_used = u64::MAX` while
+    /// `gas_limit` is finite. Without the fix, `record_regular_cost`'s `false` return
+    /// is discarded so the call lands as `Return` with the gas tracker untouched —
+    /// the transaction succeeds and refunds the precompile's "free" gas. With the fix,
+    /// the helper converts the over-spend into `PrecompileOOG`, halting the tx.
+    #[derive(Debug)]
+    struct OverspendingPrecompiles {
+        inner: EthPrecompiles,
+        warm: AddressSet,
+    }
+
+    impl OverspendingPrecompiles {
+        fn new(spec: SpecId) -> Self {
+            let inner = EthPrecompiles::new(spec);
+            let mut warm = AddressSet::default();
+            warm.clone_from(inner.warm_addresses());
+            warm.insert(OVERSPEND_PRECOMPILE);
+            Self { inner, warm }
+        }
+    }
+
+    impl<CTX> PrecompileProvider<CTX> for OverspendingPrecompiles
+    where
+        CTX: ContextTr<Cfg: Cfg<Spec = SpecId>>,
+    {
+        type Output = InterpreterResult;
+
+        fn set_spec(&mut self, spec: <CTX::Cfg as Cfg>::Spec) -> bool {
+            let changed =
+                <EthPrecompiles as PrecompileProvider<CTX>>::set_spec(&mut self.inner, spec);
+            self.warm.clone_from(self.inner.warm_addresses());
+            self.warm.insert(OVERSPEND_PRECOMPILE);
+            changed
+        }
+
+        fn run(
+            &mut self,
+            context: &mut CTX,
+            inputs: &CallInputs,
+        ) -> Result<Option<Self::Output>, String> {
+            if inputs.bytecode_address == OVERSPEND_PRECOMPILE {
+                let output = PrecompileOutput {
+                    status: PrecompileStatus::Success,
+                    gas_used: u64::MAX,
+                    gas_refunded: 0,
+                    state_gas_used: 0,
+                    reservoir: inputs.reservoir,
+                    bytes: Bytes::from_static(b"unreliable"),
+                };
+                return Ok(Some(precompile_output_to_interpreter_result(
+                    output,
+                    inputs.gas_limit,
+                )));
+            }
+            <EthPrecompiles as PrecompileProvider<CTX>>::run(&mut self.inner, context, inputs)
+        }
+
+        fn warm_addresses(&self) -> &AddressSet {
+            &self.warm
+        }
+    }
+
+    /// End-to-end regression test for Bug 3. A transaction targets a custom precompile
+    /// that lies about its gas usage. The fix turns this into an `OutOfGas(Precompile)`
+    /// halt; without the fix it is silently treated as a successful call.
+    #[test]
+    fn overspending_precompile_halts_tx_with_precompile_oog() {
+        let caller = address!("0000000000000000000000000000000000000001");
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            caller,
+            AccountInfo {
+                balance: U256::from(10).pow(U256::from(18)),
+                ..Default::default()
+            },
+        );
+
+        let spec = SpecId::default();
+        let ctx = Context::mainnet().with_db(db);
+        let mut evm = Evm {
+            ctx,
+            inspector: (),
+            instruction: EthInstructions::<EthInterpreter, _>::new_mainnet_with_spec(spec),
+            precompiles: OverspendingPrecompiles::new(spec),
+            frame_stack: FrameStack::new_prealloc(8),
+        };
+
+        let tx = TxEnv::builder()
+            .caller(caller)
+            .kind(TxKind::Call(OVERSPEND_PRECOMPILE))
+            .gas_limit(100_000)
+            .build()
+            .unwrap();
+
+        let exec = evm.transact_one(tx).expect("handler returned an error");
+
+        match exec {
+            ExecutionResult::Halt { reason, .. } => {
+                assert_eq!(
+                    reason,
+                    HaltReason::OutOfGas(OutOfGasError::Precompile),
+                    "expected precompile OOG halt for over-spending precompile",
+                );
+            }
+            ExecutionResult::Success { .. } => panic!(
+                "before-fix behavior leaked: over-spending precompile reported Success \
+                 instead of halting with PrecompileOOG"
+            ),
+            ExecutionResult::Revert { .. } => panic!("expected Halt(PrecompileOOG), got Revert"),
+        }
     }
 }


### PR DESCRIPTION
When `record_regular_cost` returns false the over-spend was silently discarded, letting the call appear successful. Convert it into a PrecompileOOG halt instead, and add a regression test.