### PR TITLE
perf: opt all zeros check

### DIFF
--- a/crates/precompile/bench/bls12_381_zero_check.rs
+++ b/crates/precompile/bench/bls12_381_zero_check.rs
@@ -1,0 +1,148 @@
+//! Microbenchmark for the BLS12-381 pairing zero-check (point-at-infinity filter).
+//!
+//! Compares:
+//! - `iter_all`: original `arr.iter().all(|&b| b == 0)` (byte loop)
+//! - `u64_safe`: `[u64::from_ne_bytes(arr[k..k+8].try_into().unwrap()); 6]` then
+//!   `.iter().all(|&x| x == 0)` (current production)
+
+use criterion::{black_box, measurement::Measurement, BenchmarkGroup};
+
+const FP: usize = 48;
+
+type G1 = ([u8; FP], [u8; FP]);
+type G2 = ([u8; FP], [u8; FP], [u8; FP], [u8; FP]);
+type Pair = (G1, G2);
+
+#[derive(Copy, Clone)]
+enum WorkloadMode {
+    AllZero,
+    AllNonZero,
+    Mixed,
+    TrailingNonZero,
+}
+
+fn build_pairs(n: usize, mode: WorkloadMode) -> Vec<Pair> {
+    let mut v = Vec::with_capacity(n);
+    for i in 0..n {
+        let pair = match mode {
+            WorkloadMode::AllZero => (
+                ([0u8; FP], [0u8; FP]),
+                ([0u8; FP], [0u8; FP], [0u8; FP], [0u8; FP]),
+            ),
+            WorkloadMode::AllNonZero => {
+                let mut a = [0u8; FP];
+                a[FP - 1] = (i as u8).wrapping_add(1);
+                a[0] = 1;
+                let mut b = [0u8; FP];
+                b[0] = 2;
+                ((a, b), (a, b, a, b))
+            }
+            WorkloadMode::Mixed => {
+                if i % 2 == 0 {
+                    (
+                        ([0u8; FP], [0u8; FP]),
+                        ([0u8; FP], [0u8; FP], [0u8; FP], [0u8; FP]),
+                    )
+                } else {
+                    let mut a = [0u8; FP];
+                    a[0] = 7;
+                    ((a, a), (a, a, a, a))
+                }
+            }
+            // Worst case for byte-level early-exit: only the last byte is non-zero.
+            WorkloadMode::TrailingNonZero => {
+                let mut a = [0u8; FP];
+                a[FP - 1] = 1;
+                ((a, a), (a, a, a, a))
+            }
+        };
+        v.push(pair);
+    }
+    v
+}
+
+#[inline(never)]
+fn check_iter_all(pairs: &[Pair]) -> (usize, usize) {
+    let mut g1_zero_count = 0usize;
+    let mut g2_zero_count = 0usize;
+    for ((g1_x, g1_y), (g2_x_0, g2_x_1, g2_y_0, g2_y_1)) in pairs {
+        let g1_is_zero = g1_x.iter().all(|&b| b == 0) && g1_y.iter().all(|&b| b == 0);
+        let g2_is_zero = g2_x_0.iter().all(|&b| b == 0)
+            && g2_x_1.iter().all(|&b| b == 0)
+            && g2_y_0.iter().all(|&b| b == 0)
+            && g2_y_1.iter().all(|&b| b == 0);
+        if g1_is_zero {
+            g1_zero_count += 1;
+        }
+        if g2_is_zero {
+            g2_zero_count += 1;
+        }
+    }
+    (g1_zero_count, g2_zero_count)
+}
+
+#[inline(always)]
+fn fp_is_zero(a: &[u8; FP]) -> bool {
+    let w = [
+        u64::from_ne_bytes(a[0..8].try_into().unwrap()),
+        u64::from_ne_bytes(a[8..16].try_into().unwrap()),
+        u64::from_ne_bytes(a[16..24].try_into().unwrap()),
+        u64::from_ne_bytes(a[24..32].try_into().unwrap()),
+        u64::from_ne_bytes(a[32..40].try_into().unwrap()),
+        u64::from_ne_bytes(a[40..48].try_into().unwrap()),
+    ];
+    w.iter().all(|&x| x == 0)
+}
+
+#[inline(never)]
+fn check_u64_safe(pairs: &[Pair]) -> (usize, usize) {
+    let mut g1_zero_count = 0usize;
+    let mut g2_zero_count = 0usize;
+    for ((g1_x, g1_y), (g2_x_0, g2_x_1, g2_y_0, g2_y_1)) in pairs {
+        let g1_is_zero = fp_is_zero(g1_x) && fp_is_zero(g1_y);
+        let g2_is_zero =
+            fp_is_zero(g2_x_0) && fp_is_zero(g2_x_1) && fp_is_zero(g2_y_0) && fp_is_zero(g2_y_1);
+        if g1_is_zero {
+            g1_zero_count += 1;
+        }
+        if g2_is_zero {
+            g2_zero_count += 1;
+        }
+    }
+    (g1_zero_count, g2_zero_count)
+}
+
+fn assert_equivalent(pairs: &[Pair]) {
+    assert_eq!(check_iter_all(pairs), check_u64_safe(pairs));
+}
+
+pub fn add_zero_check_benches<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
+    let sizes = [1usize, 2, 8, 16];
+    let modes = [
+        ("all_zero", WorkloadMode::AllZero),
+        ("all_nonzero", WorkloadMode::AllNonZero),
+        ("mixed", WorkloadMode::Mixed),
+        ("trailing_nonzero", WorkloadMode::TrailingNonZero),
+    ];
+
+    for (mode_name, mode) in modes {
+        for n in sizes {
+            let pairs = build_pairs(n, mode);
+            assert_equivalent(&pairs);
+
+            group.bench_function(format!("zero_check/iter_all/{mode_name}/n={n}"), |b| {
+                b.iter(|| {
+                    let r = check_iter_all(black_box(&pairs));
+                    black_box(r);
+                });
+            });
+
+            group.bench_function(format!("zero_check/u64_safe/{mode_name}/n={n}"), |b| {
+                b.iter(|| {
+                    let r = check_u64_safe(black_box(&pairs));
+                    black_box(r);
+                });
+            });
+        }
+    }
+}

