### PR TITLE
refactor: remove unused spec ids

### DIFF
--- a/bins/revme/src/cmd/blockchaintest.rs
+++ b/bins/revme/src/cmd/blockchaintest.rs
@@ -1064,8 +1064,9 @@ fn fork_to_spec_id(fork: ForkSpec) -> SpecId {
         ForkSpec::Byzantium
         | ForkSpec::EIP158ToByzantiumAt5
         | ForkSpec::ByzantiumToConstantinopleFixAt5 => SpecId::BYZANTIUM,
-        ForkSpec::Constantinople | ForkSpec::ByzantiumToConstantinopleAt5 => SpecId::PETERSBURG,
-        ForkSpec::ConstantinopleFix => SpecId::PETERSBURG,
+        ForkSpec::Constantinople
+        | ForkSpec::ByzantiumToConstantinopleAt5
+        | ForkSpec::ConstantinopleFix => SpecId::PETERSBURG,
         ForkSpec::Istanbul => SpecId::ISTANBUL,
         ForkSpec::Berlin => SpecId::BERLIN,
         ForkSpec::London | ForkSpec::BerlinToLondonAt5 => SpecId::LONDON,

--- a/bins/revme/src/cmd/blockchaintest/post_block.rs
+++ b/bins/revme/src/cmd/blockchaintest/post_block.rs
@@ -69,7 +69,7 @@ pub const fn block_reward(spec: SpecId, ommers: usize) -> u128 {
         return 0;
     }
 
-    let reward = if spec.is_enabled_in(SpecId::CONSTANTINOPLE) {
+    let reward = if spec.is_enabled_in(SpecId::PETERSBURG) {
         ONE_ETHER * 2
     } else if spec.is_enabled_in(SpecId::BYZANTIUM) {
         ONE_ETHER * 3

--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -145,7 +145,7 @@ impl GasParams {
                 TABLE.get_or_init(|| Self::new_spec_inner(spec))
             }
             // EXP cost was increased in spurious dragon fork.
-            SPURIOUS_DRAGON | BYZANTIUM | CONSTANTINOPLE | PETERSBURG => {
+            SPURIOUS_DRAGON | BYZANTIUM | PETERSBURG => {
                 static TABLE: OnceLock<GasParams> = OnceLock::new();
                 TABLE.get_or_init(|| Self::new_spec_inner(spec))
             }

--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -130,12 +130,12 @@ impl GasParams {
     pub fn new_spec(spec: SpecId) -> Self {
         use SpecId::*;
         let gas_params = match spec {
-            FRONTIER | FRONTIER_THAWING => {
+            FRONTIER => {
                 static TABLE: OnceLock<GasParams> = OnceLock::new();
                 TABLE.get_or_init(|| Self::new_spec_inner(spec))
             }
             // Transaction creation cost was added in homestead fork.
-            HOMESTEAD | DAO_FORK => {
+            HOMESTEAD => {
                 static TABLE: OnceLock<GasParams> = OnceLock::new();
                 TABLE.get_or_init(|| Self::new_spec_inner(spec))
             }
@@ -150,7 +150,7 @@ impl GasParams {
                 TABLE.get_or_init(|| Self::new_spec_inner(spec))
             }
             // SSTORE gas calculation changed in istanbul fork.
-            ISTANBUL | MUIR_GLACIER => {
+            ISTANBUL => {
                 static TABLE: OnceLock<GasParams> = OnceLock::new();
                 TABLE.get_or_init(|| Self::new_spec_inner(spec))
             }
@@ -160,7 +160,7 @@ impl GasParams {
                 TABLE.get_or_init(|| Self::new_spec_inner(spec))
             }
             // Refund reduction in london fork.
-            LONDON | ARROW_GLACIER | GRAY_GLACIER | MERGE => {
+            LONDON | MERGE => {
                 static TABLE: OnceLock<GasParams> = OnceLock::new();
                 TABLE.get_or_init(|| Self::new_spec_inner(spec))
             }

--- a/crates/interpreter/src/instructions/bitwise.rs
+++ b/crates/interpreter/src/instructions/bitwise.rs
@@ -118,7 +118,7 @@ pub fn byte<IT: ITy, H: ?Sized>(context: Ictx<'_, H, IT>) -> Result {
 
 /// EIP-145: Bitwise shifting instructions in EVM
 pub fn shl<IT: ITy, H: ?Sized>(context: Ictx<'_, H, IT>) -> Result {
-    check!(context.interpreter, CONSTANTINOPLE);
+    check!(context.interpreter, PETERSBURG);
     popn_top!([op1], op2, context.interpreter);
     let shift = as_usize_saturated!(op1);
     *op2 = if shift < 256 {
@@ -131,7 +131,7 @@ pub fn shl<IT: ITy, H: ?Sized>(context: Ictx<'_, H, IT>) -> Result {
 
 /// EIP-145: Bitwise shifting instructions in EVM
 pub fn shr<IT: ITy, H: ?Sized>(context: Ictx<'_, H, IT>) -> Result {
-    check!(context.interpreter, CONSTANTINOPLE);
+    check!(context.interpreter, PETERSBURG);
     popn_top!([op1], op2, context.interpreter);
     let shift = as_usize_saturated!(op1);
     *op2 = if shift < 256 {
@@ -144,7 +144,7 @@ pub fn shr<IT: ITy, H: ?Sized>(context: Ictx<'_, H, IT>) -> Result {
 
 /// EIP-145: Bitwise shifting instructions in EVM
 pub fn sar<IT: ITy, H: ?Sized>(context: Ictx<'_, H, IT>) -> Result {
-    check!(context.interpreter, CONSTANTINOPLE);
+    check!(context.interpreter, PETERSBURG);
     popn_top!([op1], op2, context.interpreter);
     let shift = as_usize_saturated!(op1);
     *op2 = if shift < 256 {

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -67,7 +67,7 @@ pub fn extcodesize<IT: ITy, H: Host + ?Sized>(context: Ictx<'_, H, IT>) -> Resul
 
 /// EIP-1052: EXTCODEHASH opcode
 pub fn extcodehash<IT: ITy, H: Host + ?Sized>(context: Ictx<'_, H, IT>) -> Result {
-    check!(context.interpreter, CONSTANTINOPLE);
+    check!(context.interpreter, PETERSBURG);
     popn_top!([], top, context.interpreter);
     let address = top.into_address();
     let account = load_account(&mut context.interpreter.gas, context.host, address, false)?;

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -451,12 +451,10 @@ impl PrecompileSpecId {
     pub const fn from_spec_id(spec_id: SpecId) -> Self {
         use SpecId::*;
         match spec_id {
-            FRONTIER | FRONTIER_THAWING | HOMESTEAD | DAO_FORK | TANGERINE | SPURIOUS_DRAGON => {
-                Self::HOMESTEAD
-            }
+            FRONTIER | HOMESTEAD | TANGERINE | SPURIOUS_DRAGON => Self::HOMESTEAD,
             BYZANTIUM | CONSTANTINOPLE | PETERSBURG => Self::BYZANTIUM,
-            ISTANBUL | MUIR_GLACIER => Self::ISTANBUL,
-            BERLIN | LONDON | ARROW_GLACIER | GRAY_GLACIER | MERGE | SHANGHAI => Self::BERLIN,
+            ISTANBUL => Self::ISTANBUL,
+            BERLIN | LONDON | MERGE | SHANGHAI => Self::BERLIN,
             CANCUN => Self::CANCUN,
             PRAGUE => Self::PRAGUE,
             OSAKA | AMSTERDAM => Self::OSAKA,

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -452,7 +452,7 @@ impl PrecompileSpecId {
         use SpecId::*;
         match spec_id {
             FRONTIER | HOMESTEAD | TANGERINE | SPURIOUS_DRAGON => Self::HOMESTEAD,
-            BYZANTIUM | CONSTANTINOPLE | PETERSBURG => Self::BYZANTIUM,
+            BYZANTIUM | PETERSBURG => Self::BYZANTIUM,
             ISTANBUL => Self::ISTANBUL,
             BERLIN | LONDON | MERGE | SHANGHAI => Self::BERLIN,
             CANCUN => Self::CANCUN,

--- a/crates/primitives/src/hardfork.rs
+++ b/crates/primitives/src/hardfork.rs
@@ -16,15 +16,9 @@ pub enum SpecId {
     /// Frontier hard fork
     /// Activated at block 0
     FRONTIER = 0,
-    /// Frontier Thawing hard fork
-    /// Activated at block 200000
-    FRONTIER_THAWING,
     /// Homestead hard fork
     /// Activated at block 1150000
     HOMESTEAD,
-    /// DAO Fork hard fork
-    /// Activated at block 1920000
-    DAO_FORK,
     /// Tangerine Whistle hard fork
     /// Activated at block 2463000
     TANGERINE,
@@ -43,21 +37,12 @@ pub enum SpecId {
     /// Istanbul hard fork
     /// Activated at block 9069000
     ISTANBUL,
-    /// Muir Glacier hard fork
-    /// Activated at block 9200000
-    MUIR_GLACIER,
     /// Berlin hard fork
     /// Activated at block 12244000
     BERLIN,
     /// London hard fork
     /// Activated at block 12965000
     LONDON,
-    /// Arrow Glacier hard fork
-    /// Activated at block 13773000
-    ARROW_GLACIER,
-    /// Gray Glacier hard fork
-    /// Activated at block 15050000
-    GRAY_GLACIER,
     /// Paris/Merge hard fork
     /// Activated at block 15537394 (TTD: 58750000000000000000000)
     MERGE,
@@ -126,12 +111,8 @@ impl TryFrom<u8> for SpecId {
 pub mod name {
     /// String identifier for the Frontier hardfork
     pub const FRONTIER: &str = "Frontier";
-    /// String identifier for the Frontier Thawing hardfork
-    pub const FRONTIER_THAWING: &str = "Frontier Thawing";
     /// String identifier for the Homestead hardfork
     pub const HOMESTEAD: &str = "Homestead";
-    /// String identifier for the DAO Fork hardfork
-    pub const DAO_FORK: &str = "DAO Fork";
     /// String identifier for the Tangerine Whistle hardfork
     pub const TANGERINE: &str = "Tangerine";
     /// String identifier for the Spurious Dragon hardfork
@@ -144,16 +125,10 @@ pub mod name {
     pub const PETERSBURG: &str = "Petersburg";
     /// String identifier for the Istanbul hardfork
     pub const ISTANBUL: &str = "Istanbul";
-    /// String identifier for the Muir Glacier hardfork
-    pub const MUIR_GLACIER: &str = "MuirGlacier";
     /// String identifier for the Berlin hardfork
     pub const BERLIN: &str = "Berlin";
     /// String identifier for the London hardfork
     pub const LONDON: &str = "London";
-    /// String identifier for the Arrow Glacier hardfork
-    pub const ARROW_GLACIER: &str = "Arrow Glacier";
-    /// String identifier for the Gray Glacier hardfork
-    pub const GRAY_GLACIER: &str = "Gray Glacier";
     /// String identifier for the Paris/Merge hardfork
     pub const MERGE: &str = "Merge";
     /// String identifier for the Shanghai hardfork
@@ -180,20 +155,15 @@ impl FromStr for SpecId {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             name::FRONTIER => Ok(Self::FRONTIER),
-            name::FRONTIER_THAWING => Ok(Self::FRONTIER_THAWING),
             name::HOMESTEAD => Ok(Self::HOMESTEAD),
-            name::DAO_FORK => Ok(Self::DAO_FORK),
             name::TANGERINE => Ok(Self::TANGERINE),
             name::SPURIOUS_DRAGON => Ok(Self::SPURIOUS_DRAGON),
             name::BYZANTIUM => Ok(Self::BYZANTIUM),
             name::CONSTANTINOPLE => Ok(Self::CONSTANTINOPLE),
             name::PETERSBURG => Ok(Self::PETERSBURG),
             name::ISTANBUL => Ok(Self::ISTANBUL),
-            name::MUIR_GLACIER => Ok(Self::MUIR_GLACIER),
             name::BERLIN => Ok(Self::BERLIN),
             name::LONDON => Ok(Self::LONDON),
-            name::ARROW_GLACIER => Ok(Self::ARROW_GLACIER),
-            name::GRAY_GLACIER => Ok(Self::GRAY_GLACIER),
             name::MERGE => Ok(Self::MERGE),
             name::SHANGHAI => Ok(Self::SHANGHAI),
             name::CANCUN => Ok(Self::CANCUN),
@@ -209,20 +179,15 @@ impl From<SpecId> for &'static str {
     fn from(spec_id: SpecId) -> Self {
         match spec_id {
             SpecId::FRONTIER => name::FRONTIER,
-            SpecId::FRONTIER_THAWING => name::FRONTIER_THAWING,
             SpecId::HOMESTEAD => name::HOMESTEAD,
-            SpecId::DAO_FORK => name::DAO_FORK,
             SpecId::TANGERINE => name::TANGERINE,
             SpecId::SPURIOUS_DRAGON => name::SPURIOUS_DRAGON,
             SpecId::BYZANTIUM => name::BYZANTIUM,
             SpecId::CONSTANTINOPLE => name::CONSTANTINOPLE,
             SpecId::PETERSBURG => name::PETERSBURG,
             SpecId::ISTANBUL => name::ISTANBUL,
-            SpecId::MUIR_GLACIER => name::MUIR_GLACIER,
             SpecId::BERLIN => name::BERLIN,
             SpecId::LONDON => name::LONDON,
-            SpecId::ARROW_GLACIER => name::ARROW_GLACIER,
-            SpecId::GRAY_GLACIER => name::GRAY_GLACIER,
             SpecId::MERGE => name::MERGE,
             SpecId::SHANGHAI => name::SHANGHAI,
             SpecId::CANCUN => name::CANCUN,

--- a/crates/primitives/src/hardfork.rs
+++ b/crates/primitives/src/hardfork.rs
@@ -33,10 +33,6 @@ pub enum SpecId {
     ///
     /// Activated at block 4370000
     BYZANTIUM,
-    /// Constantinople
-    ///
-    /// Activated at block 7280000
-    CONSTANTINOPLE,
     /// Petersburg
     ///
     /// Activated at block 7280000
@@ -135,8 +131,6 @@ pub mod name {
     pub const SPURIOUS_DRAGON: &str = "Spurious";
     /// String identifier for the Byzantium hardfork
     pub const BYZANTIUM: &str = "Byzantium";
-    /// String identifier for the Constantinople hardfork
-    pub const CONSTANTINOPLE: &str = "Constantinople";
     /// String identifier for the Petersburg hardfork
     pub const PETERSBURG: &str = "Petersburg";
     /// String identifier for the Istanbul hardfork
@@ -175,7 +169,6 @@ impl FromStr for SpecId {
             name::TANGERINE => Ok(Self::TANGERINE),
             name::SPURIOUS_DRAGON => Ok(Self::SPURIOUS_DRAGON),
             name::BYZANTIUM => Ok(Self::BYZANTIUM),
-            name::CONSTANTINOPLE => Ok(Self::CONSTANTINOPLE),
             name::PETERSBURG => Ok(Self::PETERSBURG),
             name::ISTANBUL => Ok(Self::ISTANBUL),
             name::BERLIN => Ok(Self::BERLIN),
@@ -199,7 +192,6 @@ impl From<SpecId> for &'static str {
             SpecId::TANGERINE => name::TANGERINE,
             SpecId::SPURIOUS_DRAGON => name::SPURIOUS_DRAGON,
             SpecId::BYZANTIUM => name::BYZANTIUM,
-            SpecId::CONSTANTINOPLE => name::CONSTANTINOPLE,
             SpecId::PETERSBURG => name::PETERSBURG,
             SpecId::ISTANBUL => name::ISTANBUL,
             SpecId::BERLIN => name::BERLIN,

--- a/crates/primitives/src/hardfork.rs
+++ b/crates/primitives/src/hardfork.rs
@@ -6,60 +6,76 @@ use core::str::FromStr;
 pub use std::string::{String, ToString};
 pub use SpecId::*;
 
-/// Specification IDs and their activation block.
+/// Specification IDs and their activation points.
 ///
 /// Information was obtained from the [Ethereum Execution Specifications](https://github.com/ethereum/execution-specs).
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SpecId {
-    /// Frontier hard fork
-    /// Activated at block 0
+    /// Frontier
+    ///
+    /// Activated at block 1
     FRONTIER = 0,
-    /// Homestead hard fork
+    /// Homestead
+    ///
     /// Activated at block 1150000
     HOMESTEAD,
-    /// Tangerine Whistle hard fork
+    /// Tangerine Whistle
+    ///
     /// Activated at block 2463000
     TANGERINE,
-    /// Spurious Dragon hard fork
+    /// Spurious Dragon
+    ///
     /// Activated at block 2675000
     SPURIOUS_DRAGON,
-    /// Byzantium hard fork
+    /// Byzantium
+    ///
     /// Activated at block 4370000
     BYZANTIUM,
-    /// Constantinople hard fork
-    /// Activated at block 7280000 is overwritten with PETERSBURG
+    /// Constantinople
+    ///
+    /// Activated at block 7280000
     CONSTANTINOPLE,
-    /// Petersburg hard fork
+    /// Petersburg
+    ///
     /// Activated at block 7280000
     PETERSBURG,
-    /// Istanbul hard fork
+    /// Istanbul
+    ///
     /// Activated at block 9069000
     ISTANBUL,
-    /// Berlin hard fork
+    /// Berlin
+    ///
     /// Activated at block 12244000
     BERLIN,
-    /// London hard fork
+    /// London
+    ///
     /// Activated at block 12965000
     LONDON,
-    /// Paris/Merge hard fork
-    /// Activated at block 15537394 (TTD: 58750000000000000000000)
+    /// Paris/Merge
+    ///
+    /// Activated at block 15537394
     MERGE,
-    /// Shanghai hard fork
-    /// Activated at block 17034870 (Timestamp: 1681338455)
+    /// Shanghai
+    ///
+    /// Activated at block 17034870 (timestamp 1681338455)
     SHANGHAI,
-    /// Cancun hard fork
-    /// Activated at block 19426587 (Timestamp: 1710338135)
+    /// Cancun
+    ///
+    /// Activated at block 19426587 (timestamp 1710338135)
     CANCUN,
-    /// Prague hard fork
-    /// Activated at block 22431084 (Timestamp: 1746612311)
+    /// Prague
+    ///
+    /// Activated at block 22431084
     PRAGUE,
-    /// Osaka hard fork
-    /// Activated at slot 13164544 (Timestamp: 1764798551)
+    /// Osaka
+    ///
+    /// Activated at block 23935694
     #[default]
     OSAKA,
-    /// Amsterdam hard fork
+    /// Amsterdam
+    ///
     /// Activated at block TBD
     AMSTERDAM,
 }


### PR DESCRIPTION
This removes `SpecId` variants that do not have distinct implementation in this repository and were only kept as metadata names or aliases in grouped match arms.
