### PR TITLE
perf(interpreter): cache init_code_hash in CreateInputs for inspector reuse

### DIFF
--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -15,14 +15,14 @@ use interpreter::{
     interpreter::{EthInterpreter, ExtBytecode},
     interpreter_action::FrameInit,
     interpreter_types::ReturnData,
-    CallInput, CallInputs, CallOutcome, CallValue, CreateInputs, CreateOutcome, CreateScheme,
-    FrameInput, Gas, InputsImpl, InstructionResult, Interpreter, InterpreterAction,
-    InterpreterResult, InterpreterTypes, SharedMemory,
+    CallInput, CallInputs, CallOutcome, CallValue, CreateInputs, CreateOutcome, FrameInput, Gas,
+    InputsImpl, InstructionResult, Interpreter, InterpreterAction, InterpreterResult,
+    InterpreterTypes, SharedMemory,
 };
 use primitives::{
     constants::CALL_STACK_LIMIT,
     hardfork::SpecId::{self, HOMESTEAD, LONDON, SPURIOUS_DRAGON},
-    keccak256, Address, Bytes, U256,
+    Address, Bytes, U256,
 };
 use state::Bytecode;
 use std::{borrow::ToOwned, boxed::Box, vec::Vec};
@@ -297,16 +297,9 @@ impl EthFrame<EthInterpreter> {
             return return_error(InstructionResult::Return);
         };
 
-        // Create address
-        let mut init_code_hash = None;
-        let created_address = match inputs.scheme() {
-            CreateScheme::Create => inputs.caller().create(old_nonce),
-            CreateScheme::Create2 { salt } => {
-                let init_code_hash = *init_code_hash.insert(keccak256(inputs.init_code()));
-                inputs.caller().create2(salt.to_be_bytes(), init_code_hash)
-            }
-            CreateScheme::Custom { address } => address,
-        };
+        // Create address — uses OnceCell cache so that if an inspector already called
+        // `created_address`, the expensive keccak256 is not recomputed.
+        let created_address = inputs.created_address(old_nonce);
 
         drop(caller_info); // Drop caller info to avoid borrow checker issues.
 
@@ -324,10 +317,7 @@ impl EthFrame<EthInterpreter> {
             Err(e) => return return_error(e.into()),
         };
 
-        let bytecode = ExtBytecode::new_with_optional_hash(
-            Bytecode::new_legacy(inputs.init_code().clone()),
-            init_code_hash,
-        );
+        let bytecode = ExtBytecode::new(Bytecode::new_legacy(inputs.init_code().clone()));
 
         let interpreter_input = InputsImpl {
             target_address: created_address,

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -15,9 +15,9 @@ use interpreter::{
     interpreter::{EthInterpreter, ExtBytecode},
     interpreter_action::FrameInit,
     interpreter_types::ReturnData,
-    CallInput, CallInputs, CallOutcome, CallValue, CreateInputs, CreateOutcome, FrameInput, Gas,
-    InputsImpl, InstructionResult, Interpreter, InterpreterAction, InterpreterResult,
-    InterpreterTypes, SharedMemory,
+    CallInput, CallInputs, CallOutcome, CallValue, CreateInputs, CreateOutcome, CreateScheme,
+    FrameInput, Gas, InputsImpl, InstructionResult, Interpreter, InterpreterAction,
+    InterpreterResult, InterpreterTypes, SharedMemory,
 };
 use primitives::{
     constants::CALL_STACK_LIMIT,
@@ -300,6 +300,8 @@ impl EthFrame<EthInterpreter> {
         // Create address — uses OnceCell cache so that if an inspector already called
         // `created_address`, the expensive keccak256 is not recomputed.
         let created_address = inputs.created_address(old_nonce);
+        let init_code_hash = matches!(inputs.scheme(), CreateScheme::Create2 { .. })
+            .then(|| inputs.init_code_hash());
 
         drop(caller_info); // Drop caller info to avoid borrow checker issues.
 
@@ -317,7 +319,10 @@ impl EthFrame<EthInterpreter> {
             Err(e) => return return_error(e.into()),
         };
 
-        let bytecode = ExtBytecode::new(Bytecode::new_legacy(inputs.init_code().clone()));
+        let bytecode = ExtBytecode::new_with_optional_hash(
+            Bytecode::new_legacy(inputs.init_code().clone()),
+            init_code_hash,
+        );
 
         let interpreter_input = InputsImpl {
             target_address: created_address,

--- a/crates/interpreter/src/interpreter_action/create_inputs.rs
+++ b/crates/interpreter/src/interpreter_action/create_inputs.rs
@@ -1,6 +1,6 @@
 use context_interface::CreateScheme;
 use core::cell::OnceCell;
-use primitives::{Address, Bytes, U256};
+use primitives::{keccak256, Address, Bytes, B256, U256};
 
 /// Inputs for a create call
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -22,6 +22,11 @@ pub struct CreateInputs {
     /// redundant keccak computations when inspectors call `created_address`.
     #[cfg_attr(feature = "serde", serde(skip))]
     cached_address: OnceCell<Address>,
+    /// Cached init code hash. Shared between `created_address()` (for CREATE2)
+    /// and frame initialization (for `ExtBytecode`), ensuring keccak256 of the
+    /// init code is computed at most once.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    cached_init_code_hash: OnceCell<B256>,
 }
 
 impl CreateInputs {
@@ -42,6 +47,7 @@ impl CreateInputs {
             gas_limit,
             reservoir,
             cached_address: OnceCell::new(),
+            cached_init_code_hash: OnceCell::new(),
         }
     }
 
@@ -53,9 +59,19 @@ impl CreateInputs {
             CreateScheme::Create => self.caller.create(nonce),
             CreateScheme::Create2 { salt } => self
                 .caller
-                .create2_from_code(salt.to_be_bytes(), &self.init_code),
+                .create2(salt.to_be_bytes(), self.init_code_hash()),
             CreateScheme::Custom { address } => address,
         })
+    }
+
+    /// Returns the keccak256 hash of the init code.
+    ///
+    /// The result is cached so that `created_address()` and frame initialization
+    /// share a single hash computation.
+    pub fn init_code_hash(&self) -> B256 {
+        *self
+            .cached_init_code_hash
+            .get_or_init(|| keccak256(self.init_code.as_ref()))
     }
 
     /// Returns the caller address of the EVM.
@@ -104,6 +120,7 @@ impl CreateInputs {
     pub fn set_init_code(&mut self, init_code: Bytes) {
         self.init_code = init_code;
         self.cached_address = OnceCell::new();
+        self.cached_init_code_hash = OnceCell::new();
     }
 
     /// Set gas limit


### PR DESCRIPTION
## Summary

Adds a cached `init_code_hash()` method to `CreateInputs` and wires it into both `created_address()` and `make_create_frame`, so the keccak256 of init code is computed at most once.

## Why

Inspectors that call `CreateInputs::created_address()` (e.g. to check the target before frame init) trigger `keccak256(init_code)` via `create2_from_code`. When `make_create_frame` runs afterwards, it
computed the same hash independently since it bypassed the `OnceCell` cache. By routing both paths through a shared `init_code_hash` cache, inspectors that pre-derive the address no longer cause a
redundant hash over the full init code.

No change in behavior for standard revm without custom inspectors — this is purely a caching optimization for inspector use cases.