### PR TITLE
docs: expand `BalError` documentation

### DIFF
--- a/crates/state/src/bal.rs
+++ b/crates/state/src/bal.rs
@@ -237,24 +237,53 @@ impl Bal {
     }
 }
 
-/// BAL error.
+/// Error returned when a BAL (Block Access List, [EIP-7928]) lookup
+/// cannot find data the caller expected to be present.
+///
+/// A BAL is supposed to enumerate every account and storage slot a block
+/// will touch, so when execution queries the BAL for an entry that is
+/// missing, the BAL is either malformed or being consulted for state that
+/// it does not cover. Each variant identifies which kind of lookup failed
+/// and carries the key that was queried so callers can report it.
+///
+/// Produced by [`Bal`] read paths ([`Bal::populate_account_info`],
+/// [`Bal::populate_storage_slot`], [`Bal::populate_storage_slot_by_account_id`],
+/// [`Bal::account_storage`], [`StorageBal::get`], [`StorageBal::get_bal_writes`])
+/// and surfaced through `BalState` / `BalDatabase` in `revm-database-interface`,
+/// where it is wrapped into `EvmDatabaseError::Bal` before reaching the EVM.
+///
+/// [EIP-7928]: https://eips.ethereum.org/EIPS/eip-7928
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BalError {
-    /// Account not found in BAL by address.
+    /// The address was not present in the BAL's accounts map.
+    ///
+    /// Returned by address-keyed lookups (e.g. `BalState::get_account_id`,
+    /// `BalState::storage`, `Bal::populate_storage_slot`) when the BAL is
+    /// attached but does not list this account. Means the BAL is
+    /// incomplete for the access being attempted.
     AccountNotFound {
         /// Address that was not found.
         address: Address,
     },
-    /// Account id does not point at a valid entry in the BAL accounts map.
+    /// The supplied [`AccountId`] index is out of range for the BAL's
+    /// accounts map.
     ///
-    /// Signals that a stale or mismatched id was supplied — the id is expected to come
-    /// from a prior BAL lookup against the same BAL.
+    /// `AccountId`s are positional indices into the BAL — they are only
+    /// valid for the same BAL they were obtained from. This variant
+    /// indicates a stale or mismatched id was used (e.g. an id from a
+    /// different BAL, or one created before the current BAL was built).
     InvalidAccountId {
         /// Account id that was supplied.
         account_id: AccountId,
     },
-    /// Slot not found in BAL for a given account.
+    /// The account exists in the BAL but the requested storage slot is not
+    /// listed under it.
+    ///
+    /// Returned by storage lookups when the account is covered by the BAL
+    /// yet this particular slot was not declared. As with
+    /// [`BalError::AccountNotFound`], this indicates the BAL is incomplete
+    /// for the access being attempted.
     SlotNotFound {
         /// Address of the account whose slot was missing.
         address: Address,


### PR DESCRIPTION
## Summary
- Rewrites the `BalError` enum docs in `crates/state/src/bal.rs` to explain what a BAL miss actually means (an EIP-7928 BAL is supposed to enumerate every account/slot the block touches, so a missing entry signals the BAL is incomplete or being consulted out-of-scope).
- Documents per variant which lookups produce it: `AccountNotFound` from address-keyed reads, `InvalidAccountId` from a stale/mismatched positional id, `SlotNotFound` from storage reads against an account that is in the BAL but missing this slot.
- Lists the producing call sites (`Bal::populate_account_info`, `populate_storage_slot{,_by_account_id}`, `account_storage`, `StorageBal::get{,_bal_writes}`) and notes that `BalState` / `BalDatabase` wrap the error into `EvmDatabaseError::Bal` before it reaches the EVM.

Pure documentation change — no behavior or API changes.

## Test plan
- [x] `cargo check -p revm-state`
- [x] `cargo doc -p revm-state --no-deps` (intra-doc links resolve)