### PR TITLE
docs(interpreter): fix typos in signextend and push! comments

### DIFF
--- a/crates/interpreter/src/instructions/arithmetic.rs
+++ b/crates/interpreter/src/instructions/arithmetic.rs
@@ -122,7 +122,7 @@ pub fn exp<IT: ITy, H: Host + ?Sized>(context: Ictx<'_, H, IT>) -> Result {
 /// `y | !mask` where `|` is the bitwise `OR` and `!` is bitwise negation.
 ///
 /// Similarly, if `b == 0` then the yellow paper says the output should start with all zeros,
-/// then end with bits from `b`; this is equal to `y & mask` where `&` is bitwise `AND`.
+/// then end with bits from `y`; this is equal to `y & mask` where `&` is bitwise `AND`.
 pub fn signextend<IT: ITy, H: ?Sized>(context: Ictx<'_, H, IT>) -> Result {
     popn_top!([ext], x, context.interpreter);
     // For 31 we also don't need to do anything.

--- a/crates/interpreter/src/instructions/macros.rs
+++ b/crates/interpreter/src/instructions/macros.rs
@@ -95,7 +95,7 @@ macro_rules! popn_top {
     };
 }
 
-/// Pushes a `B256` value onto the stack. Fails the instruction if the stack is full.
+/// Pushes a `U256` value onto the stack. Fails the instruction if the stack is full.
 #[macro_export]
 #[collapse_debuginfo(yes)]
 macro_rules! push {


### PR DESCRIPTION
## What

Two doc-only typo fixes under `crates/interpreter/src/instructions/`:

1. **`arithmetic.rs::signextend`**: the `b == 0` case said *"end with bits from `b`"*, but `b` is a single bit (the `t`-th bit of `y`). The intended description, parallel to the `b == 1` case immediately above (which correctly says *"the remaining bits of `y`"*), is *"end with bits from `y`"*. The implementation (`y & mask`) confirms `y` is what's intended.

2. **`macros.rs::push!`**: the doc said *"Pushes a `B256` value onto the stack"*, but the underlying `Stack::push` takes a `U256`, and every call site under `instructions/` (e.g. `block_info.rs`, `tx_info.rs`, `system.rs`) passes a `U256`.

## Why

Doc-only, no behavior change. Both surfaced while reading these files for educational material — the `signextend` typo in particular is misleading enough to derail a careful reader trying to understand the algorithm.

## Test plan

- [x] `cargo build -p revm-interpreter`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p revm-interpreter --no-deps` (no warnings)