### PR TITLE
ci: run develop EEST fixtures by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ cargo check --target riscv32imac-unknown-none-elf -p revm-database --no-default-
 cargo check --target riscv64imac-unknown-none-elf -p revm-database --no-default-features
 
 ./scripts/run-tests.sh
-cargo run --release -p revme -- statetest test-fixtures/main/stable/state_tests
+cargo run --release -p revme -- statetest test-fixtures/main/develop/state_tests
 ```
 
 Run `cargo fmt --all` before committing.

--- a/book/src/revme.md
+++ b/book/src/revme.md
@@ -27,7 +27,7 @@ Test suites for the latest hardforks can be found in [EEST releases](https://git
 Revm can run statetest type of tests with `revme` using the following command:
 `cargo run --release -p revme -- statetest folder_path`
 
-For running EEST tests, we can use the `./scripts/run-tests.sh`.
+For running EEST tests, we can use the `./scripts/run-tests.sh`. It downloads and runs the develop fixtures by default; set `REVM_STATETEST_STABLE=1` to use stable fixtures instead.
 
 For legacy tests, we need to first download the repo `git clone https://github.com/ethereum/legacytests` and then run it with `cargo run --release -p revme -- statetest legacytests/Cancun/GeneralStateTests`
 All statetest that can be run by revme can be found in the `GeneralStateTests` folder.

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -17,13 +17,20 @@ MAIN_DEVELOP_DIR="$MAIN_DIR/develop"
 DEVNET_DIR="$FIXTURES_DIR/devnet"
 DEVNET_DEVELOP_DIR="$DEVNET_DIR/develop"
 
-LEGACY_DIR="$FIXTURES_DIR/legacytests" 
+LEGACY_DIR="$FIXTURES_DIR/legacytests"
 
 ### URL and filenames ###
 FIXTURES_URL="https://github.com/ethereum/execution-spec-tests/releases/download"
 
-MAIN_STABLE_TAR="fixtures_stable.tar.gz"
-MAIN_DEVELOP_TAR="fixtures_develop.tar.gz"
+if [[ -n "${REVM_STATETEST_STABLE:-}" && "${REVM_STATETEST_STABLE:-}" != "0" ]]; then
+    MAIN_DIR="$MAIN_STABLE_DIR"
+    MAIN_TAR="fixtures_stable.tar.gz"
+    MAIN_LABEL="main stable"
+else
+    MAIN_DIR="$MAIN_DEVELOP_DIR"
+    MAIN_TAR="fixtures_develop.tar.gz"
+    MAIN_LABEL="main develop"
+fi
 
 DEVNET_TAR="fixtures_bal.tar.gz"
 
@@ -35,6 +42,9 @@ usage() {
     echo ""
     echo "Flags (can be specified before or after 'clean'):"
     echo "  --keep-going  Continue running tests even after failures."
+    echo ""
+    echo "Environment:"
+    echo "  REVM_STATETEST_STABLE=1  Download and run EEST stable fixtures instead of develop."
     echo ""
     echo "Arguments (after optional 'clean' and '--keep-going'):"
     echo "  runner   (Optional) Rust runner command. Must be either 'cargo' or 'cross'. Defaults to 'cargo'."
@@ -78,7 +88,7 @@ clean() {
 
 # Check if all required fixture directories exist
 check_fixtures() {
-    if [ -d "$MAIN_STABLE_DIR" ] && [ -d "$MAIN_DEVELOP_DIR" ] && [ -d "$DEVNET_DIR" ] && [ -d "$LEGACY_DIR" ]; then
+    if [ -d "$MAIN_DIR/state_tests" ] && [ -d "$DEVNET_DIR" ] && [ -d "$LEGACY_DIR" ]; then
         return 0
     else
         return 1
@@ -129,10 +139,9 @@ download_and_extract() {
 # Download all fixtures
 download_fixtures() {
     echo "Creating fixtures directory structure..."
-    mkdir -p "$MAIN_STABLE_DIR" "$MAIN_DEVELOP_DIR" "$DEVNET_DIR" "$LEGACY_DIR"
-    
-    download_and_extract "$MAIN_STABLE_DIR" "$MAIN_STABLE_TAR" "main stable" "$MAIN_VERSION"
-    download_and_extract "$MAIN_DEVELOP_DIR" "$MAIN_DEVELOP_TAR" "main develop" "$MAIN_VERSION"
+    mkdir -p "$MAIN_DIR" "$DEVNET_DIR" "$LEGACY_DIR"
+
+    download_and_extract "$MAIN_DIR" "$MAIN_TAR" "$MAIN_LABEL" "$MAIN_VERSION"
     download_and_extract "$DEVNET_DIR" "$DEVNET_TAR" "devnet" "$DEVNET_VERSION"
 
     # Clone legacytests repository
@@ -165,11 +174,8 @@ build_cargo_options() {
 
 # Run tests for each set of fixtures using the chosen runner.
 run_tests() {
-    echo "Running main stable statetests..."
-    $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest $KEEP_GOING_FLAG "$MAIN_STABLE_DIR/state_tests"
-
-    echo "Running main develop statetests..."
-    $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest $KEEP_GOING_FLAG "$MAIN_DEVELOP_DIR/state_tests"
+    echo "Running $MAIN_LABEL statetests..."
+    $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest $KEEP_GOING_FLAG "$MAIN_DIR/state_tests"
 
     echo "SKIP Running devnet statetests..."
     #$RUST_RUNNER run $CARGO_OPTS -p revme -- statetest $KEEP_GOING_FLAG "$DEVNET_DIR/state_tests"
@@ -180,11 +186,8 @@ run_tests() {
     echo "Running legacy Constantinople tests..."
     $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest $KEEP_GOING_FLAG "$LEGACY_DIR/Constantinople/GeneralStateTests"
 
-    echo "Running main develop blockchain tests..."
-    $RUST_RUNNER run $CARGO_OPTS -p revme -- btest $KEEP_GOING_FLAG "$MAIN_DEVELOP_DIR/blockchain_tests"
-
-    echo "Running main stable blockchain tests..."
-    $RUST_RUNNER run $CARGO_OPTS -p revme -- btest $KEEP_GOING_FLAG "$MAIN_STABLE_DIR/blockchain_tests"
+    echo "Running $MAIN_LABEL blockchain tests..."
+    $RUST_RUNNER run $CARGO_OPTS -p revme -- btest $KEEP_GOING_FLAG "$MAIN_DIR/blockchain_tests"
 
     echo "SKIP Running devnet blockchain tests..."
     #$RUST_RUNNER run $CARGO_OPTS -p revme -- btest $KEEP_GOING_FLAG "$DEVNET_DIR/blockchain_tests"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 # Usage: ./scripts/run-tests.sh --help
 
 # Version for the execution spec tests
-MAIN_VERSION="v5.3.0"
+MAIN_VERSION="v5.4.0"
 DEVNET_VERSION="bal%40v5.4.0"
 
 ### Directories ###


### PR DESCRIPTION
EEST develop fixture releases are supersets of stable, so running both duplicates coverage and increases setup/runtime. This switches the fixture script to download and run develop by default, while keeping stable selectable with `REVM_STATETEST_STABLE=1` for cases where the narrower fixture set is desired.
