### PR TITLE
docs(ee-tests): reference `eip8037.md` instead of stale `tip1016.md` in README

### DIFF
--- a/crates/ee-tests/README.md
+++ b/crates/ee-tests/README.md
@@ -8,8 +8,8 @@ Shared test utilities and integration tests for **revm**.
 # Run all tests
 cargo test -p revm-ee-tests
 
-# Run a specific test subset (e.g. TIP-1016 state gas tests)
-cargo test -p revm-ee-tests tip1016
+# Run a specific test subset (e.g. EIP-8037 / TIP-1016 state gas tests)
+cargo test -p revm-ee-tests eip8037
 ```
 
 ## Directory Structure
@@ -21,7 +21,7 @@ crates/ee-tests/
 │   └── revm_tests.rs       # Integration tests for mainnet revm
 ├── tests/
 │   └── revm_testdata/      # Golden JSON snapshots for revm tests
-├── tip1016.md              # TIP-1016 State Gas test plan
+├── eip8037.md              # EIP-8037 / TIP-1016 State Gas test plan
 └── Cargo.toml
 ```
 


### PR DESCRIPTION
ref https://linear.app/tempoxyz/issue/SIGP-253

The `ee-tests` README pointed at `tip1016.md` and a `cargo test` filter of `tip1016`, but the file on disk is `eip8037.md` and the tests are named `eip8037_*`. Updates both references so the documented filter actually selects
the EIP-8037 / TIP-1016 state gas tests.