### PR TITLE
feat(state): add Bal::try_from_alloy

### DIFF
--- a/crates/state/src/bal.rs
+++ b/crates/state/src/bal.rs
@@ -284,8 +284,9 @@ impl core::error::Error for BalError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_eip7928::{AccountChanges as AlloyAccountChanges, CodeChange as AlloyCodeChange};
     use bytecode::Bytecode;
-    use primitives::{B256, U256};
+    use primitives::{Bytes, B256, U256};
     use std::collections::BTreeMap;
 
     fn code(byte: u8) -> (B256, Bytecode) {
@@ -398,5 +399,33 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![idx(3), idx(7)]
         );
+    }
+
+    #[test]
+    fn try_from_alloy_decodes_block_access_list() {
+        let address = Address::with_last_byte(1);
+        let code_bytes = Bytes::from_static(&[0x60, 0x00]);
+        let alloy_bal = vec![AlloyAccountChanges {
+            address,
+            code_changes: vec![AlloyCodeChange::new(idx(1), code_bytes.clone())],
+            ..Default::default()
+        }];
+
+        let bal = Bal::try_from_alloy(alloy_bal).unwrap();
+        let account = bal.accounts.get(&address).unwrap();
+        let (_, bytecode) = &account.account_info.code.writes[0].1;
+
+        assert_eq!(bytecode.original_bytes(), code_bytes);
+    }
+
+    #[test]
+    fn try_from_alloy_errors_on_invalid_code_change() {
+        let alloy_bal = vec![AlloyAccountChanges {
+            address: Address::with_last_byte(1),
+            code_changes: vec![AlloyCodeChange::new(idx(1), vec![0xef, 0x01, 0xde].into())],
+            ..Default::default()
+        }];
+
+        assert!(Bal::try_from_alloy(alloy_bal).is_err());
     }
 }

--- a/crates/state/src/bal/account.rs
+++ b/crates/state/src/bal/account.rs
@@ -70,7 +70,14 @@ impl AccountBal {
         self.storage.update(bal_index, &account.storage);
     }
 
-    /// Create account from alloy account changes.
+    /// Create an account BAL from EIP-7928 [`AlloyAccountChanges`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BytecodeDecodeError`] if any code change contains bytecode rejected by
+    /// [`Bytecode::new_raw_checked`]. This currently happens for malformed EIP-7702
+    /// bytecode, such as bytes with the EIP-7702 magic prefix but an invalid length or
+    /// unsupported version.
     #[inline]
     pub fn try_from_alloy(
         alloy_account: AlloyAccountChanges,

--- a/crates/state/src/bal/alloy.rs
+++ b/crates/state/src/bal/alloy.rs
@@ -12,10 +12,17 @@ use bytecode::{Bytecode, BytecodeDecodeError};
 use primitives::{AddressIndexMap, B256, U256};
 use std::vec::Vec;
 
-impl TryFrom<AlloyBal> for Bal {
-    type Error = BytecodeDecodeError;
-
-    fn try_from(alloy_bal: AlloyBal) -> Result<Self, Self::Error> {
+impl Bal {
+    /// Convert an EIP-7928 [`AlloyBal`] into a [`Bal`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BytecodeDecodeError`] if any account code change contains bytecode
+    /// rejected by [`Bytecode::new_raw_checked`]. This currently happens for malformed
+    /// EIP-7702 bytecode, such as bytes with the EIP-7702 magic prefix but an invalid
+    /// length or unsupported version.
+    #[inline]
+    pub fn try_from_alloy(alloy_bal: AlloyBal) -> Result<Self, BytecodeDecodeError> {
         let accounts = AddressIndexMap::from_iter(
             alloy_bal
                 .into_iter()
@@ -24,6 +31,15 @@ impl TryFrom<AlloyBal> for Bal {
         );
 
         Ok(Self { accounts })
+    }
+}
+
+impl TryFrom<AlloyBal> for Bal {
+    type Error = BytecodeDecodeError;
+
+    #[inline]
+    fn try_from(alloy_bal: AlloyBal) -> Result<Self, Self::Error> {
+        Self::try_from_alloy(alloy_bal)
     }
 }
 


### PR DESCRIPTION
Adds explicit `Bal::try_from_alloy` for converting EIP-7928 Alloy block access lists into `Bal`, leaving `TryFrom<AlloyBal>` as a thin delegating wrapper.

Documents the bytecode decode failure mode for block and account Alloy conversions, making it clear that conversion can fail when code changes contain bytecode rejected by `Bytecode::new_raw_checked`, currently malformed EIP-7702 bytecode.

Includes focused tests for successful block access list decoding and invalid code change propagation.