### PR TITLE
docs(precompile): fix typos and HOMESTEAD spec doc

### DIFF
--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -217,7 +217,7 @@ impl Precompiles {
 
     /// Extends the precompiles with the given precompiles.
     ///
-    /// Other precompiles with overwrite existing precompiles.
+    /// Other precompiles will overwrite existing precompiles.
     pub fn extend(&mut self, other: impl IntoIterator<Item = Precompile>) {
         let iter = other.into_iter();
         let (lower, _) = iter.size_hint();
@@ -393,12 +393,16 @@ impl Precompile {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum PrecompileSpecId {
-    /// Frontier spec.
+    /// Homestead spec — initial precompile set
+    /// (ECRECOVER, SHA256, RIPEMD160, IDENTITY).
+    ///
+    /// Used for every hardfork from FRONTIER through SPURIOUS_DRAGON; see
+    /// [`PrecompileSpecId::from_spec_id`].
     HOMESTEAD,
     /// Byzantium spec introduced
-    /// * [EIP-198](https://eips.ethereum.org/EIPS/eip-198) a EIP-198: Big integer modular exponentiation (at 0x05 address).
-    /// * [EIP-196](https://eips.ethereum.org/EIPS/eip-196) a bn_add (at 0x06 address) and bn_mul (at 0x07 address) precompile
-    /// * [EIP-197](https://eips.ethereum.org/EIPS/eip-197) a bn_pair (at 0x08 address) precompile
+    /// * [`EIP-198: Big integer modular exponentiation`](https://eips.ethereum.org/EIPS/eip-198) (at 0x05 address).
+    /// * [`EIP-196: Precompiled contracts for addition and scalar multiplication on alt_bn128`](https://eips.ethereum.org/EIPS/eip-196): bn_add (0x06) and bn_mul (0x07).
+    /// * [`EIP-197: Optimal ate pairing check on alt_bn128`](https://eips.ethereum.org/EIPS/eip-197): bn_pair (0x08).
     BYZANTIUM,
     /// Istanbul spec introduced
     /// * [`EIP-152: Add BLAKE2 compression function`](https://eips.ethereum.org/EIPS/eip-152) `F` precompile (at 0x09 address).


### PR DESCRIPTION
## What

Doc-only cleanup pass on `crates/precompile/src/lib.rs`:

1. **`Precompiles::extend`**: typo `with` → `will`.
2. **`PrecompileSpecId::HOMESTEAD`**: doc said `Frontier spec.`, which contradicts both the variant name and the actual mapping in `from_spec_id` (which covers `FRONTIER` through `SPURIOUS_DRAGON`). Replaced with a description of the precompile set this variant represents, plus a pointer to `from_spec_id`.
3. **`PrecompileSpecId::BYZANTIUM`**: each EIP bullet had a stray `a` and EIP-198 was duplicated in its own line. Reformatted to match the `[\`EIP-N: name\`](url)` style already used by the `ISTANBUL`, `CANCUN`, `PRAGUE`, and `OSAKA` blocks immediately below.

## Why

No behavior change. Surfaced while reading this file for educational material — these were the most disorienting bits for a new reader, and they show up directly in `cargo doc` output (rendered HTML).

## Test plan

- [x] `cargo build -p revm-precompile`
- [x] `cargo test -p revm-precompile --lib` (51 passed, 0 failed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p revm-precompile --no-deps` (no warnings — confirms the new intra-doc link to `from_spec_id` resolves)