### PR TITLE
refactor(example): split local execution tracer modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,6 +1996,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2607,6 +2617,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2856,6 +2872,19 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "local-execution-tracer"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "clap",
+ "eyre",
+ "hex",
+ "revm",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "lock_api"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "examples/custom_opcodes",
     "examples/custom_precompile_journal",
     "examples/bal_example",
+    "examples/local_execution_tracer",
 ]
 resolver = "2"
 default-members = ["crates/revm"]

--- a/examples/local_execution_tracer/Cargo.toml
+++ b/examples/local_execution_tracer/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "local-execution-tracer"
+version = "0.1.0"
+publish = false
+authors.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
+rust-version.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true
+
+[dependencies]
+revm = { workspace = true, features = ["std", "alloydb"] }
+alloy-primitives = {workspace = true}
+clap = { workspace = true }
+serde = { workspace = true }
+serde_json = {workspace = true}
+hex = "0.4"
+eyre = "0.6"

--- a/examples/local_execution_tracer/src/main.rs
+++ b/examples/local_execution_tracer/src/main.rs
@@ -1,0 +1,48 @@
+//! A minimal local execution tracer built with a custom `Inspector`.
+//!
+//! The example is deterministic and does not require RPC access. It installs
+//! runtime bytecode into an in-memory account, executes one synthetic
+//! transaction, and serializes a compact JSON trace with opcode steps, calls,
+//! logs, storage touches, a call tree, and final storage diffs.
+
+mod output;
+mod scenario;
+mod tracer;
+
+use output::{build_call_tree, collect_state_diff, TraceOutput, TraceSummary};
+use revm::{Context, InspectEvm, MainBuilder, MainContext};
+use scenario::{build_db, build_tx};
+use std::error::Error;
+use tracer::MiniTracer;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let db = build_db()?;
+    let tx = build_tx();
+
+    let tracer = MiniTracer::default();
+    let context = Context::mainnet()
+        .modify_cfg_chained(|cfg| cfg.tx_gas_limit_cap = Some(u64::MAX))
+        .with_db(db);
+    let mut evm = context.build_mainnet_with_inspector(tracer);
+
+    let result_and_state = evm.inspect_tx(tx)?;
+    let tracer = evm.into_inspector();
+
+    let trace = TraceOutput {
+        summary: TraceSummary {
+            success: result_and_state.result.is_success(),
+            gas_used: result_and_state.result.tx_gas_used(),
+            step_count: tracer.steps.len(),
+            call_count: tracer.calls.len(),
+            log_count: tracer.logs.len(),
+        },
+        steps: tracer.steps,
+        calls: tracer.calls.clone(),
+        call_tree: build_call_tree(&tracer.calls),
+        logs: tracer.logs,
+        state_diff: collect_state_diff(&result_and_state.state),
+    };
+
+    println!("{}", serde_json::to_string_pretty(&trace)?);
+    Ok(())
+}

