### PR TITLE
refactor: restructure `Journal` traits

### DIFF
--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -4,10 +4,7 @@ pub mod account;
 pub mod entry;
 
 use crate::{
-    context::{SStoreResult, SelfDestructResult},
-    host::LoadError,
-    journaled_state::account::JournaledAccountTr,
-    ErasedError,
+    ErasedError, context::{SStoreResult, SelfDestructResult}, host::LoadError, journaled_state::{account::JournaledAccountTr}
 };
 use core::ops::{Deref, DerefMut};
 use database_interface::Database;
@@ -34,10 +31,30 @@ pub trait JournalTr {
     fn new(database: Self::Database) -> Self;
 
     /// Returns a mutable reference to the database.
-    fn db_mut(&mut self) -> &mut Self::Database;
+    fn db_mut(&mut self) -> &mut Self::Database {
+        self.db_and_state_mut().0
+    }
 
     /// Returns an immutable reference to the database.
-    fn db(&self) -> &Self::Database;
+    fn db(&self) -> &Self::Database {
+        self.db_and_state().0
+    }
+
+    /// Return the mutable current Journaled state.
+    fn evm_state_mut(&mut self) -> &mut Self::State {
+        self.db_and_state_mut().1
+    }
+
+    /// Return the current Journaled state.
+    fn evm_state(&self) -> &Self::State {
+        self.db_and_state().1
+    }
+
+    /// Returns immutable reference to the database and state.
+    fn db_and_state(&self) -> (&Self::Database, &Self::State);
+
+    /// Returns mutable reference to the database and state.
+    fn db_and_state_mut(&mut self) -> (&mut Self::Database, &mut Self::State);
 
     /// Returns the storage value from Journal state.
     ///

--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -4,7 +4,10 @@ pub mod account;
 pub mod entry;
 
 use crate::{
-    ErasedError, context::{SStoreResult, SelfDestructResult}, host::LoadError, journaled_state::{account::JournaledAccountTr}
+    context::{SStoreResult, SelfDestructResult},
+    host::LoadError,
+    journaled_state::account::JournaledAccountTr,
+    ErasedError,
 };
 use core::ops::{Deref, DerefMut};
 use database_interface::Database;

--- a/crates/context/src/journal.rs
+++ b/crates/context/src/journal.rs
@@ -106,14 +106,13 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
         }
     }
 
-    #[inline]
-    fn db(&self) -> &Self::Database {
-        &self.database
+    fn db_and_state(&self) -> (&Self::Database, &Self::State) {
+        (&self.database, &self.inner.state)
     }
 
     #[inline]
-    fn db_mut(&mut self) -> &mut Self::Database {
-        &mut self.database
+    fn db_and_state_mut(&mut self) -> (&mut Self::Database, &mut Self::State) {
+        (&mut self.database, &mut self.inner.state)
     }
 
     fn sload(

--- a/crates/inspector/src/inspector.rs
+++ b/crates/inspector/src/inspector.rs
@@ -1,5 +1,5 @@
 use auto_impl::auto_impl;
-use context::{Database, Journal, JournalEntry};
+use context::{Database, Journal, JournalEntry, JournalTr};
 use handler::FrameResult;
 use interpreter::{
     interpreter::EthInterpreter, CallInputs, CallOutcome, CreateInputs, CreateOutcome, FrameInput,
@@ -223,31 +223,15 @@ where
 
 /// Extends the journal with additional methods that are used by the inspector.
 #[auto_impl(&mut, Box)]
-pub trait JournalExt {
+pub trait JournalExt: JournalTr<State = EvmState> {
     /// Get the journal entries that are created from last checkpoint.
     /// new checkpoint is created when sub call is made.
     fn journal(&self) -> &[JournalEntry];
-
-    /// Return the current Journaled state.
-    fn evm_state(&self) -> &EvmState;
-
-    /// Return the mutable current Journaled state.
-    fn evm_state_mut(&mut self) -> &mut EvmState;
 }
 
 impl<DB: Database> JournalExt for Journal<DB> {
     #[inline]
     fn journal(&self) -> &[JournalEntry] {
         &self.journal
-    }
-
-    #[inline]
-    fn evm_state(&self) -> &EvmState {
-        &self.state
-    }
-
-    #[inline]
-    fn evm_state_mut(&mut self) -> &mut EvmState {
-        &mut self.state
     }
 }

--- a/examples/cheatcode_inspector/src/main.rs
+++ b/examples/cheatcode_inspector/src/main.rs
@@ -66,12 +66,12 @@ impl JournalTr for Backend {
         Self::new(SpecId::default(), database)
     }
 
-    fn db(&self) -> &Self::Database {
-        self.journaled_state.db()
+    fn db_and_state(&self) -> (&Self::Database, &Self::State) {
+        self.journaled_state.db_and_state()
     }
 
-    fn db_mut(&mut self) -> &mut Self::Database {
-        self.journaled_state.db_mut()
+    fn db_and_state_mut(&mut self) -> (&mut Self::Database, &mut Self::State) {
+        self.journaled_state.db_and_state_mut()
     }
 
     fn sload(
@@ -328,14 +328,6 @@ impl JournalTr for Backend {
 impl JournalExt for Backend {
     fn journal(&self) -> &[JournalEntry] {
         self.journaled_state.journal()
-    }
-
-    fn evm_state(&self) -> &EvmState {
-        self.journaled_state.evm_state()
-    }
-
-    fn evm_state_mut(&mut self) -> &mut EvmState {
-        self.journaled_state.evm_state_mut()
     }
 }
 


### PR DESCRIPTION
Slightly changes `Journal` and `JournalExt` traits so that it's possible to get access to both database and state &mut references