### PR TITLE
feat: add borrowed alloy BAL conversion

### DIFF
--- a/crates/state/src/bal.rs
+++ b/crates/state/src/bal.rs
@@ -284,7 +284,11 @@ impl core::error::Error for BalError {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_eip7928::{AccountChanges as AlloyAccountChanges, CodeChange as AlloyCodeChange};
+    use alloy_eip7928::{
+        AccountChanges as AlloyAccountChanges, BalanceChange as AlloyBalanceChange,
+        CodeChange as AlloyCodeChange, NonceChange as AlloyNonceChange,
+        SlotChanges as AlloySlotChanges, StorageChange as AlloyStorageChange,
+    };
     use bytecode::Bytecode;
     use primitives::{Bytes, B256, U256};
     use std::collections::BTreeMap;
@@ -419,6 +423,29 @@ mod tests {
     }
 
     #[test]
+    fn clone_from_alloy_matches_owned_conversion() {
+        let address = Address::with_last_byte(1);
+        let code_bytes = Bytes::from_static(&[0x60, 0x00]);
+        let alloy_bal = vec![AlloyAccountChanges {
+            address,
+            storage_changes: vec![AlloySlotChanges::new(
+                U256::from(1),
+                vec![AlloyStorageChange::new(idx(1), U256::from(10))],
+            )],
+            storage_reads: vec![U256::from(2)],
+            balance_changes: vec![AlloyBalanceChange::new(idx(2), U256::from(20))],
+            nonce_changes: vec![AlloyNonceChange::new(idx(3), 30)],
+            code_changes: vec![AlloyCodeChange::new(idx(4), code_bytes.clone())],
+        }];
+
+        let borrowed = Bal::clone_from_alloy(&alloy_bal).unwrap();
+        let owned = Bal::try_from_alloy(alloy_bal.clone()).unwrap();
+
+        assert_eq!(borrowed, owned);
+        assert_eq!(alloy_bal[0].code_changes[0].new_code(), &code_bytes);
+    }
+
+    #[test]
     fn try_from_alloy_errors_on_invalid_code_change() {
         let alloy_bal = vec![AlloyAccountChanges {
             address: Address::with_last_byte(1),
@@ -427,5 +454,16 @@ mod tests {
         }];
 
         assert!(Bal::try_from_alloy(alloy_bal).is_err());
+    }
+
+    #[test]
+    fn clone_from_alloy_errors_on_invalid_code_change() {
+        let alloy_bal = vec![AlloyAccountChanges {
+            address: Address::with_last_byte(1),
+            code_changes: vec![AlloyCodeChange::new(idx(1), vec![0xef, 0x01, 0xde].into())],
+            ..Default::default()
+        }];
+
+        assert!(Bal::clone_from_alloy(&alloy_bal).is_err());
     }
 }

--- a/crates/state/src/bal/account.rs
+++ b/crates/state/src/bal/account.rs
@@ -106,6 +106,42 @@ impl AccountBal {
         ))
     }
 
+    /// Clone an account BAL from EIP-7928 [`AlloyAccountChanges`] without consuming the source.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BytecodeDecodeError`] if any code change contains bytecode rejected by
+    /// [`Bytecode::new_raw_checked`]. This currently happens for malformed EIP-7702
+    /// bytecode, such as bytes with the EIP-7702 magic prefix but an invalid length or
+    /// unsupported version.
+    #[inline]
+    pub fn clone_from_alloy(
+        alloy_account: &AlloyAccountChanges,
+    ) -> Result<(Address, Self), BytecodeDecodeError> {
+        Ok((
+            alloy_account.address,
+            AccountBal {
+                account_info: AccountInfoBal {
+                    nonce: BalWrites::from(alloy_account.nonce_changes.as_slice()),
+                    balance: BalWrites::from(alloy_account.balance_changes.as_slice()),
+                    code: BalWrites::try_from(alloy_account.code_changes.as_slice())?,
+                },
+                storage: StorageBal::from_iter(
+                    alloy_account
+                        .storage_changes
+                        .iter()
+                        .map(|slot| (slot.slot, BalWrites::from(slot.changes.as_slice())))
+                        .chain(
+                            alloy_account
+                                .storage_reads
+                                .iter()
+                                .map(|key| (*key, BalWrites::default())),
+                        ),
+                ),
+            },
+        ))
+    }
+
     /// Consumes `AccountBal` and converts it into canonical EIP-7928
     /// [`AlloyAccountChanges`].
     ///

