### PR TITLE
refactor: change &mut self to &self for read-only methods

### DIFF
--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -361,7 +361,7 @@ impl<SPEC: Into<SpecId> + Clone> CfgEnv<SPEC> {
     ///
     /// Default values for Cancun is [`primitives::eip4844::BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN`]
     /// and for Prague is [`primitives::eip4844::BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE`].
-    pub fn blob_base_fee_update_fraction(&mut self) -> u64 {
+    pub fn blob_base_fee_update_fraction(&self) -> u64 {
         self.blob_base_fee_update_fraction.unwrap_or_else(|| {
             let spec: SpecId = self.spec.clone().into();
             if spec.is_enabled_in(SpecId::PRAGUE) {

--- a/crates/interpreter/src/interpreter/ext_bytecode.rs
+++ b/crates/interpreter/src/interpreter/ext_bytecode.rs
@@ -80,7 +80,7 @@ impl ExtBytecode {
 
     /// Returns the bytecode hash.
     #[inline]
-    pub const fn hash(&mut self) -> Option<B256> {
+    pub const fn hash(&self) -> Option<B256> {
         self.bytecode_hash
     }
 


### PR DESCRIPTION
Changed `blob_base_fee_update_fraction` and `hash` to take `&self` instead of `&mut self` since neither method performs any mutation.