--- a/crates/precompile/bench/main.rs
+++ b/crates/precompile/bench/main.rs
@@ -2,6 +2,7 @@
 //! Benchmarks for the crypto precompiles
 
 pub mod blake2;
+pub mod bls12_381_zero_check;
 pub mod ecrecover;
 pub mod eip1962;
 pub mod eip2537;
@@ -39,6 +40,8 @@ pub fn benchmark_crypto_precompiles(c: &mut Criterion) {
 
     // Run secp256r1 benchmarks
     secp256r1::add_benches(&mut group);
+
+    bls12_381_zero_check::add_zero_check_benches(&mut group);
 }
 
 criterion_group! {

--- a/crates/precompile/src/bls12_381/pairing_common.rs
+++ b/crates/precompile/src/bls12_381/pairing_common.rs
@@ -7,6 +7,24 @@
 use crate::PrecompileHalt;
 use std::vec::Vec;
 
+/// Zero-check on a 48-byte field element via 6 `u64` chunks. Faster than a
+/// byte loop because LLVM emits a SIMD load + horizontal reduce on aarch64
+/// and an SSE compare on x86_64 while still short-circuiting at the field
+/// boundary. The `try_into` panics are elided since slice lengths are
+/// statically known.
+#[inline]
+fn fp_is_zero(a: &[u8; 48]) -> bool {
+    let w = [
+        u64::from_ne_bytes(a[0..8].try_into().unwrap()),
+        u64::from_ne_bytes(a[8..16].try_into().unwrap()),
+        u64::from_ne_bytes(a[16..24].try_into().unwrap()),
+        u64::from_ne_bytes(a[24..32].try_into().unwrap()),
+        u64::from_ne_bytes(a[32..40].try_into().unwrap()),
+        u64::from_ne_bytes(a[40..48].try_into().unwrap()),
+    ];
+    w.iter().all(|&x| x == 0)
+}
+
 /// Shared implementation of `pairing_check_bytes`.
 #[inline]
 pub(super) fn pairing_check_bytes_generic<G1, G2, ReadG1, ReadG2, PairingCheck>(
@@ -27,13 +45,11 @@ where
     let mut parsed_pairs = Vec::with_capacity(pairs.len());
     for ((g1_x, g1_y), (g2_x_0, g2_x_1, g2_y_0, g2_y_1)) in pairs {
         // Check if G1 point is zero (point at infinity)
-        let g1_is_zero = g1_x.iter().all(|&b| b == 0) && g1_y.iter().all(|&b| b == 0);
+        let g1_is_zero = fp_is_zero(g1_x) && fp_is_zero(g1_y);
 
         // Check if G2 point is zero (point at infinity)
-        let g2_is_zero = g2_x_0.iter().all(|&b| b == 0)
-            && g2_x_1.iter().all(|&b| b == 0)
-            && g2_y_0.iter().all(|&b| b == 0)
-            && g2_y_1.iter().all(|&b| b == 0);
+        let g2_is_zero =
+            fp_is_zero(g2_x_0) && fp_is_zero(g2_x_1) && fp_is_zero(g2_y_0) && fp_is_zero(g2_y_1);
 
         // Skip this pair if either point is at infinity as it's a no-op
         if g1_is_zero || g2_is_zero {


### PR DESCRIPTION
Sanity benchmark (n=8):
- all_zero case: iter_all 232 ns → u64_safe 18.8 ns (12.4× faster)
- all_nonzero case: iter_all 5.4 ns → u64_safe 3.4 ns (1.6× faster)