### PR TITLE
fix(database): AlloyDB returns None for non-existent accounts (#2454)

### DIFF
--- a/crates/database/src/alloydb.rs
+++ b/crates/database/src/alloydb.rs
@@ -8,7 +8,7 @@ use alloy_provider::{
 use alloy_transport::TransportError;
 use core::error::Error;
 use database_interface::{async_db::DatabaseAsyncRef, DBErrorMarker};
-use primitives::{Address, StorageKey, StorageValue, B256};
+use primitives::{Address, StorageKey, StorageValue, B256, KECCAK_EMPTY};
 use state::{AccountInfo, Bytecode};
 use std::fmt::Display;
 
@@ -83,27 +83,51 @@ impl<N: Network, P: Provider<N>> DatabaseAsyncRef for AlloyDB<N, P> {
     type Error = AlloyDBError;
 
     async fn basic_async_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
-        let nonce = self
+        // Use `eth_getProof` instead of the legacy `eth_getBalance` + `eth_getNonce` +
+        // `eth_getCode` trio. The proof response returns `code_hash` as its own field, which
+        // is the only RPC signal that distinguishes a non-existent account from an
+        // existent-but-empty one (post Spurious Dragon, EIP-161):
+        //
+        //   * non-existent account: `code_hash == B256::ZERO`
+        //   * existent, empty:      `code_hash == KECCAK_EMPTY`
+        //   * existent, non-empty:  `code_hash == keccak(code)`
+        //
+        // See the discussion at https://github.com/ethereum/go-ethereum/issues/28441 and the
+        // reference fix in helios at https://github.com/a16z/helios/pull/714. Previously,
+        // `eth_getBalance`/`eth_getCode` returned zero values for both empty and missing
+        // accounts, so AlloyDB always wrapped them in `Some(AccountInfo)`, which leaks the
+        // wrong existence verdict into revm's EIP-161 state-clear check
+        // (`crates/state/src/lib.rs:43+`).
+        let proof = self
             .provider
-            .get_transaction_count(address)
-            .block_id(self.block_number);
-        let balance = self
-            .provider
-            .get_balance(address)
-            .block_id(self.block_number);
-        let code = self
-            .provider
-            .get_code_at(address)
-            .block_id(self.block_number);
+            .get_proof(address, Vec::new())
+            .block_id(self.block_number)
+            .await?;
 
-        let (nonce, balance, code) = tokio::join!(nonce, balance, code,);
+        if proof.code_hash == B256::ZERO {
+            // RPC providers send all-zero code_hash for accounts that don't exist in state.
+            return Ok(None);
+        }
 
-        let balance = balance?;
-        let code = Bytecode::new_raw(code?.0.into());
-        let code_hash = code.hash_slow();
-        let nonce = nonce?;
+        // Skip the extra `eth_getCode` round-trip when the account has no code: the proof
+        // already told us so via `KECCAK_EMPTY`.
+        let code = if proof.code_hash == KECCAK_EMPTY {
+            Bytecode::new()
+        } else {
+            let code_bytes = self
+                .provider
+                .get_code_at(address)
+                .block_id(self.block_number)
+                .await?;
+            Bytecode::new_raw(code_bytes.0.into())
+        };
 
-        Ok(Some(AccountInfo::new(balance, nonce, code_hash, code)))
+        Ok(Some(AccountInfo::new(
+            proof.balance,
+            proof.nonce,
+            proof.code_hash,
+            code,
+        )))
     }
 
     async fn block_hash_async_ref(&self, number: u64) -> Result<B256, Self::Error> {


### PR DESCRIPTION
Closes #2454.

## The bug

`AlloyDB::basic_async_ref` always returns `Some(AccountInfo)`, even for accounts that don't exist on-chain. That breaks revm's EIP-161 state-clear check at `crates/state/src/lib.rs:43+`, which relies on the `Option<AccountInfo>` to distinguish existent-empty from non-existent.

Reporter [@nora-coder-dot](https://github.com/nora-coder-dot) hit this replaying tx `0x1ae5f96a...` (calls precompile `0x4`) via the `examples/block_traces` flow.

## Why the previous code couldn't fix it inline

Three parallel RPCs: `eth_getTransactionCount` + `eth_getBalance` + `eth_getCode`. All three return zeros for both **existent-but-empty** and **non-existent** accounts post Spurious Dragon. No signal disambiguates the two cases.

## The fix

Use `eth_getProof` instead. It returns `code_hash` as its own field — the only RPC signal that distinguishes existence vs emptiness:

| Account state | `code_hash` |
|---|---|
| non-existent | `B256::ZERO` |
| existent, empty | `KECCAK_EMPTY` |
| existent, non-empty | `keccak(code)` |

```rust
let proof = self.provider.get_proof(address, Vec::new()).block_id(self.block_number).await?;

if proof.code_hash == B256::ZERO {
    return Ok(None);  // EIP-161: account doesn't exist
}

let code = if proof.code_hash == KECCAK_EMPTY {
    Bytecode::new()  // skip the extra eth_getCode round-trip
} else {
    let code_bytes = self.provider.get_code_at(address).block_id(self.block_number).await?;
    Bytecode::new_raw(code_bytes.0.into())
};

Ok(Some(AccountInfo::new(proof.balance, proof.nonce, proof.code_hash, code)))
```

## References

[@rakita](https://github.com/rakita) flagged this approach in #2454 (Oct 2025) citing the discussion at ethereum/go-ethereum#28441 and the reference fix at a16z/helios#714 — both establish the `code_hash == ZERO` convention as the canonical non-existence signal.

## Differences from the previous attempt (#2468, closed)

| | #2468 | This PR |
|---|---|---|
| Public API | adds `spec_id: SpecId` to `AlloyDB::new` (breaking) | unchanged |
| Decision logic | check `nonce==0 && balance==0 && code.is_empty()` post Spurious Dragon | direct `code_hash` field from `eth_getProof` |
| Provider requirement | none new | `eth_getProof` (geth/erigon/reth/besu/nethermind all support it) |
| RPC count for empty / non-existent | still 3 in parallel | 1 |
| RPC count for accounts with code | 3 in parallel | 1 + 1 sequential |

## Trade-offs

- **No public API break.** `AlloyDB::new` signature unchanged.
- **RPC efficiency:** 1 call instead of 3 for empty / non-existent accounts (the common case in trace replays). 2 sequential calls when there's code to fetch — slightly worse than 3-in-parallel under high latency, but typical mixed workloads come out neutral to better.
- **Requires `eth_getProof`.** Every major Ethereum execution client supports it (it's been a standard JSON-RPC method since EIP-1186 / 2018).
- **Behaviour change for downstream callers:** anyone relying on always-Some now sees None for non-existent accounts. This matches the Ethereum spec, so any prior reliance was already a latent bug — but worth calling out in the changelog.

## Testing

The bug only manifests against a live RPC node, and the existing `can_get_basic` integration test is marked `#[ignore = "flaky RPC"]`. I'd be happy to add unit tests against a mocked `Provider` if you have a preferred mock pattern (didn't want to invent one). Manually reproducible by:

1. Pick any address that didn't exist at the test block (e.g. a freshly-generated EOA).
2. Call `basic_async_ref` via `WrapDatabaseAsync`.
3. On `main` → `Some(AccountInfo { ... all zeros ... })`. With this PR → `None`.