### PR TITLE
fix(eip8037): align bal-devnet-7 system call gas limit

### DIFF
--- a/crates/ee-tests/src/eip8037.rs
+++ b/crates/ee-tests/src/eip8037.rs
@@ -1525,10 +1525,12 @@ fn test_eip8037_precompile_no_state_gas() {
 
 // ---- Category 7: Reservoir Refill ----
 //
-// The reservoir refill logic (handler_reservoir_refill) is invoked on HALT or REVERT:
-// `new_reservoir = reservoir + max(0, state_gas_spent_final - reservoir)`
+// The reservoir refill logic is invoked on HALT or REVERT using the conserved
+// `reservoir + state_gas_spent` invariant:
+// `new_reservoir = reservoir + state_gas_spent_final`
 //
-// This accounts for state gas that had to be drawn from regular gas.
+// This accounts for both state gas borrowed from regular gas and nested refill
+// unwinds that can make `state_gas_spent_final` temporarily negative.
 // On OK: reservoir stays unchanged (no refill needed).
 // On REVERT: remaining is reimbursed, then refill applied.
 // On HALT: remaining is NOT reimbursed, refill applied to final gas accounting.

--- a/crates/handler/src/system_call.rs
+++ b/crates/handler/src/system_call.rs
@@ -26,11 +26,21 @@ use crate::{
 use context::{result::ExecResultAndState, ContextSetters, ContextTr, Evm, JournalTr, TxEnv};
 use database_interface::DatabaseCommit;
 use interpreter::{interpreter::EthInterpreter, InterpreterResult};
-use primitives::{address, Address, Bytes, TxKind};
+use primitives::{address, eip8037, Address, Bytes, TxKind};
 use state::EvmState;
 
 /// The system address used for system calls.
 pub const SYSTEM_ADDRESS: Address = address!("0xfffffffffffffffffffffffffffffffffffffffe");
+
+/// Maximum number of SSTOREs a bal-devnet-7 system call reserves state gas for.
+pub const SYSTEM_MAX_SSTORES_PER_CALL: u64 = 16;
+
+/// Gas limit for system calls under bal-devnet-7.
+///
+/// Per `tests-bal@v7.0.0`, system calls get the base 30M regular-gas budget plus
+/// a state-gas reservoir sized for `SYSTEM_MAX_SSTORES_PER_CALL` storage writes.
+pub const SYSTEM_CALL_GAS_LIMIT: u64 = 30_000_000
+    + eip8037::SSTORE_SET_BYTES * eip8037::CPSB_GLAMSTERDAM * SYSTEM_MAX_SSTORES_PER_CALL;
 
 /// Creates the system transaction with default values and set data and tx call target to system contract address
 /// that is going to be called.
@@ -62,7 +72,7 @@ impl SystemCallTx for TxEnv {
             .caller(caller)
             .data(data)
             .kind(TxKind::Call(system_contract_address))
-            .gas_limit(30_000_000)
+            .gas_limit(SYSTEM_CALL_GAS_LIMIT)
             .build()
             .unwrap()
     }
@@ -299,8 +309,8 @@ mod tests {
             .system_call(HISTORY_STORAGE_ADDRESS, block_hash.0.into())
             .unwrap();
 
-        // system call gas limit is 30M
-        assert_eq!(evm.ctx.tx().gas_limit(), 30_000_000);
+        // bal-devnet-7 adds a state-gas reservoir on top of the 30M base limit.
+        assert_eq!(evm.ctx.tx().gas_limit(), SYSTEM_CALL_GAS_LIMIT);
 
         assert_eq!(
             output.result,

--- a/crates/primitives/src/eip8037.rs
+++ b/crates/primitives/src/eip8037.rs
@@ -3,8 +3,7 @@
 //! Introduces a reservoir model that separates *state gas* (storage/code/account
 //! creation) from *regular* execution gas. State-gas charges are expressed as
 //! a number of "state bytes" that get multiplied by `cost_per_state_byte` (CPSB).
-//! CPSB itself is derived from the current block's gas limit so that the state
-//! growth target scales with block capacity.
+//! In `bal-devnet-7` / Glamsterdam, CPSB is fixed at `1530`.
 
 /// Blocks per year at a 12-second block time (used by the CPSB formula).
 pub const BLOCKS_PER_YEAR: u64 = 2_628_000;


### PR DESCRIPTION
Update system calls to use the bal-devnet-7 gas limit formula instead of the legacy fixed 30M cap.

Changes:

- add SYSTEM_MAX_SSTORES_PER_CALL = 16

- derive SYSTEM_CALL_GAS_LIMIT as

  30_000_000 + SSTORE_SET_BYTES * CPSB_GLAMSTERDAM * SYSTEM_MAX_SSTORES_PER_CALL

- update the system_call test to assert the new limit

- sync stale EIP-8037 docs/comments with the current bal-devnet-7 behavior

This matches tests-bal@v7.0.0, where system calls receive a dedicated state-gas reservoir on top of the 30M regular-gas budget.