### PR TITLE
fix(context): keep AccountLoad.is_empty on target account

### DIFF
--- a/crates/context/interface/src/host.rs
+++ b/crates/context/interface/src/host.rs
@@ -158,6 +158,7 @@ pub trait Host {
         let mut account_load = StateLoad::new(
             AccountLoad {
                 is_delegate_account_cold: None,
+                // Keep `is_empty` bound to the originally requested account.
                 is_empty: account.is_empty,
             },
             account.is_cold,
@@ -169,7 +170,6 @@ pub trait Host {
                 .load_account_info_skip_cold_load(address, true, false)
                 .ok()?;
             account_load.data.is_delegate_account_cold = Some(delegate_account.is_cold);
-            account_load.data.is_empty = delegate_account.is_empty;
         }
 
         Some(account_load)

--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -494,7 +494,8 @@ impl<T> StateLoad<T> {
 pub struct AccountLoad {
     /// Does account have delegate code and delegated account is cold loaded
     pub is_delegate_account_cold: Option<bool>,
-    /// Is account empty, if `true` account is not created
+    /// Is the originally requested account empty, if `true` account is not created.
+    /// This does not change based on delegated account state.
     pub is_empty: bool,
 }
 

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -735,8 +735,8 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
     ///
     /// It will mark both this and delegated account as warm loaded.
     ///
-    /// Returns information about the account (If it is empty or cold loaded) and if present the information
-    /// about the delegated account (If it is cold loaded).
+    /// Returns information about the requested account (empty/cold state), and if present information
+    /// about the delegated account (cold state).
     #[inline]
     pub fn load_account_delegated<DB: Database>(
         &mut self,


### PR DESCRIPTION
This change keeps `AccountLoad.is_empty` bound to the originally requested account in delegated loads, and aligns Host and Journal delegated-loading semantics to prevent inconsistent emptiness decisions.