### PR TITLE
fix(inspector): notify on EIP-6780 no-op SELFDESTRUCT(self)

### DIFF
--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -6,11 +6,11 @@ use context::{
 use handler::{evm::FrameTr, EvmTr, FrameResult, Handler, ItemOrResult};
 use interpreter::{
     instructions::{GasTable, InstructionTable},
-    interpreter_types::{Jumps, LoopControl},
+    interpreter_types::{InputsTr, Jumps, LoopControl},
     FrameInput, Host, InitialAndFloorGas, InstructionResult, Interpreter, InterpreterAction,
     InterpreterTypes,
 };
-use primitives::hints_util::cold_path;
+use primitives::{hints_util::cold_path, Address, U256};
 use state::bytecode::opcode;
 
 /// Trait that extends [`Handler`] with inspection functionality.
@@ -271,7 +271,7 @@ where
     // Handle selfdestruct.
     if let InterpreterAction::Return(result) = &next_action {
         if result.result == InstructionResult::SelfDestruct {
-            inspect_selfdestruct(context, &mut inspector);
+            inspect_selfdestruct(context, &mut inspector, interpreter.input.target_address());
         }
     }
 
@@ -304,8 +304,11 @@ fn inspect_log<CTX, IT>(
 
 #[inline(never)]
 #[cold]
-fn inspect_selfdestruct<CTX, IT>(context: &mut CTX, inspector: &mut impl Inspector<CTX, IT>)
-where
+fn inspect_selfdestruct<CTX, IT>(
+    context: &mut CTX,
+    inspector: &mut impl Inspector<CTX, IT>,
+    contract_address: Address,
+) where
     CTX: ContextTr<Journal: JournalExt> + Host,
     IT: InterpreterTypes,
 {
@@ -325,5 +328,18 @@ where
     ) = context.journal_mut().journal().last()
     {
         inspector.selfdestruct(*contract, *to, *balance);
+    } else {
+        // EIP-6780 no-op SELFDESTRUCT: post-Cancun, the contract was not created in the
+        // current transaction, and `target == contract`. State is unchanged so the journal
+        // does not record an `AccountDestroyed` or `BalanceTransfer` entry, but the
+        // SELFDESTRUCT opcode still ran. Inspectors must still be notified for trace
+        // fidelity (e.g. Geth `callTracer` / Parity flat-trace correctness). By
+        // construction in this branch, `target` equals the contract's own address and no
+        // balance was transferred.
+        //
+        // See `JournalInner::selfdestruct` in `crates/context/src/journal/inner.rs`:
+        // the trailing `else` branch returns `None` (no journal entry) precisely for
+        // this case.
+        inspector.selfdestruct(contract_address, contract_address, U256::ZERO);
     }
 }

--- a/crates/inspector/src/inspector_tests.rs
+++ b/crates/inspector/src/inspector_tests.rs
@@ -449,6 +449,82 @@ mod tests {
     }
 
     #[test]
+    fn test_selfdestruct_self_target_eip6780_noop() {
+        // EIP-6780 no-op SELFDESTRUCT regression test:
+        //
+        // Pre-Cancun, SELFDESTRUCT(self) burned the contract's balance and destroyed the
+        // account at end of tx. Post-Cancun (EIP-6780), if the contract was NOT created in
+        // the current transaction and `target == self`, the operation is a complete no-op
+        // for state — neither balance transfer nor destruction. `JournalInner::selfdestruct`
+        // returns no journal entry for this branch (see crates/context/src/journal/inner.rs,
+        // trailing `else` arm). Before this fix, `inspect_selfdestruct` only matched
+        // `JournalEntry::AccountDestroyed | BalanceTransfer`, so the inspector hook was
+        // silently skipped — yet the SELFDESTRUCT opcode still returned
+        // `InstructionResult::SelfDestruct`, leaving downstream tracers (e.g. Geth
+        // `callTracer` in `revm-inspectors`) to emit synthetic frames with `from=0x0…0`,
+        // missing `to`, missing `value` — see https://github.com/bluealloy/revm/issues/<TBD>.
+        //
+        // Bytecode: PUSH20 BENCH_TARGET; SELFDESTRUCT
+        // BenchmarkDB pre-deploys the bytecode at BENCH_TARGET, so the contract is *not*
+        // same-tx-created when we call into it.
+        let mut code = vec![opcode::PUSH20];
+        code.extend_from_slice(BENCH_TARGET.as_ref());
+        code.push(opcode::SELFDESTRUCT);
+
+        let bytecode = Bytecode::new_raw(Bytes::from(code));
+        let ctx = Context::mainnet().with_db(BenchmarkDB::new_bytecode(bytecode));
+        let mut evm = ctx.build_mainnet_with_inspector(TestInspector::new());
+
+        let _ = evm.inspect_one_tx(
+            TxEnv::builder()
+                .caller(BENCH_CALLER)
+                .kind(TxKind::Call(BENCH_TARGET))
+                .gas_limit(100_000)
+                .build()
+                .unwrap(),
+        );
+
+        let inspector = &evm.inspector;
+        let events = inspector.get_events();
+
+        let selfdestruct_events: Vec<_> = events
+            .iter()
+            .filter_map(|e| {
+                if let InspectorEvent::Selfdestruct {
+                    address,
+                    beneficiary,
+                    value,
+                } = e
+                {
+                    Some((address, beneficiary, value))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        assert_eq!(
+            selfdestruct_events.len(),
+            1,
+            "Inspector must receive a SELFDESTRUCT event even for the EIP-6780 no-op case",
+        );
+        let (address, beneficiary, value) = selfdestruct_events[0];
+        assert_eq!(
+            *address, BENCH_TARGET,
+            "Selfdestructing contract should be reported as BENCH_TARGET, not the zero address",
+        );
+        assert_eq!(
+            *beneficiary, BENCH_TARGET,
+            "Refund target equals the contract itself in the no-op branch",
+        );
+        assert_eq!(
+            *value,
+            U256::ZERO,
+            "No balance was transferred; reported value should be zero",
+        );
+    }
+
+    #[test]
     fn test_comprehensive_inspector_integration() {
         // Complex contract with multiple operations:
         // 1. PUSH and arithmetic


### PR DESCRIPTION
Post-Cancun, when a contract is not created in the current transaction and
SELFDESTRUCT is called with `target == self`, the operation is a complete
state no-op: no balance transfer, no destruction. `JournalInner::selfdestruct`
correctly records nothing in this branch (see crates/context/src/journal/inner.rs,
trailing `else` arm).

However, the SELFDESTRUCT opcode still returns
`InstructionResult::SelfDestruct`, and `inspect_selfdestruct` only matched
`JournalEntry::AccountDestroyed | BalanceTransfer`. With neither variant
present, the inspector hook was silently skipped — leaving downstream tracers
(notably the Geth `callTracer` and Parity flat-trace builders in
`revm-inspectors`) to emit synthetic frames with `from = 0x000…0`,
omitted `to`, and omitted `value`. Consumers that strict-cast addresses
(e.g. Blockscout) would then reject these frames and crash their indexers.

Fix: pass the executing contract's address through to `inspect_selfdestruct`
and, when no journal entry matches, fire the hook with
`(contract, contract, 0)` — accurately reflecting that the opcode ran with
target == self and zero balance was transferred.

Adds a regression test `test_selfdestruct_self_target_eip6780_noop` that
exercises this path against a `BenchmarkDB`-pre-deployed contract calling
SELFDESTRUCT(self), and asserts the inspector receives one event with the
correct `(address, beneficiary, value)`