### PR TITLE
perf(database): pre-filter changed slots before transforming map

### DIFF
--- a/crates/database/src/states/cache.rs
+++ b/crates/database/src/states/cache.rs
@@ -182,7 +182,7 @@ impl CacheState {
     pub(crate) fn apply_account_state(
         &mut self,
         address: Address,
-        account: Account,
+        mut account: Account,
     ) -> Option<TransitionAccount> {
         // Not touched account are never changed.
         if !account.is_touched() {
@@ -204,10 +204,15 @@ impl CacheState {
         let is_empty = account.is_empty();
 
         // Transform evm storage to storage with previous value.
+        //
+        // Drop unchanged slots in place first so the subsequent collect can use
+        // the post-filter `ExactSizeIterator` length as its capacity hint —
+        // avoiding the rehashes the previous `filter+map+collect` triggered
+        // (its `(0, Some(n))` size hint reserved nothing up front).
+        account.storage.retain(|_, slot| slot.is_changed());
         let changed_storage = account
             .storage
             .into_iter()
-            .filter(|(_, slot)| slot.is_changed())
             .map(|(key, slot)| (key, slot.into()))
             .collect();
 


### PR DESCRIPTION
Closes #3374.

> Opening as **draft** to confirm direction with @rakita before polishing — see "Approach question" below.

## What

`CacheState::apply_account_state` previously built `changed_storage` as:

```rust
let changed_storage = account
    .storage
    .into_iter()
    .filter(|(_, slot)| slot.is_changed())
    .map(|(key, slot)| (key, slot.into()))
    .collect();
```

`Filter` collapses the iterator's size hint to `(0, Some(n))`, so the collected `HashMap` reserves no capacity up front and rehashes as items are inserted. Pretty much exactly the wasteful `collect` the issue points at.

This PR drops unchanged slots in place via `retain` first; the resulting `HashMap::into_iter()` is `ExactSizeIterator`, which `map` preserves, so `collect` reserves the exact final capacity in one shot — one allocation, no rehashes.

## Approach question (for @rakita)

The issue suggests *"reuse the map"*. A literal in-place reuse isn't possible — `EvmStorageSlot` and `StorageSlot` differ in size (the former carries `transaction_id` and `is_cold`), so a transmute would be unsound. This PR is the next-best thing: keep one allocation, eliminate the rehashes.

If you had a different shape in mind — e.g. changing `change`/`newly_created` to take `EvmStorageSlot`-keyed input and doing the conversion downstream, or a custom container that can shrink in place — happy to redo this. Marking as draft so we can settle on the approach before I add a benchmark and polish further.

## Notes

- `account: Account` became `mut account: Account` since `retain` needs `&mut HashMap`. The function still consumes `account`, so this is purely local.
- No test changes — existing `revm-database` tests still pass.

## Test plan

- [x] `cargo build -p revm-database`
- [x] `cargo test -p revm-database --lib` (23 passed, 0 failed)
- [x] `cargo check --workspace`
- [ ] Benchmark (will add once direction is confirmed)