### PR TITLE
feat(precompile): add matter-labs bn254 backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,7 +691,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "zeroize",
@@ -708,7 +708,7 @@ dependencies = [
  "ark-serialize 0.3.0",
  "ark-std 0.3.0",
  "derivative",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "paste",
  "rustc_version 0.3.3",
@@ -728,7 +728,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "paste",
  "rustc_version 0.4.1",
@@ -749,7 +749,7 @@ dependencies = [
  "digest 0.10.7",
  "educe",
  "itertools 0.13.0",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "paste",
  "zeroize",
@@ -791,7 +791,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "quote",
  "syn 1.0.109",
@@ -803,7 +803,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -816,7 +816,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -849,7 +849,7 @@ dependencies = [
  "ark-relations",
  "ark-std 0.5.0",
  "educe",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "tracing",
@@ -885,7 +885,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.6",
 ]
 
 [[package]]
@@ -898,7 +898,7 @@ dependencies = [
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.6",
 ]
 
 [[package]]
@@ -1893,6 +1893,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "eth_pairings"
+version = "0.6.0"
+source = "git+https://github.com/matter-labs/eip1962?rev=17ba98bdbdd7bdf239c09cd88ca46a486124f5e7#17ba98bdbdd7bdf239c09cd88ca46a486124f5e7"
+dependencies = [
+ "byteorder",
+ "eth_pairings_repr_derive",
+ "fixed_width_field",
+ "fixed_width_group_and_loop",
+ "num-bigint 0.2.6",
+ "num-traits",
+ "once_cell",
+ "static_assertions",
+]
+
+[[package]]
+name = "eth_pairings_repr_derive"
+version = "0.2.0"
+source = "git+https://github.com/matter-labs/eip1962?rev=17ba98bdbdd7bdf239c09cd88ca46a486124f5e7#17ba98bdbdd7bdf239c09cd88ca46a486124f5e7"
+dependencies = [
+ "byteorder",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "example-bal"
 version = "0.0.0"
 dependencies = [
@@ -2049,6 +2075,22 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
+]
+
+[[package]]
+name = "fixed_width_field"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/eip1962?rev=17ba98bdbdd7bdf239c09cd88ca46a486124f5e7#17ba98bdbdd7bdf239c09cd88ca46a486124f5e7"
+dependencies = [
+ "simple_uint",
+]
+
+[[package]]
+name = "fixed_width_group_and_loop"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/eip1962?rev=17ba98bdbdd7bdf239c09cd88ca46a486124f5e7#17ba98bdbdd7bdf239c09cd88ca46a486124f5e7"
+dependencies = [
+ "simple_uint",
 ]
 
 [[package]]
@@ -2942,11 +2984,22 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-complex",
  "num-integer",
  "num-iter",
  "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3001,7 +3054,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
 ]
@@ -3871,6 +3924,7 @@ dependencies = [
  "c-kzg",
  "cfg-if",
  "codspeed-criterion-compat",
+ "eth_pairings",
  "gmp-mpfr-sys",
  "k256",
  "p256",
@@ -4027,7 +4081,7 @@ dependencies = [
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "parity-scale-codec",
@@ -4491,6 +4545,17 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "simple_uint"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/eip1962?rev=17ba98bdbdd7bdf239c09cd88ca46a486124f5e7#17ba98bdbdd7bdf239c09cd88ca46a486124f5e7"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "rustc-hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ ark-ec = { version = "0.5", default-features = false }
 ark-ff = { version = "0.5", default-features = false }
 ark-serialize = { version = "0.5", default-features = false }
 ark-std = { version = "0.5", default-features = false }
+eth_pairings = { git = "https://github.com/matter-labs/eip1962", rev = "17ba98bdbdd7bdf239c09cd88ca46a486124f5e7", default-features = false }
 aurora-engine-modexp = { version = "1.2", default-features = false }
 gmp-mpfr-sys = { version = "1.6", default-features = false }
 blst = "0.3.15"

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -43,6 +43,9 @@ ripemd.workspace = true
 # Optionally use substrate implementation for eip1962
 bn = { workspace = true, optional = true }
 
+# Use matter-labs implementation for eip1962
+eth_pairings = { workspace = true, features = ["eip_196"], optional = true }
+
 # Use arkworks implementation for eip1962
 ark-bn254 = { workspace = true, features = ["curve"] }
 ark-ec = { workspace = true }
@@ -77,7 +80,7 @@ rstest.workspace = true
 p256 = { workspace = true, features = ["ecdsa"] }
 
 [features]
-default = ["std", "secp256k1", "blst", "c-kzg", "portable"]
+default = ["std", "secp256k1", "blst", "c-kzg", "portable", "matter-labs-eip1962"]
 
 std = [
 	"primitives/std",
@@ -115,6 +118,9 @@ secp256k1 = ["dep:secp256k1"]
 
 # Enables the blst implementation of the BLS12-381 precompile.
 blst = ["dep:blst"]
+
+# Enables the matter-labs implementation of eip1962.
+matter-labs-eip1962 = ["dep:eth_pairings"]
 
 # Enables the substrate implementation of eip1962
 bn = ["dep:bn"]

--- a/crates/precompile/src/bn254.rs
+++ b/crates/precompile/src/bn254.rs
@@ -6,11 +6,17 @@ use crate::{
 };
 use std::vec::Vec;
 
-#[cfg_attr(feature = "bn", expect(dead_code))]
+#[cfg_attr(
+    any(feature = "bn", feature = "matter-labs-eip1962"),
+    expect(dead_code)
+)]
 pub mod arkworks;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "bn")]{
+    if #[cfg(feature = "matter-labs-eip1962")] {
+        pub(crate) mod matter_labs;
+        pub(crate) use matter_labs as crypto_backend;
+    } else if #[cfg(feature = "bn")] {
         pub(crate) mod substrate;
         pub(crate) use substrate as crypto_backend;
     } else {

--- a/crates/precompile/src/bn254/matter_labs.rs
+++ b/crates/precompile/src/bn254/matter_labs.rs
@@ -1,0 +1,155 @@
+use super::{FQ_LEN, G1_LEN, G2_LEN, SCALAR_LEN};
+use crate::PrecompileHalt;
+use eth_pairings::{
+    engines::bn254::*,
+    extension_towers::fp12_as_2_over3_over_2::Fp12,
+    field::U256Repr,
+    integers::MaxGroupSizeUint,
+    pairings::PairingEngine,
+    public_interface::{decode_g1, decode_g2},
+    traits::{Group, ZeroAndOne},
+};
+use std::vec::Vec;
+
+type G1Point = eth_pairings::weierstrass::curve::CurvePoint<
+    'static,
+    eth_pairings::weierstrass::CurveOverFpParameters<
+        'static,
+        U256Repr,
+        eth_pairings::field::PrimeField<U256Repr>,
+    >,
+>;
+
+type G2Point = eth_pairings::weierstrass::curve::CurvePoint<
+    'static,
+    eth_pairings::weierstrass::CurveOverFp2Parameters<
+        'static,
+        U256Repr,
+        eth_pairings::field::PrimeField<U256Repr>,
+    >,
+>;
+
+type Fr = MaxGroupSizeUint;
+
+#[inline]
+fn read_g1_point(input: &[u8]) -> Result<G1Point, PrecompileHalt> {
+    let (point, _) = decode_g1::decode_g1_point_from_xy_oversized(input, FQ_LEN, &BN254_G1_CURVE)
+        .map_err(|_| PrecompileHalt::Bn254AffineGFailedToCreate)?;
+
+    if !point.is_on_curve() {
+        return Err(PrecompileHalt::Bn254AffineGFailedToCreate);
+    }
+
+    Ok(point)
+}
+
+#[inline]
+fn encode_g1_point(point: G1Point) -> [u8; G1_LEN] {
+    let mut output = [0u8; G1_LEN];
+
+    if !point.is_zero() {
+        let encoded = decode_g1::serialize_g1_point(FQ_LEN, &point)
+            .expect("failed to serialize BN254 G1 point");
+        output.copy_from_slice(&encoded);
+    }
+
+    output
+}
+
+#[inline]
+fn read_g2_point(input: &[u8]) -> Result<G2Point, PrecompileHalt> {
+    let mut swapped_encoding = [0u8; G2_LEN];
+
+    let x_0 = &input[0..FQ_LEN];
+    let x_1 = &input[FQ_LEN..(FQ_LEN * 2)];
+    let y_0 = &input[(FQ_LEN * 2)..(FQ_LEN * 3)];
+    let y_1 = &input[(FQ_LEN * 3)..(FQ_LEN * 4)];
+
+    swapped_encoding[0..FQ_LEN].copy_from_slice(x_1);
+    swapped_encoding[FQ_LEN..(FQ_LEN * 2)].copy_from_slice(x_0);
+    swapped_encoding[(FQ_LEN * 2)..(FQ_LEN * 3)].copy_from_slice(y_1);
+    swapped_encoding[(FQ_LEN * 3)..(FQ_LEN * 4)].copy_from_slice(y_0);
+
+    let (point, _) = decode_g2::decode_g2_point_from_xy_in_fp2_oversized(
+        &swapped_encoding,
+        FQ_LEN,
+        &BN254_G2_CURVE,
+    )
+    .map_err(|_| PrecompileHalt::Bn254AffineGFailedToCreate)?;
+
+    if !point.is_on_curve() {
+        return Err(PrecompileHalt::Bn254FieldPointNotAMember);
+    }
+
+    if point.is_zero() {
+        return Ok(point);
+    }
+
+    if !point
+        .wnaf_mul_with_window_size(&BN254_SUBGROUP_ORDER[..], 5)
+        .is_zero()
+    {
+        return Err(PrecompileHalt::Bn254FieldPointNotAMember);
+    }
+
+    Ok(point)
+}
+
+#[inline]
+fn read_scalar(input: &[u8]) -> Fr {
+    assert_eq!(
+        input.len(),
+        SCALAR_LEN,
+        "unexpected scalar length. got {}, expected {SCALAR_LEN}",
+        input.len()
+    );
+    let (scalar, _) = decode_g1::decode_scalar_representation(input, SCALAR_LEN).unwrap();
+    scalar
+}
+
+#[inline]
+pub(crate) fn g1_point_add(
+    p1_bytes: &[u8],
+    p2_bytes: &[u8],
+) -> Result<[u8; G1_LEN], PrecompileHalt> {
+    let mut p1 = read_g1_point(p1_bytes)?;
+    let p2 = read_g1_point(p2_bytes)?;
+    p1.add_assign(&p2);
+    Ok(encode_g1_point(p1))
+}
+
+#[inline]
+pub(crate) fn g1_point_mul(
+    point_bytes: &[u8],
+    scalar_bytes: &[u8],
+) -> Result<[u8; G1_LEN], PrecompileHalt> {
+    let p = read_g1_point(point_bytes)?;
+    let scalar = read_scalar(scalar_bytes);
+    Ok(encode_g1_point(p.mul(scalar)))
+}
+
+#[inline]
+pub(crate) fn pairing_check(pairs: &[(&[u8], &[u8])]) -> Result<bool, PrecompileHalt> {
+    let mut g1_points = Vec::with_capacity(pairs.len());
+    let mut g2_points = Vec::with_capacity(pairs.len());
+
+    for (g1_bytes, g2_bytes) in pairs {
+        let g1 = read_g1_point(g1_bytes)?;
+        let g2 = read_g2_point(g2_bytes)?;
+
+        if !g1.is_zero() && !g2.is_zero() {
+            g1_points.push(g1);
+            g2_points.push(g2);
+        }
+    }
+
+    if g1_points.is_empty() {
+        return Ok(true);
+    }
+
+    let Some(pairing_result) = BN254_PAIRING_ENGINE.pair(&g1_points, &g2_points) else {
+        return Ok(false);
+    };
+
+    Ok(pairing_result == Fp12::one(&BN254_EXT12_FIELD))
+}

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -37,9 +37,16 @@ pub use interface::*;
 
 use core::fmt::{self, Debug};
 
-// silence arkworks lint as bn impl will be used as default if both are enabled.
+// Silence unused backend lints when an alternative BN254 implementation is selected.
 cfg_if::cfg_if! {
-    if #[cfg(feature = "bn")]{
+    if #[cfg(feature = "matter-labs-eip1962")] {
+        #[cfg(feature = "bn")]
+        use bn as _;
+        use ark_bn254 as _;
+        use ark_ff as _;
+        use ark_ec as _;
+        use ark_serialize as _;
+    } else if #[cfg(feature = "bn")] {
         use ark_bn254 as _;
         use ark_ff as _;
         use ark_ec as _;

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -37,7 +37,7 @@ serde_json = { workspace = true, features = ["alloc", "preserve_order"] }
 serde = { workspace = true, features = ["derive"] }
 
 [features]
-default = ["std", "secp256k1", "portable", "tracer", "c-kzg", "blst"]
+default = ["std", "secp256k1", "portable", "tracer", "c-kzg", "blst", "matter-labs-eip1962"]
 std = [
 	"interpreter/std",
 	"precompile/std",
@@ -109,6 +109,7 @@ c-kzg = ["precompile/c-kzg"]
 # blst will be enabled both for bls precompiles and for kzg precompile.
 blst = ["precompile/blst"]
 bn = ["precompile/bn"]
+matter-labs-eip1962 = ["precompile/matter-labs-eip1962"]
 asm-sha2 = ["precompile/asm-sha2"]
 
 # Compile in portable mode, without ISA extensions.


### PR DESCRIPTION
Adds the matter-labs EIP-1962 implementation as a BN254 backend and enables it by default so the existing precompile benchmarks exercise it in CI. The existing arkworks and substrate-bn backends remain available by disabling default features or enabling `bn` without `matter-labs-eip1962`.

Local smoke benchmark with `--sample-size 10` showed `bn254 add` at about 1.83µs, `bn254 mul` at about 60.7µs, and `ecpairing` at about 1.41ms.