--- a/examples/local_execution_tracer/src/output.rs
+++ b/examples/local_execution_tracer/src/output.rs
@@ -1,0 +1,155 @@
+use revm::state::EvmState;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub(crate) struct TraceOutput {
+    pub(crate) summary: TraceSummary,
+    pub(crate) steps: Vec<StepTrace>,
+    pub(crate) calls: Vec<CallTrace>,
+    pub(crate) call_tree: Vec<CallTreeNode>,
+    pub(crate) logs: Vec<LogTrace>,
+    pub(crate) state_diff: Vec<StateDiff>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct TraceSummary {
+    pub(crate) success: bool,
+    pub(crate) gas_used: u64,
+    pub(crate) step_count: usize,
+    pub(crate) call_count: usize,
+    pub(crate) log_count: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct StepTrace {
+    pub(crate) depth: usize,
+    pub(crate) pc: usize,
+    pub(crate) opcode: &'static str,
+    pub(crate) gas_remaining: u64,
+    pub(crate) stack_top: Vec<String>,
+    pub(crate) memory_size: usize,
+    pub(crate) memory_preview: String,
+    pub(crate) memory_truncated: bool,
+    pub(crate) storage: Vec<StepStorageTrace>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct StepStorageTrace {
+    pub(crate) op: &'static str,
+    pub(crate) address: String,
+    pub(crate) slot: String,
+    pub(crate) value_before: Option<String>,
+    pub(crate) value_after: Option<String>,
+    pub(crate) write_value: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct CallTrace {
+    pub(crate) depth: usize,
+    pub(crate) kind: String,
+    pub(crate) from: String,
+    pub(crate) to: String,
+    pub(crate) value: String,
+    pub(crate) input: String,
+    pub(crate) gas_limit: u64,
+    pub(crate) success: Option<bool>,
+    pub(crate) gas_used: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct CallTreeNode {
+    depth: usize,
+    kind: String,
+    from: String,
+    to: String,
+    value: String,
+    gas_limit: u64,
+    success: Option<bool>,
+    gas_used: Option<u64>,
+    children: Vec<CallTreeNode>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct LogTrace {
+    pub(crate) address: String,
+    pub(crate) topics: Vec<String>,
+    pub(crate) data: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct StateDiff {
+    address: String,
+    storage: Vec<StorageDiff>,
+}
+
+#[derive(Debug, Serialize)]
+struct StorageDiff {
+    slot: String,
+    before: String,
+    after: String,
+}
+
+pub(crate) fn collect_state_diff(state: &EvmState) -> Vec<StateDiff> {
+    let mut diffs = state
+        .iter()
+        .filter_map(|(address, account)| {
+            let mut storage = account
+                .changed_storage_slots()
+                .map(|(slot, value)| StorageDiff {
+                    slot: format!("{slot:#x}"),
+                    before: format!("{:#x}", value.original_value()),
+                    after: format!("{:#x}", value.present_value()),
+                })
+                .collect::<Vec<_>>();
+
+            storage.sort_by(|left, right| left.slot.cmp(&right.slot));
+            (!storage.is_empty()).then(|| StateDiff {
+                address: address.to_string(),
+                storage,
+            })
+        })
+        .collect::<Vec<_>>();
+    diffs.sort_by(|left, right| left.address.cmp(&right.address));
+    diffs
+}
+
+pub(crate) fn build_call_tree(calls: &[CallTrace]) -> Vec<CallTreeNode> {
+    let mut roots = Vec::new();
+    let mut stack: Vec<CallTreeNode> = Vec::new();
+
+    for call in calls {
+        while stack.len() > call.depth {
+            flush_call_tree_node(&mut stack, &mut roots);
+        }
+
+        stack.push(CallTreeNode {
+            depth: call.depth,
+            kind: call.kind.clone(),
+            from: call.from.clone(),
+            to: call.to.clone(),
+            value: call.value.clone(),
+            gas_limit: call.gas_limit,
+            success: call.success,
+            gas_used: call.gas_used,
+            children: Vec::new(),
+        });
+    }
+
+    while !stack.is_empty() {
+        flush_call_tree_node(&mut stack, &mut roots);
+    }
+
+    roots
+}
+
+fn flush_call_tree_node(stack: &mut Vec<CallTreeNode>, roots: &mut Vec<CallTreeNode>) {
+    let Some(node) = stack.pop() else {
+        return;
+    };
+
+    if let Some(parent) = stack.last_mut() {
+        parent.children.push(node);
+    } else {
+        roots.push(node);
+    }
+}

--- a/examples/local_execution_tracer/src/scenario.rs
+++ b/examples/local_execution_tracer/src/scenario.rs
@@ -1,0 +1,50 @@
+use revm::{
+    context::TxEnv,
+    database::{CacheDB, EmptyDB},
+    primitives::{Address, Bytes, TxKind, U256},
+    state::{AccountInfo, Bytecode},
+};
+
+const CALLER: Address = Address::new([0x10; 20]);
+const CONTRACT: Address = Address::new([0x20; 20]);
+
+/// Runtime bytecode used by this example.
+///
+/// It exercises memory, storage, logs, and a nested call:
+/// - `MSTORE` stores `0x2a` at memory offset `0`
+/// - `SSTORE` writes storage slot `0`
+/// - `SSTORE` writes storage slot `2`
+/// - `SLOAD` reads storage slot `0`
+/// - `LOG1` emits one event
+/// - `CALL` invokes the `ecrecover` precompile at address `0x01`
+const CONTRACT_BYTECODE: &str = concat!(
+    "602a600052",
+    "6001600055",
+    "61beef600255",
+    "60005450",
+    "7f1111111111111111111111111111111111111111111111111111111111111111",
+    "60206000a1",
+    "6000600060006000600060006001612710f1",
+    "00",
+);
+
+pub(crate) fn build_db() -> Result<CacheDB<EmptyDB>, hex::FromHexError> {
+    let mut db = CacheDB::new(EmptyDB::new());
+    db.insert_account_info(CALLER, AccountInfo::default().with_balance(U256::MAX));
+    db.insert_account_info(
+        CONTRACT,
+        AccountInfo::default().with_code(Bytecode::new_legacy(Bytes::from(hex::decode(
+            CONTRACT_BYTECODE,
+        )?))),
+    );
+
+    Ok(db)
+}
+
+pub(crate) fn build_tx() -> TxEnv {
+    TxEnv::builder()
+        .caller(CALLER)
+        .kind(TxKind::Call(CONTRACT))
+        .gas_limit(30_000_000)
+        .build_fill()
+}

--- a/examples/local_execution_tracer/src/tracer.rs
+++ b/examples/local_execution_tracer/src/tracer.rs
@@ -1,0 +1,313 @@
+use crate::output::{CallTrace, LogTrace, StepStorageTrace, StepTrace};
+use revm::{
+    bytecode::opcode,
+    context::JournalTr,
+    context_interface::ContextTr,
+    inspector::JournalExt,
+    interpreter::{
+        interpreter::EthInterpreter,
+        interpreter_types::{InputsTr, Jumps},
+        CallInputs, CallOutcome, Interpreter,
+    },
+    primitives::{Address, Log, U256},
+    Inspector, JournalEntry,
+};
+
+#[derive(Debug, Default)]
+pub(crate) struct MiniTracer {
+    pub(crate) steps: Vec<StepTrace>,
+    pub(crate) calls: Vec<CallTrace>,
+    pub(crate) logs: Vec<LogTrace>,
+    depth: usize,
+    call_stack: Vec<usize>,
+    last_journal_len: usize,
+    pending_storage_step: Option<PendingStorageStep>,
+}
+
+impl MiniTracer {
+    fn current_frame_depth(&self) -> usize {
+        self.depth.saturating_sub(1)
+    }
+}
+
+impl<CTX> Inspector<CTX, EthInterpreter> for MiniTracer
+where
+    CTX: ContextTr<Journal: JournalExt>,
+{
+    fn step(&mut self, interp: &mut Interpreter<EthInterpreter>, context: &mut CTX) {
+        let opcode = interp.bytecode.opcode();
+        self.last_journal_len = context.journal_ref().journal().len();
+
+        let stack_top = interp
+            .stack
+            .data()
+            .iter()
+            .rev()
+            .take(4)
+            .map(|value| format!("{value:#x}"))
+            .collect();
+
+        let memory = memory_preview(interp, 32);
+        let step_index = self.steps.len();
+        let (storage, pending_storage_step) = storage_for_step(interp, context, opcode)
+            .map(|storage| {
+                let pending = PendingStorageStep {
+                    step_index,
+                    address: interp.input.target_address(),
+                    slot: storage.slot_raw,
+                };
+                (vec![storage.trace], Some(pending))
+            })
+            .unwrap_or_default();
+        self.pending_storage_step = pending_storage_step;
+
+        self.steps.push(StepTrace {
+            depth: self.current_frame_depth(),
+            pc: interp.bytecode.pc(),
+            opcode: opcode_name(opcode),
+            gas_remaining: interp.gas.remaining(),
+            stack_top,
+            memory_size: interp.memory.len(),
+            memory_preview: memory.preview,
+            memory_truncated: memory.truncated,
+            storage,
+        });
+    }
+
+    fn step_end(&mut self, _interp: &mut Interpreter<EthInterpreter>, context: &mut CTX) {
+        let Some(pending) = self.pending_storage_step.take() else {
+            return;
+        };
+
+        let journal = context.journal_ref().journal();
+        let storage_change = if journal.len() != self.last_journal_len {
+            journal
+                .last()
+                .and_then(|entry| storage_change(entry, context))
+        } else {
+            None
+        };
+        let fallback = storage_values(context, pending.address, pending.slot);
+
+        let Some(step) = self.steps.get_mut(pending.step_index) else {
+            return;
+        };
+        let Some(storage) = step.storage.first_mut() else {
+            return;
+        };
+
+        if let Some(change) = storage_change {
+            if change.address == pending.address && change.slot == pending.slot {
+                storage.value_before = Some(change.value_before);
+                storage.value_after = Some(change.value_after);
+                return;
+            }
+        }
+
+        if let Some(values) = fallback {
+            storage.value_before.get_or_insert(values.present.clone());
+            storage.value_after = Some(values.present);
+        }
+    }
+
+    fn call(&mut self, context: &mut CTX, inputs: &mut CallInputs) -> Option<CallOutcome> {
+        let input = inputs.input.bytes(context);
+        let call = CallTrace {
+            depth: self.depth,
+            kind: format!("{:?}", inputs.scheme).to_uppercase(),
+            from: inputs.caller.to_string(),
+            to: inputs.target_address.to_string(),
+            value: format!("{:#x}", inputs.call_value()),
+            input: format!("0x{}", hex::encode(input)),
+            gas_limit: inputs.gas_limit,
+            success: None,
+            gas_used: None,
+        };
+
+        let call_index = self.calls.len();
+        self.calls.push(call);
+        self.call_stack.push(call_index);
+        self.depth += 1;
+        None
+    }
+
+    fn call_end(&mut self, _context: &mut CTX, _inputs: &CallInputs, outcome: &mut CallOutcome) {
+        self.depth = self.depth.saturating_sub(1);
+
+        if let Some(call_index) = self.call_stack.pop() {
+            if let Some(call) = self.calls.get_mut(call_index) {
+                call.success = Some(outcome.result.is_ok());
+                call.gas_used = Some(outcome.result.gas.total_gas_spent());
+            }
+        }
+    }
+
+    fn log(&mut self, _context: &mut CTX, log: Log) {
+        self.logs.push(LogTrace {
+            address: log.address.to_string(),
+            topics: log.data.topics().iter().map(ToString::to_string).collect(),
+            data: format!("0x{}", hex::encode(&log.data.data)),
+        });
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PendingStorageStep {
+    step_index: usize,
+    address: Address,
+    slot: U256,
+}
+
+#[derive(Debug)]
+struct StorageForStep {
+    trace: StepStorageTrace,
+    slot_raw: U256,
+}
+
+fn storage_for_step<CTX>(
+    interp: &Interpreter<EthInterpreter>,
+    context: &CTX,
+    opcode: u8,
+) -> Option<StorageForStep>
+where
+    CTX: ContextTr<Journal: JournalExt>,
+{
+    let address = interp.input.target_address();
+    match opcode {
+        opcode::SLOAD => {
+            let slot = interp.stack.peek(0).ok()?;
+            let before = storage_values(context, address, slot).map(|values| values.present);
+
+            Some(StorageForStep {
+                trace: StepStorageTrace {
+                    op: "SLOAD",
+                    address: address.to_string(),
+                    slot: format!("{slot:#x}"),
+                    value_before: before,
+                    value_after: None,
+                    write_value: None,
+                },
+                slot_raw: slot,
+            })
+        }
+        opcode::SSTORE => {
+            let slot = interp.stack.peek(0).ok()?;
+            let write_value = interp.stack.peek(1).ok()?;
+            let before = storage_values(context, address, slot).map(|values| values.present);
+
+            Some(StorageForStep {
+                trace: StepStorageTrace {
+                    op: "SSTORE",
+                    address: address.to_string(),
+                    slot: format!("{slot:#x}"),
+                    value_before: before,
+                    value_after: None,
+                    write_value: Some(format!("{write_value:#x}")),
+                },
+                slot_raw: slot,
+            })
+        }
+        _ => None,
+    }
+}
+
+#[derive(Debug)]
+struct StorageValues {
+    original: String,
+    present: String,
+}
+
+fn storage_values<CTX>(context: &CTX, address: Address, slot: U256) -> Option<StorageValues>
+where
+    CTX: ContextTr<Journal: JournalExt>,
+{
+    let slot = context
+        .journal_ref()
+        .evm_state()
+        .get(&address)?
+        .storage
+        .get(&slot)?;
+
+    Some(StorageValues {
+        original: format!("{:#x}", slot.original_value()),
+        present: format!("{:#x}", slot.present_value()),
+    })
+}
+
+#[derive(Debug)]
+struct StorageChange {
+    address: Address,
+    slot: U256,
+    value_before: String,
+    value_after: String,
+}
+
+fn storage_change<CTX>(entry: &JournalEntry, context: &CTX) -> Option<StorageChange>
+where
+    CTX: ContextTr<Journal: JournalExt>,
+{
+    match entry {
+        JournalEntry::StorageChanged {
+            address,
+            key,
+            had_value,
+        } => {
+            let value_after = context
+                .journal_ref()
+                .evm_state()
+                .get(address)?
+                .storage
+                .get(key)?
+                .present_value();
+
+            Some(StorageChange {
+                address: *address,
+                slot: *key,
+                value_before: format!("{had_value:#x}"),
+                value_after: format!("{value_after:#x}"),
+            })
+        }
+        JournalEntry::StorageWarmed { address, key } => {
+            let values = storage_values(context, *address, *key)?;
+            Some(StorageChange {
+                address: *address,
+                slot: *key,
+                value_before: values.original,
+                value_after: values.present,
+            })
+        }
+        _ => None,
+    }
+}
+
+#[derive(Debug)]
+struct MemoryPreview {
+    preview: String,
+    truncated: bool,
+}
+
+fn memory_preview(interp: &Interpreter<EthInterpreter>, max_bytes: usize) -> MemoryPreview {
+    let memory = interp.memory.context_memory();
+    let preview_size = memory.len().min(max_bytes);
+
+    MemoryPreview {
+        preview: format!("0x{}", hex::encode(&memory[..preview_size])),
+        truncated: memory.len() > max_bytes,
+    }
+}
+
+fn opcode_name(opcode: u8) -> &'static str {
+    match opcode {
+        opcode::STOP => "STOP",
+        opcode::MSTORE => "MSTORE",
+        opcode::SLOAD => "SLOAD",
+        opcode::SSTORE => "SSTORE",
+        opcode::POP => "POP",
+        opcode::LOG1 => "LOG1",
+        opcode::CALL => "CALL",
+        opcode::PUSH1 => "PUSH1",
+        opcode::PUSH2 => "PUSH2",
+        opcode::PUSH32 => "PUSH32",
+        _ => "UNKNOWN",
+    }
+}


### PR DESCRIPTION
this example is helpful to fully understand the evm execution step by step at an opcode level