### PR TITLE
Revert "refactor: use `Cow` for warm precompile addresses"

### DIFF
--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -36,7 +36,7 @@ pub fn load_accounts<
         // When precompiles addresses are changed we reset the warmed hashmap to those new addresses.
         context
             .journal_mut()
-            .warm_precompiles(&precompiles.warm_addresses());
+            .warm_precompiles(precompiles.warm_addresses());
     }
 
     // Load coinbase

--- a/crates/handler/src/precompile_provider.rs
+++ b/crates/handler/src/precompile_provider.rs
@@ -4,10 +4,7 @@ use context_interface::{ContextTr, JournalTr};
 use interpreter::{CallInputs, Gas, InstructionResult, InterpreterResult};
 use precompile::{PrecompileOutput, PrecompileSpecId, PrecompileStatus, Precompiles};
 use primitives::{hardfork::SpecId, Address, AddressSet, Bytes};
-use std::{
-    borrow::Cow,
-    string::{String, ToString},
-};
+use std::string::{String, ToString};
 
 /// Provider for precompiled contracts in the EVM.
 #[auto_impl(&mut, Box)]
@@ -28,7 +25,7 @@ pub trait PrecompileProvider<CTX: ContextTr> {
     ) -> Result<Option<Self::Output>, String>;
 
     /// Get the warm addresses.
-    fn warm_addresses(&self) -> Cow<'_, AddressSet>;
+    fn warm_addresses(&self) -> &AddressSet;
 
     /// Check if the address is a precompile.
     fn contains(&self, address: &Address) -> bool {
@@ -176,8 +173,8 @@ impl<CTX: ContextTr> PrecompileProvider<CTX> for EthPrecompiles {
         Ok(Some(result))
     }
 
-    fn warm_addresses(&self) -> Cow<'_, AddressSet> {
-        Cow::Borrowed(self.warm_addresses())
+    fn warm_addresses(&self) -> &AddressSet {
+        Self::warm_addresses(self)
     }
 
     fn contains(&self, address: &Address) -> bool {
@@ -257,8 +254,8 @@ mod tests {
             <EthPrecompiles as PrecompileProvider<CTX>>::run(&mut self.inner, context, inputs)
         }
 
-        fn warm_addresses(&self) -> Cow<'_, AddressSet> {
-            Cow::Borrowed(&self.warm)
+        fn warm_addresses(&self) -> &AddressSet {
+            &self.warm
         }
     }
 

--- a/examples/custom_precompile_journal/src/precompile_provider.rs
+++ b/examples/custom_precompile_journal/src/precompile_provider.rs
@@ -8,7 +8,7 @@ use revm::{
     precompile::{EthPrecompileOutput, EthPrecompileResult, PrecompileHalt, PrecompileOutput},
     primitives::{address, hardfork::SpecId, Address, AddressSet, Bytes, Log, B256, U256},
 };
-use std::{borrow::Cow, string::String};
+use std::string::String;
 
 // Define our custom precompile address
 pub const CUSTOM_PRECOMPILE_ADDRESS: Address = address!("0000000000000000000000000000000000000100");
@@ -72,8 +72,8 @@ where
         self.inner.run(context, inputs)
     }
 
-    fn warm_addresses(&self) -> Cow<'_, AddressSet> {
-        Cow::Borrowed(&self.addresses)
+    fn warm_addresses(&self) -> &AddressSet {
+        &self.addresses
     }
 }
 


### PR DESCRIPTION
Reverts bluealloy/revm#3652

actually i was wrong and we do have `AddressSet` stored in the alloy-evm's DynPrecompiles