--- a/crates/state/src/bal/alloy.rs
+++ b/crates/state/src/bal/alloy.rs
@@ -32,6 +32,26 @@ impl Bal {
 
         Ok(Self { accounts })
     }
+
+    /// Clone an EIP-7928 [`AlloyBal`] into a [`Bal`] without consuming the source.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BytecodeDecodeError`] if any account code change contains bytecode
+    /// rejected by [`Bytecode::new_raw_checked`]. This currently happens for malformed
+    /// EIP-7702 bytecode, such as bytes with the EIP-7702 magic prefix but an invalid
+    /// length or unsupported version.
+    #[inline]
+    pub fn clone_from_alloy(alloy_bal: &AlloyBal) -> Result<Self, BytecodeDecodeError> {
+        let accounts = AddressIndexMap::from_iter(
+            alloy_bal
+                .iter()
+                .map(AccountBal::clone_from_alloy)
+                .collect::<Result<Vec<_>, _>>()?,
+        );
+
+        Ok(Self { accounts })
+    }
 }
 
 impl TryFrom<AlloyBal> for Bal {
@@ -54,11 +74,33 @@ impl From<Vec<AlloyBalanceChange>> for BalWrites<U256> {
     }
 }
 
+impl From<&[AlloyBalanceChange]> for BalWrites<U256> {
+    fn from(value: &[AlloyBalanceChange]) -> Self {
+        Self {
+            writes: value
+                .iter()
+                .map(|change| (change.block_access_index, change.post_balance))
+                .collect(),
+        }
+    }
+}
+
 impl From<Vec<AlloyNonceChange>> for BalWrites<u64> {
     fn from(value: Vec<AlloyNonceChange>) -> Self {
         Self {
             writes: value
                 .into_iter()
+                .map(|change| (change.block_access_index, change.new_nonce))
+                .collect(),
+        }
+    }
+}
+
+impl From<&[AlloyNonceChange]> for BalWrites<u64> {
+    fn from(value: &[AlloyNonceChange]) -> Self {
+        Self {
+            writes: value
+                .iter()
                 .map(|change| (change.block_access_index, change.new_nonce))
                 .collect(),
         }
@@ -76,6 +118,17 @@ impl From<Vec<AlloyStorageChange>> for BalWrites<U256> {
     }
 }
 
+impl From<&[AlloyStorageChange]> for BalWrites<U256> {
+    fn from(value: &[AlloyStorageChange]) -> Self {
+        Self {
+            writes: value
+                .iter()
+                .map(|change| (change.block_access_index, change.new_value))
+                .collect(),
+        }
+    }
+}
+
 impl TryFrom<Vec<AlloyCodeChange>> for BalWrites<(B256, Bytecode)> {
     type Error = BytecodeDecodeError;
 
@@ -86,6 +139,24 @@ impl TryFrom<Vec<AlloyCodeChange>> for BalWrites<(B256, Bytecode)> {
                 .map(|change| {
                     // convert bytes to bytecode.
                     Bytecode::new_raw_checked(change.new_code).map(|bytecode| {
+                        let hash = bytecode.hash_slow();
+                        (change.block_access_index, (hash, bytecode))
+                    })
+                })
+                .collect::<Result<Vec<_>, Self::Error>>()?,
+        })
+    }
+}
+
+impl TryFrom<&[AlloyCodeChange]> for BalWrites<(B256, Bytecode)> {
+    type Error = BytecodeDecodeError;
+
+    fn try_from(value: &[AlloyCodeChange]) -> Result<Self, Self::Error> {
+        Ok(Self {
+            writes: value
+                .iter()
+                .map(|change| {
+                    Bytecode::new_raw_checked(change.new_code.clone()).map(|bytecode| {
                         let hash = bytecode.hash_slow();
                         (change.block_access_index, (hash, bytecode))
                     })


### PR DESCRIPTION
Adds a borrowed `Bal::clone_from_alloy(&AlloyBal)` conversion alongside the existing consuming `try_from_alloy` path.

The new path clones from slices for nested alloy changes, so callers can convert borrowed BAL data without first cloning the whole outer `AlloyBal`. Scalar changes are copied directly and code bytes are cloned only where bytecode decoding needs owned bytes.

This should simplify callers that currently have to materialize `Vec<_>::from(bal.clone())` before constructing a revm BAL.