### PR TITLE
feat(eip8038): implement state-access gas cost update

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           cache-on-failure: true
       - name: Install cargo-codspeed
-        uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
+        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2.77.7
         with:
           tool: cargo-codspeed
       - name: Build the benchmark target(s)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17
+      - uses: EmbarkStudios/cargo-deny-action@6c8f9facfa5047ec02d8485b6bf52b587b7777d1 # v2.0.18
         with:
           command: check all
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: crate-ci/typos@bbaefadf97b0ec5fdc942684b647f1a6ab250274 # v1.46.0
+      - uses: crate-ci/typos@5374cbf686e897b15713110e233094e2874de7ef # v1.46.1
 
   ci-success:
     name: ci success

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ cargo nextest run --workspace --no-default-features
 cargo nextest run --workspace --all-features
 cargo clippy --workspace --all-targets --all-features
 cargo fmt --all --check
+typos
 
 cargo check --target riscv32imac-unknown-none-elf --no-default-features
 cargo check --target riscv64imac-unknown-none-elf --no-default-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
 
+# v109
+date: 20.05.2026
+
+Bump revm-database-interface major version. All dependent crates bumped accordingly.
+
+* `revm-database-interface`: 11.1.0 -> 12.0.0 (⚠ API breaking changes)
+* `revm-context-interface`: 18.0.0 -> 19.0.0 (⚠ dependency bump)
+* `revm-database`: 14.0.0 -> 15.0.0 (⚠ dependency bump)
+* `revm-context`: 17.0.0 -> 18.0.0 (⚠ dependency bump)
+* `revm-interpreter`: 36.0.0 -> 37.0.0 (⚠ dependency bump)
+* `revm-precompile`: 35.0.0 -> 36.0.0 (⚠ dependency bump)
+* `revm-handler`: 19.0.0 -> 20.0.0 (⚠ dependency bump)
+* `revm-inspector`: 20.0.0 -> 21.0.0 (⚠ dependency bump)
+* `revm-statetest-types`: 18.0.0 -> 19.0.0 (⚠ dependency bump)
+* `revm`: 39.0.0 -> 40.0.0 (⚠ dependency bump)
+* `revm-ee-tests`: 0.2.0 -> 0.3.0 (⚠ dependency bump)
+* `revme`: 16.0.0 -> 17.0.0 (⚠ dependency bump)
+
 # v108
 date: 19.05.2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
 
+# v108
+date: 19.05.2026
+
+Prep for Amsteradam, bal-devnet-7 version (EIP-8037)
+
+* `revm-primitives`: 23.0.0 -> 24.0.0 (⚠ API breaking changes)
+* `revm-bytecode`: 10.0.0 -> 11.0.0 (⚠ API breaking changes)
+* `revm-state`: 11.0.1 -> 12.0.0 (⚠ API breaking changes)
+* `revm-database-interface`: 11.0.1 -> 11.1.0 (✓ API compatible changes)
+* `revm-context-interface`: 17.0.1 -> 18.0.0 (⚠ API breaking changes)
+* `revm-context`: 16.0.1 -> 17.0.0 (⚠ API breaking changes)
+* `revm-database`: 13.0.1 -> 14.0.0 (✓ API compatible changes)
+* `revm-interpreter`: 35.0.1 -> 36.0.0 (⚠ API breaking changes)
+* `revm-precompile`: 34.0.0 -> 35.0.0 (⚠ API breaking changes)
+* `revm-handler`: 18.1.0 -> 19.0.0 (⚠ API breaking changes)
+* `revm-inspector`: 19.0.0 -> 20.0.0 (⚠ API breaking changes)
+* `revm-statetest-types`: 17.0.1 -> 18.0.0 (✓ API compatible changes)
+* `revm`: 38.0.0 -> 39.0.0 (✓ API compatible changes)
+* `revme`: 15.0.0 -> 16.0.0 (✓ API compatible changes)
+
 # v107
 date: 17.04.2026
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3706,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "38.0.0"
+version = "38.0.1"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3726,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "10.0.0"
+version = "11.0.0"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "16.0.1"
+version = "17.0.0"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "17.0.1"
+version = "18.0.0"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "13.0.1"
+version = "13.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-provider",
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "11.0.1"
+version = "11.1.0"
 dependencies = [
  "auto_impl",
  "either",
@@ -3807,7 +3807,7 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "alloy-signer",
  "alloy-signer-local",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "auto_impl",
  "either",
@@ -3844,7 +3844,7 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "35.0.1"
+version = "36.0.0"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "34.0.0"
+version = "35.0.0"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3886,7 +3886,7 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -3895,7 +3895,7 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "11.0.1"
+version = "12.0.0"
 dependencies = [
  "alloy-eip7928 0.4.0",
  "bitflags",
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "revm-statetest-types"
-version = "17.0.1"
+version = "17.0.2"
 dependencies = [
  "alloy-eip7928 0.4.0",
  "k256",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "revme"
-version = "15.0.0"
+version = "15.0.1"
 dependencies = [
  "alloy-rlp",
  "alloy-sol-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3706,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "38.0.1"
+version = "39.0.0"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "13.1.0"
+version = "14.0.0"
 dependencies = [
  "alloy-eips",
  "alloy-provider",
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "revm-statetest-types"
-version = "17.0.2"
+version = "18.0.0"
 dependencies = [
  "alloy-eip7928 0.4.0",
  "k256",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "revme"
-version = "15.0.1"
+version = "16.0.0"
 dependencies = [
  "alloy-rlp",
  "alloy-sol-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3706,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "39.0.0"
+version = "40.0.0"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "18.0.0"
+version = "19.0.0"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "14.0.0"
+version = "15.0.0"
 dependencies = [
  "alloy-eips",
  "alloy-provider",
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "11.1.0"
+version = "12.0.0"
 dependencies = [
  "auto_impl",
  "either",
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "revm-ee-tests"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "insta",
  "revm",
@@ -3807,7 +3807,7 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "alloy-signer",
  "alloy-signer-local",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "20.0.0"
+version = "21.0.0"
 dependencies = [
  "auto_impl",
  "either",
@@ -3844,7 +3844,7 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "revm-statetest-types"
-version = "18.0.0"
+version = "19.0.0"
 dependencies = [
  "alloy-eip7928 0.4.0",
  "k256",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "revme"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "alloy-rlp",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,19 +41,19 @@ default-members = ["crates/revm"]
 
 [workspace.dependencies]
 # revm
-revm = { path = "crates/revm", version = "38.0.0", default-features = false }
-primitives = { path = "crates/primitives", package = "revm-primitives", version = "23.0.0", default-features = false }
-bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "10.0.0", default-features = false }
-database = { path = "crates/database", package = "revm-database", version = "13.0.1", default-features = false }
-database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "11.0.1", default-features = false }
-state = { path = "crates/state", package = "revm-state", version = "11.0.1", default-features = false }
-interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "35.0.1", default-features = false }
-inspector = { path = "crates/inspector", package = "revm-inspector", version = "19.0.0", default-features = false }
-precompile = { path = "crates/precompile", package = "revm-precompile", version = "34.0.0", default-features = false }
-statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "17.0.1", default-features = false }
-context = { path = "crates/context", package = "revm-context", version = "16.0.1", default-features = false }
-context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "17.0.1", default-features = false }
-handler = { path = "crates/handler", package = "revm-handler", version = "18.1.0", default-features = false }
+revm = { path = "crates/revm", version = "38.0.1", default-features = false }
+primitives = { path = "crates/primitives", package = "revm-primitives", version = "24.0.0", default-features = false }
+bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "11.0.0", default-features = false }
+database = { path = "crates/database", package = "revm-database", version = "13.1.0", default-features = false }
+database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "11.1.0", default-features = false }
+state = { path = "crates/state", package = "revm-state", version = "12.0.0", default-features = false }
+interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "36.0.0", default-features = false }
+inspector = { path = "crates/inspector", package = "revm-inspector", version = "20.0.0", default-features = false }
+precompile = { path = "crates/precompile", package = "revm-precompile", version = "35.0.0", default-features = false }
+statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "17.0.2", default-features = false }
+context = { path = "crates/context", package = "revm-context", version = "17.0.0", default-features = false }
+context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "18.0.0", default-features = false }
+handler = { path = "crates/handler", package = "revm-handler", version = "19.0.0", default-features = false }
 ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "0.2.0", default-features = false }
 
 # alloy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,20 +41,20 @@ default-members = ["crates/revm"]
 
 [workspace.dependencies]
 # revm
-revm = { path = "crates/revm", version = "39.0.0", default-features = false }
+revm = { path = "crates/revm", version = "40.0.0", default-features = false }
 primitives = { path = "crates/primitives", package = "revm-primitives", version = "24.0.0", default-features = false }
 bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "11.0.0", default-features = false }
-database = { path = "crates/database", package = "revm-database", version = "14.0.0", default-features = false }
-database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "11.1.0", default-features = false }
+database = { path = "crates/database", package = "revm-database", version = "15.0.0", default-features = false }
+database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "12.0.0", default-features = false }
 state = { path = "crates/state", package = "revm-state", version = "12.0.0", default-features = false }
-interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "36.0.0", default-features = false }
-inspector = { path = "crates/inspector", package = "revm-inspector", version = "20.0.0", default-features = false }
-precompile = { path = "crates/precompile", package = "revm-precompile", version = "35.0.0", default-features = false }
-statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "18.0.0", default-features = false }
-context = { path = "crates/context", package = "revm-context", version = "17.0.0", default-features = false }
-context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "18.0.0", default-features = false }
-handler = { path = "crates/handler", package = "revm-handler", version = "19.0.0", default-features = false }
-ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "0.2.0", default-features = false }
+interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "37.0.0", default-features = false }
+inspector = { path = "crates/inspector", package = "revm-inspector", version = "21.0.0", default-features = false }
+precompile = { path = "crates/precompile", package = "revm-precompile", version = "36.0.0", default-features = false }
+statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "19.0.0", default-features = false }
+context = { path = "crates/context", package = "revm-context", version = "18.0.0", default-features = false }
+context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "19.0.0", default-features = false }
+handler = { path = "crates/handler", package = "revm-handler", version = "20.0.0", default-features = false }
+ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "0.3.0", default-features = false }
 
 # alloy
 alloy-eip2930 = { version = "0.2.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,16 +41,16 @@ default-members = ["crates/revm"]
 
 [workspace.dependencies]
 # revm
-revm = { path = "crates/revm", version = "38.0.1", default-features = false }
+revm = { path = "crates/revm", version = "39.0.0", default-features = false }
 primitives = { path = "crates/primitives", package = "revm-primitives", version = "24.0.0", default-features = false }
 bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "11.0.0", default-features = false }
-database = { path = "crates/database", package = "revm-database", version = "13.1.0", default-features = false }
+database = { path = "crates/database", package = "revm-database", version = "14.0.0", default-features = false }
 database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "11.1.0", default-features = false }
 state = { path = "crates/state", package = "revm-state", version = "12.0.0", default-features = false }
 interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "36.0.0", default-features = false }
 inspector = { path = "crates/inspector", package = "revm-inspector", version = "20.0.0", default-features = false }
 precompile = { path = "crates/precompile", package = "revm-precompile", version = "35.0.0", default-features = false }
-statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "17.0.2", default-features = false }
+statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "18.0.0", default-features = false }
 context = { path = "crates/context", package = "revm-context", version = "17.0.0", default-features = false }
 context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "18.0.0", default-features = false }
 handler = { path = "crates/handler", package = "revm-handler", version = "19.0.0", default-features = false }

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,4 +1,58 @@
 
+# v108 tag (revm v39.0.0)
+
+### EIP-8037 Amsterdam — bal-devnet-7 ([#3667](https://github.com/bluealloy/revm/pull/3667))
+* `Cfg`, `Host`, `LocalContextTr` gained required `cpsb()`. `LocalContextTr` also gained `set_cpsb`.
+* `InitialAndFloorGas`: `initial_total_gas` / `eip7702_reservoir_refund` removed; `initial_regular_gas` / `state_refund` added.
+* `ResultGas::state_gas_spent` removed — use `state_gas_spent_final`.
+* New struct fields (break literal construction): `LocalContext.cpsb`, `CallInputs.charged_new_account_state_gas`, `CallOutcome.charged_new_account_state_gas`, `PrecompileOutput.refill_amount`.
+* `GasParams` accessors (`sstore_state_gas`, `new_account_state_gas`, `code_deposit_state_gas`, `create_state_gas`, `tx_eip7702_per_empty_account_cost`, `tx_eip7702_auth_refund`, `initial_tx_gas`) each gained one CPSB param. `tx_eip7702_per_auth_state_gas` and `split_eip7702_refund` removed (also dropped from `GasId`).
+* `calculate_initial_tx_gas` 6→7 params; `calculate_initial_tx_gas_for_tx` 2→3; `validate_initial_tx_gas` 5→6; `build_result_gas` 2→3; `apply_auth_list` 4→3; `initial_gas_and_reservoir` 2→3.
+* `Handler::last_frame_result` trait method 2→3 params. `return_create` 5→4 params and 2→1 generics.
+
+### JournalTr restructure ([#3663](https://github.com/bluealloy/revm/pull/3663))
+* New required methods `db_and_state` / `db_and_state_mut` (no default).
+* `JournalExt` now requires `JournalTr` as supertrait and is no longer dyn-compatible. `evm_state` / `evm_state_mut` removed.
+
+### Instructions return `Result` ([#3558](https://github.com/bluealloy/revm/pull/3558))
+* Opcode fns now return `InstructionExecResult` instead of `()`.
+* New `InstructionResult::Suspend` variant (update exhaustive matches).
+* `InstructionResult::is_error` / `InterpreterResult::is_error` deprecated.
+
+### Split instruction & gas tables ([#3561](https://github.com/bluealloy/revm/pull/3561))
+* `Instruction::new` 2→1 param; `Instruction::static_gas` removed.
+* `InstructionProvider` gained required `gas_table(&self) -> &GasTable`.
+* `EthInstructions`: no longer struct-literal constructible (`instruction_table` field removed). `new` 2→3 params; `insert_instruction` 2→3.
+* `Interpreter::step` / `run_plain` / `run_plain_as_output` 2→3 params; `inspect_instructions` 4→5.
+* `interpreter::instruction_table_gas_changes_spec` removed.
+
+### Reservoir in OOG constructors ([#3580](https://github.com/bluealloy/revm/pull/3580))
+* `Gas::new_spent` removed.
+* `InterpreterResult::new_oog`, `CallOutcome::new_oog`, `CreateOutcome::new_oog`, `FrameResult::new_call_oog`, `FrameResult::new_create_oog` each gained a trailing `reservoir` param.
+
+### SpecId cleanup ([#3593](https://github.com/bluealloy/revm/pull/3593), [#3649](https://github.com/bluealloy/revm/pull/3649))
+* `num_enum` dropped — use the manual `TryFrom<u8>`. New `SpecId::NEXT` constant.
+* Variants removed: `FRONTIER_THAWING`, `DAO_FORK`, `CONSTANTINOPLE`, `MUIR_GLACIER`, `ARROW_GLACIER`, `GRAY_GLACIER` (with their `name::*` consts).
+* Discriminants of the remaining variants shifted (e.g. `HOMESTEAD` 2→1, `AMSTERDAM` 20→14) — fix any `as u8` / pointer-cast usage.
+
+### `op-revm` removed ([#3568](https://github.com/bluealloy/revm/pull/3568))
+Moved to `ethereum-optimism/optimism` (`rust/op-revm`). Update dependency paths.
+
+### Other
+* `Bytecode::new_analyzed` is now `unsafe` ([#3557](https://github.com/bluealloy/revm/pull/3557)) — no PUSH-padding validation.
+* `OpCode::new_unchecked` deprecated ([#3566](https://github.com/bluealloy/revm/pull/3566)).
+* `BalError` ([#3619](https://github.com/bluealloy/revm/pull/3619)): `AccountNotFound` / `SlotNotFound` are now struct variants; new `InvalidAccountId` variant; discriminants no longer stable.
+* `StorageBal::get` 2→3 params; `get_bal_writes` 1→2.
+* `Account.original_info` pub field removed (now private — use accessors) ([#3590](https://github.com/bluealloy/revm/pull/3590)).
+* `MemoryTr::limit_reached` 2→1 param ([#3599](https://github.com/bluealloy/revm/pull/3599)).
+* CALL handlers unified ([#3626](https://github.com/bluealloy/revm/pull/3626)): `contract::call_code` / `delegate_call` / `static_call` removed — use `contract::call::<KIND, _, _>`. `contract::create` swapped const-generic / type-generic order.
+* `MemoryExtensionResult` enum removed ([#3646](https://github.com/bluealloy/revm/pull/3646)).
+* Removed: `Stack::pop_unsafe`, `Stack::top_unsafe`, `Interpreter::step_dummy`.
+* Macros removed: `resize_memory!`, `as_usize_or_fail_ret!`, `as_isize_saturated!`, `berlin_load_account!`.
+* `LoadError` variant discriminants swapped (`DBError` 0→1, `ColdLoadSkipped` 1→0).
+* `GasParams::get` and `log_cost` no longer `const fn` ([#3608](https://github.com/bluealloy/revm/pull/3608)).
+* `revm_precompile::blake2::algo` module + `SIGMA` / `IV` consts removed ([#3609](https://github.com/bluealloy/revm/pull/3609)).
+
 # v107 tag (revm v38.0.0)
 
 * `Handler::first_frame_input` ([#3578](https://github.com/bluealloy/revm/pull/3578)): `init_and_floor_gas: &InitialAndFloorGas` param replaced by `reservoir: u64`. Compute via `InitialAndFloorGas::initial_gas_and_reservoir(tx_gas_limit, tx_gas_limit_cap, is_eip8037) -> (gas_limit, reservoir)`.

--- a/bins/revme/CHANGELOG.md
+++ b/bins/revme/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.1](https://github.com/bluealloy/revm/compare/revme-v15.0.0...revme-v15.0.1) - 2026-05-19
+
+### Other
+
+- remove unused spec ids ([#3649](https://github.com/bluealloy/revm/pull/3649))
+- reject nonce-max senders before execution ([#3531](https://github.com/bluealloy/revm/pull/3531))
+- audit #[allow] attributes ([#3611](https://github.com/bluealloy/revm/pull/3611))
+
 ## [15.0.0](https://github.com/bluealloy/revm/compare/revme-v14.0.0...revme-v15.0.0) - 2026-04-17
 
 ### Other

--- a/bins/revme/CHANGELOG.md
+++ b/bins/revme/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [16.0.0](https://github.com/bluealloy/revm/compare/revme-v15.0.0...revme-v16.0.0) - 2026-05-19
+## [17.0.0](https://github.com/bluealloy/revm/compare/revme-v15.0.0...revme-v17.0.0) - 2026-05-19
 
 ### Other
 

--- a/bins/revme/CHANGELOG.md
+++ b/bins/revme/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [15.0.1](https://github.com/bluealloy/revm/compare/revme-v15.0.0...revme-v15.0.1) - 2026-05-19
+## [16.0.0](https://github.com/bluealloy/revm/compare/revme-v15.0.0...revme-v16.0.0) - 2026-05-19
 
 ### Other
 

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revme"
 description = "Rust Ethereum Virtual Machine Executable"
-version = "15.0.0"
+version = "15.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revme"
 description = "Rust Ethereum Virtual Machine Executable"
-version = "15.0.1"
+version = "16.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revme"
 description = "Rust Ethereum Virtual Machine Executable"
-version = "16.0.0"
+version = "17.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/bytecode/CHANGELOG.md
+++ b/crates/bytecode/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.0.0](https://github.com/bluealloy/revm/compare/revm-bytecode-v10.0.0...revm-bytecode-v11.0.0) - 2026-05-19
+
+### Fixed
+
+- opcode struct panics/safety ([#3566](https://github.com/bluealloy/revm/pull/3566))
+- *(bytecode)* mark `Bytecode::new_analyzed` as unsafe ([#3557](https://github.com/bluealloy/revm/pull/3557))
+
+### Other
+
+- enable and fix clippy::missing_const_for_fn ([#3592](https://github.com/bluealloy/revm/pull/3592))
+- no alloc for empty accounts ([#3590](https://github.com/bluealloy/revm/pull/3590))
+- avoid cloning precompiles on warmup ([#3586](https://github.com/bluealloy/revm/pull/3586))
+- rm op-revm (migrated to ethereum-optimism/optimism) ([#3568](https://github.com/bluealloy/revm/pull/3568))
+
 ## [10.0.0](https://github.com/bluealloy/revm/compare/revm-bytecode-v9.0.0...revm-bytecode-v10.0.0) - 2026-04-10
 
 ### Added

--- a/crates/bytecode/Cargo.toml
+++ b/crates/bytecode/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-bytecode"
 description = "EVM Bytecodes"
-version = "10.0.0"
+version = "11.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/context/CHANGELOG.md
+++ b/crates/context/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [17.0.0](https://github.com/bluealloy/revm/compare/revm-context-v16.0.1...revm-context-v17.0.0) - 2026-05-19
+## [18.0.0](https://github.com/bluealloy/revm/compare/revm-context-v16.0.1...revm-context-v18.0.0) - 2026-05-19
 
 ### Added
 

--- a/crates/context/CHANGELOG.md
+++ b/crates/context/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [17.0.0](https://github.com/bluealloy/revm/compare/revm-context-v16.0.1...revm-context-v17.0.0) - 2026-05-19
+
+### Added
+
+- *(eip8037)* Amsterdam bal-devnet-7 ([#3667](https://github.com/bluealloy/revm/pull/3667))
+- *(state)* Optimized index type for transaction ID using non-max ([#3610](https://github.com/bluealloy/revm/pull/3610))
+
+### Fixed
+
+- *(context)* use storage_by_account_id fast path in sload ([#3535](https://github.com/bluealloy/revm/pull/3535))
+
+### Other
+
+- *(context)* centralize cfg-to-journal sync ([#3686](https://github.com/bluealloy/revm/pull/3686))
+- change &mut self to &self for read-only methods ([#3669](https://github.com/bluealloy/revm/pull/3669))
+- restructure `Journal` traits ([#3663](https://github.com/bluealloy/revm/pull/3663))
+- use get instead of get_mut ([#3643](https://github.com/bluealloy/revm/pull/3643))
+- remove unused spec ids ([#3649](https://github.com/bluealloy/revm/pull/3649))
+- *(gas)* simplify log2floor ([#3629](https://github.com/bluealloy/revm/pull/3629))
+- audit #[allow] attributes ([#3611](https://github.com/bluealloy/revm/pull/3611))
+- backport v107 release notes from branch ([#3617](https://github.com/bluealloy/revm/pull/3617))
+- remove pointer field from GasParams ([#3608](https://github.com/bluealloy/revm/pull/3608))
+- [**breaking**] return Result from instruction functions ([#3558](https://github.com/bluealloy/revm/pull/3558))
+- enable and fix clippy::missing_const_for_fn ([#3592](https://github.com/bluealloy/revm/pull/3592))
+- no alloc for empty accounts ([#3590](https://github.com/bluealloy/revm/pull/3590))
+- avoid cloning precompiles on warmup ([#3586](https://github.com/bluealloy/revm/pull/3586))
+- pass reservoir into `first_frame_input` ([#3578](https://github.com/bluealloy/revm/pull/3578))
+- rm op-revm (migrated to ethereum-optimism/optimism) ([#3568](https://github.com/bluealloy/revm/pull/3568))
+
 ## [16.0.1](https://github.com/bluealloy/revm/compare/revm-context-v16.0.0...revm-context-v16.0.1) - 2026-04-17
 
 ### Other

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-context"
 description = "Revm context crates"
-version = "16.0.1"
+version = "17.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-context"
 description = "Revm context crates"
-version = "17.0.0"
+version = "18.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/context/interface/CHANGELOG.md
+++ b/crates/context/interface/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [18.0.0](https://github.com/bluealloy/revm/compare/revm-context-interface-v17.0.1...revm-context-interface-v18.0.0) - 2026-05-19
+
+### Added
+
+- *(eip8037)* Amsterdam bal-devnet-7 ([#3667](https://github.com/bluealloy/revm/pull/3667))
+- *(state)* Optimized index type for transaction ID using non-max ([#3610](https://github.com/bluealloy/revm/pull/3610))
+
+### Fixed
+
+- *(context)* use storage_by_account_id fast path in sload ([#3535](https://github.com/bluealloy/revm/pull/3535))
+
+### Other
+
+- restructure `Journal` traits ([#3663](https://github.com/bluealloy/revm/pull/3663))
+- remove unused spec ids ([#3649](https://github.com/bluealloy/revm/pull/3649))
+- *(gas)* simplify log2floor ([#3629](https://github.com/bluealloy/revm/pull/3629))
+- audit #[allow] attributes ([#3611](https://github.com/bluealloy/revm/pull/3611))
+- backport v107 release notes from branch ([#3617](https://github.com/bluealloy/revm/pull/3617))
+- remove pointer field from GasParams ([#3608](https://github.com/bluealloy/revm/pull/3608))
+- [**breaking**] return Result from instruction functions ([#3558](https://github.com/bluealloy/revm/pull/3558))
+- enable and fix clippy::missing_const_for_fn ([#3592](https://github.com/bluealloy/revm/pull/3592))
+- avoid cloning precompiles on warmup ([#3586](https://github.com/bluealloy/revm/pull/3586))
+- pass reservoir into `first_frame_input` ([#3578](https://github.com/bluealloy/revm/pull/3578))
+- rm op-revm (migrated to ethereum-optimism/optimism) ([#3568](https://github.com/bluealloy/revm/pull/3568))
+
 ## [17.0.1](https://github.com/bluealloy/revm/compare/revm-context-interface-v17.0.0...revm-context-interface-v17.0.1) - 2026-04-17
 
 ### Other

--- a/crates/context/interface/CHANGELOG.md
+++ b/crates/context/interface/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [18.0.0](https://github.com/bluealloy/revm/compare/revm-context-interface-v17.0.1...revm-context-interface-v18.0.0) - 2026-05-19
+## [19.0.0](https://github.com/bluealloy/revm/compare/revm-context-interface-v17.0.1...revm-context-interface-v19.0.0) - 2026-05-19
 
 ### Added
 

--- a/crates/context/interface/Cargo.toml
+++ b/crates/context/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-context-interface"
 description = "Revm context interface crates"
-version = "17.0.1"
+version = "18.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/context/interface/Cargo.toml
+++ b/crates/context/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-context-interface"
 description = "Revm context interface crates"
-version = "18.0.0"
+version = "19.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/context/interface/src/cfg.rs
+++ b/crates/context/interface/src/cfg.rs
@@ -94,6 +94,13 @@ pub trait Cfg {
     /// via the reservoir model. EIP-8037 specifies concrete gas values based on
     /// `cost_per_state_byte` and adds a hash cost for deployed bytecode.
     fn is_amsterdam_eip8037_enabled(&self) -> bool;
+
+    /// Returns the EIP-8037 `cost_per_state_byte` (CPSB).
+    ///
+    /// When [`Cfg::is_amsterdam_eip8037_enabled`] is `false` this returns `0`.
+    /// Otherwise, if an override is configured it is returned directly; otherwise
+    /// the fixed Glamsterdam value [`primitives::eip8037::CPSB_GLAMSTERDAM`] is returned.
+    fn cpsb(&self) -> u64;
 }
 
 /// What bytecode analysis to perform

--- a/crates/context/interface/src/cfg.rs
+++ b/crates/context/interface/src/cfg.rs
@@ -95,6 +95,15 @@ pub trait Cfg {
     /// `cost_per_state_byte` and adds a hash cost for deployed bytecode.
     fn is_amsterdam_eip8037_enabled(&self) -> bool;
 
+    /// Returns whether EIP-2780 (Amsterdam) reduced intrinsic transaction gas
+    /// is enabled.
+    ///
+    /// When enabled, the legacy `21,000` intrinsic base is replaced with the
+    /// decomposed `TX_BASE_COST + to-based + value-based` model and top-level
+    /// execution charges are applied for empty recipients with value and
+    /// EIP-7702-delegated recipients.
+    fn is_amsterdam_eip2780_enabled(&self) -> bool;
+
     /// Returns the EIP-8037 `cost_per_state_byte` (CPSB).
     ///
     /// When [`Cfg::is_amsterdam_eip8037_enabled`] is `false` this returns `0`.

--- a/crates/context/interface/src/cfg/gas.rs
+++ b/crates/context/interface/src/cfg/gas.rs
@@ -1,6 +1,10 @@
 //! Gas constants and functions for gas calculation.
 
-use crate::{cfg::GasParams, transaction::AccessListItemTr as _, Transaction, TransactionType};
+use crate::{
+    cfg::{gas_params, GasParams},
+    transaction::AccessListItemTr as _,
+    Transaction, TransactionType,
+};
 use primitives::hardfork::SpecId;
 
 /// Tracker for gas during execution.
@@ -488,6 +492,7 @@ impl InitialAndFloorGas {
 ///
 /// - Intrinsic gas
 /// - Number of tokens in calldata
+#[allow(clippy::too_many_arguments)]
 pub fn calculate_initial_tx_gas(
     spec_id: SpecId,
     input: &[u8],
@@ -496,6 +501,7 @@ pub fn calculate_initial_tx_gas(
     access_list_storages: u64,
     authorization_list_num: u64,
     cpsb: u64,
+    eip2780: Option<gas_params::Eip2780TxInfo>,
 ) -> InitialAndFloorGas {
     GasParams::new_spec(spec_id).initial_tx_gas(
         input,
@@ -504,6 +510,7 @@ pub fn calculate_initial_tx_gas(
         access_list_storages,
         authorization_list_num,
         cpsb,
+        eip2780,
     )
 }
 
@@ -518,6 +525,7 @@ pub fn calculate_initial_tx_gas_for_tx(
     tx: impl Transaction,
     spec: SpecId,
     cpsb: u64,
+    eip2780: Option<gas_params::Eip2780TxInfo>,
 ) -> InitialAndFloorGas {
     let mut accounts = 0;
     let mut storages = 0;
@@ -544,6 +552,7 @@ pub fn calculate_initial_tx_gas_for_tx(
         storages as u64,
         tx.authorization_list_len() as u64,
         cpsb,
+        eip2780,
     )
 }
 

--- a/crates/context/interface/src/cfg/gas.rs
+++ b/crates/context/interface/src/cfg/gas.rs
@@ -16,8 +16,18 @@ pub struct GasTracker {
     /// State gas reservoir (gas exceeding TX_MAX_GAS_LIMIT). Starts as `execution_gas - min(execution_gas, regular_gas_budget)`.
     /// When 0, all remaining gas is regular gas with hard cap at `TX_MAX_GAS_LIMIT`.
     reservoir: u64,
-    /// Total state gas spent so far.
-    state_gas_spent: u64,
+    /// Net state gas spent so far.
+    ///
+    /// Can be negative within a call frame when 0→x→0 storage restoration refills
+    /// more state gas than the frame itself has charged (the parent previously
+    /// charged the 0→x portion). The net is reconciled on frame return.
+    state_gas_spent: i64,
+    /// Cumulative reservoir refill amount from 0→x→0 storage restorations
+    /// performed by this frame (EIP-8037 issue #2). Tracked so that on
+    /// revert/halt the parent can subtract this inflation when propagating
+    /// the child's reservoir, without confusing it with legitimate reservoir
+    /// growth from grandchild halt/revert refunds.
+    refill_amount: u64,
     /// Refunded gas. Used to refund the gas to the caller at the end of execution.
     refunded: i64,
 }
@@ -31,6 +41,7 @@ impl GasTracker {
             remaining,
             reservoir,
             state_gas_spent: 0,
+            refill_amount: 0,
             refunded: 0,
         }
     }
@@ -79,13 +90,13 @@ impl GasTracker {
 
     /// Returns the state gas spent.
     #[inline]
-    pub const fn state_gas_spent(&self) -> u64 {
+    pub const fn state_gas_spent(&self) -> i64 {
         self.state_gas_spent
     }
 
     /// Sets the state gas spent.
     #[inline]
-    pub const fn set_state_gas_spent(&mut self, val: u64) {
+    pub const fn set_state_gas_spent(&mut self, val: i64) {
         self.state_gas_spent = val;
     }
 
@@ -125,7 +136,7 @@ impl GasTracker {
     #[must_use = "In case of not enough gas, the interpreter should halt with an out-of-gas error"]
     pub const fn record_state_cost(&mut self, cost: u64) -> bool {
         if self.reservoir >= cost {
-            self.state_gas_spent = self.state_gas_spent.saturating_add(cost);
+            self.state_gas_spent = self.state_gas_spent.saturating_add(cost as i64);
             self.reservoir -= cost;
             return true;
         }
@@ -134,10 +145,41 @@ impl GasTracker {
 
         let success = self.record_regular_cost(spill);
         if success {
-            self.state_gas_spent = self.state_gas_spent.saturating_add(cost);
+            self.state_gas_spent = self.state_gas_spent.saturating_add(cost as i64);
             self.reservoir = 0;
         }
         success
+    }
+
+    /// Refills the reservoir with state gas that is returned by 0→x→0 storage
+    /// restoration (EIP-8037 issue #2).
+    ///
+    /// Per the spec, when a storage slot is restored to its original zero value
+    /// within the same transaction, the state gas charged for the initial 0→x
+    /// transition is directly restored to the reservoir rather than routed
+    /// through the capped refund counter.
+    ///
+    /// `state_gas_spent` is decremented by the same amount and may become
+    /// negative if the matching 0→x charge was made by a parent frame. The
+    /// parent's total is reconciled on frame return.
+    #[inline]
+    pub const fn refill_reservoir(&mut self, amount: u64) {
+        self.reservoir = self.reservoir.saturating_add(amount);
+        self.state_gas_spent = self.state_gas_spent.saturating_sub(amount as i64);
+        self.refill_amount = self.refill_amount.saturating_add(amount);
+    }
+
+    /// Returns cumulative reservoir refill amount from 0→x→0 restorations
+    /// performed in this frame.
+    #[inline]
+    pub const fn refill_amount(&self) -> u64 {
+        self.refill_amount
+    }
+
+    /// Sets the refill amount.
+    #[inline]
+    pub const fn set_refill_amount(&mut self, val: u64) {
+        self.refill_amount = val;
     }
 
     /// Records a refund value.
@@ -233,7 +275,7 @@ pub const NON_ZERO_BYTE_DATA_COST_ISTANBUL: u64 = 16;
 /// The multiplier for a non zero byte in calldata adjusted by [EIP-2028](https://eips.ethereum.org/EIPS/eip-2028).
 pub const NON_ZERO_BYTE_MULTIPLIER_ISTANBUL: u64 =
     NON_ZERO_BYTE_DATA_COST_ISTANBUL / STANDARD_TOKEN_COST;
-/// The cost floor per token as defined by EIP-2028.
+/// The cost floor per token as defined by [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623).
 pub const TOTAL_COST_FLOOR_PER_TOKEN: u64 = 10;
 
 /// Gas cost for EOF CREATE instruction.
@@ -267,51 +309,55 @@ pub const CALL_STIPEND: u64 = 2300;
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InitialAndFloorGas {
-    /// Initial gas for transaction.
-    pub initial_total_gas: u64,
-    /// State gas component of initial_gas (subset of initial_total_gas).
+    /// Regular (non-state) portion of the initial intrinsic gas.
+    ///
+    /// Under EIP-8037, this is the part constrained by `TX_MAX_GAS_LIMIT`;
+    /// state gas uses its own reservoir and is not subject to that cap.
+    pub initial_regular_gas: u64,
+    /// State gas component of the initial intrinsic gas.
     /// Under EIP-8037, this includes:
     /// - EIP-7702 auth list state gas (per-auth account creation + metadata costs)
     /// - For CREATE transactions: `create_state_gas` (account creation + contract metadata)
     /// - For CALL transactions: 0 (state gas is unpredictable at validation time)
     pub initial_state_gas: u64,
+    /// EIP-7702 refund for existing authorities.
+    /// This is the refund given when an authorization is applied to an already existing account.
+    pub state_refund: u64,
     /// If transaction is a Call and Prague is enabled
     /// floor_gas is at least amount of gas that is going to be spent.
     pub floor_gas: u64,
-    /// EIP-7702 state gas refund for existing authorities.
-    /// Added to the reservoir after initial_state_gas is deducted.
-    /// In the Python spec, set_delegation adds this back to state_gas_reservoir
-    /// rather than reducing initial_state_gas, so the refunded gas stays as
-    /// reservoir gas (not regular gas).
-    pub eip7702_reservoir_refund: u64,
 }
 
 impl InitialAndFloorGas {
+    /***** Constructors *****/
+
     /// Create a new InitialAndFloorGas instance.
     #[inline]
-    pub const fn new(initial_total_gas: u64, floor_gas: u64) -> Self {
+    pub const fn new(initial_regular_gas: u64, floor_gas: u64) -> Self {
         Self {
-            initial_total_gas,
+            initial_regular_gas,
             initial_state_gas: 0,
+            state_refund: 0,
             floor_gas,
-            eip7702_reservoir_refund: 0,
         }
     }
 
     /// Create a new InitialAndFloorGas instance with state gas tracking.
     #[inline]
     pub const fn new_with_state_gas(
-        initial_total_gas: u64,
+        initial_regular_gas: u64,
         initial_state_gas: u64,
         floor_gas: u64,
     ) -> Self {
         Self {
-            initial_total_gas,
+            initial_regular_gas,
             initial_state_gas,
+            state_refund: 0,
             floor_gas,
-            eip7702_reservoir_refund: 0,
         }
     }
+
+    /***** Simple getters *****/
 
     /// Regular (non-state) portion of the initial intrinsic gas.
     ///
@@ -319,7 +365,69 @@ impl InitialAndFloorGas {
     /// state gas uses its own reservoir and is not subject to that cap.
     #[inline]
     pub const fn initial_regular_gas(&self) -> u64 {
-        self.initial_total_gas - self.initial_state_gas
+        self.initial_regular_gas
+    }
+
+    /// State gas component of the initial intrinsic gas.
+    /// This is the state gas component of the initial intrinsic gas minus the EIP-7702 refund.
+    #[inline]
+    pub const fn initial_state_gas_final(&self) -> u64 {
+        self.initial_state_gas - self.state_refund
+    }
+
+    /// EIP-7623 floor gas.
+    #[inline]
+    pub const fn floor_gas(&self) -> u64 {
+        self.floor_gas
+    }
+
+    /// Total initial intrinsic gas: `initial_regular_gas + initial_state_gas`.
+    #[inline]
+    pub const fn initial_total_gas(&self) -> u64 {
+        self.initial_regular_gas + self.initial_state_gas_final()
+    }
+
+    /***** Simple setters *****/
+
+    /// Sets the `initial_regular_gas` field by mutable reference.
+    #[inline]
+    pub const fn set_initial_regular_gas(&mut self, initial_regular_gas: u64) {
+        self.initial_regular_gas = initial_regular_gas;
+    }
+
+    /// Sets the `initial_state_gas` field by mutable reference.
+    #[inline]
+    pub const fn set_initial_state_gas(&mut self, initial_state_gas: u64) {
+        self.initial_state_gas = initial_state_gas;
+    }
+
+    /// Sets the `floor_gas` field by mutable reference.
+    #[inline]
+    pub const fn set_floor_gas(&mut self, floor_gas: u64) {
+        self.floor_gas = floor_gas;
+    }
+
+    /***** Builder with_* methods *****/
+
+    /// Sets the `initial_regular_gas` field.
+    #[inline]
+    pub const fn with_initial_regular_gas(mut self, initial_regular_gas: u64) -> Self {
+        self.initial_regular_gas = initial_regular_gas;
+        self
+    }
+
+    /// Sets the `initial_state_gas` field.
+    #[inline]
+    pub const fn with_initial_state_gas(mut self, initial_state_gas: u64) -> Self {
+        self.initial_state_gas = initial_state_gas;
+        self
+    }
+
+    /// Sets the `floor_gas` field.
+    #[inline]
+    pub const fn with_floor_gas(mut self, floor_gas: u64) -> Self {
+        self.floor_gas = floor_gas;
+        self
     }
 
     /// Computes the regular gas budget and reservoir for the initial call frame.
@@ -340,42 +448,36 @@ impl InitialAndFloorGas {
         &self,
         tx_gas_limit: u64,
         tx_gas_limit_cap: u64,
-        is_eip8037: bool,
     ) -> (u64, u64) {
         let execution_gas = tx_gas_limit - self.initial_regular_gas();
 
         // System calls pass InitialAndFloorGas with all zeros and should not be
         // subject to the TX_MAX_GAS_LIMIT cap.
-        let regular_gas_cap = if self.initial_total_gas == 0 {
+        let tx_gas_limit_cap = if self.initial_total_gas() == 0 {
             u64::MAX
-        } else if is_eip8037 {
-            tx_gas_limit_cap.saturating_sub(self.initial_regular_gas())
         } else {
             tx_gas_limit_cap
         };
 
-        let mut gas_limit = core::cmp::min(execution_gas, regular_gas_cap);
-        let mut reservoir = execution_gas - gas_limit;
+        let mut regular_gas_limit = core::cmp::min(tx_gas_limit, tx_gas_limit_cap)
+            .saturating_sub(self.initial_regular_gas());
+        let mut reservoir = execution_gas - regular_gas_limit;
 
         // Deduct initial state gas from the reservoir. When the reservoir is
         // insufficient, the deficit is charged from the regular gas budget.
-        if self.initial_state_gas > 0 {
-            if reservoir >= self.initial_state_gas {
-                reservoir -= self.initial_state_gas;
-            } else {
-                gas_limit -= self.initial_state_gas - reservoir;
-                reservoir = 0;
-            }
+        if reservoir >= self.initial_state_gas {
+            reservoir -= self.initial_state_gas;
+        } else {
+            regular_gas_limit -= self.initial_state_gas - reservoir;
+            reservoir = 0;
         }
 
         // EIP-7702 state gas refund for existing authorities goes directly to
         // the reservoir. In the Python spec, set_delegation adds this refund to
         // state_gas_reservoir so it stays as state gas (not regular gas).
-        if self.eip7702_reservoir_refund > 0 {
-            reservoir += self.eip7702_reservoir_refund;
-        }
+        reservoir += self.state_refund;
 
-        (gas_limit, reservoir)
+        (regular_gas_limit, reservoir)
     }
 }
 
@@ -393,6 +495,7 @@ pub fn calculate_initial_tx_gas(
     access_list_accounts: u64,
     access_list_storages: u64,
     authorization_list_num: u64,
+    cpsb: u64,
 ) -> InitialAndFloorGas {
     GasParams::new_spec(spec_id).initial_tx_gas(
         input,
@@ -400,6 +503,7 @@ pub fn calculate_initial_tx_gas(
         access_list_accounts,
         access_list_storages,
         authorization_list_num,
+        cpsb,
     )
 }
 
@@ -410,7 +514,11 @@ pub fn calculate_initial_tx_gas(
 ///
 /// - Intrinsic gas
 /// - Number of tokens in calldata
-pub fn calculate_initial_tx_gas_for_tx(tx: impl Transaction, spec: SpecId) -> InitialAndFloorGas {
+pub fn calculate_initial_tx_gas_for_tx(
+    tx: impl Transaction,
+    spec: SpecId,
+    cpsb: u64,
+) -> InitialAndFloorGas {
     let mut accounts = 0;
     let mut storages = 0;
     // legacy is only tx type that does not have access list.
@@ -435,6 +543,7 @@ pub fn calculate_initial_tx_gas_for_tx(tx: impl Transaction, spec: SpecId) -> In
         accounts as u64,
         storages as u64,
         tx.authorization_list_len() as u64,
+        cpsb,
     )
 }
 

--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use core::hash::{Hash, Hasher};
 use primitives::{
-    eip7702,
+    eip7702, eip8037,
     hardfork::SpecId::{self},
     OnceLock, U256,
 };
@@ -304,13 +304,16 @@ impl GasParams {
 
             table[GasId::tx_floor_cost_per_token().as_usize()] = gas::TOTAL_COST_FLOOR_PER_TOKEN;
             table[GasId::tx_floor_cost_base_gas().as_usize()] = 21000;
+            // EIP-7623 floor tokens reuse `tokens_in_calldata`, i.e. zero bytes count as
+            // one token each.
+            table[GasId::tx_floor_token_zero_byte_multiplier().as_usize()] = 1;
         }
 
-        // EIP-8037: State creation gas cost increase
+        // EIP-8037: State creation gas cost increase.
+        // State-gas entries store *byte counts* here; the helper methods multiply
+        // by the current `cost_per_state_byte` (CPSB), which is derived from the
+        // block gas limit at charge time via `Cfg::cpsb`.
         if spec.is_enabled_in(SpecId::AMSTERDAM) {
-            // Hardcoded cost_per_state_byte for 100M block gas limit
-            const CPSB: u64 = 1174;
-
             // Regular gas changes
             table[GasId::create().as_usize()] = 9000;
             table[GasId::tx_create_cost().as_usize()] = 9000;
@@ -321,25 +324,46 @@ impl GasParams {
             // sstore_set_without_load_cost = 2900 - WARM_STORAGE_READ_COST(100) = 2800
             table[GasId::sstore_set_without_load_cost().as_usize()] = 2800;
 
-            // State gas values
-            table[GasId::sstore_set_state_gas().as_usize()] = 32 * CPSB;
-            table[GasId::new_account_state_gas().as_usize()] = 112 * CPSB;
-            table[GasId::code_deposit_state_gas().as_usize()] = CPSB;
-            table[GasId::create_state_gas().as_usize()] = 112 * CPSB;
+            // State gas byte counts (multiplied by CPSB at charge time).
+            table[GasId::sstore_set_state_gas().as_usize()] = eip8037::SSTORE_SET_BYTES;
+            table[GasId::new_account_state_gas().as_usize()] = eip8037::NEW_ACCOUNT_BYTES;
+            table[GasId::code_deposit_state_gas().as_usize()] = eip8037::CODE_DEPOSIT_PER_BYTE;
+            table[GasId::create_state_gas().as_usize()] = eip8037::NEW_ACCOUNT_BYTES;
+            table[GasId::tx_eip7702_state_gas_bytecode().as_usize()] = eip8037::AUTH_BASE_BYTES;
 
-            // SSTORE refund for 0→X→0 restoration: state gas + regular gas
-            table[GasId::sstore_set_refund().as_usize()] = 32 * CPSB + 2800;
+            // SSTORE refund for 0→X→0 restoration: regular gas only.
+            // The state-gas portion (SSTORE_SET_BYTES × CPSB) is restored directly
+            // to the reservoir via `GasParams::sstore_state_gas_refill`.
+            table[GasId::sstore_set_refund().as_usize()] = 2800;
 
-            // EIP-7702 parameter updates under EIP-8037
-            // Total per auth charged pessimistically:
-            //   regular: PER_AUTH_BASE_COST_REGULAR (7500)
-            //   state: (PER_EMPTY_ACCOUNT 112 + PER_AUTH_BASE 23) × CPSB
-            table[GasId::tx_eip7702_per_empty_account_cost().as_usize()] = 7500 + (112 + 23) * CPSB;
-            // Refund for existing accounts: PER_EMPTY_ACCOUNT state gas (112 × CPSB)
-            table[GasId::tx_eip7702_auth_refund().as_usize()] = 112 * CPSB;
+            // EIP-7702 under EIP-8037: only the regular-gas slots live here.
+            // The state-gas portions are sourced from `new_account_state_gas`
+            // (per-account) and `tx_eip7702_state_gas_bytecode` (per-bytecode);
+            // helpers in `GasParams` combine them with the current CPSB.
+            //   regular per-auth cost: 7500 (state bytes added pessimistically in `initial_tx_gas`)
+            //   regular refund:        0   (per-auth refund is entirely state gas)
+            table[GasId::tx_eip7702_per_empty_account_cost().as_usize()] =
+                eip8037::EIP7702_PER_EMPTY_ACCOUNT_REGULAR;
+            table[GasId::tx_eip7702_auth_refund().as_usize()] = 0;
 
-            // State gas per auth for initial_state_gas tracking
-            table[GasId::tx_eip7702_per_auth_state_gas().as_usize()] = (112 + 23) * CPSB;
+            // EIP-7976: Increase calldata floor cost from 10/40 to 64/64 gas per byte
+            // (zero/nonzero). The per-token constant bumps from 10 to 16, and
+            // `floor_tokens_in_calldata` switches from `zero + nonzero * 4` to
+            // `(zero + nonzero) * 4`, i.e. every byte now costs 16 * 4 = 64 gas in the floor.
+            table[GasId::tx_floor_cost_per_token().as_usize()] = 16;
+            table[GasId::tx_floor_token_zero_byte_multiplier().as_usize()] =
+                table[GasId::tx_token_non_zero_byte_multiplier().as_usize()];
+
+            // EIP-7981: Charge access list data at 64 gas per byte, matching
+            // calldata floor pricing. Per-item costs bake in the data charge:
+            //   address: 2400 + 20 * 64 = 3680
+            //   key:     1900 + 32 * 64 = 3948
+            // And every access-list byte contributes 4 floor tokens (16 * 4 = 64 gas).
+            table[GasId::tx_access_list_address_cost().as_usize()] =
+                gas::ACCESS_LIST_ADDRESS + 20 * 64;
+            table[GasId::tx_access_list_storage_key_cost().as_usize()] =
+                gas::ACCESS_LIST_STORAGE_KEY + 32 * 64;
+            table[GasId::tx_access_list_floor_byte_multiplier().as_usize()] = 4;
         }
 
         Self::new(Arc::new(table))
@@ -667,12 +691,29 @@ impl GasParams {
 
     /// State gas for SSTORE: charges for new slot creation (zero → non-zero).
     #[inline]
-    pub fn sstore_state_gas(&self, vals: &SStoreResult) -> u64 {
+    pub fn sstore_state_gas(&self, vals: &SStoreResult, cpsb: u64) -> u64 {
         if vals.new_values_changes_present()
             && vals.is_original_eq_present()
             && vals.is_original_zero()
         {
-            self.get(GasId::sstore_set_state_gas())
+            self.get(GasId::sstore_set_state_gas()).saturating_mul(cpsb)
+        } else {
+            0
+        }
+    }
+
+    /// State gas to refill the reservoir on 0→x→0 storage restoration (EIP-8037).
+    ///
+    /// When a storage slot is restored to its original zero value within the
+    /// same transaction, the state gas originally charged for the 0→x
+    /// transition is returned directly to the reservoir (not via the capped
+    /// refund counter). Returns 0 in any other case.
+    ///
+    /// `cpsb` is the current `cost_per_state_byte` (see [`super::Cfg::cpsb`]).
+    #[inline]
+    pub fn sstore_state_gas_refill(&self, vals: &SStoreResult, cpsb: u64) -> u64 {
+        if !vals.is_new_eq_present() && vals.is_original_eq_new() && vals.is_original_zero() {
+            self.get(GasId::sstore_set_state_gas()).saturating_mul(cpsb)
         } else {
             0
         }
@@ -680,70 +721,92 @@ impl GasParams {
 
     /// State gas for new account creation.
     #[inline]
-    pub fn new_account_state_gas(&self) -> u64 {
+    pub fn new_account_state_gas(&self, cpsb: u64) -> u64 {
         self.get(GasId::new_account_state_gas())
+            .saturating_mul(cpsb)
     }
 
-    /// State gas per byte for code deposit.
+    /// State gas for code deposit of `len` bytes.
     #[inline]
-    pub fn code_deposit_state_gas(&self, len: usize) -> u64 {
+    pub fn code_deposit_state_gas(&self, len: usize, cpsb: u64) -> u64 {
         self.get(GasId::code_deposit_state_gas())
             .saturating_mul(len as u64)
+            .saturating_mul(cpsb)
     }
 
     /// State gas for contract metadata creation.
     #[inline]
-    pub fn create_state_gas(&self) -> u64 {
-        self.get(GasId::create_state_gas())
+    pub fn create_state_gas(&self, cpsb: u64) -> u64 {
+        self.get(GasId::create_state_gas()).saturating_mul(cpsb)
     }
 
-    /// Used in [GasParams::initial_tx_gas] to calculate the eip7702 per empty account cost.
+    /// Used in [GasParams::initial_tx_gas] to calculate the eip7702 per-auth cost.
+    ///
+    /// Under EIP-8037 this combines a regular portion with a state-bytes portion
+    /// (new-account + bytecode) multiplied by `cpsb`. Pre-EIP-8037 the state-bytes
+    /// portion is zero so this returns the legacy `PER_EMPTY_ACCOUNT_COST`.
     #[inline]
-    pub fn tx_eip7702_per_empty_account_cost(&self) -> u64 {
-        self.get(GasId::tx_eip7702_per_empty_account_cost())
+    pub fn tx_eip7702_per_empty_account_cost(&self, cpsb: u64) -> u64 {
+        let regular = self.get(GasId::tx_eip7702_per_empty_account_cost());
+        let state = self.tx_eip7702_state_gas(cpsb);
+        regular.saturating_add(state)
     }
 
     /// EIP-7702 authorization refund per existing account.
     ///
-    /// This is the gas refund given when an EIP-7702 authorization is applied
-    /// to an account that already exists in the trie. By default this is
-    /// `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST` (25000 - 12500 = 12500).
+    /// Pre-Amsterdam this is a fixed regular-gas refund (`PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST`).
+    /// Under EIP-8037 the refund is fully state gas, equal to the per-account
+    /// state-gas portion (`NEW_ACCOUNT_BYTES * cpsb`).
     #[inline]
-    pub fn tx_eip7702_auth_refund(&self) -> u64 {
-        self.get(GasId::tx_eip7702_auth_refund())
+    pub fn tx_eip7702_auth_refund(&self, cpsb: u64) -> u64 {
+        let regular = self.get(GasId::tx_eip7702_auth_refund());
+        let state = self.new_account_state_gas(cpsb);
+        regular.saturating_add(state)
     }
 
     /// EIP-8037: State gas per EIP-7702 authorization (pessimistic).
     ///
-    /// Used for `initial_state_gas` tracking. Zero before AMSTERDAM.
+    /// Sums the new-account and bytecode state-bytes portions and multiplies by
+    /// `cpsb`. Used for `initial_state_gas` tracking. Zero before AMSTERDAM.
     #[inline]
-    pub fn tx_eip7702_per_auth_state_gas(&self) -> u64 {
-        self.get(GasId::tx_eip7702_per_auth_state_gas())
+    pub fn tx_eip7702_state_gas(&self, cpsb: u64) -> u64 {
+        let new_account = self.get(GasId::new_account_state_gas());
+        let bytecode = self.get(GasId::tx_eip7702_state_gas_bytecode());
+        new_account.saturating_add(bytecode).saturating_mul(cpsb)
     }
 
-    /// EIP-8037: Splits a total EIP-7702 refund into state gas and regular gas portions.
+    /// EIP-7702 total state-gas refund for a transaction.
     ///
-    /// At validation time, `initial_tx_gas` splits each auth cost into state + regular.
-    /// This method is the inverse: it recovers how much of the total refund was state gas.
-    ///
-    /// The state gas portion reduces `initial_state_gas` directly (not subject to refund caps).
-    /// The regular gas portion goes through the standard 1/5 refund cap.
-    ///
-    /// # Returns
-    ///
-    /// `(state_refund, regular_refund)` for the given total refund.
+    /// Combines the per-account refund (`NEW_ACCOUNT_BYTES * cpsb` per refunded
+    /// account, when the authorization targets an account that already exists)
+    /// with the per-bytecode refund (`AUTH_BASE_BYTES * cpsb` per refunded
+    /// bytecode, when the delegation target is already deployed). Returns zero
+    /// before AMSTERDAM.
     #[inline]
-    pub fn split_eip7702_refund(&self, total_refund: u64) -> (u64, u64) {
-        let per_auth_refund = self.tx_eip7702_auth_refund();
-        let per_auth_state_gas = self.tx_eip7702_per_auth_state_gas();
-        if per_auth_state_gas > 0 && per_auth_refund > 0 && total_refund > 0 {
-            let state_refund_per_auth = core::cmp::min(per_auth_refund, per_auth_state_gas);
-            let num_refunded = total_refund / per_auth_refund;
-            let state_refund = num_refunded * state_refund_per_auth;
-            (state_refund, total_refund - state_refund)
-        } else {
-            (0, total_refund)
-        }
+    pub fn tx_eip7702_state_refund(
+        &self,
+        refunded_accounts: u64,
+        refunded_bytecodes: u64,
+        cpsb: u64,
+    ) -> u64 {
+        let per_account = self
+            .get(GasId::new_account_state_gas())
+            .saturating_mul(refunded_accounts);
+        let per_bytecode = self
+            .get(GasId::tx_eip7702_state_gas_bytecode())
+            .saturating_mul(refunded_bytecodes);
+        per_account
+            .saturating_add(per_bytecode)
+            .saturating_mul(cpsb)
+    }
+
+    /// EIP-7702 per-auth refund: regular-gas portion only.
+    ///
+    /// Pre-Amsterdam this is `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST` (12500).
+    /// Under EIP-8037 it is zero — the refund is entirely state gas.
+    #[inline]
+    pub fn tx_eip7702_auth_refund_regular(&self) -> u64 {
+        self.get(GasId::tx_eip7702_auth_refund())
     }
 
     /// Used in [GasParams::initial_tx_gas] to calculate the token non zero byte multiplier.
@@ -763,12 +826,43 @@ impl GasParams {
         self.get(GasId::tx_floor_cost_per_token())
     }
 
-    /// Used [GasParams::initial_tx_gas] to calculate the floor gas.
+    /// Multiplier for a zero byte in the floor tokens calculation.
     ///
-    /// Floor gas is introduced in EIP-7623.
+    /// Under EIP-7623 this is `1` (zero bytes count as one token), so the floor
+    /// reuses `tokens_in_calldata`. Under [EIP-7976](https://eips.ethereum.org/EIPS/eip-7976)
+    /// it is raised to [`tx_token_non_zero_byte_multiplier`](Self::tx_token_non_zero_byte_multiplier)
+    /// so every calldata byte contributes the same amount (`floor_tokens_in_calldata =
+    /// (zero + nonzero) * 4`).
+    pub fn tx_floor_token_zero_byte_multiplier(&self) -> u64 {
+        self.get(GasId::tx_floor_token_zero_byte_multiplier())
+    }
+
+    /// Floor gas cost for a transaction with the given calldata.
+    ///
+    /// Introduced by EIP-7623 and further updated by EIP-7976. Computes
+    /// `tx_floor_cost_per_token * floor_tokens_in_calldata + tx_floor_cost_base_gas`,
+    /// where
+    /// `floor_tokens_in_calldata = zero * tx_floor_token_zero_byte_multiplier + nonzero * tx_token_non_zero_byte_multiplier`.
+    /// When the two multipliers match (EIP-7976), every byte contributes the
+    /// same amount, so the zero/nonzero split is skipped and `input.len()` is
+    /// used directly; otherwise (EIP-7623 path, zero multiplier = 1) the result
+    /// matches `get_tokens_in_calldata(input, nonzero)`.
     #[inline]
-    pub fn tx_floor_cost(&self, tokens_in_calldata: u64) -> u64 {
-        self.tx_floor_cost_per_token() * tokens_in_calldata + self.tx_floor_cost_base_gas()
+    pub fn tx_floor_cost(&self, input: &[u8]) -> u64 {
+        let zero_multiplier = self.tx_floor_token_zero_byte_multiplier();
+        let non_zero_multiplier = self.tx_token_non_zero_byte_multiplier();
+        let floor_tokens = if zero_multiplier == non_zero_multiplier {
+            input.len() as u64 * non_zero_multiplier
+        } else {
+            get_tokens_in_calldata(input, non_zero_multiplier)
+        };
+        self.tx_floor_cost_with_tokens(floor_tokens)
+    }
+
+    /// Calculate the floor gas cost for a transaction with the given number of tokens.
+    #[inline]
+    pub fn tx_floor_cost_with_tokens(&self, tokens: u64) -> u64 {
+        self.tx_floor_cost_per_token() * tokens + self.tx_floor_cost_base_gas()
     }
 
     /// Used in [GasParams::initial_tx_gas] to calculate the floor gas base gas.
@@ -810,6 +904,30 @@ impl GasParams {
             .saturating_add(storages.saturating_mul(self.tx_access_list_storage_key_cost()))
     }
 
+    /// Floor tokens contributed per access-list byte ([EIP-7981]).
+    ///
+    /// Zero before AMSTERDAM. From AMSTERDAM onward this is `4`, so each
+    /// access-list byte contributes the same 64 gas to the floor as a calldata
+    /// byte under EIP-7976.
+    ///
+    /// [EIP-7981]: https://eips.ethereum.org/EIPS/eip-7981
+    #[inline]
+    pub fn tx_access_list_floor_byte_multiplier(&self) -> u64 {
+        self.get(GasId::tx_access_list_floor_byte_multiplier())
+    }
+
+    /// Floor tokens contributed by an access list with the given address and
+    /// storage-key counts (EIP-7981). Each address is 20 bytes, each storage
+    /// key is 32 bytes; tokens per byte come from
+    /// [`tx_access_list_floor_byte_multiplier`](Self::tx_access_list_floor_byte_multiplier).
+    #[inline]
+    pub fn tx_floor_tokens_in_access_list(&self, accounts: u64, storages: u64) -> u64 {
+        let bytes = accounts
+            .saturating_mul(20)
+            .saturating_add(storages.saturating_mul(32));
+        bytes.saturating_mul(self.tx_access_list_floor_byte_multiplier())
+    }
+
     /// Used in [GasParams::initial_tx_gas] to calculate the base transaction stipend.
     pub fn tx_base_stipend(&self) -> u64 {
         self.get(GasId::tx_base_stipend())
@@ -833,8 +951,9 @@ impl GasParams {
     /// Initial gas that is deducted for transaction to be included.
     /// Initial gas contains initial stipend gas, gas for access list and input data.
     ///
-    /// Under EIP-8037, state gas is tracked separately in `initial_state_gas` and
-    /// added to `initial_total_gas` at the end. The state gas components are:
+    /// Under EIP-8037, state gas is tracked separately in `initial_state_gas`,
+    /// while regular intrinsic gas accumulates in `initial_regular_gas`. The state
+    /// gas components are:
     /// - EIP-7702 auth list state gas (per-auth account creation + metadata costs)
     /// - For CREATE transactions: `create_state_gas` (account creation + contract metadata)
     ///
@@ -851,21 +970,21 @@ impl GasParams {
         access_list_accounts: u64,
         access_list_storages: u64,
         authorization_list_num: u64,
+        cpsb: u64,
     ) -> InitialAndFloorGas {
-        let mut gas = InitialAndFloorGas::default();
-
         // Initdate stipend
         let tokens_in_calldata =
             get_tokens_in_calldata(input, self.tx_token_non_zero_byte_multiplier());
 
         // EIP-7702: Compute auth list costs.
         // Under EIP-8037, tx_eip7702_per_empty_account_cost bundles regular + state gas.
-        // We split them: regular goes in initial_total_gas, state goes in initial_state_gas.
-        let auth_total_cost = authorization_list_num * self.tx_eip7702_per_empty_account_cost();
-        let auth_state_gas = authorization_list_num * self.tx_eip7702_per_auth_state_gas();
+        // We split them: regular goes in initial_regular_gas, state goes in initial_state_gas.
+        let auth_total_cost = authorization_list_num * self.tx_eip7702_per_empty_account_cost(cpsb);
+        let auth_state_gas = authorization_list_num * self.tx_eip7702_state_gas(cpsb);
+
         let auth_regular_cost = auth_total_cost - auth_state_gas;
 
-        gas.initial_total_gas += tokens_in_calldata * self.tx_token_cost()
+        let mut initial_regular_gas = tokens_in_calldata * self.tx_token_cost()
             // before berlin tx_access_list_address_cost will be zero
             + access_list_accounts * self.tx_access_list_address_cost()
             // before berlin tx_access_list_storage_key_cost will be zero
@@ -875,29 +994,31 @@ impl GasParams {
             + auth_regular_cost;
 
         // EIP-8037: Track auth list state gas separately for reservoir handling.
-        // State gas is added to initial_total_gas at the end of this function.
-        gas.initial_state_gas += auth_state_gas;
+        let mut initial_state_gas = auth_state_gas;
 
         if is_create {
             // EIP-2: Homestead Hard-fork Changes
-            gas.initial_total_gas += self.tx_create_cost();
+            initial_regular_gas += self.tx_create_cost();
 
             // EIP-3860: Limit and meter initcode
-            gas.initial_total_gas += self.tx_initcode_cost(input.len());
+            initial_regular_gas += self.tx_initcode_cost(input.len());
 
             // EIP-8037: State gas for CREATE transactions.
             // create_state_gas covers both account creation and contract metadata.
-            gas.initial_state_gas += self.create_state_gas();
+            initial_state_gas += self.create_state_gas(cpsb);
         }
 
-        // Calculate gas floor for EIP-7623
-        gas.floor_gas = self.tx_floor_cost(tokens_in_calldata);
+        // Calculate gas floor. Introduced by EIP-7623, updated by EIP-7976, and
+        // extended by EIP-7981 to include access-list data alongside calldata.
+        let access_list_floor_tokens =
+            self.tx_floor_tokens_in_access_list(access_list_accounts, access_list_storages);
+        let floor_gas =
+            self.tx_floor_cost(input) + access_list_floor_tokens * self.tx_floor_cost_per_token();
 
-        // EIP-8037: Include state gas in total initial gas.
-        // State gas is a subset of initial_total_gas, deducted before execution starts.
-        gas.initial_total_gas += gas.initial_state_gas;
-
-        gas
+        InitialAndFloorGas::default()
+            .with_initial_regular_gas(initial_regular_gas)
+            .with_initial_state_gas(initial_state_gas)
+            .with_floor_gas(floor_gas)
     }
 }
 
@@ -1001,8 +1122,14 @@ impl GasId {
             x if x == Self::new_account_state_gas().as_u8() => "new_account_state_gas",
             x if x == Self::code_deposit_state_gas().as_u8() => "code_deposit_state_gas",
             x if x == Self::create_state_gas().as_u8() => "create_state_gas",
-            x if x == Self::tx_eip7702_per_auth_state_gas().as_u8() => {
-                "tx_eip7702_per_auth_state_gas"
+            x if x == Self::tx_eip7702_state_gas_bytecode().as_u8() => {
+                "tx_eip7702_state_gas_bytecode"
+            }
+            x if x == Self::tx_floor_token_zero_byte_multiplier().as_u8() => {
+                "tx_floor_token_zero_byte_multiplier"
+            }
+            x if x == Self::tx_access_list_floor_byte_multiplier().as_u8() => {
+                "tx_access_list_floor_byte_multiplier"
             }
             _ => "unknown",
         }
@@ -1068,7 +1195,13 @@ impl GasId {
             "new_account_state_gas" => Some(Self::new_account_state_gas()),
             "code_deposit_state_gas" => Some(Self::code_deposit_state_gas()),
             "create_state_gas" => Some(Self::create_state_gas()),
-            "tx_eip7702_per_auth_state_gas" => Some(Self::tx_eip7702_per_auth_state_gas()),
+            "tx_eip7702_state_gas_bytecode" => Some(Self::tx_eip7702_state_gas_bytecode()),
+            "tx_floor_token_zero_byte_multiplier" => {
+                Some(Self::tx_floor_token_zero_byte_multiplier())
+            }
+            "tx_access_list_floor_byte_multiplier" => {
+                Some(Self::tx_access_list_floor_byte_multiplier())
+            }
             _ => None,
         }
     }
@@ -1293,11 +1426,30 @@ impl GasId {
         Self::new(43)
     }
 
-    /// EIP-8037: State gas per EIP-7702 authorization (pessimistic).
-    /// Includes both PER_EMPTY_ACCOUNT (112 × cpsb) and PER_AUTH_BASE (23 × cpsb).
+    /// EIP-8037: State bytes for the bytecode (delegation) portion of an EIP-7702 authorization.
+    /// Equals `eip8037::AUTH_BASE_BYTES`. Multiplied by CPSB at charge time.
     /// Zero before AMSTERDAM.
-    pub const fn tx_eip7702_per_auth_state_gas() -> GasId {
+    pub const fn tx_eip7702_state_gas_bytecode() -> GasId {
         Self::new(44)
+    }
+
+    /// Multiplier for a zero byte in `floor_tokens_in_calldata`.
+    ///
+    /// `1` under [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623) and raised
+    /// to [`tx_token_non_zero_byte_multiplier`](Self::tx_token_non_zero_byte_multiplier)
+    /// under [EIP-7976](https://eips.ethereum.org/EIPS/eip-7976), which makes the
+    /// floor cost uniform across zero and nonzero calldata bytes. Zero before PRAGUE.
+    pub const fn tx_floor_token_zero_byte_multiplier() -> GasId {
+        Self::new(45)
+    }
+
+    /// Floor tokens contributed per byte of access-list data (EIP-7981).
+    ///
+    /// Zero before AMSTERDAM. From AMSTERDAM onward, set to `4` so every
+    /// access-list byte contributes the same 16 × 4 = 64 gas as a calldata byte
+    /// under EIP-7976.
+    pub const fn tx_access_list_floor_byte_multiplier() -> GasId {
+        Self::new(46)
     }
 }
 
@@ -1369,11 +1521,11 @@ mod tests {
             "Not all unique names are resolvable via from_str"
         );
 
-        // We should have exactly 44 known GasIds (based on the indices 1-44 used)
+        // We should have exactly 46 known GasIds (based on the indices 1-46 used)
         assert_eq!(
             unique_names.len(),
-            44,
-            "Expected 44 unique GasIds, found {}",
+            46,
+            "Expected 46 unique GasIds, found {}",
             unique_names.len()
         );
     }
@@ -1419,28 +1571,65 @@ mod tests {
 
     #[test]
     fn test_initial_state_gas_for_create() {
-        // Use AMSTERDAM spec since EIP-8037 state gas is only enabled starting from Amsterdam
+        // Use AMSTERDAM spec since EIP-8037 state gas is only enabled starting from Amsterdam.
         let gas_params = GasParams::new_spec(SpecId::AMSTERDAM);
+        let cpsb = eip8037::CPSB_GLAMSTERDAM;
 
         // Test CREATE transaction (is_create = true)
-        let create_gas = gas_params.initial_tx_gas(b"", true, 0, 0, 0);
-        let expected_state_gas = gas_params.create_state_gas();
+        let create_gas = gas_params.initial_tx_gas(b"", true, 0, 0, 0, cpsb);
+        let expected_state_gas = gas_params.create_state_gas(cpsb);
 
-        assert_eq!(create_gas.initial_state_gas, expected_state_gas);
-        assert_eq!(create_gas.initial_state_gas, 131488);
+        assert_eq!(create_gas.initial_state_gas_final(), expected_state_gas);
+        assert_eq!(
+            create_gas.initial_state_gas_final(),
+            eip8037::NEW_ACCOUNT_BYTES * eip8037::CPSB_GLAMSTERDAM
+        );
 
-        // initial_total_gas includes both regular and state gas
+        // initial_total_gas() returns both regular and state gas combined
         let create_cost = gas_params.tx_create_cost();
         let initcode_cost = gas_params.tx_initcode_cost(0);
         assert_eq!(
-            create_gas.initial_total_gas,
+            create_gas.initial_total_gas(),
             gas_params.tx_base_stipend() + create_cost + initcode_cost + expected_state_gas
         );
 
         // Test CALL transaction (is_create = false)
-        let call_gas = gas_params.initial_tx_gas(b"", false, 0, 0, 0);
-        assert_eq!(call_gas.initial_state_gas, 0);
+        let call_gas = gas_params.initial_tx_gas(b"", false, 0, 0, 0, cpsb);
+        assert_eq!(call_gas.initial_state_gas_final(), 0);
         // initial_gas should be unchanged for calls
-        assert_eq!(call_gas.initial_total_gas, gas_params.tx_base_stipend());
+        assert_eq!(call_gas.initial_total_gas(), gas_params.tx_base_stipend());
+    }
+
+    #[test]
+    fn test_eip7981_access_list_cost_amsterdam() {
+        // EIP-7981 folds a 64 gas/byte data charge into the per-item access-list cost
+        // and adds 4 floor tokens per access-list byte on top of the EIP-7976 floor.
+        let params = GasParams::new_spec(SpecId::AMSTERDAM);
+
+        // Per-item intrinsic cost: base + bytes * 64
+        assert_eq!(params.tx_access_list_address_cost(), 2400 + 20 * 64);
+        assert_eq!(params.tx_access_list_storage_key_cost(), 1900 + 32 * 64);
+        assert_eq!(params.tx_access_list_cost(1, 0), 2400 + 20 * 64);
+        assert_eq!(params.tx_access_list_cost(0, 1), 1900 + 32 * 64);
+
+        // Floor multiplier activates at AMSTERDAM.
+        assert_eq!(params.tx_access_list_floor_byte_multiplier(), 4);
+        // 2 addresses (40 bytes) + 3 keys (96 bytes) = 136 bytes => 544 floor tokens.
+        assert_eq!(params.tx_floor_tokens_in_access_list(2, 3), (40 + 96) * 4);
+
+        // Floor gas includes both calldata (empty here) and access-list contribution.
+        let gas = params.initial_tx_gas(b"", false, 2, 3, 0, 0);
+        let expected_al_floor = (40 + 96) * 4 * params.tx_floor_cost_per_token();
+        assert_eq!(
+            gas.floor_gas(),
+            params.tx_floor_cost_base_gas() + expected_al_floor,
+        );
+
+        // Pre-AMSTERDAM the access-list floor contribution is zero.
+        let prague = GasParams::new_spec(SpecId::PRAGUE);
+        assert_eq!(prague.tx_access_list_floor_byte_multiplier(), 0);
+        assert_eq!(prague.tx_floor_tokens_in_access_list(2, 3), 0);
+        let prague_gas = prague.initial_tx_gas(b"", false, 2, 3, 0, 0);
+        assert_eq!(prague_gas.floor_gas(), prague.tx_floor_cost_base_gas());
     }
 }

--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use core::hash::{Hash, Hasher};
 use primitives::{
-    eip7702, eip8037,
+    eip2780, eip7702, eip8037, eip8038,
     hardfork::SpecId::{self},
     OnceLock, U256,
 };
@@ -364,6 +364,15 @@ impl GasParams {
             table[GasId::tx_access_list_storage_key_cost().as_usize()] =
                 gas::ACCESS_LIST_STORAGE_KEY + 32 * 64;
             table[GasId::tx_access_list_floor_byte_multiplier().as_usize()] = 4;
+
+            // EIP-2780: Intrinsic gas decomposition. The new path uses
+            // `eip2780::TX_BASE_COST` directly for the sender base and these
+            // entries for the additional `to`- and `value`-based charges.
+            // ACCOUNT_WRITE / CREATE_ACCESS source from `eip8038` so a single
+            // change to the placeholder TBD values propagates everywhere.
+            table[GasId::tx_transfer_log_cost().as_usize()] = eip2780::TRANSFER_LOG_COST;
+            table[GasId::tx_account_write_cost().as_usize()] = eip8038::ACCOUNT_WRITE;
+            table[GasId::tx_create_access_cost().as_usize()] = eip8038::CREATE_ACCESS;
         }
 
         Self::new(Arc::new(table))
@@ -933,6 +942,29 @@ impl GasParams {
         self.get(GasId::tx_base_stipend())
     }
 
+    /// EIP-2780: regular gas cost of the EIP-7708 transfer log emitted on
+    /// every nonzero-value transfer to a different account. Zero before AMSTERDAM.
+    #[inline]
+    pub fn tx_transfer_log_cost(&self) -> u64 {
+        self.get(GasId::tx_transfer_log_cost())
+    }
+
+    /// EIP-2780/EIP-8038: regular gas cost of an account-leaf write, added
+    /// when `tx.value > 0` and the recipient differs from the sender.
+    /// Zero before AMSTERDAM.
+    #[inline]
+    pub fn tx_account_write_cost(&self) -> u64 {
+        self.get(GasId::tx_account_write_cost())
+    }
+
+    /// EIP-2780/EIP-8038: regular gas cost of a top-level CREATE access,
+    /// in addition to [`Self::tx_base_stipend`] and the EIP-8037 state gas.
+    /// Zero before AMSTERDAM.
+    #[inline]
+    pub fn tx_create_access_cost(&self) -> u64 {
+        self.get(GasId::tx_create_access_cost())
+    }
+
     /// Used in [GasParams::initial_tx_gas] to calculate the create cost.
     ///
     /// Similar to the [`Self::create_cost`] method but it got activated in different fork,
@@ -957,12 +989,18 @@ impl GasParams {
     /// - EIP-7702 auth list state gas (per-auth account creation + metadata costs)
     /// - For CREATE transactions: `create_state_gas` (account creation + contract metadata)
     ///
+    /// When `eip2780` is `Some`, the legacy `21,000`-style base + create-cost
+    /// stipend is replaced with the EIP-2780 decomposition
+    /// (`TX_BASE_COST + to-based + value-based`). Calldata, access list, and
+    /// authorization-list costs are unchanged.
+    ///
     /// Note: `code_deposit_state_gas` is not included since deployed code size is unknown at validation time.
     ///
     /// # Returns
     ///
     /// - Intrinsic gas (including state gas for CREATE)
     /// - Number of tokens in calldata
+    #[allow(clippy::too_many_arguments)]
     pub fn initial_tx_gas(
         &self,
         input: &[u8],
@@ -971,6 +1009,7 @@ impl GasParams {
         access_list_storages: u64,
         authorization_list_num: u64,
         cpsb: u64,
+        eip2780: Option<Eip2780TxInfo>,
     ) -> InitialAndFloorGas {
         // Initdate stipend
         let tokens_in_calldata =
@@ -984,12 +1023,24 @@ impl GasParams {
 
         let auth_regular_cost = auth_total_cost - auth_state_gas;
 
+        let base_and_to_and_value_gas = match eip2780 {
+            None => {
+                let mut base = self.tx_base_stipend();
+                if is_create {
+                    // EIP-2: Homestead Hard-fork Changes
+                    base += self.tx_create_cost();
+                }
+                base
+            }
+            Some(info) => self.eip2780_base_to_value_gas(is_create, &info),
+        };
+
         let mut initial_regular_gas = tokens_in_calldata * self.tx_token_cost()
             // before berlin tx_access_list_address_cost will be zero
             + access_list_accounts * self.tx_access_list_address_cost()
             // before berlin tx_access_list_storage_key_cost will be zero
             + access_list_storages * self.tx_access_list_storage_key_cost()
-            + self.tx_base_stipend()
+            + base_and_to_and_value_gas
             // EIP-7702: Only the regular portion of auth list cost
             + auth_regular_cost;
 
@@ -997,9 +1048,6 @@ impl GasParams {
         let mut initial_state_gas = auth_state_gas;
 
         if is_create {
-            // EIP-2: Homestead Hard-fork Changes
-            initial_regular_gas += self.tx_create_cost();
-
             // EIP-3860: Limit and meter initcode
             initial_regular_gas += self.tx_initcode_cost(input.len());
 
@@ -1020,6 +1068,47 @@ impl GasParams {
             .with_initial_state_gas(initial_state_gas)
             .with_floor_gas(floor_gas)
     }
+
+    /// EIP-2780: sum of the sender base, `tx.to`-based, and `tx.value`-based
+    /// regular-gas charges. Excludes calldata, access list, authorizations,
+    /// and initcode/state-gas pieces which are added by the caller.
+    ///
+    /// The self-transfer and precompile zero-charge edge cases from the
+    /// current EIP-2780 draft are not implemented — a future revision is
+    /// expected to drop those carve-outs, so self-transfers and precompile
+    /// transfers pay the same `to`/`value` charges as any other recipient.
+    fn eip2780_base_to_value_gas(&self, is_create: bool, info: &Eip2780TxInfo) -> u64 {
+        // tx.to charge
+        let to_cost = if is_create {
+            self.tx_create_access_cost()
+        } else {
+            eip8038::COLD_ACCOUNT_ACCESS
+        };
+
+        // tx.value charge
+        let value_cost = if info.value.is_zero() {
+            0
+        } else if is_create {
+            self.tx_transfer_log_cost()
+        } else {
+            self.tx_transfer_log_cost() + self.tx_account_write_cost()
+        };
+
+        eip2780::TX_BASE_COST + to_cost + value_cost
+    }
+}
+
+/// EIP-2780 inputs to [`GasParams::initial_tx_gas`].
+///
+/// Only carries the transferred value — the decomposed intrinsic model only
+/// branches on `is_create` (already passed to `initial_tx_gas`) and whether
+/// `tx.value` is zero. The self-transfer and precompile carve-outs in the
+/// current draft are intentionally not implemented; see
+/// [`GasParams::eip2780_base_to_value_gas`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Eip2780TxInfo {
+    /// Transferred value.
+    pub value: U256,
 }
 
 #[inline]
@@ -1131,6 +1220,9 @@ impl GasId {
             x if x == Self::tx_access_list_floor_byte_multiplier().as_u8() => {
                 "tx_access_list_floor_byte_multiplier"
             }
+            x if x == Self::tx_transfer_log_cost().as_u8() => "tx_transfer_log_cost",
+            x if x == Self::tx_account_write_cost().as_u8() => "tx_account_write_cost",
+            x if x == Self::tx_create_access_cost().as_u8() => "tx_create_access_cost",
             _ => "unknown",
         }
     }
@@ -1202,6 +1294,9 @@ impl GasId {
             "tx_access_list_floor_byte_multiplier" => {
                 Some(Self::tx_access_list_floor_byte_multiplier())
             }
+            "tx_transfer_log_cost" => Some(Self::tx_transfer_log_cost()),
+            "tx_account_write_cost" => Some(Self::tx_account_write_cost()),
+            "tx_create_access_cost" => Some(Self::tx_create_access_cost()),
             _ => None,
         }
     }
@@ -1451,6 +1546,26 @@ impl GasId {
     pub const fn tx_access_list_floor_byte_multiplier() -> GasId {
         Self::new(46)
     }
+
+    /// EIP-2780: regular gas cost of the EIP-7708 transfer log emitted on every
+    /// nonzero-value transfer to a different account. Zero before AMSTERDAM.
+    pub const fn tx_transfer_log_cost() -> GasId {
+        Self::new(47)
+    }
+
+    /// EIP-2780/EIP-8038: regular gas cost of an account-leaf write at the
+    /// intrinsic level (added when `tx.value > 0` and the recipient differs
+    /// from the sender). Zero before AMSTERDAM.
+    pub const fn tx_account_write_cost() -> GasId {
+        Self::new(48)
+    }
+
+    /// EIP-2780/EIP-8038: regular gas cost of a top-level CREATE access, in
+    /// addition to [`Self::tx_base_stipend`] and the EIP-8037 state gas.
+    /// Zero before AMSTERDAM.
+    pub const fn tx_create_access_cost() -> GasId {
+        Self::new(49)
+    }
 }
 
 #[cfg(test)]
@@ -1521,11 +1636,11 @@ mod tests {
             "Not all unique names are resolvable via from_str"
         );
 
-        // We should have exactly 46 known GasIds (based on the indices 1-46 used)
+        // We should have exactly 49 known GasIds (based on the indices 1-49 used)
         assert_eq!(
             unique_names.len(),
-            46,
-            "Expected 46 unique GasIds, found {}",
+            49,
+            "Expected 49 unique GasIds, found {}",
             unique_names.len()
         );
     }
@@ -1576,7 +1691,7 @@ mod tests {
         let cpsb = eip8037::CPSB_GLAMSTERDAM;
 
         // Test CREATE transaction (is_create = true)
-        let create_gas = gas_params.initial_tx_gas(b"", true, 0, 0, 0, cpsb);
+        let create_gas = gas_params.initial_tx_gas(b"", true, 0, 0, 0, cpsb, None);
         let expected_state_gas = gas_params.create_state_gas(cpsb);
 
         assert_eq!(create_gas.initial_state_gas_final(), expected_state_gas);
@@ -1594,7 +1709,7 @@ mod tests {
         );
 
         // Test CALL transaction (is_create = false)
-        let call_gas = gas_params.initial_tx_gas(b"", false, 0, 0, 0, cpsb);
+        let call_gas = gas_params.initial_tx_gas(b"", false, 0, 0, 0, cpsb, None);
         assert_eq!(call_gas.initial_state_gas_final(), 0);
         // initial_gas should be unchanged for calls
         assert_eq!(call_gas.initial_total_gas(), gas_params.tx_base_stipend());
@@ -1618,7 +1733,7 @@ mod tests {
         assert_eq!(params.tx_floor_tokens_in_access_list(2, 3), (40 + 96) * 4);
 
         // Floor gas includes both calldata (empty here) and access-list contribution.
-        let gas = params.initial_tx_gas(b"", false, 2, 3, 0, 0);
+        let gas = params.initial_tx_gas(b"", false, 2, 3, 0, 0, None);
         let expected_al_floor = (40 + 96) * 4 * params.tx_floor_cost_per_token();
         assert_eq!(
             gas.floor_gas(),
@@ -1629,7 +1744,7 @@ mod tests {
         let prague = GasParams::new_spec(SpecId::PRAGUE);
         assert_eq!(prague.tx_access_list_floor_byte_multiplier(), 0);
         assert_eq!(prague.tx_floor_tokens_in_access_list(2, 3), 0);
-        let prague_gas = prague.initial_tx_gas(b"", false, 2, 3, 0, 0);
+        let prague_gas = prague.initial_tx_gas(b"", false, 2, 3, 0, 0, None);
         assert_eq!(prague_gas.floor_gas(), prague.tx_floor_cost_base_gas());
     }
 }

--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use core::hash::{Hash, Hasher};
 use primitives::{
-    eip7702, eip8037,
+    eip7702, eip8037, eip8038,
     hardfork::SpecId::{self},
     OnceLock, U256,
 };
@@ -364,6 +364,64 @@ impl GasParams {
             table[GasId::tx_access_list_storage_key_cost().as_usize()] =
                 gas::ACCESS_LIST_STORAGE_KEY + 32 * 64;
             table[GasId::tx_access_list_floor_byte_multiplier().as_usize()] = 4;
+
+            // EIP-8038: State-access gas cost update. All TBD parameters are
+            // set to `previous_value + 1` per the user-supplied rule.
+            //   WARM_ACCESS                  100 -> 101
+            //   COLD_ACCOUNT_ACCESS        2,600 -> 2,601
+            //   ACCOUNT_WRITE              6,700 -> 6,701
+            //   COLD_STORAGE_ACCESS        2,100 -> 2,101
+            //   STORAGE_WRITE              2,800 -> 2,801
+            //   STORAGE_CLEAR_REFUND       4,800 -> 4,801
+            //   CREATE_ACCESS              7,000 -> 7,001
+            //   ACCESS_LIST_ADDRESS_COST   2,400 -> 2,401
+            //   ACCESS_LIST_STORAGE_KEY_COST 1,900 -> 1,901
+            //
+            // Account access table values.
+            table[GasId::warm_storage_read_cost().as_usize()] = eip8038::WARM_ACCESS;
+            table[GasId::cold_account_additional_cost().as_usize()] =
+                eip8038::COLD_ACCOUNT_ACCESS_ADDITIONAL;
+            table[GasId::cold_storage_additional_cost().as_usize()] =
+                eip8038::COLD_STORAGE_ACCESS_ADDITIONAL;
+            table[GasId::cold_storage_cost().as_usize()] = eip8038::COLD_STORAGE_ACCESS;
+            // CALL_VALUE = ACCOUNT_WRITE + CALL_STIPEND.
+            table[GasId::transfer_value_cost().as_usize()] = eip8038::CALL_VALUE;
+            // ACCOUNT_WRITE surcharge for first-time writes to an account: CALL
+            // to empty account, SELFDESTRUCT sending balance to empty account.
+            // Under EIP-8037 these were zeroed out (cost moved to state gas);
+            // EIP-8038 reintroduces a regular-gas surcharge.
+            table[GasId::new_account_cost().as_usize()] = eip8038::ACCOUNT_WRITE;
+            table[GasId::new_account_cost_for_selfdestruct().as_usize()] = eip8038::ACCOUNT_WRITE;
+
+            // SSTORE table values.
+            //   warm-base       = WARM_ACCESS         (sstore_static)
+            //   write surcharge = STORAGE_WRITE       (sstore_set / sstore_reset dynamic)
+            //   refunds         = STORAGE_WRITE / STORAGE_CLEAR_REFUND
+            table[GasId::sstore_static().as_usize()] = eip8038::WARM_ACCESS;
+            table[GasId::sstore_set_without_load_cost().as_usize()] = eip8038::STORAGE_WRITE;
+            table[GasId::sstore_reset_without_cold_load_cost().as_usize()] = eip8038::STORAGE_WRITE;
+            table[GasId::sstore_set_refund().as_usize()] = eip8038::STORAGE_WRITE;
+            table[GasId::sstore_reset_refund().as_usize()] = eip8038::STORAGE_WRITE;
+            table[GasId::sstore_clearing_slot_refund().as_usize()] = eip8038::STORAGE_CLEAR_REFUND;
+
+            // CREATE / CREATE2 regular-gas access cost.
+            //   `create` slot is the regular-gas portion charged at the
+            //   CREATE/CREATE2 opcodes and for create-kind txns.
+            table[GasId::create().as_usize()] = eip8038::CREATE_ACCESS;
+            table[GasId::tx_create_cost().as_usize()] = eip8038::CREATE_ACCESS;
+
+            // Access-list per-item costs: bump the base by +1 each, keeping the
+            // EIP-7981 64 gas/byte data charge on top.
+            table[GasId::tx_access_list_address_cost().as_usize()] =
+                eip8038::ACCESS_LIST_ADDRESS_COST + 20 * 64;
+            table[GasId::tx_access_list_storage_key_cost().as_usize()] =
+                eip8038::ACCESS_LIST_STORAGE_KEY_COST + 32 * 64;
+
+            // EIP-7702: regular-gas portion of the per-auth cost shifts with
+            // ACCOUNT_WRITE / COLD_ACCOUNT_ACCESS / WARM_ACCESS (see
+            // [`eip8038::EIP7702_PER_EMPTY_ACCOUNT_REGULAR`]).
+            table[GasId::tx_eip7702_per_empty_account_cost().as_usize()] =
+                eip8038::EIP7702_PER_EMPTY_ACCOUNT_REGULAR;
         }
 
         Self::new(Arc::new(table))
@@ -1604,13 +1662,15 @@ mod tests {
     fn test_eip7981_access_list_cost_amsterdam() {
         // EIP-7981 folds a 64 gas/byte data charge into the per-item access-list cost
         // and adds 4 floor tokens per access-list byte on top of the EIP-7976 floor.
+        // EIP-8038 bumps the per-item base by +1 (ACCESS_LIST_ADDRESS_COST 2400 ->
+        // 2401, ACCESS_LIST_STORAGE_KEY_COST 1900 -> 1901).
         let params = GasParams::new_spec(SpecId::AMSTERDAM);
 
         // Per-item intrinsic cost: base + bytes * 64
-        assert_eq!(params.tx_access_list_address_cost(), 2400 + 20 * 64);
-        assert_eq!(params.tx_access_list_storage_key_cost(), 1900 + 32 * 64);
-        assert_eq!(params.tx_access_list_cost(1, 0), 2400 + 20 * 64);
-        assert_eq!(params.tx_access_list_cost(0, 1), 1900 + 32 * 64);
+        assert_eq!(params.tx_access_list_address_cost(), 2401 + 20 * 64);
+        assert_eq!(params.tx_access_list_storage_key_cost(), 1901 + 32 * 64);
+        assert_eq!(params.tx_access_list_cost(1, 0), 2401 + 20 * 64);
+        assert_eq!(params.tx_access_list_cost(0, 1), 1901 + 32 * 64);
 
         // Floor multiplier activates at AMSTERDAM.
         assert_eq!(params.tx_access_list_floor_byte_multiplier(), 4);

--- a/crates/context/interface/src/host.rs
+++ b/crates/context/interface/src/host.rs
@@ -69,6 +69,13 @@ pub trait Host {
     /// Returns whether state gas (EIP-8037) is enabled.
     fn is_amsterdam_eip8037_enabled(&self) -> bool;
 
+    /// Returns the EIP-8037 `cost_per_state_byte` for the current transaction.
+    ///
+    /// Reads the cached value set on the local context at transaction start
+    /// (via `cfg.cpsb()`, honoring `cpsb_override`). Returns
+    /// `0` when EIP-8037 is not enabled.
+    fn cpsb(&self) -> u64;
+
     /* Database */
 
     /// Block hash, calls `ContextTr::journal_mut().db().block_hash(number)`
@@ -241,6 +248,10 @@ impl Host for DummyHost {
 
     fn is_amsterdam_eip8037_enabled(&self) -> bool {
         false
+    }
+
+    fn cpsb(&self) -> u64 {
+        0
     }
 
     fn difficulty(&self) -> U256 {

--- a/crates/context/interface/src/local.rs
+++ b/crates/context/interface/src/local.rs
@@ -234,6 +234,20 @@ pub trait LocalContextTr {
     ///
     /// Returns `Some(String)` if a precompile error message was recorded.
     fn take_precompile_error_context(&mut self) -> Option<String>;
+
+    /// EIP-8037 `cost_per_state_byte` cached for the current transaction.
+    ///
+    /// Populated by [`LocalContextTr::set_cpsb`] at transaction start so that
+    /// the hot-path `Host::cpsb` is a single field read instead of recomputing
+    /// `cfg.cpsb()`.
+    fn cpsb(&self) -> u64;
+
+    /// Caches the EIP-8037 `cost_per_state_byte` for the current transaction.
+    ///
+    /// Called at the start of every execution entry point (regular transaction,
+    /// system call, and their inspector variants). The value must be derived via
+    /// `cfg.cpsb()` so that `cpsb_override` is honored.
+    fn set_cpsb(&mut self, cpsb: u64);
 }
 
 #[cfg(test)]

--- a/crates/context/interface/src/result.rs
+++ b/crates/context/interface/src/result.rs
@@ -53,12 +53,12 @@ impl<R, S> ExecResultAndState<R, S> {
 /// | [`total_gas_spent()`]  | `Gas::spent()` = limit − remaining | Total gas consumed before refund               |
 /// | [`inner_refunded()`]   | `Gas::refunded()` as u64           | Gas refunded (capped per EIP-3529)             |
 /// | [`floor_gas()`]        | `InitialAndFloorGas::floor_gas`    | EIP-7623 floor gas (0 if not applicable)       |
-/// | [`state_gas_spent()`]  | `Gas::state_gas_spent`             | State gas consumed during execution (EIP-8037) |
+/// | [`state_gas_spent_final()`] | `Gas::state_gas_spent`        | State gas consumed during execution (EIP-8037) |
 ///
 /// [`total_gas_spent()`]: ResultGas::total_gas_spent
 /// [`inner_refunded()`]: ResultGas::inner_refunded
 /// [`floor_gas()`]: ResultGas::floor_gas
-/// [`state_gas_spent()`]: ResultGas::state_gas_spent
+/// [`state_gas_spent_final()`]: ResultGas::state_gas_spent_final
 ///
 /// ## Derived values
 ///
@@ -74,7 +74,8 @@ pub struct ResultGas {
     /// For actual gas used, use [`used()`](ResultGas::used).
     #[cfg_attr(feature = "serde", serde(rename = "gas_spent"))]
     total_gas_spent: u64,
-    /// State gas consumed during execution (EIP-8037).
+    /// State gas consumed during execution (EIP-8037), net of the EIP-7702
+    /// per-authorization state-gas refund applied at result-build time.
     /// Tracks gas for storage creation, account creation, and code deposit.
     /// Zero when state gas is not enabled.
     #[cfg_attr(feature = "serde", serde(default))]
@@ -133,11 +134,14 @@ impl ResultGas {
         self.total_gas_spent
     }
 
-    /// Returns the state gas spent during execution (EIP-8037).
+    /// Returns the final state gas spent during execution (EIP-8037).
+    ///
+    /// The stored value is already net of the EIP-7702 per-authorization
+    /// state-gas refund (subtracted when the result is built).
     ///
     /// This is same as [`ResultGas::block_state_gas_used`] for the transaction.
     #[inline]
-    pub const fn state_gas_spent(&self) -> u64 {
+    pub const fn state_gas_spent_final(&self) -> u64 {
         self.state_gas_spent
     }
 
@@ -268,16 +272,16 @@ impl ResultGas {
     pub const fn block_regular_gas_used(&self) -> u64 {
         let execution_gas_spent = self
             .total_gas_spent()
-            .saturating_sub(self.state_gas_spent());
+            .saturating_sub(self.state_gas_spent_final());
         max(execution_gas_spent, self.floor_gas())
     }
 
     /// Returns the state gas used by the block.
     ///
-    /// This is same as [`ResultGas::state_gas_spent`] for the block.
+    /// This is same as [`ResultGas::state_gas_spent_final`] for the block.
     #[inline]
     pub const fn block_state_gas_used(&self) -> u64 {
-        self.state_gas_spent()
+        self.state_gas_spent_final()
     }
 
     /// Returns the final gas used: `max(spent - refunded, floor_gas)`.

--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -2,7 +2,7 @@
 pub use context_interface::Cfg;
 
 use context_interface::cfg::GasParams;
-use primitives::{eip170, eip3860, eip7825, eip7954, hardfork::SpecId};
+use primitives::{eip170, eip3860, eip7825, eip7954, eip8037, hardfork::SpecId};
 
 /// EVM configuration
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -67,6 +67,12 @@ pub struct CfgEnv<SPEC = SpecId> {
     /// Introduced in Osaka in [EIP-7825: Transaction Gas Limit Cap](https://eips.ethereum.org/EIPS/eip-7825)
     /// with initials cap of 30M.
     pub tx_gas_limit_cap: Option<u64>,
+    /// Overrides the EIP-8037 `cost_per_state_byte` (CPSB).
+    ///
+    /// If `None`, CPSB defaults to [`primitives::eip8037::CPSB_GLAMSTERDAM`]
+    /// when EIP-8037 is enabled. If `Some`, the provided value is used
+    /// verbatim (useful for tests and replay).
+    pub cpsb_override: Option<u64>,
     /// A hard memory limit in bytes beyond which
     /// [OutOfGasError::Memory][context_interface::result::OutOfGasError::Memory] cannot be resized.
     ///
@@ -245,6 +251,7 @@ impl<SPEC> CfgEnv<SPEC> {
             spec,
             disable_nonce_check: self.disable_nonce_check,
             tx_gas_limit_cap: self.tx_gas_limit_cap,
+            cpsb_override: self.cpsb_override,
             max_blobs_per_tx: self.max_blobs_per_tx,
             blob_base_fee_update_fraction: self.blob_base_fee_update_fraction,
             gas_params,
@@ -329,6 +336,7 @@ impl<SPEC: Into<SpecId> + Clone> CfgEnv<SPEC> {
             disable_nonce_check: false,
             max_blobs_per_tx: None,
             tx_gas_limit_cap: None,
+            cpsb_override: None,
             blob_base_fee_update_fraction: None,
             gas_params,
             #[cfg(feature = "memory_limit")]
@@ -570,6 +578,14 @@ impl<SPEC: Into<SpecId> + Clone> Cfg for CfgEnv<SPEC> {
 
     fn is_amsterdam_eip8037_enabled(&self) -> bool {
         self.enable_amsterdam_eip8037
+    }
+
+    #[inline]
+    fn cpsb(&self) -> u64 {
+        if !self.enable_amsterdam_eip8037 {
+            return 0;
+        }
+        self.cpsb_override.unwrap_or(eip8037::CPSB_GLAMSTERDAM)
     }
 }
 

--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -145,6 +145,15 @@ pub struct CfgEnv<SPEC = SpecId> {
     ///
     /// By default, it is set to `false`.
     pub enable_amsterdam_eip8037: bool,
+    /// Enables EIP-2780 (Amsterdam) reduced intrinsic transaction gas.
+    ///
+    /// Replaces the legacy 21,000 base with the decomposed
+    /// `TX_BASE_COST + to-based + value-based` model and adds top-level
+    /// execution charges for empty recipients with value (state gas) and
+    /// EIP-7702-delegated recipients (extra cold access).
+    ///
+    /// By default, it is set to `false`.
+    pub enable_amsterdam_eip2780: bool,
     /// Disables EIP-7708 (ETH transfers emit logs).
     ///
     /// By default, it is set to `false`.
@@ -223,15 +232,17 @@ impl<SPEC> CfgEnv<SPEC> {
 
     /// Sets the spec for the `CfgEnv` and the gas params to the mainnet gas params.
     ///
-    /// Automatically enables EIP-8037 for AMSTERDAM and later.
+    /// Automatically enables EIP-8037 and EIP-2780 for AMSTERDAM and later.
     pub fn with_spec_and_mainnet_gas_params<OSPEC: Into<SpecId> + Clone>(
         self,
         spec: OSPEC,
     ) -> CfgEnv<OSPEC> {
         let is_amsterdam = spec.clone().into().is_enabled_in(SpecId::AMSTERDAM);
         let enable_amsterdam_eip8037 = self.enable_amsterdam_eip8037 || is_amsterdam;
+        let enable_amsterdam_eip2780 = self.enable_amsterdam_eip2780 || is_amsterdam;
         let mut cfg = self.with_spec_and_gas_params(spec.clone(), GasParams::new_spec(spec.into()));
         cfg.enable_amsterdam_eip8037 = enable_amsterdam_eip8037;
+        cfg.enable_amsterdam_eip2780 = enable_amsterdam_eip2780;
         cfg
     }
 
@@ -274,6 +285,7 @@ impl<SPEC> CfgEnv<SPEC> {
             #[cfg(feature = "optional_fee_charge")]
             disable_fee_charge: self.disable_fee_charge,
             enable_amsterdam_eip8037: self.enable_amsterdam_eip8037,
+            enable_amsterdam_eip2780: self.enable_amsterdam_eip2780,
             amsterdam_eip7708_disabled: self.amsterdam_eip7708_disabled,
             amsterdam_eip7708_delayed_burn_disabled: self.amsterdam_eip7708_delayed_burn_disabled,
         }
@@ -321,6 +333,13 @@ impl<SPEC> CfgEnv<SPEC> {
         self.enable_amsterdam_eip8037 = enable;
         self
     }
+
+    /// Sets the enable EIP-2780 (Amsterdam) reduced intrinsic transaction
+    /// gas flag.
+    pub const fn with_enable_amsterdam_eip2780(mut self, enable: bool) -> Self {
+        self.enable_amsterdam_eip2780 = enable;
+        self
+    }
 }
 
 impl<SPEC: Into<SpecId> + Clone> CfgEnv<SPEC> {
@@ -358,6 +377,7 @@ impl<SPEC: Into<SpecId> + Clone> CfgEnv<SPEC> {
             #[cfg(feature = "optional_fee_charge")]
             disable_fee_charge: false,
             enable_amsterdam_eip8037: is_amsterdam,
+            enable_amsterdam_eip2780: is_amsterdam,
             amsterdam_eip7708_disabled: false,
             amsterdam_eip7708_delayed_burn_disabled: false,
         }
@@ -398,14 +418,15 @@ impl<SPEC: Into<SpecId> + Clone> CfgEnv<SPEC> {
 
     /// Sets the spec for the `CfgEnv` and the gas params to the mainnet gas params.
     ///
-    /// Automatically enables EIP-8037 for AMSTERDAM and later.
+    /// Automatically enables EIP-8037 and EIP-2780 for AMSTERDAM and later.
     #[inline]
     pub fn set_spec_and_mainnet_gas_params(&mut self, spec: SPEC) {
         self.spec = spec.clone();
         self.set_gas_params(GasParams::new_spec(spec.clone().into()));
-        // EIP-8037: Enable EIP-8037 for AMSTERDAM and later
+        // EIP-8037/EIP-2780: Enable for AMSTERDAM and later
         if spec.into().is_enabled_in(SpecId::AMSTERDAM) {
             self.enable_amsterdam_eip8037 = true;
+            self.enable_amsterdam_eip2780 = true;
         }
     }
 }
@@ -578,6 +599,10 @@ impl<SPEC: Into<SpecId> + Clone> Cfg for CfgEnv<SPEC> {
 
     fn is_amsterdam_eip8037_enabled(&self) -> bool {
         self.enable_amsterdam_eip8037
+    }
+
+    fn is_amsterdam_eip2780_enabled(&self) -> bool {
+        self.enable_amsterdam_eip2780
     }
 
     #[inline]

--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -40,6 +40,15 @@ pub struct Context<
     pub error: Result<(), ContextError<DB::Error>>,
 }
 
+#[inline]
+fn sync_cfg_to_journal<CFG: Cfg, JOURNAL: JournalTr>(cfg: &CFG, journal: &mut JOURNAL) {
+    journal.set_spec_id(cfg.spec().into());
+    journal.set_eip7708_config(
+        cfg.is_eip7708_disabled(),
+        cfg.is_eip7708_delayed_burn_disabled(),
+    );
+}
+
 impl<
         BLOCK: Block,
         TX: Transaction,
@@ -143,11 +152,7 @@ impl<
     pub fn new(db: DB, spec: SPEC) -> Self {
         let cfg = CfgEnv::new_with_spec(spec);
         let mut journaled_state = JOURNAL::new(db);
-        journaled_state.set_spec_id(cfg.spec.clone().into());
-        journaled_state.set_eip7708_config(
-            cfg.amsterdam_eip7708_disabled,
-            cfg.amsterdam_eip7708_delayed_burn_disabled,
-        );
+        sync_cfg_to_journal(&cfg, &mut journaled_state);
         Self {
             tx: TX::default(),
             block: BLOCK::default(),
@@ -174,11 +179,7 @@ where
         self,
         mut journal: OJOURNAL,
     ) -> Context<BLOCK, TX, CFG, DB, OJOURNAL, CHAIN, LOCAL> {
-        journal.set_spec_id(self.cfg.spec().into());
-        journal.set_eip7708_config(
-            self.cfg.is_eip7708_disabled(),
-            self.cfg.is_eip7708_delayed_burn_disabled(),
-        );
+        sync_cfg_to_journal(&self.cfg, &mut journal);
         Context {
             tx: self.tx,
             block: self.block,
@@ -198,11 +199,7 @@ where
         db: ODB,
     ) -> Context<BLOCK, TX, CFG, ODB, Journal<ODB>, CHAIN, LOCAL> {
         let mut journaled_state = Journal::new(db);
-        journaled_state.set_spec_id(self.cfg.spec().into());
-        journaled_state.set_eip7708_config(
-            self.cfg.is_eip7708_disabled(),
-            self.cfg.is_eip7708_delayed_burn_disabled(),
-        );
+        sync_cfg_to_journal(&self.cfg, &mut journaled_state);
         Context {
             tx: self.tx,
             block: self.block,
@@ -221,11 +218,7 @@ where
     ) -> Context<BLOCK, TX, CFG, WrapDatabaseRef<ODB>, Journal<WrapDatabaseRef<ODB>>, CHAIN, LOCAL>
     {
         let mut journaled_state = Journal::new(WrapDatabaseRef(db));
-        journaled_state.set_spec_id(self.cfg.spec().into());
-        journaled_state.set_eip7708_config(
-            self.cfg.is_eip7708_disabled(),
-            self.cfg.is_eip7708_delayed_burn_disabled(),
-        );
+        sync_cfg_to_journal(&self.cfg, &mut journaled_state);
         Context {
             tx: self.tx,
             block: self.block,
@@ -286,11 +279,7 @@ where
         mut self,
         cfg: OCFG,
     ) -> Context<BLOCK, TX, OCFG, DB, JOURNAL, CHAIN, LOCAL> {
-        self.journaled_state.set_spec_id(cfg.spec().into());
-        self.journaled_state.set_eip7708_config(
-            cfg.is_eip7708_disabled(),
-            cfg.is_eip7708_delayed_burn_disabled(),
-        );
+        sync_cfg_to_journal(&cfg, &mut self.journaled_state);
         Context {
             tx: self.tx,
             block: self.block,
@@ -325,11 +314,7 @@ where
         F: FnOnce(&mut CFG),
     {
         f(&mut self.cfg);
-        self.journaled_state.set_spec_id(self.cfg.spec().into());
-        self.journaled_state.set_eip7708_config(
-            self.cfg.is_eip7708_disabled(),
-            self.cfg.is_eip7708_delayed_burn_disabled(),
-        );
+        sync_cfg_to_journal(&self.cfg, &mut self.journaled_state);
         self
     }
 
@@ -405,11 +390,7 @@ where
         F: FnOnce(&mut CFG),
     {
         f(&mut self.cfg);
-        self.journaled_state.set_spec_id(self.cfg.spec().into());
-        self.journaled_state.set_eip7708_config(
-            self.cfg.is_eip7708_disabled(),
-            self.cfg.is_eip7708_delayed_burn_disabled(),
-        );
+        sync_cfg_to_journal(&self.cfg, &mut self.journaled_state);
     }
 
     /// Modifies the context chain.

--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -467,6 +467,11 @@ impl<
         self.cfg().is_amsterdam_eip8037_enabled()
     }
 
+    #[inline]
+    fn cpsb(&self) -> u64 {
+        self.local().cpsb()
+    }
+
     fn block_number(&self) -> U256 {
         self.block().number()
     }

--- a/crates/context/src/local.rs
+++ b/crates/context/src/local.rs
@@ -10,6 +10,11 @@ pub struct LocalContext {
     pub shared_memory_buffer: Rc<RefCell<Vec<u8>>>,
     /// Optional precompile error message to bubble up.
     pub precompile_error_message: Option<String>,
+    /// EIP-8037 `cost_per_state_byte` cached for the current transaction.
+    ///
+    /// Populated at transaction start from `cfg.cpsb(block.gas_limit())`
+    /// (honoring `cpsb_override`). Read by the hot-path `Host::cpsb`.
+    pub cpsb: u64,
 }
 
 impl Default for LocalContext {
@@ -17,6 +22,7 @@ impl Default for LocalContext {
         Self {
             shared_memory_buffer: Rc::new(RefCell::new(Vec::with_capacity(1024 * 4))),
             precompile_error_message: None,
+            cpsb: 0,
         }
     }
 }
@@ -26,6 +32,7 @@ impl LocalContextTr for LocalContext {
         // Sets len to 0 but it will not shrink to drop the capacity.
         unsafe { self.shared_memory_buffer.borrow_mut().set_len(0) };
         self.precompile_error_message = None;
+        self.cpsb = 0;
     }
 
     fn shared_memory_buffer(&self) -> &Rc<RefCell<Vec<u8>>> {
@@ -38,6 +45,14 @@ impl LocalContextTr for LocalContext {
 
     fn take_precompile_error_context(&mut self) -> Option<String> {
         self.precompile_error_message.take()
+    }
+
+    fn cpsb(&self) -> u64 {
+        self.cpsb
+    }
+
+    fn set_cpsb(&mut self, cpsb: u64) {
+        self.cpsb = cpsb;
     }
 }
 

--- a/crates/database/CHANGELOG.md
+++ b/crates/database/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [13.1.0](https://github.com/bluealloy/revm/compare/revm-database-v13.0.1...revm-database-v13.1.0) - 2026-05-19
+
+### Added
+
+- show address or slot in BAL error ([#3619](https://github.com/bluealloy/revm/pull/3619))
+- *(state)* Optimized index type for transaction ID using non-max ([#3610](https://github.com/bluealloy/revm/pull/3610))
+- *(account)* Optimized index type for account ID using `non-max` ([#3605](https://github.com/bluealloy/revm/pull/3605))
+- *(database)* add State::has_bal helper ([#3604](https://github.com/bluealloy/revm/pull/3604))
+
+### Fixed
+
+- gracefully handle commits of non-cached accounts ([#3657](https://github.com/bluealloy/revm/pull/3657))
+
+### Other
+
+- *(database)* preserve commit_iter semantics ([#3681](https://github.com/bluealloy/revm/pull/3681))
+- update alloy-eip7928 to newer version ([#3627](https://github.com/bluealloy/revm/pull/3627))
+- backport v107 release notes from branch ([#3617](https://github.com/bluealloy/revm/pull/3617))
+- enable and fix clippy::missing_const_for_fn ([#3592](https://github.com/bluealloy/revm/pull/3592))
+- rm op-revm (migrated to ethereum-optimism/optimism) ([#3568](https://github.com/bluealloy/revm/pull/3568))
+
 ## [13.0.1](https://github.com/bluealloy/revm/compare/revm-database-v13.0.0...revm-database-v13.0.1) - 2026-04-17
 
 ### Other

--- a/crates/database/CHANGELOG.md
+++ b/crates/database/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [13.1.0](https://github.com/bluealloy/revm/compare/revm-database-v13.0.1...revm-database-v13.1.0) - 2026-05-19
+## [14.0.0](https://github.com/bluealloy/revm/compare/revm-database-v13.0.1...revm-database-v14.0.0) - 2026-05-19
 
 ### Added
 

--- a/crates/database/CHANGELOG.md
+++ b/crates/database/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [14.0.0](https://github.com/bluealloy/revm/compare/revm-database-v13.0.1...revm-database-v14.0.0) - 2026-05-19
+## [15.0.0](https://github.com/bluealloy/revm/compare/revm-database-v13.0.1...revm-database-v15.0.0) - 2026-05-19
 
 ### Added
 

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-database"
 description = "Revm Database implementations"
-version = "13.0.1"
+version = "13.1.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-database"
 description = "Revm Database implementations"
-version = "14.0.0"
+version = "15.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-database"
 description = "Revm Database implementations"
-version = "13.1.0"
+version = "14.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/database/interface/CHANGELOG.md
+++ b/crates/database/interface/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.1.0](https://github.com/bluealloy/revm/compare/revm-database-interface-v11.0.1...revm-database-interface-v11.1.0) - 2026-05-19
+## [12.0.0](https://github.com/bluealloy/revm/compare/revm-database-interface-v11.0.1...revm-database-interface-v12.0.0) - 2026-05-19
 
 ### Added
 

--- a/crates/database/interface/CHANGELOG.md
+++ b/crates/database/interface/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.1.0](https://github.com/bluealloy/revm/compare/revm-database-interface-v11.0.1...revm-database-interface-v11.1.0) - 2026-05-19
+
+### Added
+
+- show address or slot in BAL error ([#3619](https://github.com/bluealloy/revm/pull/3619))
+- *(state)* Optimized index type for transaction ID using non-max ([#3610](https://github.com/bluealloy/revm/pull/3610))
+- *(account)* Optimized index type for account ID using `non-max` ([#3605](https://github.com/bluealloy/revm/pull/3605))
+
+### Other
+
+- *(database)* preserve commit_iter semantics ([#3681](https://github.com/bluealloy/revm/pull/3681))
+- update alloy-eip7928 to newer version ([#3627](https://github.com/bluealloy/revm/pull/3627))
+- backport v107 release notes from branch ([#3617](https://github.com/bluealloy/revm/pull/3617))
+- enable and fix clippy::missing_const_for_fn ([#3592](https://github.com/bluealloy/revm/pull/3592))
+- rm op-revm (migrated to ethereum-optimism/optimism) ([#3568](https://github.com/bluealloy/revm/pull/3568))
+
 ## [11.0.1](https://github.com/bluealloy/revm/compare/revm-database-interface-v11.0.0...revm-database-interface-v11.0.1) - 2026-04-17
 
 ### Other

--- a/crates/database/interface/Cargo.toml
+++ b/crates/database/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-database-interface"
 description = "Revm Database interface"
-version = "11.0.1"
+version = "11.1.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/database/interface/Cargo.toml
+++ b/crates/database/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-database-interface"
 description = "Revm Database interface"
-version = "11.1.0"
+version = "12.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/database/interface/src/bal.rs
+++ b/crates/database/interface/src/bal.rs
@@ -388,4 +388,13 @@ impl<DB: DatabaseCommit> DatabaseCommit for BalDatabase<DB> {
         self.bal_state.commit(&changes);
         self.db.commit(changes);
     }
+
+    fn commit_iter(&mut self, changes: &mut dyn Iterator<Item = (Address, Account)>) {
+        let bal_state = &mut self.bal_state;
+        let mut changes = changes.map(|(address, account)| {
+            bal_state.commit_one(address, &account);
+            (address, account)
+        });
+        self.db.commit_iter(&mut changes);
+    }
 }

--- a/crates/database/interface/src/either.rs
+++ b/crates/database/interface/src/either.rs
@@ -68,6 +68,13 @@ where
             Self::Right(db) => db.commit(changes),
         }
     }
+
+    fn commit_iter(&mut self, changes: &mut dyn Iterator<Item = (Address, Account)>) {
+        match self {
+            Self::Left(db) => db.commit_iter(changes),
+            Self::Right(db) => db.commit_iter(changes),
+        }
+    }
 }
 
 impl<L, R> DatabaseRef for Either<L, R>

--- a/crates/database/interface/src/lib.rs
+++ b/crates/database/interface/src/lib.rs
@@ -223,6 +223,11 @@ impl<T: DatabaseRef + DatabaseCommit> DatabaseCommit for WrapDatabaseRef<T> {
     fn commit(&mut self, changes: AddressMap<Account>) {
         self.0.commit(changes)
     }
+
+    #[inline]
+    fn commit_iter(&mut self, changes: &mut dyn Iterator<Item = (Address, Account)>) {
+        self.0.commit_iter(changes)
+    }
 }
 
 impl<T: DatabaseRef> DatabaseRef for WrapDatabaseRef<T> {
@@ -380,5 +385,83 @@ mod tests {
             db_dyn.commit_from_iter(vec![]);
         }
         assert_eq!(db.commits.len(), 4);
+    }
+
+    #[test]
+    fn wrappers_forward_commit_iter() {
+        #[derive(Default)]
+        struct MockDb {
+            commits: usize,
+            commit_iters: usize,
+            committed_accounts: usize,
+        }
+
+        impl DatabaseCommit for MockDb {
+            fn commit(&mut self, changes: AddressMap<Account>) {
+                self.commits += 1;
+                self.committed_accounts += changes.len();
+            }
+
+            fn commit_iter(&mut self, changes: &mut dyn Iterator<Item = (Address, Account)>) {
+                self.commit_iters += 1;
+                self.committed_accounts += changes.count();
+            }
+        }
+
+        impl DatabaseRef for MockDb {
+            type Error = Infallible;
+
+            fn basic_ref(&self, _address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+                Ok(None)
+            }
+
+            fn code_by_hash_ref(&self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+                Ok(Bytecode::default())
+            }
+
+            fn storage_ref(
+                &self,
+                _address: Address,
+                _index: StorageKey,
+            ) -> Result<StorageValue, Self::Error> {
+                Ok(StorageValue::ZERO)
+            }
+
+            fn block_hash_ref(&self, _number: u64) -> Result<B256, Self::Error> {
+                Ok(B256::ZERO)
+            }
+        }
+
+        fn changes() -> Vec<(Address, Account)> {
+            vec![(Address::with_last_byte(1), Account::default())]
+        }
+
+        let mut db = WrapDatabaseRef(MockDb::default());
+        db.commit_iter(&mut changes().into_iter());
+        assert_eq!(db.0.commits, 0);
+        assert_eq!(db.0.commit_iters, 1);
+        assert_eq!(db.0.committed_accounts, 1);
+
+        let mut db: ::either::Either<MockDb, MockDb> = ::either::Either::Left(MockDb::default());
+        db.commit_iter(&mut changes().into_iter());
+        let ::either::Either::Left(db) = db else {
+            unreachable!()
+        };
+        assert_eq!(db.commits, 0);
+        assert_eq!(db.commit_iters, 1);
+        assert_eq!(db.committed_accounts, 1);
+
+        let address = Address::with_last_byte(2);
+        let mut account = Account::default();
+        account.mark_touch();
+
+        let mut db = bal::BalDatabase::new(MockDb::default()).with_bal_builder();
+        db.commit_iter(&mut [(address, account)].into_iter());
+        assert_eq!(db.db.commits, 0);
+        assert_eq!(db.db.commit_iters, 1);
+        assert_eq!(db.db.committed_accounts, 1);
+
+        let bal = db.bal_state.take_built_bal().expect("BAL should be built");
+        assert!(bal.accounts.get(&address).is_some());
     }
 }

--- a/crates/database/src/in_memory_db.rs
+++ b/crates/database/src/in_memory_db.rs
@@ -142,6 +142,40 @@ impl<ExtDB> CacheDB<ExtDB> {
         }
     }
 
+    fn commit_account(&mut self, address: Address, mut account: Account) {
+        if !account.is_touched() {
+            return;
+        }
+        if account.is_selfdestructed() {
+            let db_account = self.cache.accounts.entry(address).or_default();
+            db_account.storage.clear();
+            db_account.account_state = AccountState::NotExisting;
+            db_account.info = AccountInfo::default();
+            return;
+        }
+        let is_newly_created = account.is_created();
+        self.insert_contract(&mut account.info);
+
+        let db_account = self.cache.accounts.entry(address).or_default();
+        db_account.info = account.info;
+
+        db_account.account_state = if is_newly_created {
+            db_account.storage.clear();
+            AccountState::StorageCleared
+        } else if db_account.account_state.is_storage_cleared() {
+            // Preserve old account state if it already exists
+            AccountState::StorageCleared
+        } else {
+            AccountState::Touched
+        };
+        db_account.storage.extend(
+            account
+                .storage
+                .into_iter()
+                .map(|(key, value)| (key, value.present_value())),
+        );
+    }
+
     /// Wraps the cache in a [CacheDB], creating a nested cache.
     pub fn nest(self) -> CacheDB<Self> {
         CacheDB::new(self)
@@ -281,38 +315,14 @@ impl<ExtDB: DatabaseRef> CacheDB<ExtDB> {
 
 impl<ExtDB> DatabaseCommit for CacheDB<ExtDB> {
     fn commit(&mut self, changes: AddressMap<Account>) {
-        for (address, mut account) in changes {
-            if !account.is_touched() {
-                continue;
-            }
-            if account.is_selfdestructed() {
-                let db_account = self.cache.accounts.entry(address).or_default();
-                db_account.storage.clear();
-                db_account.account_state = AccountState::NotExisting;
-                db_account.info = AccountInfo::default();
-                continue;
-            }
-            let is_newly_created = account.is_created();
-            self.insert_contract(&mut account.info);
+        for (address, account) in changes {
+            self.commit_account(address, account);
+        }
+    }
 
-            let db_account = self.cache.accounts.entry(address).or_default();
-            db_account.info = account.info;
-
-            db_account.account_state = if is_newly_created {
-                db_account.storage.clear();
-                AccountState::StorageCleared
-            } else if db_account.account_state.is_storage_cleared() {
-                // Preserve old account state if it already exists
-                AccountState::StorageCleared
-            } else {
-                AccountState::Touched
-            };
-            db_account.storage.extend(
-                account
-                    .storage
-                    .into_iter()
-                    .map(|(key, value)| (key, value.present_value())),
-            );
+    fn commit_iter(&mut self, changes: &mut dyn Iterator<Item = (Address, Account)>) {
+        for (address, account) in changes {
+            self.commit_account(address, account);
         }
     }
 }
@@ -587,9 +597,9 @@ impl Database for BenchmarkDB {
 #[cfg(test)]
 mod tests {
     use super::{CacheDB, EmptyDB};
-    use database_interface::Database;
+    use database_interface::{Database, DatabaseCommit};
     use primitives::{Address, HashMap, StorageKey, StorageValue};
-    use state::AccountInfo;
+    use state::{Account, AccountInfo, EvmStorageSlot, TransactionId};
 
     #[test]
     fn test_insert_account_storage() {
@@ -641,6 +651,37 @@ mod tests {
         assert_eq!(new_state.basic(account).unwrap().unwrap().nonce, nonce);
         assert_eq!(new_state.storage(account, key0), Ok(StorageValue::ZERO));
         assert_eq!(new_state.storage(account, key1), Ok(value1));
+    }
+
+    #[test]
+    fn commit_iter_applies_repeated_account_updates_in_order() {
+        let address = Address::with_last_byte(42);
+        let key = StorageKey::from(123);
+        let value = StorageValue::from(456);
+        let mut db = CacheDB::new(EmptyDB::default());
+
+        let first = Account::from(AccountInfo {
+            nonce: 1,
+            ..Default::default()
+        })
+        .with_touched_mark()
+        .with_storage(
+            [(
+                key,
+                EvmStorageSlot::new_changed(StorageValue::ZERO, value, TransactionId::ZERO),
+            )]
+            .into_iter(),
+        );
+        let second = Account::from(AccountInfo {
+            nonce: 2,
+            ..Default::default()
+        })
+        .with_touched_mark();
+
+        db.commit_iter(&mut [(address, first), (address, second)].into_iter());
+
+        assert_eq!(db.basic(address).unwrap().unwrap().nonce, 2);
+        assert_eq!(db.storage(address, key), Ok(value));
     }
 
     #[cfg(feature = "std")]

--- a/crates/ee-tests/CHANGELOG.md
+++ b/crates/ee-tests/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0](https://github.com/bluealloy/revm/compare/revm-ee-tests-v0.1.0...revm-ee-tests-v0.2.0) - 2026-03-04
+## [0.3.0](https://github.com/bluealloy/revm/compare/revm-ee-tests-v0.1.0...revm-ee-tests-v0.3.0) - 2026-03-04
 
 ### Other
 

--- a/crates/ee-tests/Cargo.toml
+++ b/crates/ee-tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-ee-tests"
 description = "Common test utilities for REVM crates"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/ee-tests/src/eip2780.rs
+++ b/crates/ee-tests/src/eip2780.rs
@@ -1,0 +1,147 @@
+//! EIP-2780 integration tests.
+//!
+//! Verifies the decomposed intrinsic gas model (`TX_BASE_COST` + to-based +
+//! value-based) and the top-level execution charges (state gas for empty
+//! recipient with value, extra cold access for EIP-7702-delegated recipients).
+//!
+//! The self-transfer and precompile zero-charge edge cases in the current
+//! EIP-2780 draft are intentionally not implemented (a future revision is
+//! expected to drop them), so the tests below treat self-transfers and
+//! precompile transfers as regular recipients.
+
+use revm::{
+    context::TxEnv,
+    database::{BenchmarkDB, BENCH_CALLER},
+    handler::{MainnetContext, MainnetEvm},
+    primitives::{
+        address, eip2780, eip8037, eip8037::CPSB_GLAMSTERDAM, eip8038, hardfork::SpecId, TxKind,
+        U256,
+    },
+    state::Bytecode,
+    Context, ExecuteEvm, MainBuilder, MainContext,
+};
+
+type MainEvm = MainnetEvm<MainnetContext<BenchmarkDB>>;
+
+const TX_GAS_LIMIT: u64 = 1_000_000;
+
+/// Pre-EIP-2780 legacy intrinsic base.
+const LEGACY_BASE: u64 = 21_000;
+
+/// State gas for new-account creation under Glamsterdam CPSB (120 × 1530 = 183_600).
+const STATE_BYTES_PER_NEW_ACCOUNT: u64 = eip8037::NEW_ACCOUNT_BYTES * CPSB_GLAMSTERDAM;
+
+/// Builds an EVM at AMSTERDAM with EIP-2780 enabled.
+fn evm() -> MainEvm {
+    Context::mainnet()
+        .modify_cfg_chained(|cfg| {
+            cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
+            cfg.tx_gas_limit_cap = Some(u64::MAX);
+        })
+        .with_db(BenchmarkDB::new_bytecode(Bytecode::new()))
+        .build_mainnet()
+}
+
+/// Builds an EVM at AMSTERDAM with EIP-2780 disabled (legacy 21k base).
+fn evm_no_eip2780() -> MainEvm {
+    Context::mainnet()
+        .modify_cfg_chained(|cfg| {
+            cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
+            cfg.enable_amsterdam_eip2780 = false;
+            cfg.tx_gas_limit_cap = Some(u64::MAX);
+        })
+        .with_db(BenchmarkDB::new_bytecode(Bytecode::new()))
+        .build_mainnet()
+}
+
+fn tx(kind: TxKind, value: U256) -> TxEnv {
+    TxEnv::builder_for_bench()
+        .kind(kind)
+        .value(value)
+        .gas_price(0)
+        .gas_limit(TX_GAS_LIMIT)
+        .build_fill()
+}
+
+fn run(evm: &mut MainEvm, kind: TxKind, value: U256) -> revm::context_interface::result::ResultGas {
+    *evm.transact_one(tx(kind, value)).unwrap().gas()
+}
+
+/// Helper: regular gas spent (`total_gas_spent` minus the state-gas portion).
+fn regular_spent(gas: &revm::context_interface::result::ResultGas) -> u64 {
+    gas.total_gas_spent()
+        .saturating_sub(gas.state_gas_spent_final())
+}
+
+#[test]
+fn test_eip2780_self_transfer() {
+    let mut evm = evm();
+    let gas = run(&mut evm, TxKind::Call(BENCH_CALLER), U256::ZERO);
+    // Self-transfer is not special-cased: pays TX_BASE_COST + COLD_ACCOUNT_ACCESS.
+    assert_eq!(
+        gas.total_gas_spent(),
+        eip2780::TX_BASE_COST + eip8038::COLD_ACCOUNT_ACCESS
+    );
+    assert_eq!(gas.state_gas_spent_final(), 0);
+}
+
+#[test]
+fn test_eip2780_call_eoa_no_value() {
+    let mut evm = evm();
+    // Cold EOA (not a precompile, not self).
+    let to = address!("0x00000000000000000000000000000000000000aa");
+    let gas = run(&mut evm, TxKind::Call(to), U256::ZERO);
+    // Intrinsic: TX_BASE_COST + COLD_ACCOUNT_ACCESS = 14_900.
+    assert_eq!(
+        gas.total_gas_spent(),
+        eip2780::TX_BASE_COST + eip8038::COLD_ACCOUNT_ACCESS
+    );
+    assert_eq!(gas.state_gas_spent_final(), 0);
+}
+
+#[test]
+fn test_eip2780_call_empty_with_value() {
+    let mut evm = evm();
+    let to = address!("0x00000000000000000000000000000000000000ab");
+    let gas = run(&mut evm, TxKind::Call(to), U256::from(1u64));
+    // Intrinsic regular: TX_BASE_COST + COLD_ACCOUNT_ACCESS + ACCOUNT_WRITE + TRANSFER_LOG_COST = 23_356.
+    // Top-level state gas: STATE_BYTES_PER_NEW_ACCOUNT × CPSB = 183_600.
+    let expected_regular = eip2780::TX_BASE_COST
+        + eip8038::COLD_ACCOUNT_ACCESS
+        + eip8038::ACCOUNT_WRITE
+        + eip2780::TRANSFER_LOG_COST;
+    assert_eq!(regular_spent(&gas), expected_regular);
+    assert_eq!(gas.state_gas_spent_final(), STATE_BYTES_PER_NEW_ACCOUNT);
+}
+
+#[test]
+fn test_eip2780_create_no_value() {
+    let mut evm = evm();
+    let gas = run(&mut evm, TxKind::Create, U256::ZERO);
+    // Intrinsic regular: TX_BASE_COST + CREATE_ACCESS = 21_600.
+    // Intrinsic state gas: STATE_BYTES_PER_NEW_ACCOUNT × CPSB = 183_600.
+    let expected_regular = eip2780::TX_BASE_COST + eip8038::CREATE_ACCESS;
+    assert_eq!(regular_spent(&gas), expected_regular);
+    assert_eq!(gas.state_gas_spent_final(), STATE_BYTES_PER_NEW_ACCOUNT);
+}
+
+#[test]
+fn test_eip2780_create_with_value() {
+    let mut evm = evm();
+    let gas = run(&mut evm, TxKind::Create, U256::from(1u64));
+    // Intrinsic regular: TX_BASE_COST + CREATE_ACCESS + TRANSFER_LOG_COST.
+    // Intrinsic state gas: STATE_BYTES_PER_NEW_ACCOUNT × CPSB.
+    let expected_regular =
+        eip2780::TX_BASE_COST + eip8038::CREATE_ACCESS + eip2780::TRANSFER_LOG_COST;
+    assert_eq!(regular_spent(&gas), expected_regular);
+    assert_eq!(gas.state_gas_spent_final(), STATE_BYTES_PER_NEW_ACCOUNT);
+}
+
+#[test]
+fn test_eip2780_legacy_base_when_disabled() {
+    // With EIP-2780 disabled, the legacy 21,000 stipend applies.
+    let mut evm = evm_no_eip2780();
+    let to = address!("0x00000000000000000000000000000000000000aa");
+    let gas = run(&mut evm, TxKind::Call(to), U256::ZERO);
+    assert_eq!(gas.total_gas_spent(), LEGACY_BASE);
+}

--- a/crates/ee-tests/src/eip8037.rs
+++ b/crates/ee-tests/src/eip8037.rs
@@ -36,6 +36,10 @@ fn state_gas_evm(bytecode: Bytecode, cap: u64) -> MainEvm {
     Context::mainnet()
         .modify_cfg_chained(|cfg| {
             cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
+            // EIP-2780 changes intrinsic gas independently of the EIP-8037
+            // reservoir model this test file exercises; disable it here to
+            // keep the comparisons focused on state-gas behaviour.
+            cfg.enable_amsterdam_eip2780 = false;
             cfg.tx_gas_limit_cap = Some(cap);
             cfg.cpsb_override = Some(1);
             cfg.gas_params.override_gas([
@@ -55,6 +59,7 @@ fn baseline_evm(bytecode: Bytecode) -> MainEvm {
         .modify_cfg_chained(|cfg| {
             cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
             cfg.enable_amsterdam_eip8037 = false;
+            cfg.enable_amsterdam_eip2780 = false;
             cfg.tx_gas_limit_cap = Some(u64::MAX);
         })
         .with_db(BenchmarkDB::new_bytecode(bytecode))
@@ -1047,6 +1052,7 @@ fn test_eip8037_block_gas_limit_enforced_with_state_gas() {
     let mut evm = Context::mainnet()
         .modify_cfg_chained(|cfg| {
             cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
+            cfg.enable_amsterdam_eip2780 = false;
             cfg.tx_gas_limit_cap = Some(u64::MAX);
             cfg.cpsb_override = Some(1);
             cfg.gas_params.override_gas([
@@ -1081,6 +1087,7 @@ fn test_eip8037_block_gas_limit_enforced_with_state_gas() {
     let mut evm_no_state = Context::mainnet()
         .modify_cfg_chained(|cfg| {
             cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
+            cfg.enable_amsterdam_eip2780 = false;
             cfg.tx_gas_limit_cap = Some(u64::MAX);
         })
         .modify_block_chained(|block| {
@@ -2266,6 +2273,7 @@ fn test_eip8037_tx_create_collision() {
         .modify_cfg_chained(|cfg| {
             cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
             cfg.enable_amsterdam_eip8037 = false;
+            cfg.enable_amsterdam_eip2780 = false;
             cfg.tx_gas_limit_cap = Some(u64::MAX);
         })
         .with_db(build_db())
@@ -2277,6 +2285,7 @@ fn test_eip8037_tx_create_collision() {
     let mut evm = Context::mainnet()
         .modify_cfg_chained(|cfg| {
             cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
+            cfg.enable_amsterdam_eip2780 = false;
             cfg.cpsb_override = Some(1);
             cfg.gas_params.override_gas([
                 (GasId::sstore_set_state_gas(), STATE_GAS_SSTORE_SET),

--- a/crates/ee-tests/src/eip8037.rs
+++ b/crates/ee-tests/src/eip8037.rs
@@ -9,7 +9,7 @@ use revm::{
     context_interface::{cfg::GasId, result::HaltReason},
     database::{BenchmarkDB, BENCH_CALLER},
     handler::{MainnetContext, MainnetEvm},
-    primitives::{address, hardfork::SpecId, U256},
+    primitives::{address, eip7825::TX_GAS_LIMIT_CAP, hardfork::SpecId, TxKind, U256},
     state::Bytecode,
     Context, ExecuteEvm, MainBuilder, MainContext,
 };
@@ -29,11 +29,15 @@ const fn hash_cost(len: usize) -> u64 {
 type MainEvm = MainnetEvm<MainnetContext<BenchmarkDB>>;
 
 /// Builds an EVM with state gas enabled and custom gas params.
+///
+/// Sets `cpsb_override = Some(1)` so the overridden gas-table values are
+/// interpreted as final gas amounts (the CPSB multiplier becomes a no-op).
 fn state_gas_evm(bytecode: Bytecode, cap: u64) -> MainEvm {
     Context::mainnet()
         .modify_cfg_chained(|cfg| {
             cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
             cfg.tx_gas_limit_cap = Some(cap);
+            cfg.cpsb_override = Some(1);
             cfg.gas_params.override_gas([
                 (GasId::sstore_set_state_gas(), STATE_GAS_SSTORE_SET),
                 (GasId::new_account_state_gas(), STATE_GAS_NEW_ACCOUNT),
@@ -487,8 +491,8 @@ fn test_eip8037_sstore_new_slot() {
         delta, STATE_GAS_SSTORE_SET,
         "SSTORE new slot should add exactly {STATE_GAS_SSTORE_SET} state gas, got delta {delta}"
     );
-    assert_eq!(baseline_result.gas().state_gas_spent(), 0);
-    assert_eq!(result.gas().state_gas_spent(), STATE_GAS_SSTORE_SET);
+    assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
+    assert_eq!(result.gas().state_gas_spent_final(), STATE_GAS_SSTORE_SET);
     assert_eq!(result.gas().inner_refunded(), 0);
     assert!(result.logs().is_empty());
     assert_eq!(
@@ -521,8 +525,8 @@ fn test_eip8037_sstore_overwrite_no_state_gas() {
         delta, STATE_GAS_SSTORE_SET,
         "Only the first SSTORE (0->1) should charge state gas, got delta {delta}"
     );
-    assert_eq!(result.gas().state_gas_spent(), STATE_GAS_SSTORE_SET);
-    assert_eq!(baseline_result.gas().state_gas_spent(), 0);
+    assert_eq!(result.gas().state_gas_spent_final(), STATE_GAS_SSTORE_SET);
+    assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
     assert_eq!(result.gas().inner_refunded(), 0);
     assert!(result.logs().is_empty());
     crate::assert_sorted_json_snapshot!(&(baseline_result, result));
@@ -548,7 +552,7 @@ fn test_eip8037_sstore_zero_to_zero_no_state_gas() {
     assert!(result.is_success());
     let delta = result.tx_gas_used() - baseline_gas;
     assert_eq!(delta, 0, "SSTORE zero→zero should add no state gas");
-    assert_eq!(result.gas().state_gas_spent(), 0);
+    assert_eq!(result.gas().state_gas_spent_final(), 0);
     assert_eq!(result.tx_gas_used(), baseline_gas);
     assert_eq!(result.gas().inner_refunded(), 0);
     assert_eq!(
@@ -582,8 +586,8 @@ fn test_eip8037_sstore_multiple_new_slots() {
         delta, expected,
         "3 new slots should add {expected} state gas, got delta {delta}"
     );
-    assert_eq!(result.gas().state_gas_spent(), expected);
-    assert_eq!(baseline_result.gas().state_gas_spent(), 0);
+    assert_eq!(result.gas().state_gas_spent_final(), expected);
+    assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
     assert_eq!(result.gas().inner_refunded(), 0);
     assert_eq!(
         result.gas().total_gas_spent() - baseline_result.gas().total_gas_spent(),
@@ -615,8 +619,8 @@ fn test_eip8037_create_empty_code() {
     let expected = STATE_GAS_CREATE;
     let delta = result.tx_gas_used() - baseline_gas;
     assert_eq!(delta, expected);
-    assert_eq!(result.gas().state_gas_spent(), expected);
-    assert_eq!(baseline_result.gas().state_gas_spent(), 0);
+    assert_eq!(result.gas().state_gas_spent_final(), expected);
+    assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
     assert_eq!(result.tx_gas_used(), baseline_gas + expected);
     crate::assert_sorted_json_snapshot!(&(baseline_result, result));
 }
@@ -643,8 +647,8 @@ fn test_eip8037_create_with_code() {
     let expected_delta = expected_state_gas + hash_cost(10);
     let delta = result.tx_gas_used() - baseline_gas;
     assert_eq!(delta, expected_delta);
-    assert_eq!(result.gas().state_gas_spent(), expected_state_gas);
-    assert_eq!(baseline_result.gas().state_gas_spent(), 0);
+    assert_eq!(result.gas().state_gas_spent_final(), expected_state_gas);
+    assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
     assert_eq!(result.tx_gas_used(), baseline_gas + expected_delta);
     crate::assert_sorted_json_snapshot!(&(baseline_result, result));
 }
@@ -671,8 +675,8 @@ fn test_eip8037_create_with_sstore() {
     let expected_delta = expected_state_gas + hash_cost(1);
     let delta = result.tx_gas_used() - baseline_gas;
     assert_eq!(delta, expected_delta);
-    assert_eq!(result.gas().state_gas_spent(), expected_state_gas);
-    assert_eq!(baseline_result.gas().state_gas_spent(), 0);
+    assert_eq!(result.gas().state_gas_spent_final(), expected_state_gas);
+    assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
     assert_eq!(result.gas().inner_refunded(), 0);
     crate::assert_sorted_json_snapshot!(&(baseline_result, result));
 }
@@ -700,8 +704,8 @@ fn test_eip8037_create2_with_code() {
     let expected_delta = expected_state_gas + hash_cost(10);
     let delta = result.tx_gas_used() - baseline_gas;
     assert_eq!(delta, expected_delta);
-    assert_eq!(result.gas().state_gas_spent(), expected_state_gas);
-    assert_eq!(baseline_result.gas().state_gas_spent(), 0);
+    assert_eq!(result.gas().state_gas_spent_final(), expected_state_gas);
+    assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
     // CREATE2 uses more regular gas than CREATE (hashing) but same state gas
     let create_init = return_n_bytes_init_code(10);
     let mut create_evm = state_gas_evm(create_bytecode(&create_init), u64::MAX);
@@ -709,8 +713,8 @@ fn test_eip8037_create2_with_code() {
         .transact_one(TxEnv::builder_for_bench().gas_price(0).build_fill())
         .unwrap();
     assert_eq!(
-        result.gas().state_gas_spent(),
-        create_result.gas().state_gas_spent()
+        result.gas().state_gas_spent_final(),
+        create_result.gas().state_gas_spent_final()
     );
     crate::assert_sorted_json_snapshot!(&(baseline_result, result, create_result));
 }
@@ -761,7 +765,7 @@ fn test_eip8037_create_code_deposit_state_gas_oog() {
         _ => panic!("Expected Halt variant"),
     }
     assert_eq!(result.tx_gas_used(), tight_limit);
-    assert_eq!(baseline_tight_result.gas().state_gas_spent(), 0);
+    assert_eq!(baseline_tight_result.gas().state_gas_spent_final(), 0);
     crate::assert_sorted_json_snapshot!(&(baseline_result, baseline_tight_result, result));
 }
 
@@ -785,7 +789,7 @@ fn test_eip8037_call_new_account() {
         .unwrap();
 
     assert!(result.is_success());
-    assert_eq!(result.gas().state_gas_spent(), STATE_GAS_NEW_ACCOUNT);
+    assert_eq!(result.gas().state_gas_spent_final(), STATE_GAS_NEW_ACCOUNT);
     let delta = result.tx_gas_used() - baseline_gas;
     assert_eq!(delta, STATE_GAS_NEW_ACCOUNT);
     assert_eq!(
@@ -812,7 +816,7 @@ fn test_eip8037_call_existing_account() {
         .unwrap();
 
     assert!(result.is_success());
-    assert_eq!(result.gas().state_gas_spent(), 0);
+    assert_eq!(result.gas().state_gas_spent_final(), 0);
     assert_eq!(result.tx_gas_used(), baseline_gas);
     assert_eq!(
         result.gas().total_gas_spent(),
@@ -839,7 +843,7 @@ fn test_eip8037_selfdestruct_new_account() {
         .unwrap();
 
     assert!(result.is_success());
-    assert_eq!(result.gas().state_gas_spent(), STATE_GAS_NEW_ACCOUNT);
+    assert_eq!(result.gas().state_gas_spent_final(), STATE_GAS_NEW_ACCOUNT);
     let delta = result.tx_gas_used() - baseline_gas;
     assert_eq!(delta, STATE_GAS_NEW_ACCOUNT);
     assert_eq!(
@@ -866,7 +870,7 @@ fn test_eip8037_selfdestruct_existing_account() {
         .unwrap();
 
     assert!(result.is_success());
-    assert_eq!(result.gas().state_gas_spent(), 0);
+    assert_eq!(result.gas().state_gas_spent_final(), 0);
     assert_eq!(result.tx_gas_used(), baseline_gas);
     assert_eq!(
         result.gas().total_gas_spent(),
@@ -948,7 +952,7 @@ fn test_eip8037_regular_gas_cap_sufficient() {
     assert!(result.is_success());
     let delta = result.tx_gas_used() - baseline_gas;
     assert_eq!(delta, STATE_GAS_SSTORE_SET);
-    assert_eq!(result.gas().state_gas_spent(), STATE_GAS_SSTORE_SET);
+    assert_eq!(result.gas().state_gas_spent_final(), STATE_GAS_SSTORE_SET);
     assert_eq!(result.tx_gas_used(), baseline_gas + STATE_GAS_SSTORE_SET);
     crate::assert_sorted_json_snapshot!(&(baseline_result, result));
 }
@@ -1023,7 +1027,7 @@ fn test_eip8037_tx_limit_cap_not_enforced_with_state_gas() {
 
     assert!(result.is_success());
     assert!(result.tx_gas_used() > 50_000, "gas_used exceeds cap");
-    assert_eq!(result.gas().state_gas_spent(), STATE_GAS_SSTORE_SET);
+    assert_eq!(result.gas().state_gas_spent_final(), STATE_GAS_SSTORE_SET);
     let delta = result.tx_gas_used() - baseline_gas;
     // EIP-8037: tx_gas_used = tx.gas - gas_left - state_gas_left
     // Unused reservoir gas (including new account state gas that wasn't consumed)
@@ -1044,6 +1048,7 @@ fn test_eip8037_block_gas_limit_enforced_with_state_gas() {
         .modify_cfg_chained(|cfg| {
             cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
             cfg.tx_gas_limit_cap = Some(u64::MAX);
+            cfg.cpsb_override = Some(1);
             cfg.gas_params.override_gas([
                 (GasId::sstore_set_state_gas(), STATE_GAS_SSTORE_SET),
                 (GasId::new_account_state_gas(), STATE_GAS_NEW_ACCOUNT),
@@ -1132,12 +1137,13 @@ fn test_eip8037_create_child_propagates() {
     assert!(result.is_success());
     let delta = result.tx_gas_used() - baseline_gas;
     assert_eq!(delta, expected_delta);
-    assert_eq!(result.gas().state_gas_spent(), expected_state_gas);
-    assert_eq!(baseline_result.gas().state_gas_spent(), 0);
+    assert_eq!(result.gas().state_gas_spent_final(), expected_state_gas);
+    assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
     crate::assert_sorted_json_snapshot!(&(baseline_result, result));
 }
 
-/// 5.2 Reverted CREATE: child's SSTORE state gas is refunded on revert.
+/// 5.2 Reverted CREATE: both the parent's upfront CREATE state gas and the child's
+/// SSTORE state gas are refunded on revert (state changes are rolled back).
 #[test]
 fn test_eip8037_reverted_create_child() {
     let init = init_code_sstore_and_revert();
@@ -1154,21 +1160,22 @@ fn test_eip8037_reverted_create_child() {
         .transact_one(TxEnv::builder_for_bench().gas_price(0).build_fill())
         .unwrap();
 
-    // On child revert, state gas is returned to parent's reservoir (matching Python spec).
-    // Only CREATE state gas contributes to the delta (SSTORE state gas is refunded).
-    let expected_delta = STATE_GAS_CREATE;
-    let parent_state_gas = STATE_GAS_CREATE;
+    // On child revert, ALL state gas is returned to the parent's reservoir:
+    // the child's SSTORE state gas via handle_reservoir_remaining_gas, and the
+    // parent's upfront CREATE state gas via the refill_reservoir refund in return_result.
+    let expected_delta = 0;
+    let parent_state_gas = 0;
 
     assert!(result.is_success());
     let delta = result.tx_gas_used() - baseline_gas;
     assert_eq!(delta, expected_delta);
-    // state_gas_spent reflects only parent's state gas (child's SSTORE state gas refunded on revert).
-    assert_eq!(result.gas().state_gas_spent(), parent_state_gas);
-    assert_eq!(baseline_result.gas().state_gas_spent(), 0);
+    // state_gas_spent_final is fully refunded (CREATE charge undone, SSTORE charge undone).
+    assert_eq!(result.gas().state_gas_spent_final(), parent_state_gas);
+    assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
     crate::assert_sorted_json_snapshot!(&(baseline_result, result));
 }
 
-/// 5.3 CALL to contract that does SSTORE(0,1). Child's state_gas_spent propagates on success.
+/// 5.3 CALL to contract that does SSTORE(0,1). Child's state_gas_spent_final propagates on success.
 #[test]
 fn test_eip8037_call_child_sstore_propagates() {
     let child_runtime: Vec<u8> = vec![
@@ -1199,8 +1206,8 @@ fn test_eip8037_call_child_sstore_propagates() {
     assert!(result.is_success());
     let delta = result.tx_gas_used() - baseline_gas;
     assert_eq!(delta, expected_delta);
-    assert_eq!(result.gas().state_gas_spent(), expected_state_gas);
-    assert_eq!(baseline_result.gas().state_gas_spent(), 0);
+    assert_eq!(result.gas().state_gas_spent_final(), expected_state_gas);
+    assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
     crate::assert_sorted_json_snapshot!(&(baseline_result, result));
 }
 
@@ -1238,8 +1245,8 @@ fn test_eip8037_call_child_sstore_reverts() {
     let create_state_gas = STATE_GAS_CREATE + code_deposit_gas;
 
     assert!(result.is_success());
-    // state_gas_spent reflects only CREATE costs (child SSTORE refunded on revert).
-    assert_eq!(result.gas().state_gas_spent(), create_state_gas);
+    // state_gas_spent_final reflects only CREATE costs (child SSTORE refunded on revert).
+    assert_eq!(result.gas().state_gas_spent_final(), create_state_gas);
     // On child revert, state changes are rolled back and state gas is returned
     // to the parent's reservoir (matching Python spec's incorporate_child_on_error).
     // So only CREATE state gas and hash cost contribute to the delta.
@@ -1280,8 +1287,8 @@ fn test_eip8037_nested_call_create_sstore() {
     assert!(result.is_success());
     let delta = result.tx_gas_used() - baseline_gas;
     assert_eq!(delta, expected_delta);
-    assert_eq!(result.gas().state_gas_spent(), expected_state_gas);
-    assert_eq!(baseline_result.gas().state_gas_spent(), 0);
+    assert_eq!(result.gas().state_gas_spent_final(), expected_state_gas);
+    assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
 
     // Cross-validate: CREATE-only run (no CALL child SSTORE).
     let init = return_n_bytes_init_code(child_runtime.len() as u8);
@@ -1290,14 +1297,21 @@ fn test_eip8037_nested_call_create_sstore() {
         .transact_one(TxEnv::builder_for_bench().gas_price(0).build_fill())
         .unwrap();
     assert!(create_result.is_success());
-    let sstore_portion = result.gas().state_gas_spent() - create_result.gas().state_gas_spent();
+    let sstore_portion =
+        result.gas().state_gas_spent_final() - create_result.gas().state_gas_spent_final();
     assert_eq!(sstore_portion, STATE_GAS_SSTORE_SET);
     crate::assert_sorted_json_snapshot!(&(baseline_result, result, create_result));
 }
 
 // ---- Category 6: Interactions ----
 
-/// 6.1 SSTORE 0→1 (state gas), then 1→0 (refund). Refund does NOT undo state gas.
+/// 6.1 SSTORE 0→1 (state gas), then 1→0 restoration.
+///
+/// EIP-8037 issue #2: 0→x→0 storage restoration directly refills the reservoir
+/// with the state gas originally charged for the 0→x transition, rather than
+/// routing it through the capped refund counter. The state gas net-out means
+/// `state_gas_spent_final == 0` after the full set+clear cycle, and no net state
+/// gas shows up in `total_gas_spent`.
 #[test]
 fn test_eip8037_sstore_set_then_clear_refund() {
     let bytecode = sstore_set_then_clear_bytecode();
@@ -1306,7 +1320,6 @@ fn test_eip8037_sstore_set_then_clear_refund() {
     let baseline_result = baseline
         .transact_one(TxEnv::builder_for_bench().gas_price(0).build_fill())
         .unwrap();
-    let baseline_gas = baseline_result.tx_gas_used();
 
     let mut evm = state_gas_evm(bytecode, u64::MAX);
     let result = evm
@@ -1314,13 +1327,13 @@ fn test_eip8037_sstore_set_then_clear_refund() {
         .unwrap();
 
     assert!(result.is_success());
-    // State gas increases spent by exactly STATE_GAS_SSTORE_SET.
-    assert_eq!(result.gas().state_gas_spent(), STATE_GAS_SSTORE_SET);
-    let spent_delta = result.gas().total_gas_spent() - baseline_result.gas().total_gas_spent();
-    assert_eq!(spent_delta, STATE_GAS_SSTORE_SET);
-    // Refund does NOT undo state gas — gas_used is higher than baseline.
-    assert!(result.tx_gas_used() > baseline_gas);
-    assert!(result.gas().total_gas_spent() > baseline_result.gas().total_gas_spent());
+    // State gas originally charged for 0→1 is refilled by the 1→0 restoration.
+    assert_eq!(result.gas().state_gas_spent_final(), 0);
+    // Total gas spent matches baseline — reservoir ends where it started.
+    assert_eq!(
+        result.gas().total_gas_spent(),
+        baseline_result.gas().total_gas_spent()
+    );
     crate::assert_sorted_json_snapshot!(&(baseline_result, result));
 }
 
@@ -1350,8 +1363,8 @@ fn test_eip8037_state_gas_does_not_reduce_regular_gas() {
     assert!(result.is_success());
     let delta = result.tx_gas_used() - baseline_gas;
     assert_eq!(delta, STATE_GAS_SSTORE_SET);
-    assert_eq!(result.gas().state_gas_spent(), STATE_GAS_SSTORE_SET);
-    assert_eq!(baseline_result.gas().state_gas_spent(), 0);
+    assert_eq!(result.gas().state_gas_spent_final(), STATE_GAS_SSTORE_SET);
+    assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
     crate::assert_sorted_json_snapshot!(&(baseline_result, result));
 }
 
@@ -1449,14 +1462,14 @@ fn test_eip8037_spend_all_preserves_reservoir() {
         gas_limit - STATE_GAS_SSTORE_SET,
         "Halt refunds state gas via reservoir"
     );
-    // state_gas_spent is zeroed on halt (state changes rolled back).
-    assert_eq!(result.gas().state_gas_spent(), 0);
+    // state_gas_spent_final is zeroed on halt (state changes rolled back).
+    assert_eq!(result.gas().state_gas_spent_final(), 0);
     crate::assert_sorted_json_snapshot!(&(baseline_result, result));
 }
 
-/// 6.5 state_gas_spent field in ResultGas.
+/// 6.5 state_gas_spent_final field in ResultGas.
 #[test]
-fn test_eip8037_state_gas_spent_in_result() {
+fn test_eip8037_state_gas_spent_final_in_result() {
     let bytecode = sstore_bytecode(0, 1);
 
     let mut baseline = baseline_evm(bytecode.clone());
@@ -1465,7 +1478,7 @@ fn test_eip8037_state_gas_spent_in_result() {
         .unwrap();
 
     assert!(baseline_result.is_success());
-    assert_eq!(baseline_result.gas().state_gas_spent(), 0);
+    assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
 
     let mut evm = state_gas_evm(bytecode, u64::MAX);
     let result = evm
@@ -1473,7 +1486,7 @@ fn test_eip8037_state_gas_spent_in_result() {
         .unwrap();
 
     assert!(result.is_success());
-    assert_eq!(result.gas().state_gas_spent(), STATE_GAS_SSTORE_SET);
+    assert_eq!(result.gas().state_gas_spent_final(), STATE_GAS_SSTORE_SET);
     let spent_delta = result.gas().total_gas_spent() - baseline_result.gas().total_gas_spent();
     assert_eq!(spent_delta, STATE_GAS_SSTORE_SET);
     let gas_used_delta = result.tx_gas_used() - baseline_result.tx_gas_used();
@@ -1501,8 +1514,8 @@ fn test_eip8037_precompile_no_state_gas() {
     assert!(result.is_success());
     let delta = result.tx_gas_used() - baseline_gas;
     assert_eq!(delta, 0);
-    assert_eq!(result.gas().state_gas_spent(), 0);
-    assert_eq!(baseline_result.gas().state_gas_spent(), 0);
+    assert_eq!(result.gas().state_gas_spent_final(), 0);
+    assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
     assert_eq!(
         result.gas().total_gas_spent(),
         baseline_result.gas().total_gas_spent()
@@ -1512,10 +1525,12 @@ fn test_eip8037_precompile_no_state_gas() {
 
 // ---- Category 7: Reservoir Refill ----
 //
-// The reservoir refill logic (handler_reservoir_refill) is invoked on HALT or REVERT:
-// `new_reservoir = reservoir + max(0, state_gas_spent - reservoir)`
+// The reservoir refill logic is invoked on HALT or REVERT using the conserved
+// `reservoir + state_gas_spent` invariant:
+// `new_reservoir = reservoir + state_gas_spent_final`
 //
-// This accounts for state gas that had to be drawn from regular gas.
+// This accounts for both state gas borrowed from regular gas and nested refill
+// unwinds that can make `state_gas_spent_final` temporarily negative.
 // On OK: reservoir stays unchanged (no refill needed).
 // On REVERT: remaining is reimbursed, then refill applied.
 // On HALT: remaining is NOT reimbursed, refill applied to final gas accounting.
@@ -1553,9 +1568,9 @@ fn test_eip8037_reservoir_refill_revert_state_gas_less() {
     assert!(!result.is_success() && !result.is_halt(), "Expected REVERT");
     // On revert, state gas is refunded via reservoir, so no delta vs baseline.
     assert_eq!(result.tx_gas_used(), baseline_gas);
-    // state_gas_spent is zeroed on revert (state changes rolled back).
-    assert_eq!(result.gas().state_gas_spent(), 0);
-    assert_eq!(baseline_result.gas().state_gas_spent(), 0);
+    // state_gas_spent_final is zeroed on revert (state changes rolled back).
+    assert_eq!(result.gas().state_gas_spent_final(), 0);
+    assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
     assert!(
         result.tx_gas_used() < gas_limit,
         "REVERT reimburses remaining"
@@ -1598,9 +1613,9 @@ fn test_eip8037_reservoir_refill_revert_state_gas_more() {
     assert!(!result.is_success() && !result.is_halt(), "Expected REVERT");
     // On revert, state gas is refunded via reservoir, so no delta vs baseline.
     assert_eq!(result.tx_gas_used(), baseline_gas);
-    // state_gas_spent is zeroed on revert (state changes rolled back).
-    assert_eq!(result.gas().state_gas_spent(), 0);
-    assert_eq!(baseline_result.gas().state_gas_spent(), 0);
+    // state_gas_spent_final is zeroed on revert (state changes rolled back).
+    assert_eq!(result.gas().state_gas_spent_final(), 0);
+    assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
     assert!(result.tx_gas_used() < gas_limit);
     assert_eq!(result.gas().inner_refunded(), 0);
     assert!(result.logs().is_empty());
@@ -1715,9 +1730,9 @@ fn test_eip8037_reservoir_refill_halt_vs_revert_difference() {
     // since OOG happened before SSTORE could execute).
     assert_eq!(result_halt.tx_gas_used(), halt_gas_limit);
     assert!(result_revert.tx_gas_used() < revert_gas_limit);
-    // On revert/halt, state_gas_spent is zeroed (state changes rolled back).
-    assert_eq!(result_revert.gas().state_gas_spent(), 0);
-    assert_eq!(result_halt.gas().state_gas_spent(), 0);
+    // On revert/halt, state_gas_spent_final is zeroed (state changes rolled back).
+    assert_eq!(result_revert.gas().state_gas_spent_final(), 0);
+    assert_eq!(result_halt.gas().state_gas_spent_final(), 0);
     assert_eq!(result_halt.gas().inner_refunded(), 0);
     assert_eq!(result_revert.gas().inner_refunded(), 0);
     crate::assert_sorted_json_snapshot!(&(result_halt, result_revert));
@@ -1832,9 +1847,9 @@ fn test_eip8037_call_new_account_no_value() {
 
     assert!(result.is_success());
     // No value transfer → no new_account_state_gas even for empty account.
-    assert_eq!(result.gas().state_gas_spent(), 0);
+    assert_eq!(result.gas().state_gas_spent_final(), 0);
     assert_eq!(result.tx_gas_used(), baseline_gas);
-    assert_eq!(baseline_result.gas().state_gas_spent(), 0);
+    assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
     crate::assert_sorted_json_snapshot!(&(baseline_result, result));
 }
 
@@ -1861,8 +1876,8 @@ fn test_eip8037_create_large_code() {
     let expected_delta = expected_state_gas + hash_cost(200);
     let delta = result.tx_gas_used() - baseline_gas;
     assert_eq!(delta, expected_delta);
-    assert_eq!(result.gas().state_gas_spent(), expected_state_gas);
-    assert_eq!(baseline_result.gas().state_gas_spent(), 0);
+    assert_eq!(result.gas().state_gas_spent_final(), expected_state_gas);
+    assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
     // Verify code deposit portion is significant
     let code_deposit_portion = STATE_GAS_CODE_DEPOSIT * 200;
     assert_eq!(code_deposit_portion, 200_000);
@@ -1909,7 +1924,455 @@ fn test_eip8037_parent_sstore_after_child_revert() {
     assert!(result.is_success());
     let delta = result.tx_gas_used() - baseline_gas;
     assert_eq!(delta, expected_delta);
-    assert_eq!(result.gas().state_gas_spent(), expected_state_gas);
-    assert_eq!(baseline_result.gas().state_gas_spent(), 0);
+    assert_eq!(result.gas().state_gas_spent_final(), expected_state_gas);
+    assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
     crate::assert_sorted_json_snapshot!(&(baseline_result, result));
+}
+
+// ---- EIP-8037 issue #2: 0→x→0 storage reservoir refill ----
+
+/// EIP-8037 issue #2 — same frame: 0→1→0 restoration refills the reservoir
+/// with the state gas originally charged on 0→1 (via `refill_reservoir`)
+/// rather than routing it through the capped refund counter.
+///
+/// Compared against a set-only variant (0→1 with no clear): the set-then-clear
+/// variant must end with `state_gas_spent_final == 0`, while the set-only variant
+/// retains the full `STATE_GAS_SSTORE_SET` charge.
+#[test]
+fn test_eip8037_sstore_refill_same_frame() {
+    let mut evm = state_gas_evm(sstore_set_then_clear_bytecode(), u64::MAX);
+    let restored = evm
+        .transact_one(TxEnv::builder_for_bench().gas_price(0).build_fill())
+        .unwrap();
+
+    let mut evm = state_gas_evm(sstore_bytecode(0, 1), u64::MAX);
+    let set_only = evm
+        .transact_one(TxEnv::builder_for_bench().gas_price(0).build_fill())
+        .unwrap();
+
+    assert!(restored.is_success());
+    assert!(set_only.is_success());
+
+    // The refill nets state gas back to zero for the 0→1→0 round-trip.
+    assert_eq!(restored.gas().state_gas_spent_final(), 0);
+    // Without the clear, the full state gas stays spent.
+    assert_eq!(set_only.gas().state_gas_spent_final(), STATE_GAS_SSTORE_SET);
+}
+
+/// Parent SSTORE(0,1), CREATE a child, DELEGATECALL the child which SSTORE(0,0).
+///
+/// DELEGATECALL runs the child's code in the parent's storage context, so the
+/// child's SSTORE clears the slot the parent set. Used to exercise the
+/// cross-frame 0→x→0 case.
+fn sstore_parent_then_delegatecall_clear_bytecode() -> Bytecode {
+    // Child runtime: SSTORE(0, 0); STOP
+    let child_runtime: [u8; 6] = [
+        opcode::PUSH1,
+        0,
+        opcode::PUSH1,
+        0,
+        opcode::SSTORE,
+        opcode::STOP,
+    ];
+
+    // Init code: MSTORE8 each byte of child_runtime, then RETURN(0, len).
+    let mut init_code = Vec::new();
+    for (i, &byte) in child_runtime.iter().enumerate() {
+        init_code.push(opcode::PUSH1);
+        init_code.push(byte);
+        init_code.push(opcode::PUSH1);
+        init_code.push(i as u8);
+        init_code.push(opcode::MSTORE8);
+    }
+    init_code.push(opcode::PUSH1);
+    init_code.push(child_runtime.len() as u8);
+    init_code.push(opcode::PUSH1);
+    init_code.push(0);
+    init_code.push(opcode::RETURN);
+
+    // Parent: SSTORE(0, 1) — state gas charged on the parent frame.
+    let mut bytecode = vec![opcode::PUSH1, 1, opcode::PUSH1, 0, opcode::SSTORE];
+
+    // MSTORE8 init_code into memory.
+    for (i, &byte) in init_code.iter().enumerate() {
+        bytecode.push(opcode::PUSH1);
+        bytecode.push(byte);
+        bytecode.push(opcode::PUSH1);
+        bytecode.push(i as u8);
+        bytecode.push(opcode::MSTORE8);
+    }
+
+    // CREATE(value=0, offset=0, length=init_code.len())
+    bytecode.push(opcode::PUSH1);
+    bytecode.push(init_code.len() as u8);
+    bytecode.push(opcode::PUSH1);
+    bytecode.push(0);
+    bytecode.push(opcode::PUSH1);
+    bytecode.push(0);
+    bytecode.push(opcode::CREATE);
+    // Stack: [child_addr]
+
+    // DELEGATECALL args (retLen, retOff, argsLen, argsOff, addr, gas).
+    for _ in 0..4 {
+        bytecode.push(opcode::PUSH1);
+        bytecode.push(0);
+    }
+    // Stack: [child_addr, 0, 0, 0, 0]
+    bytecode.push(opcode::SWAP4);
+    // Stack: [0, 0, 0, 0, child_addr]
+    bytecode.push(opcode::GAS);
+    // Stack: [0, 0, 0, 0, child_addr, gas]
+    bytecode.push(opcode::DELEGATECALL);
+    bytecode.push(opcode::POP);
+    bytecode.push(opcode::STOP);
+
+    Bytecode::new_legacy(bytecode.into())
+}
+
+/// EIP-8037 issue #2 — cross frame: parent charges state gas on SSTORE(0,1),
+/// then DELEGATECALLs a child that does SSTORE(0,0). Because DELEGATECALL
+/// shares the caller's storage, the child performs the 0→1→0 restoration
+/// and calls `refill_reservoir` inside its own frame, driving the child's
+/// `state_gas_spent_final` to `-STATE_GAS_SSTORE_SET`. On frame return, the
+/// parent's +STATE_GAS_SSTORE_SET and the child's negative net out via the
+/// i64 accumulation in `handle_reservoir_remaining_gas`.
+///
+/// After the call, only the parent's CREATE + code-deposit state gas
+/// remains; the SSTORE round-trip leaves no net state gas.
+#[test]
+fn test_eip8037_sstore_refill_cross_frame() {
+    const CHILD_RUNTIME_LEN: u64 = 6;
+
+    let bytecode = sstore_parent_then_delegatecall_clear_bytecode();
+
+    let mut evm = state_gas_evm(bytecode, u64::MAX);
+    let result = evm
+        .transact_one(TxEnv::builder_for_bench().gas_price(0).build_fill())
+        .unwrap();
+
+    assert!(result.is_success());
+
+    // Parent charged STATE_GAS_SSTORE_SET on 0→1; the child's DELEGATECALL
+    // refills it on 1→0. Only the CREATE + code-deposit state gas remains.
+    let expected_state_gas = STATE_GAS_CREATE + STATE_GAS_CODE_DEPOSIT * CHILD_RUNTIME_LEN;
+    assert_eq!(result.gas().state_gas_spent_final(), expected_state_gas);
+}
+
+// ---- Tx-kind Create with initcode that halts / self-destructs ----
+
+/// Initcode that does SSTORE(0, 1) then hits INVALID (0xFE) — exceptional halt.
+fn init_code_sstore_and_invalid() -> Vec<u8> {
+    vec![
+        opcode::PUSH1,
+        1,
+        opcode::PUSH1,
+        0,
+        opcode::SSTORE,
+        opcode::INVALID,
+    ]
+}
+
+/// Initcode that does SSTORE(0, 1) then SELFDESTRUCTs to `beneficiary`.
+fn init_code_sstore_and_selfdestruct(beneficiary: [u8; 20]) -> Vec<u8> {
+    let mut code = vec![
+        opcode::PUSH1,
+        1,
+        opcode::PUSH1,
+        0,
+        opcode::SSTORE,
+        opcode::PUSH20,
+    ];
+    code.extend_from_slice(&beneficiary);
+    code.push(opcode::SELFDESTRUCT);
+    code
+}
+
+/// Tx-kind Create whose initcode does SSTORE(0,1) then INVALID.
+///
+/// Initcode halts → all state changes are rolled back. The SSTORE state gas
+/// charged during execution is returned to the reservoir via
+/// `last_frame_result`'s halt branch, and the intrinsic `create_state_gas` is
+/// refilled by the same function's `create_failed` branch. Net result:
+/// `state_gas_spent_final == 0` and the caller pays less than the baseline by
+/// exactly the state gas that was refunded.
+#[test]
+fn test_eip8037_tx_create_initcode_halts() {
+    let init = init_code_sstore_and_invalid();
+
+    let mut baseline = baseline_evm(Bytecode::new());
+    let baseline_result = baseline
+        .transact_one(
+            TxEnv::builder_for_bench()
+                .kind(TxKind::Create)
+                .data(init.clone().into())
+                .gas_price(0)
+                .build_fill(),
+        )
+        .unwrap();
+
+    let mut evm = state_gas_evm(Bytecode::new(), u64::MAX);
+    let result = evm
+        .transact_one(
+            TxEnv::builder_for_bench()
+                .kind(TxKind::Create)
+                .data(init.into())
+                .gas_price(0)
+                .build_fill(),
+        )
+        .unwrap();
+
+    // Both halt on INVALID inside the initcode.
+    assert!(baseline_result.is_halt());
+    assert!(result.is_halt());
+    match &result {
+        revm::context_interface::result::ExecutionResult::Halt { reason, .. } => {
+            assert!(matches!(reason, HaltReason::InvalidFEOpcode));
+        }
+        _ => panic!("Expected Halt variant"),
+    }
+
+    // No state gas should be reported as spent: execution state gas (SSTORE)
+    // is rolled back on halt, and the intrinsic create_state_gas is refilled
+    // to the reservoir via the `create_failed` branch.
+    assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
+    assert_eq!(result.gas().state_gas_spent_final(), 0);
+
+    // The state-gas variant pays less than the baseline because the refilled
+    // reservoir is reimbursed back to the caller.
+    assert!(result.tx_gas_used() < baseline_result.tx_gas_used());
+    crate::assert_sorted_json_snapshot!(&(baseline_result, result));
+}
+
+/// Tx-kind Create whose initcode does SSTORE(0,1) then SELFDESTRUCTs.
+///
+/// Per EIP-6780 the contract is erased at tx end (created and self-destructed
+/// in the same transaction). Per EIP-8037 the state gas charged for that
+/// account — both the intrinsic `create_state_gas` and the execution-time
+/// SSTORE — should ideally be refunded to the reservoir, so the caller is not
+/// billed for state gas.
+///
+/// However, the journal-based selfdestruct state-gas refund was removed (it
+/// drew on the journal's destroyed-accounts list), so the SSTORE state gas
+/// is no longer refunded. The intrinsic `create_state_gas` is also not
+/// refunded: `return_create` rewrites the frame's `SelfDestruct` result to
+/// `Return` before `last_frame_result` runs, so `create_failed` evaluates to
+/// false and the `create_failed` branch that would refill `create_state_gas`
+/// never fires. The caller therefore pays both the intrinsic state gas and
+/// the SSTORE state gas even though the contract was erased.
+#[test]
+fn test_eip8037_tx_create_initcode_selfdestruct_after_sstore() {
+    // Use BENCH_CALLER as beneficiary so we don't trigger new_account_state_gas.
+    let init = init_code_sstore_and_selfdestruct(BENCH_CALLER.into_array());
+
+    let mut baseline = baseline_evm(Bytecode::new());
+    let baseline_result = baseline
+        .transact_one(
+            TxEnv::builder_for_bench()
+                .kind(TxKind::Create)
+                .data(init.clone().into())
+                .gas_price(0)
+                .build_fill(),
+        )
+        .unwrap();
+
+    let mut evm = state_gas_evm(Bytecode::new(), u64::MAX);
+    let result = evm
+        .transact_one(
+            TxEnv::builder_for_bench()
+                .kind(TxKind::Create)
+                .data(init.into())
+                .gas_price(0)
+                .build_fill(),
+        )
+        .unwrap();
+
+    // SELFDESTRUCT during initcode is a successful create completion (with
+    // empty deployed code) that EIP-6780 then erases at tx end.
+    assert!(baseline_result.is_success());
+    assert!(result.is_success());
+
+    // Per EIP-8037 + EIP-6780 the user expects state_gas_spent_final == 0 here,
+    // but the journal-based selfdestruct refund was removed, so the SSTORE state
+    // gas is now also retained alongside the intrinsic `create_state_gas` —
+    // see the doc comment above.
+    assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
+    assert_eq!(
+        result.gas().state_gas_spent_final(),
+        STATE_GAS_SSTORE_SET + revm::primitives::eip8037::NEW_ACCOUNT_BYTES
+    );
+
+    crate::assert_sorted_json_snapshot!(&(baseline_result, result));
+}
+
+/// Tx-kind Create whose destination address already holds a non-empty account,
+/// triggering a `CreateCollision` halt in `create_account_checkpoint` before
+/// any initcode runs.
+///
+/// Verifies the failure path through `return_error` (frame.rs `make_create_frame`)
+/// into `last_frame_result`:
+/// - The halt fully consumes regular gas: `erase_cost(remaining)` is gated on
+///   `is_ok_or_revert()` and is skipped, so `gas.remaining == 0`.
+/// - `create_failed` matches (Create + not `is_ok_without_selfdestruct`), so
+///   the intrinsic `create_state_gas` is refilled to the reservoir.
+/// - `state_gas_spent` is reset to 0 (halt branch).
+///
+/// Net: the EIP-8037 variant pays exactly `STATE_GAS_CREATE` less than the
+/// baseline.
+#[test]
+fn test_eip8037_tx_create_collision() {
+    use revm::{
+        database::{CacheDB, EmptyDB},
+        state::AccountInfo,
+    };
+
+    // tx-Create from BENCH_CALLER (nonce=0) deploys to BENCH_CALLER.create(0).
+    let collision_addr = BENCH_CALLER.create(0);
+
+    // Build a DB with the caller funded and a non-empty account pre-existing
+    // at the create-address. `create_account_checkpoint` errors with
+    // `CreateCollision` when the target has nonce != 0 or non-empty code.
+    let build_db = || {
+        let mut db: CacheDB<EmptyDB> = CacheDB::new(EmptyDB::default());
+        db.insert_account_info(
+            BENCH_CALLER,
+            AccountInfo {
+                balance: U256::from(u64::MAX),
+                nonce: 0,
+                ..Default::default()
+            },
+        );
+        db.insert_account_info(
+            collision_addr,
+            AccountInfo {
+                nonce: 1,
+                ..Default::default()
+            },
+        );
+        db
+    };
+
+    let init = init_code_sstore_and_invalid();
+    let build_tx = |gas_limit: u64| {
+        TxEnv::builder_for_bench()
+            .kind(TxKind::Create)
+            .data(init.clone().into())
+            .gas_price(0)
+            .gas_limit(gas_limit)
+            .build_fill()
+    };
+
+    // Baseline: EIP-8037 disabled.
+    let mut baseline = Context::mainnet()
+        .modify_cfg_chained(|cfg| {
+            cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
+            cfg.enable_amsterdam_eip8037 = false;
+            cfg.tx_gas_limit_cap = Some(u64::MAX);
+        })
+        .with_db(build_db())
+        .build_mainnet();
+    let baseline_result = baseline.transact_one(build_tx(TX_GAS_LIMIT_CAP)).unwrap();
+
+    // State-gas variant: EIP-8037 enabled with cpsb_override = 1 so the
+    // gas-table overrides are interpreted as final amounts.
+    let mut evm = Context::mainnet()
+        .modify_cfg_chained(|cfg| {
+            cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
+            cfg.cpsb_override = Some(1);
+            cfg.gas_params.override_gas([
+                (GasId::sstore_set_state_gas(), STATE_GAS_SSTORE_SET),
+                (GasId::new_account_state_gas(), STATE_GAS_NEW_ACCOUNT),
+                (GasId::code_deposit_state_gas(), STATE_GAS_CODE_DEPOSIT),
+                (GasId::create_state_gas(), STATE_GAS_CREATE),
+            ]);
+        })
+        .with_db(build_db())
+        .build_mainnet();
+    let result = evm.transact_one(build_tx(TX_GAS_LIMIT_CAP + 10)).unwrap();
+
+    // Both halt with CreateCollision before any initcode runs.
+    assert!(baseline_result.is_halt());
+    assert!(result.is_halt());
+    match &baseline_result {
+        revm::context_interface::result::ExecutionResult::Halt { reason, .. } => {
+            assert!(matches!(reason, HaltReason::CreateCollision));
+        }
+        _ => panic!("Expected Halt variant for baseline"),
+    }
+    match &result {
+        revm::context_interface::result::ExecutionResult::Halt { reason, .. } => {
+            assert!(matches!(reason, HaltReason::CreateCollision));
+        }
+        _ => panic!("Expected Halt variant"),
+    }
+
+    // No execution state gas accrued (initcode never ran), and on halt
+    // `last_frame_result` zeros `state_gas_spent` for both variants.
+    assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
+    assert_eq!(result.gas().state_gas_spent_final(), 0);
+
+    // Halt consumes the regular gas budget in full. With cpsb_override = 1 the
+    // intrinsic create_state_gas equals STATE_GAS_CREATE, and the state-gas
+    // variant's total gas spent is exactly that much less than the baseline,
+    // because the create_failed branch refills the reservoir with it.
+    //
+    // -10 as additional gas was added to tx.gas_limit to cover reservoir handling.
+    assert_eq!(
+        baseline_result.gas().total_gas_spent() - result.gas().total_gas_spent(),
+        STATE_GAS_CREATE - 10,
+    );
+
+    crate::assert_sorted_json_snapshot!(&(baseline_result, result));
+}
+
+/// Regression test for the `last_frame_result` revert/halt branch:
+/// state gas charged purely against the reservoir must not be over-refunded
+/// when the top frame halts.
+///
+/// Setup chosen so the state cost stays in the reservoir (no spill into
+/// regular gas) and the SSTORE has enough regular gas to complete:
+/// - `gas_limit = 1_000_000`, `tx_gas_limit_cap = 50_000`.
+/// - Intrinsic regular = `TX_BASE` (21_000). Regular budget = 29_000.
+/// - Reservoir = `gas_limit - cap` = 950_000, ample for STATE_GAS_SSTORE_SET.
+///
+/// Flow: SSTORE(0,1) consumes 22_100 regular + STATE_GAS_SSTORE_SET (200_000)
+/// state from the reservoir, then INVALID halts. State changes roll back, so
+/// the state gas must come back to the reservoir, leaving regular consumption
+/// at exactly the cap (50_000 = intrinsic + budget).
+///
+/// Pre-fix bug: the halt branch computed `reservoir = original + recovered =
+/// 950_000 + 200_000 = 1_150_000`, exceeding the original budget. That
+/// underflowed `total_gas_spent` to 0, the EIP-7623 floor took over, and the
+/// test would have observed `tx_gas_used == 21_000` instead of 50_000.
+#[test]
+fn test_eip8037_halt_no_overrefund_when_state_in_reservoir() {
+    let bytecode = sstore_then_invalid_bytecode();
+    let gas_limit = 1_000_000u64;
+    let cap = 50_000u64;
+
+    let mut evm = state_gas_evm(bytecode, cap);
+    let result = evm
+        .transact_one(
+            TxEnv::builder_for_bench()
+                .gas_limit(gas_limit)
+                .gas_price(0)
+                .build_fill(),
+        )
+        .unwrap();
+
+    assert!(result.is_halt());
+    match &result {
+        revm::context_interface::result::ExecutionResult::Halt { reason, .. } => {
+            assert!(matches!(reason, HaltReason::InvalidFEOpcode));
+        }
+        _ => panic!("Expected Halt variant"),
+    }
+
+    // State changes rolled back on halt, so reported state gas is zero.
+    assert_eq!(result.gas().state_gas_spent_final(), 0);
+
+    // Regular gas is fully consumed (cap = 50_000) but the reservoir is
+    // refunded in full. tx_gas_used must equal exactly the cap — not the
+    // EIP-7623 floor, which is what the pre-fix code would have produced.
+    assert_eq!(result.tx_gas_used(), cap);
+    assert!(result.tx_gas_used() > result.gas().floor_gas());
 }

--- a/crates/ee-tests/src/lib.rs
+++ b/crates/ee-tests/src/lib.rs
@@ -19,4 +19,7 @@ macro_rules! assert_sorted_json_snapshot {
 mod revm_tests;
 
 #[cfg(test)]
+mod eip2780;
+
+#[cfg(test)]
 mod eip8037;

--- a/crates/ee-tests/src/revm_tests.rs
+++ b/crates/ee-tests/src/revm_tests.rs
@@ -439,6 +439,7 @@ const SELFDESTRUCT_TO_SELF_INIT_CODE: &[u8] = &[
 fn test_eip7708_selfdestruct_to_self() {
     let mut evm = Context::mainnet()
         .with_cfg(CfgEnv::new_with_spec(SpecId::AMSTERDAM))
+        .modify_block_chained(|block| block.gas_limit = 100_000_000)
         .with_db(BenchmarkDB::new_bytecode(Bytecode::new()))
         .build_mainnet();
 
@@ -451,7 +452,7 @@ fn test_eip7708_selfdestruct_to_self() {
                 .kind(TxKind::Create)
                 .data(SELFDESTRUCT_TO_SELF_INIT_CODE.into())
                 .value(create_value)
-                .gas_limit(200_000)
+                .gas_limit(500_000)
                 .gas_price(0)
                 .build_fill(),
         )
@@ -532,13 +533,14 @@ fn test_eip7708_call_with_value() {
 
     let mut evm = Context::mainnet()
         .with_cfg(CfgEnv::new_with_spec(SpecId::AMSTERDAM))
+        .modify_block_chained(|block| block.gas_limit = 100_000_000)
         .with_db(BenchmarkDB::new_bytecode(bytecode))
         .build_mainnet();
 
     let result = evm
         .transact_one(
             TxEnv::builder_for_bench()
-                .gas_limit(200_000)
+                .gas_limit(500_000)
                 .gas_price(0)
                 .build_fill(),
         )
@@ -626,13 +628,14 @@ fn test_eip7708_create_with_value() {
 
     let mut evm = Context::mainnet()
         .with_cfg(CfgEnv::new_with_spec(SpecId::AMSTERDAM))
+        .modify_block_chained(|block| block.gas_limit = 100_000_000)
         .with_db(BenchmarkDB::new_bytecode(bytecode))
         .build_mainnet();
 
     let result = evm
         .transact_one(
             TxEnv::builder_for_bench()
-                .gas_limit(200_000)
+                .gas_limit(500_000)
                 .gas_price(0)
                 .build_fill(),
         )

--- a/crates/ee-tests/src/revm_tests.rs
+++ b/crates/ee-tests/src/revm_tests.rs
@@ -279,12 +279,15 @@ fn test_eip7708_transfer_log_tx_value() {
 
     let tx_value = U256::from(1_000_000_000_000_000u128); // 0.001 ETH (within balance)
 
+    // ETH transfer creating new account costs ~207k gas under EIP-2780
+    // (TX_BASE_COST + COLD_ACCOUNT_ACCESS + ACCOUNT_WRITE + TRANSFER_LOG_COST
+    //  + STATE_BYTES_PER_NEW_ACCOUNT × CPSB at top-level execution).
     let result = evm
         .transact_one(
             TxEnv::builder_for_bench()
                 .to(recipient)
                 .value(tx_value)
-                .gas_limit(100_000)
+                .gas_limit(300_000)
                 .gas_price(0) // Zero gas price to avoid balance issues
                 .build_fill(),
         )

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_block_gas_limit_enforced_with_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_block_gas_limit_enforced_with_state_gas.snap
@@ -6,7 +6,7 @@ expression: "&result_fits"
   "Success": {
     "reason": "Stop",
     "gas": {
-      "gas_spent": 226006,
+      "gas_spent": 226009,
       "state_gas_spent": 200000,
       "gas_refunded": 0,
       "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_propagates.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_propagates.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 35525,
+        "gas_spent": 33530,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 571531,
+        "gas_spent": 569536,
         "state_gas_spent": 536000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_reverts.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_reverts.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 35747,
+        "gas_spent": 33752,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 375753,
+        "gas_spent": 373758,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_existing_account.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_existing_account.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 27822,
+        "gas_spent": 27824,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -32,7 +32,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 27822,
+        "gas_spent": 27824,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 30322,
+        "gas_spent": 37025,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -32,7 +32,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 280322,
+        "gas_spent": 287025,
         "state_gas_spent": 250000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account_no_value.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account_no_value.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 23622,
+        "gas_spent": 23623,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 23622,
+        "gas_spent": 23623,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create2_with_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create2_with_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 30079,
+        "gas_spent": 28080,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 370085,
+        "gas_spent": 368086,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -37,7 +37,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 370076,
+        "gas_spent": 368077,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_child_propagates.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_child_propagates.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 35121,
+        "gas_spent": 33125,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 566127,
+        "gas_spent": 564131,
         "state_gas_spent": 531000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_code_deposit_state_gas_oog.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_code_deposit_state_gas_oog.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, baseline_tight_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 30079,
+        "gas_spent": 28080,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, baseline_tight_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 30079,
+        "gas_spent": 28080,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -39,7 +39,7 @@ expression: "&(baseline_result, baseline_tight_result, result)"
         "OutOfGas": "Basic"
       },
       "gas": {
-        "gas_spent": 30080,
+        "gas_spent": 28081,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_empty_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_empty_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 30067,
+        "gas_spent": 28068,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 360067,
+        "gas_spent": 358068,
         "state_gas_spent": 330000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_large_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_large_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 30088,
+        "gas_spent": 28089,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 560130,
+        "gas_spent": 558131,
         "state_gas_spent": 530000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 30070,
+        "gas_spent": 28071,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 370076,
+        "gas_spent": 368077,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_sstore.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 35121,
+        "gas_spent": 33125,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 566127,
+        "gas_spent": 564131,
         "state_gas_spent": 531000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_nested_call_create_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_nested_call_create_sstore.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 35525,
+        "gas_spent": 33530,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 571531,
+        "gas_spent": 569536,
         "state_gas_spent": 536000,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -37,7 +37,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 366076,
+        "gas_spent": 364077,
         "state_gas_spent": 336000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_parent_sstore_after_child_revert.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_parent_sstore_after_child_revert.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 40753,
+        "gas_spent": 38761,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 580759,
+        "gas_spent": 578767,
         "state_gas_spent": 540000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_precompile_no_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_precompile_no_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 21137,
+        "gas_spent": 21138,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 21137,
+        "gas_spent": 21138,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_causes_oog.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_causes_oog.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_sufficient.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_sufficient.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226006,
+        "gas_spent": 226009,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_state_gas_less.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_state_gas_less.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_vs_revert_difference.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_vs_revert_difference.snap
@@ -20,7 +20,7 @@ expression: "&(result_halt, result_revert)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 26012,
+        "gas_spent": 26015,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_less.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_less.snap
@@ -6,7 +6,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 26012,
+        "gas_spent": 26015,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -18,7 +18,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 26012,
+        "gas_spent": 26015,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_more.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_more.snap
@@ -6,7 +6,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 31018,
+        "gas_spent": 31024,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -18,7 +18,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 31018,
+        "gas_spent": 31024,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reverted_create_child.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reverted_create_child.snap
@@ -22,8 +22,8 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 365118,
-        "state_gas_spent": 330000,
+        "gas_spent": 35118,
+        "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
       },

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reverted_create_child.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reverted_create_child.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 35118,
+        "gas_spent": 33122,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 35118,
+        "gas_spent": 33122,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_selfdestruct_new_account.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_selfdestruct_new_account.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "SelfDestruct",
       "gas": {
-        "gas_spent": 28603,
+        "gas_spent": 35305,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -32,7 +32,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "SelfDestruct",
       "gas": {
-        "gas_spent": 278603,
+        "gas_spent": 285305,
         "state_gas_spent": 250000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_multiple_new_slots.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_multiple_new_slots.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 36018,
+        "gas_spent": 36027,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 636018,
+        "gas_spent": 636027,
         "state_gas_spent": 600000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_new_slot.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_new_slot.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226006,
+        "gas_spent": 226009,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_overwrite_no_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_overwrite_no_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26112,
+        "gas_spent": 26116,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226112,
+        "gas_spent": 226116,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_set_then_clear_refund.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_set_then_clear_refund.snap
@@ -7,9 +7,9 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26112,
+        "gas_spent": 26116,
         "state_gas_spent": 0,
-        "gas_refunded": 2800,
+        "gas_refunded": 2801,
         "floor_gas": 21000
       },
       "logs": [],
@@ -22,9 +22,9 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26112,
+        "gas_spent": 26116,
         "state_gas_spent": 0,
-        "gas_refunded": 2800,
+        "gas_refunded": 2801,
         "floor_gas": 21000
       },
       "logs": [],

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_zero_to_zero_no_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_zero_to_zero_no_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 23206,
+        "gas_spent": 23208,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 23206,
+        "gas_spent": 23208,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_does_not_reduce_regular_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_does_not_reduce_regular_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226006,
+        "gas_spent": 226009,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_oog_remaining.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_oog_remaining.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_spent_final_in_result.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_spent_final_in_result.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226006,
+        "gas_spent": 226009,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_spent_final_in_result.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_spent_final_in_result.snap
@@ -7,9 +7,9 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26112,
+        "gas_spent": 26006,
         "state_gas_spent": 0,
-        "gas_refunded": 2800,
+        "gas_refunded": 0,
         "floor_gas": 21000
       },
       "logs": [],
@@ -22,9 +22,9 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26112,
-        "state_gas_spent": 0,
-        "gas_refunded": 2800,
+        "gas_spent": 226006,
+        "state_gas_spent": 200000,
+        "gas_refunded": 0,
         "floor_gas": 21000
       },
       "logs": [],

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_spent_in_result.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_spent_in_result.snap
@@ -9,6 +9,7 @@ expression: "&(baseline_result, result)"
       "gas": {
         "gas_spent": 26006,
         "state_gas_spent": 0,
+        "eip7702_state_refund": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
       },
@@ -24,6 +25,7 @@ expression: "&(baseline_result, result)"
       "gas": {
         "gas_spent": 226006,
         "state_gas_spent": 200000,
+        "eip7702_state_refund": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
       },

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_collision.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_collision.snap
@@ -1,0 +1,30 @@
+---
+source: crates/ee-tests/src/eip8037.rs
+expression: "&(baseline_result, result)"
+---
+[
+  {
+    "Halt": {
+      "reason": "CreateCollision",
+      "gas": {
+        "gas_spent": 16777216,
+        "state_gas_spent": 0,
+        "gas_refunded": 0,
+        "floor_gas": 21384
+      },
+      "logs": []
+    }
+  },
+  {
+    "Halt": {
+      "reason": "CreateCollision",
+      "gas": {
+        "gas_spent": 16447226,
+        "state_gas_spent": 0,
+        "gas_refunded": 0,
+        "floor_gas": 21384
+      },
+      "logs": []
+    }
+  }
+]

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_halts.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_halts.snap
@@ -1,0 +1,30 @@
+---
+source: crates/ee-tests/src/eip8037.rs
+expression: "&(baseline_result, result)"
+---
+[
+  {
+    "Halt": {
+      "reason": "InvalidFEOpcode",
+      "gas": {
+        "gas_spent": 1000000000,
+        "state_gas_spent": 0,
+        "gas_refunded": 0,
+        "floor_gas": 21384
+      },
+      "logs": []
+    }
+  },
+  {
+    "Halt": {
+      "reason": "InvalidFEOpcode",
+      "gas": {
+        "gas_spent": 999470000,
+        "state_gas_spent": 0,
+        "gas_refunded": 0,
+        "floor_gas": 21384
+      },
+      "logs": []
+    }
+  }
+]

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_selfdestruct_after_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_selfdestruct_after_sstore.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Return",
       "gas": {
-        "gas_spent": 40431,
+        "gas_spent": 38435,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 22728
@@ -25,7 +25,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Return",
       "gas": {
-        "gas_spent": 240551,
+        "gas_spent": 238555,
         "state_gas_spent": 200120,
         "gas_refunded": 0,
         "floor_gas": 22728

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_selfdestruct_after_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_selfdestruct_after_sstore.snap
@@ -1,0 +1,42 @@
+---
+source: crates/ee-tests/src/eip8037.rs
+expression: "&(baseline_result, result)"
+---
+[
+  {
+    "Success": {
+      "reason": "Return",
+      "gas": {
+        "gas_spent": 40431,
+        "state_gas_spent": 0,
+        "gas_refunded": 0,
+        "floor_gas": 22728
+      },
+      "logs": [],
+      "output": {
+        "Create": [
+          "0x",
+          "0x84bcbaa99ae6d1f7f70b37d5f6c27c9631eeb2f2"
+        ]
+      }
+    }
+  },
+  {
+    "Success": {
+      "reason": "Return",
+      "gas": {
+        "gas_spent": 240551,
+        "state_gas_spent": 200120,
+        "gas_refunded": 0,
+        "floor_gas": 22728
+      },
+      "logs": [],
+      "output": {
+        "Create": [
+          "0x",
+          "0x84bcbaa99ae6d1f7f70b37d5f6c27c9631eeb2f2"
+        ]
+      }
+    }
+  }
+]

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_limit_cap_not_enforced_with_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_limit_cap_not_enforced_with_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226006,
+        "gas_spent": 226009,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/handler/CHANGELOG.md
+++ b/crates/handler/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [19.0.0](https://github.com/bluealloy/revm/compare/revm-handler-v18.1.0...revm-handler-v19.0.0) - 2026-05-19
+## [20.0.0](https://github.com/bluealloy/revm/compare/revm-handler-v18.1.0...revm-handler-v20.0.0) - 2026-05-19
 
 ### Added
 

--- a/crates/handler/CHANGELOG.md
+++ b/crates/handler/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [19.0.0](https://github.com/bluealloy/revm/compare/revm-handler-v18.1.0...revm-handler-v19.0.0) - 2026-05-19
+
+### Added
+
+- *(eip8037)* Amsterdam bal-devnet-7 ([#3667](https://github.com/bluealloy/revm/pull/3667))
+- propagate InitialAndFloorGas to validate_against_state_and_deduct_caller ([#3577](https://github.com/bluealloy/revm/pull/3577))
+
+### Fixed
+
+- *(precompile)* halt with PrecompileOOG when precompile over-spends gas ([#3639](https://github.com/bluealloy/revm/pull/3639))
+- re-add PrecompileOutput::gas_refunded ([#3574](https://github.com/bluealloy/revm/pull/3574))
+- *(handler)* skip reimburse_caller and reward_beneficiary when fee charge is disabled ([#3559](https://github.com/bluealloy/revm/pull/3559))
+
+### Other
+
+- *(interpreter)* cache init_code_hash in CreateInputs for inspector reuse ([#3664](https://github.com/bluealloy/revm/pull/3664))
+- Revert "refactor: use `Cow` for warm precompile addresses ([#3652](https://github.com/bluealloy/revm/pull/3652))" ([#3653](https://github.com/bluealloy/revm/pull/3653))
+- use `Cow` for warm precompile addresses ([#3652](https://github.com/bluealloy/revm/pull/3652))
+- reject nonce-max senders before execution ([#3531](https://github.com/bluealloy/revm/pull/3531))
+- audit #[allow] attributes ([#3611](https://github.com/bluealloy/revm/pull/3611))
+- backport v107 release notes from branch ([#3617](https://github.com/bluealloy/revm/pull/3617))
+- enable and fix clippy::missing_const_for_fn ([#3592](https://github.com/bluealloy/revm/pull/3592))
+- avoid cloning precompiles on warmup ([#3586](https://github.com/bluealloy/revm/pull/3586))
+- *(interpreter)* separate instruction and gas tables ([#3561](https://github.com/bluealloy/revm/pull/3561))
+- thread reservoir through OOG constructors ([#3580](https://github.com/bluealloy/revm/pull/3580))
+- pass reservoir into `first_frame_input` ([#3578](https://github.com/bluealloy/revm/pull/3578))
+- rm op-revm (migrated to ethereum-optimism/optimism) ([#3568](https://github.com/bluealloy/revm/pull/3568))
+
 ## [18.1.0](https://github.com/bluealloy/revm/compare/revm-handler-v18.0.0...revm-handler-v18.1.0) - 2026-04-17
 
 ### Added

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-handler"
 description = "Revm handler crates"
-version = "18.1.0"
+version = "19.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-handler"
 description = "Revm handler crates"
-version = "19.0.0"
+version = "20.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/handler/src/execution.rs
+++ b/crates/handler/src/execution.rs
@@ -47,6 +47,7 @@ pub fn create_init_frame<CTX: ContextTr>(
                 is_static: false,
                 return_memory_offset: 0..0,
                 reservoir,
+                charged_new_account_state_gas: false,
             })))
         }
         TxKind::Create => Ok(FrameInput::Create(Box::new(CreateInputs::new(

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -2,7 +2,7 @@ use crate::{
     evm::FrameTr, item_or_result::FrameInitOrResult, precompile_provider::PrecompileProvider,
     CallFrame, CreateFrame, FrameData, FrameResult, ItemOrResult,
 };
-use context::result::FromStringError;
+use context::{result::FromStringError, LocalContextTr};
 use context_interface::{
     context::{take_error, ContextError},
     journaled_state::{account::JournaledAccountTr, JournalCheckpoint, JournalTr},
@@ -154,6 +154,7 @@ impl EthFrame<EthInterpreter> {
         inputs: Box<CallInputs>,
     ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR> {
         let reservoir_remaining_gas = inputs.reservoir;
+        let charged_new_account_state_gas = inputs.charged_new_account_state_gas;
         let gas =
             Gas::new_with_regular_gas_and_reservoir(inputs.gas_limit, reservoir_remaining_gas);
         let return_result = |instruction_result: InstructionResult| {
@@ -166,6 +167,7 @@ impl EthFrame<EthInterpreter> {
                 memory_offset: inputs.return_memory_offset.clone(),
                 was_precompile_called: false,
                 precompile_call_logs: Vec::new(),
+                charged_new_account_state_gas,
             })))
         };
 
@@ -217,6 +219,7 @@ impl EthFrame<EthInterpreter> {
                 memory_offset: inputs.return_memory_offset.clone(),
                 was_precompile_called: true,
                 precompile_call_logs: logs,
+                charged_new_account_state_gas,
             })));
         }
 
@@ -262,6 +265,10 @@ impl EthFrame<EthInterpreter> {
     ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR> {
         let reservoir_remaining_gas = inputs.reservoir();
         let spec = context.cfg().spec().into();
+        // EIP-8037 refund for the CREATE opcode's upfront `create_state_gas` is
+        // applied uniformly in `return_result` when the create fails (revert,
+        // halt, or early-fail with `address == None`), so early-fail results
+        // only carry the reservoir they inherited from the parent.
         let return_error = |e| {
             Ok(ItemOrResult::Result(FrameResult::Create(CreateOutcome {
                 result: InterpreterResult {
@@ -414,16 +421,21 @@ impl EthFrame<EthInterpreter> {
                 } else {
                     context.journal_mut().checkpoint_revert(self.checkpoint);
                 }
-                ItemOrResult::Result(FrameResult::Call(CallOutcome::new(
-                    interpreter_result,
-                    frame.return_memory_range.clone(),
-                )))
+                // Propagate EIP-8037 new-account state-gas flag from the frame
+                // input so the parent can refund the upfront charge if the call
+                // ends in revert/halt.
+                let charged_new_account_state_gas = match &self.input {
+                    FrameInput::Call(inputs) => inputs.charged_new_account_state_gas,
+                    _ => false,
+                };
+                let mut outcome =
+                    CallOutcome::new(interpreter_result, frame.return_memory_range.clone());
+                outcome.charged_new_account_state_gas = charged_new_account_state_gas;
+                ItemOrResult::Result(FrameResult::Call(outcome))
             }
             FrameData::Create(frame) => {
-                let (cfg, journal) = context.cfg_journal_mut();
                 return_create(
-                    journal,
-                    cfg,
+                    context,
                     self.checkpoint,
                     &mut interpreter_result,
                     frame.created_address,
@@ -483,7 +495,7 @@ impl EthFrame<EthInterpreter> {
                 }
 
                 // handle reservoir remaining gas
-                handle_reservoir_remaining_gas(&mut interpreter.gas, &out_gas, ins_result);
+                handle_reservoir_remaining_gas(ins_result, &mut interpreter.gas, &out_gas);
 
                 if ins_result.is_ok() {
                     interpreter.gas.record_refund(out_gas.refunded());
@@ -516,7 +528,26 @@ impl EthFrame<EthInterpreter> {
                 }
 
                 // handle reservoir remaining gas
-                handle_reservoir_remaining_gas(this_gas, outcome.gas(), instruction_result);
+                handle_reservoir_remaining_gas(instruction_result, this_gas, outcome.gas());
+
+                // EIP-8037: The CREATE opcode charged `create_state_gas` upfront on
+                // this frame's tracker. When the child fails to deploy a contract
+                // (revert, halt, or early-fail paths that return `address == None`
+                // such as nonce overflow, depth, OutOfFunds), refund the upfront
+                // charge to the reservoir and undo it on `state_gas_spent`.
+                // The nonce-overflow path reports `InstructionResult::Return` (ok)
+                // with `address == None`, so gate on address rather than the result.
+                //
+                // Use `refill_reservoir` so that this refund is counted in
+                // `refill_amount` and gets unwound if the parent itself
+                // reverts/halts (matching 0→x→0 storage restoration).
+                let create_failed = outcome.address.is_none() || !instruction_result.is_ok();
+
+                if create_failed && ctx.cfg().is_amsterdam_eip8037_enabled() {
+                    let state_gas_charged =
+                        ctx.cfg().gas_params().create_state_gas(ctx.local().cpsb());
+                    this_gas.refill_reservoir(state_gas_charged);
+                }
 
                 let stack_item = if instruction_result.is_ok() {
                     this_gas.record_refund(outcome.gas().refunded());
@@ -537,42 +568,75 @@ impl EthFrame<EthInterpreter> {
 /// Handles the remaining gas of the parent frame.
 #[inline]
 pub const fn handle_reservoir_remaining_gas(
+    instruction_result: InstructionResult,
     parent_gas: &mut Gas,
     child_gas: &Gas,
-    result: InstructionResult,
 ) {
-    if result.is_ok() {
+    if instruction_result.is_ok() {
         // On success: parent takes the child's final reservoir.
         parent_gas.set_reservoir(child_gas.reservoir());
         // Accumulate child's state gas into parent's total.
         // Parent may have already charged state gas (e.g., new_account + create) before
         // creating the child frame. Child starts with state_gas_spent=0, so we must add
         // rather than overwrite to preserve the parent's prior charges.
-        parent_gas.set_state_gas_spent(parent_gas.state_gas_spent() + child_gas.state_gas_spent());
+        //
+        // `child.state_gas_spent()` can be negative (EIP-8037 issue #2) when the
+        // child did more 0→x→0 restorations than 0→x creations; the negative
+        // contribution is the parent's matching charge flowing back out.
+        parent_gas.set_state_gas_spent(
+            parent_gas
+                .state_gas_spent()
+                .saturating_add(child_gas.state_gas_spent()),
+        );
+        // Propagate child's 0→x→0 refill total so that if the parent
+        // later reverts/halts, the refill contribution can be unwound.
+        parent_gas.set_refill_amount(
+            parent_gas
+                .refill_amount()
+                .saturating_add(child_gas.refill_amount()),
+        );
     } else {
-        // On revert or halt: state changes are undone, so ALL state gas returns
-        // to the parent's reservoir.
-        // - child.state_gas_spent(): state gas the child consumed (state rolled back, so refunded)
-        // - child.reservoir(): state gas the child didn't use (including gas returned from
-        //   deeper failed frames)
-        // This replaces (not adds to) the parent's reservoir because the child started with
-        // the parent's reservoir value (REVM doesn't zero it before the call), so the child's
-        // total already includes the parent's original reservoir.
-        parent_gas.set_reservoir(child_gas.state_gas_spent() + child_gas.reservoir());
+        // On revert/halt: the child's state changes are rolled back, so any
+        // 0→x→0 refills the child (or its descendants) credited to the
+        // reservoir must unwind too — the underlying clears no longer exist.
+        //
+        // Invariant when no reservoir→remaining spill happened in the child:
+        //     pre_call_reservoir = child.reservoir + child.state_gas_spent
+        // because every reservoir-funded `record_state_cost(c)` increments
+        // state_gas_spent by `c` while decrementing reservoir by `c`, and every
+        // `refill_reservoir(r)` does the opposite. Adding the (possibly negative)
+        // state_gas_spent back to the final reservoir recovers the pre-call value
+        // — discarding the negative branch (the old `.max(0)`) would leak
+        // grandchild refill credits up through a reverting parent.
+        parent_gas.set_reservoir(
+            child_gas
+                .reservoir()
+                .saturating_add_signed(child_gas.state_gas_spent()),
+        );
     }
 }
 
 /// Handles the result of a CREATE operation, including validation and state updates.
-pub fn return_create<JOURNAL: JournalTr, CFG: Cfg>(
-    journal: &mut JOURNAL,
-    cfg: CFG,
+///
+/// The EIP-8037 upfront CREATE state gas is charged on the parent's tracker by
+/// the CREATE/CREATE2 opcode. On child failure (revert/halt/early-fail) it is
+/// refunded to the parent in `return_result`. The child frame is NOT allowed to
+/// borrow the upfront charge to pay for code deposit: it must cover code deposit
+/// state gas from its own reservoir and remaining gas.
+pub fn return_create<CTX: ContextTr>(
+    context: &mut CTX,
     checkpoint: JournalCheckpoint,
     interpreter_result: &mut InterpreterResult,
     address: Address,
 ) {
+    let (_, _, cfg, journal, _, local) = context.all_mut();
+
     let max_code_size = cfg.max_code_size();
     let is_eip3541_disabled = cfg.is_eip3541_disabled();
     let spec_id = cfg.spec().into();
+    let is_amsterdam_eip8037 = cfg.is_amsterdam_eip8037_enabled();
+    let cpsb = local.cpsb();
+    let gas_params = cfg.gas_params();
 
     // If return is not ok revert and return.
     if !interpreter_result.result.is_ok() {
@@ -604,9 +668,7 @@ pub fn return_create<JOURNAL: JournalTr, CFG: Cfg>(
     }
 
     // regular gas for code deposit. It is zero in EIP-8037.
-    let gas_for_code = cfg
-        .gas_params()
-        .code_deposit_cost(interpreter_result.output.len());
+    let gas_for_code = gas_params.code_deposit_cost(interpreter_result.output.len());
     if !interpreter_result.gas.record_regular_cost(gas_for_code) {
         // Record code deposit gas cost and check if we are out of gas.
         // EIP-2 point 3: If contract creation does not have enough gas to pay for the
@@ -627,10 +689,8 @@ pub fn return_create<JOURNAL: JournalTr, CFG: Cfg>(
     // to compute the code_hash stored in the account. CREATE2's existing keccak256 charge
     // (in create2_cost) is for hashing the init code during address derivation, which is
     // a different hash.
-    if cfg.is_amsterdam_eip8037_enabled() {
-        let hash_cost = cfg
-            .gas_params()
-            .keccak256_cost(interpreter_result.output.len());
+    if is_amsterdam_eip8037 {
+        let hash_cost = gas_params.keccak256_cost(interpreter_result.output.len());
         if !interpreter_result.gas.record_regular_cost(hash_cost) {
             journal.checkpoint_revert(checkpoint);
             interpreter_result.result = InstructionResult::OutOfGas;
@@ -641,9 +701,8 @@ pub fn return_create<JOURNAL: JournalTr, CFG: Cfg>(
         //
         // Note: This should be last operation before checkpoint commit as spending state before this messes
         // with refilling of state gas.
-        let state_gas_for_code = cfg
-            .gas_params()
-            .code_deposit_state_gas(interpreter_result.output.len());
+        let state_gas_for_code =
+            gas_params.code_deposit_state_gas(interpreter_result.output.len(), cpsb);
         if state_gas_for_code > 0 && !interpreter_result.gas.record_state_cost(state_gas_for_code) {
             journal.checkpoint_revert(checkpoint);
             interpreter_result.result = InstructionResult::OutOfGas;

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -21,6 +21,7 @@ use interpreter::{
 };
 use primitives::{
     constants::CALL_STACK_LIMIT,
+    eip8038,
     hardfork::SpecId::{self, HOMESTEAD, LONDON, SPURIOUS_DRAGON},
     Address, Bytes, U256,
 };
@@ -154,9 +155,54 @@ impl EthFrame<EthInterpreter> {
         inputs: Box<CallInputs>,
     ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR> {
         let reservoir_remaining_gas = inputs.reservoir;
-        let charged_new_account_state_gas = inputs.charged_new_account_state_gas;
-        let gas =
+        let mut charged_new_account_state_gas = inputs.charged_new_account_state_gas;
+        let mut gas =
             Gas::new_with_regular_gas_and_reservoir(inputs.gas_limit, reservoir_remaining_gas);
+
+        // EIP-2780 top-level execution charges. Applied before any state changes
+        // so the recipient's pre-call state determines the charge.
+        let mut early_halt: Option<InstructionResult> = None;
+        if depth == 0
+            && ctx.cfg().is_amsterdam_eip2780_enabled()
+            && !precompiles.contains(&inputs.target_address)
+        {
+            // Load the (already-cached) recipient account.
+            let acc_info = ctx
+                .journal_mut()
+                .load_account(inputs.target_address)
+                .ok()
+                .map(|a| a.info.clone());
+
+            if let Some(info) = acc_info {
+                // 7702 delegation: additional COLD_ACCOUNT_ACCESS regular gas.
+                let is_7702_delegated = info
+                    .code
+                    .as_ref()
+                    .and_then(Bytecode::eip7702_address)
+                    .is_some();
+                if is_7702_delegated && !gas.record_regular_cost(eip8038::COLD_ACCOUNT_ACCESS) {
+                    early_halt = Some(InstructionResult::OutOfGas);
+                }
+
+                // Empty recipient + nonzero value: charge `new_account_state_gas`.
+                // Refunded on revert via the existing `state_gas_spent`/reservoir
+                // reconciliation in `last_frame_result`.
+                if early_halt.is_none() {
+                    if let CallValue::Transfer(value) = inputs.value {
+                        if !value.is_zero() && info.is_empty() {
+                            let cpsb = ctx.cfg().cpsb();
+                            let charge = ctx.cfg().gas_params().new_account_state_gas(cpsb);
+                            if !gas.record_state_cost(charge) {
+                                early_halt = Some(InstructionResult::OutOfGas);
+                            } else {
+                                charged_new_account_state_gas = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         let return_result = |instruction_result: InstructionResult| {
             Ok(ItemOrResult::Result(FrameResult::Call(CallOutcome {
                 result: InterpreterResult {
@@ -170,6 +216,10 @@ impl EthFrame<EthInterpreter> {
                 charged_new_account_state_gas,
             })))
         };
+
+        if let Some(halt) = early_halt {
+            return return_result(halt);
+        }
 
         // Check depth
         if depth > CALL_STACK_LIMIT as usize {

--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -41,6 +41,17 @@ impl<
 {
 }
 
+/// Caches the EIP-8037 `cost_per_state_byte` on the local context for the
+/// current transaction, honoring `cfg.cpsb_override`.
+///
+/// Called at the start of every top-level execution entry point so that
+/// `Host::cpsb` becomes a single field read instead of a recomputation.
+#[inline]
+pub fn cache_cpsb_on_local<CTX: ContextTr>(ctx: &mut CTX) {
+    let cpsb = ctx.cfg().cpsb();
+    ctx.local_mut().set_cpsb(cpsb);
+}
+
 /// The main implementation of Ethereum Mainnet transaction execution.
 ///
 /// The [`Handler::run`] method serves as the entry point for execution and provides
@@ -98,6 +109,9 @@ pub trait Handler {
         &mut self,
         evm: &mut Self::Evm,
     ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
+        // Cache EIP-8037 cost_per_state_byte on the local context so the hot-path
+        // Host::cpsb is a single field read. Honors cfg.cpsb_override.
+        cache_cpsb_on_local(evm.ctx_mut());
         // Run inner handler and catch all errors to handle cleanup.
         match self.run_without_catch_error(evm) {
             Ok(output) => Ok(output),
@@ -124,6 +138,10 @@ pub trait Handler {
         &mut self,
         evm: &mut Self::Evm,
     ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
+        // Cache EIP-8037 cost_per_state_byte on the local context. System calls
+        // skip validation/pre-execution but still execute interpreter code that
+        // reads Host::cpsb, so this must be populated here too.
+        cache_cpsb_on_local(evm.ctx_mut());
         // dummy values that are not used.
         let init_and_floor_gas = InitialAndFloorGas::new(0, 0);
         // call execution and than output.
@@ -132,7 +150,7 @@ pub trait Handler {
             .and_then(|exec_result| {
                 // System calls have no intrinsic gas; build ResultGas from frame result.
                 let gas = exec_result.gas();
-                let result_gas = build_result_gas(gas, init_and_floor_gas);
+                let result_gas = build_result_gas(false, gas, init_and_floor_gas);
                 self.execution_result(evm, exec_result, result_gas)
             }) {
             out @ Ok(_) => out,
@@ -213,7 +231,6 @@ pub trait Handler {
         let (gas_limit, reservoir) = init_and_floor_gas.initial_gas_and_reservoir(
             evm.ctx().tx().gas_limit(),
             evm.ctx().cfg().tx_gas_limit_cap(),
-            evm.ctx().cfg().is_amsterdam_eip8037_enabled(),
         );
 
         // Create first frame action
@@ -224,7 +241,7 @@ pub trait Handler {
         let mut frame_result = self.run_exec_loop(evm, first_frame_input)?;
 
         // Handle last frame result
-        self.last_frame_result(evm, &mut frame_result)?;
+        self.last_frame_result(evm, reservoir, &mut frame_result)?;
         Ok(frame_result)
     }
 
@@ -251,7 +268,11 @@ pub trait Handler {
 
         // Build ResultGas from the final gas state
         // This includes all necessary fields and gas values.
-        let result_gas = post_execution::build_result_gas(exec_result.gas(), init_and_floor_gas);
+        let result_gas = post_execution::build_result_gas(
+            exec_result.instruction_result().is_halt(),
+            exec_result.gas(),
+            init_and_floor_gas,
+        );
 
         // Ensure gas floor is met and minimum floor gas is spent.
         // if `cfg.is_eip7623_disabled` is true, floor gas will be set to zero
@@ -292,6 +313,7 @@ pub trait Handler {
             ctx.cfg().is_eip7623_disabled(),
             ctx.cfg().is_amsterdam_eip8037_enabled(),
             ctx.cfg().tx_gas_limit_cap(),
+            ctx.cfg().cpsb(),
         )?;
 
         Ok(gas)
@@ -362,14 +384,23 @@ pub trait Handler {
     fn last_frame_result(
         &mut self,
         evm: &mut Self::Evm,
+        _original_reservoir: u64,
         frame_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
     ) -> Result<(), Self::Error> {
         let instruction_result = frame_result.interpreter_result().result;
+
+        // Detect a failed top-level CREATE so the intrinsic `create_state_gas`
+        // charged at tx entry can be unwound below. Mirrors the `create_failed`
+        // condition used in `EthFrame::return_result` for nested creates.
+        let create_failed =
+            matches!(frame_result, FrameResult::Create(_)) && !instruction_result.is_ok();
+
         let gas = frame_result.gas_mut();
         let remaining = gas.remaining();
         let refunded = gas.refunded();
         let reservoir = gas.reservoir();
         let state_gas_spent = gas.state_gas_spent();
+        let state_refill = gas.refill_amount();
 
         // Spend the gas limit. Gas is reimbursed when the tx returns successfully.
         *gas = Gas::new_spent_with_reservoir(evm.ctx().tx().gas_limit(), reservoir);
@@ -383,20 +414,42 @@ pub trait Handler {
             gas.record_refund(refunded);
         }
 
-        // Reservoir handling at the top-level frame:
-        // - On success: use the frame's final reservoir as-is, state gas was consumed.
-        // - On revert/halt: restore state gas spent back to the reservoir,
-        //   because state changes are rolled back so state gas should be refunded.
-        //
-        // Note: eth devnet3 does NOT do this — it ignores state_gas_spent and
-        // unconditionally sets gas.set_reservoir(reservoir) regardless of the
-        // instruction_result kind. This is a bug in the devnet3 spec.
+        // return zero state gas on halt/revert.
         if instruction_result.is_ok() {
             gas.set_state_gas_spent(state_gas_spent);
+            gas.set_refill_amount(gas.refill_amount() + state_refill);
         } else {
-            // State changes rolled back, so no execution state gas was consumed.
             gas.set_state_gas_spent(0);
-            gas.set_reservoir(reservoir + state_gas_spent);
+        }
+
+        // state gas
+        if !instruction_result.is_ok() {
+            // State changes rolled back (revert or halt). Apply the same
+            // invariant used by `handle_reservoir_remaining_gas` to recover
+            // the pre-call reservoir value: signed `reservoir + state_gas_spent`.
+            //
+            // record_state_cost increments state_gas_spent and decrements
+            // reservoir by the same amount; refill_reservoir does the inverse.
+            // Their sum is conserved, so adding the (possibly negative)
+            // state_gas_spent back to the final reservoir recovers the
+            // pre-call (here: pre-tx) value. The negative branch unwinds any
+            // 0→x→0 refill inflation propagated up from descendants — the
+            // grandchild-leak fix at the frame level applied to the top frame.
+            gas.set_reservoir(reservoir.saturating_add_signed(state_gas_spent));
+        }
+
+        // EIP-8037: for a failed top-level CREATE (or one that self-destructs
+        // in init code, see EIP-6780), refund the intrinsic `create_state_gas`
+        // to the reservoir. The nested-create equivalent is
+        // `EthFrame::return_result`'s `refill_reservoir(create_state_gas)`; at
+        // the top level the same charge is deducted in
+        // `initial_gas_and_reservoir` rather than via `record_state_cost`, so
+        // it would otherwise stay consumed when the deployment is rolled back
+        // or erased.
+        if create_failed && evm.ctx().cfg().is_amsterdam_eip8037_enabled() {
+            let ctx = evm.ctx();
+            let state_gas_charged = ctx.cfg().gas_params().create_state_gas(ctx.local().cpsb());
+            gas.refill_reservoir(state_gas_charged);
         }
 
         Ok(())

--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -10,12 +10,13 @@ use context::{
     LocalContextTr,
 };
 use context_interface::{
+    cfg::gas_params,
     context::{take_error, ContextError},
     result::{HaltReasonTr, InvalidHeader, InvalidTransaction, ResultGas},
     Cfg, ContextTr, Database, JournalTr, Transaction,
 };
 use interpreter::{interpreter_action::FrameInit, Gas, InitialAndFloorGas, SharedMemory};
-use primitives::U256;
+use primitives::{hardfork::SpecId, U256};
 
 /// Trait for errors that can occur during EVM execution.
 ///
@@ -306,14 +307,25 @@ pub trait Handler {
         &self,
         evm: &mut Self::Evm,
     ) -> Result<InitialAndFloorGas, Self::Error> {
-        let ctx = evm.ctx_ref();
+        let ctx = evm.ctx();
+        let cfg = ctx.cfg();
+        let spec: SpecId = cfg.spec().into();
+        let is_eip7623_disabled = cfg.is_eip7623_disabled();
+        let is_amsterdam_eip8037_enabled = cfg.is_amsterdam_eip8037_enabled();
+        let is_amsterdam_eip2780_enabled = cfg.is_amsterdam_eip2780_enabled();
+        let tx_gas_limit_cap = cfg.tx_gas_limit_cap();
+        let cpsb = cfg.cpsb();
+        let tx = ctx.tx();
+        let eip2780 =
+            is_amsterdam_eip2780_enabled.then(|| gas_params::Eip2780TxInfo { value: tx.value() });
         let gas = validation::validate_initial_tx_gas(
-            ctx.tx(),
-            ctx.cfg().spec().into(),
-            ctx.cfg().is_eip7623_disabled(),
-            ctx.cfg().is_amsterdam_eip8037_enabled(),
-            ctx.cfg().tx_gas_limit_cap(),
-            ctx.cfg().cpsb(),
+            tx,
+            spec,
+            is_eip7623_disabled,
+            is_amsterdam_eip8037_enabled,
+            tx_gas_limit_cap,
+            cpsb,
+            eip2780,
         )?;
 
         Ok(gas)

--- a/crates/handler/src/lib.rs
+++ b/crates/handler/src/lib.rs
@@ -45,7 +45,7 @@ pub use api::{ExecuteCommitEvm, ExecuteEvm};
 pub use evm::{EvmTr, FrameTr};
 pub use frame::{handle_reservoir_remaining_gas, return_create, ContextTrDbError, EthFrame};
 pub use frame_data::{CallFrame, CreateFrame, FrameData, FrameResult};
-pub use handler::{EvmTrError, Handler};
+pub use handler::{cache_cpsb_on_local, EvmTrError, Handler};
 pub use item_or_result::{FrameInitOrResult, ItemOrResult};
 pub use mainnet_builder::{MainBuilder, MainContext, MainnetContext, MainnetEvm};
 pub use mainnet_handler::MainnetHandler;

--- a/crates/handler/src/post_execution.rs
+++ b/crates/handler/src/post_execution.rs
@@ -9,11 +9,24 @@ use interpreter::{Gas, InitialAndFloorGas, SuccessOrHalt};
 use primitives::{hardfork::SpecId, U256};
 
 /// Builds a [`ResultGas`] from the execution [`Gas`] struct and [`InitialAndFloorGas`].
-pub fn build_result_gas(gas: &Gas, init_and_floor_gas: InitialAndFloorGas) -> ResultGas {
+pub fn build_result_gas(
+    _is_halt: bool,
+    gas: &Gas,
+    init_and_floor_gas: InitialAndFloorGas,
+) -> ResultGas {
+    // `state_gas_spent` is tracked as i64 to allow a child frame's count to go
+    // negative on 0→x→0 restoration; at the top level, post-reconciliation it
+    // is expected to be >= 0 and is clamped defensively before combining with
+    // intrinsic state gas.
+    //
+    // Per the spec, tx_state_gas = intrinsic_state_gas + execution_state_gas,
+    // then reduced by the EIP-7702 per-authorization state-gas refund (which
+    // was also added back to the reservoir budget at tx start).
     let state_gas = gas
         .state_gas_spent()
-        .saturating_add(init_and_floor_gas.initial_state_gas)
-        .saturating_sub(init_and_floor_gas.eip7702_reservoir_refund);
+        .saturating_add_unsigned(init_and_floor_gas.initial_state_gas)
+        .max(0) as u64;
+    let state_gas = state_gas.saturating_sub(init_and_floor_gas.state_refund);
 
     ResultGas::default()
         .with_total_gas_spent(
@@ -22,7 +35,7 @@ pub fn build_result_gas(gas: &Gas, init_and_floor_gas: InitialAndFloorGas) -> Re
                 .saturating_sub(gas.reservoir()),
         )
         .with_refunded(gas.refunded() as u64)
-        .with_floor_gas(init_and_floor_gas.floor_gas)
+        .with_floor_gas(init_and_floor_gas.floor_gas())
         .with_state_gas_spent(state_gas)
 }
 
@@ -36,11 +49,13 @@ pub const fn eip7623_check_gas_floor(gas: &mut Gas, init_and_floor_gas: InitialA
     // The floor must apply to this combined value, not just (limit - remaining).
     let gas_used_before_refund = gas.total_gas_spent().saturating_sub(gas.reservoir());
     let gas_used_after_refund = gas_used_before_refund.saturating_sub(gas.refunded() as u64);
-    if gas_used_after_refund < init_and_floor_gas.floor_gas {
-        // Set spent so that (limit - remaining - reservoir) = floor_gas
-        // i.e. remaining = limit - floor_gas - reservoir
-        gas.set_spent(init_and_floor_gas.floor_gas + gas.reservoir());
-        // clear refund
+    if gas_used_after_refund < init_and_floor_gas.floor_gas() {
+        // Match execution-specs: when the floor wins, the unused state gas
+        // (reservoir) is absorbed into the floor cost rather than reimbursed
+        // separately. Zeroing it keeps `reimburse_caller`'s
+        // `remaining + reservoir + refunded` sum equal to `limit - floor`.
+        gas.set_spent(init_and_floor_gas.floor_gas());
+        gas.set_reservoir(0);
         gas.set_refund(0);
     }
 }

--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -202,31 +202,37 @@ pub fn apply_eip7702_auth_list<
     init_and_floor_gas: &mut InitialAndFloorGas,
 ) -> Result<u64, ERROR> {
     let chain_id = context.cfg().chain_id();
-    let refund_per_auth = context.cfg().gas_params().tx_eip7702_auth_refund();
+    let cpsb = context.cfg().cpsb();
+    let is_eip8037 = context.cfg().is_amsterdam_eip8037_enabled();
     let (tx, journal) = context.tx_journal_mut();
 
     // Return if not EIP-7702 transaction.
     if tx.tx_type() != TransactionType::Eip7702 {
         return Ok(0);
     }
-    let eip7702_refund =
-        apply_auth_list::<_, ERROR>(chain_id, refund_per_auth, tx.authorization_list(), journal)?;
+    let (number_of_refunded_accounts, number_of_refunded_bytecodes) =
+        apply_auth_list::<_, ERROR>(chain_id, tx.authorization_list(), journal)?;
 
-    // EIP-8037: Split auth list refund into state gas and regular gas portions.
-    // The state gas portion is added to the reservoir after initial_state_gas deduction,
-    // matching the Python spec where set_delegation adds state refund directly to
-    // state_gas_reservoir. This ensures refunded state gas stays as reservoir gas
-    // (not regular gas), so it's not consumed on frame halt.
-    // The regular gas portion goes through the normal refund mechanism.
-    let (eip7702_state_refund, eip7702_regular_refund_raw) = context
-        .cfg()
-        .gas_params()
-        .split_eip7702_refund(eip7702_refund);
-    if eip7702_state_refund > 0 {
-        init_and_floor_gas.eip7702_reservoir_refund = eip7702_state_refund;
+    let params = context.cfg().gas_params();
+
+    // EIP-8037: Split per-auth refund into state and regular components. The
+    // state portion is credited back to the reservoir by reducing
+    // `initial_state_gas` (which is what `initial_gas_and_reservoir` deducts
+    // from the reservoir). The regular portion is returned and routed through
+    // the standard refund counter, subject to the 1/5 cap.
+    if is_eip8037 {
+        init_and_floor_gas.state_refund += params.tx_eip7702_state_refund(
+            number_of_refunded_accounts,
+            number_of_refunded_bytecodes,
+            cpsb,
+        );
     }
 
-    Ok(eip7702_regular_refund_raw)
+    let regular_gas_refund = params
+        .tx_eip7702_auth_refund_regular()
+        .saturating_mul(number_of_refunded_accounts);
+
+    Ok(regular_gas_refund)
 }
 
 /// Apply EIP-7702 style auth list and return number gas refund on already created accounts.
@@ -236,17 +242,19 @@ pub fn apply_eip7702_auth_list<
 /// The `refund_per_auth` parameter specifies the gas refund per existing account authorization.
 /// By default this is `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST` (25000 - 12500 = 12500),
 /// but can be configured via [`GasParams::tx_eip7702_auth_refund`](context_interface::cfg::gas_params::GasParams::tx_eip7702_auth_refund).
+///
+/// Return number of refunded account and number of refunded bytecodes (Delegation length is already fixed).
 #[inline]
 pub fn apply_auth_list<
     JOURNAL: JournalTr,
     ERROR: From<InvalidTransaction> + From<<JOURNAL::Database as Database>::Error>,
 >(
     chain_id: u64,
-    refund_per_auth: u64,
     auth_list: impl Iterator<Item = impl AuthorizationTr>,
     journal: &mut JOURNAL,
-) -> Result<u64, ERROR> {
+) -> Result<(u64, u64), ERROR> {
     let mut refunded_accounts = 0;
+    let mut refunded_bytecodes = 0;
     for authorization in auth_list {
         // 1. Verify the chain id is either 0 or the chain's current ID.
         let auth_chain_id = authorization.chain_id();
@@ -292,6 +300,10 @@ pub fn apply_auth_list<
             refunded_accounts += 1;
         }
 
+        if !authority_acc_info.is_code_hash_empty_or_zero() || authorization.address().is_zero() {
+            refunded_bytecodes += 1;
+        }
+
         // 8. Set the code of `authority` to be `0xef0100 || address`. This is a delegation designation.
         //  * As a special case, if `address` is `0x0000000000000000000000000000000000000000` do not write the designation.
         //    Clear the accounts code and reset the account's code hash to the empty hash `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`.
@@ -299,9 +311,7 @@ pub fn apply_auth_list<
         authority_acc.delegate(authorization.address());
     }
 
-    let refunded_gas = refunded_accounts * refund_per_auth;
-
-    Ok(refunded_gas)
+    Ok((refunded_accounts, refunded_bytecodes))
 }
 
 #[cfg(test)]

--- a/crates/handler/src/precompile_provider.rs
+++ b/crates/handler/src/precompile_provider.rs
@@ -96,7 +96,8 @@ pub fn precompile_output_to_interpreter_result(
     };
 
     // set state gas, reservoir is already set in the Gas constructor
-    result.gas.set_state_gas_spent(output.state_gas_used);
+    result.gas.set_state_gas_spent(output.state_gas_used as i64);
+    result.gas.set_refill_amount(output.refill_amount);
     result.gas.record_refund(output.gas_refunded);
 
     // spend used gas.
@@ -244,6 +245,7 @@ mod tests {
                     gas_refunded: 0,
                     state_gas_used: 0,
                     reservoir: inputs.reservoir,
+                    refill_amount: 0,
                     bytes: Bytes::from_static(b"unreliable"),
                 };
                 return Ok(Some(precompile_output_to_interpreter_result(

--- a/crates/handler/src/system_call.rs
+++ b/crates/handler/src/system_call.rs
@@ -26,11 +26,21 @@ use crate::{
 use context::{result::ExecResultAndState, ContextSetters, ContextTr, Evm, JournalTr, TxEnv};
 use database_interface::DatabaseCommit;
 use interpreter::{interpreter::EthInterpreter, InterpreterResult};
-use primitives::{address, Address, Bytes, TxKind};
+use primitives::{address, eip8037, Address, Bytes, TxKind};
 use state::EvmState;
 
 /// The system address used for system calls.
 pub const SYSTEM_ADDRESS: Address = address!("0xfffffffffffffffffffffffffffffffffffffffe");
+
+/// Maximum number of SSTOREs a bal-devnet-7 system call reserves state gas for.
+pub const SYSTEM_MAX_SSTORES_PER_CALL: u64 = 16;
+
+/// Gas limit for system calls under bal-devnet-7.
+///
+/// Per `tests-bal@v7.0.0`, system calls get the base 30M regular-gas budget plus
+/// a state-gas reservoir sized for `SYSTEM_MAX_SSTORES_PER_CALL` storage writes.
+pub const SYSTEM_CALL_GAS_LIMIT: u64 = 30_000_000
+    + eip8037::SSTORE_SET_BYTES * eip8037::CPSB_GLAMSTERDAM * SYSTEM_MAX_SSTORES_PER_CALL;
 
 /// Creates the system transaction with default values and set data and tx call target to system contract address
 /// that is going to be called.
@@ -62,7 +72,7 @@ impl SystemCallTx for TxEnv {
             .caller(caller)
             .data(data)
             .kind(TxKind::Call(system_contract_address))
-            .gas_limit(30_000_000)
+            .gas_limit(SYSTEM_CALL_GAS_LIMIT)
             .build()
             .unwrap()
     }
@@ -299,8 +309,8 @@ mod tests {
             .system_call(HISTORY_STORAGE_ADDRESS, block_hash.0.into())
             .unwrap();
 
-        // system call gas limit is 30M
-        assert_eq!(evm.ctx.tx().gas_limit(), 30_000_000);
+        // bal-devnet-7 adds a state-gas reservoir on top of the 30M base limit.
+        assert_eq!(evm.ctx.tx().gas_limit(), SYSTEM_CALL_GAS_LIMIT);
 
         assert_eq!(
             output.result,

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -242,26 +242,27 @@ pub fn validate_initial_tx_gas(
     is_eip7623_disabled: bool,
     is_amsterdam_eip8037_enabled: bool,
     tx_gas_limit_cap: u64,
+    cpsb: u64,
 ) -> Result<InitialAndFloorGas, InvalidTransaction> {
-    let mut gas = calculate_initial_tx_gas_for_tx(&tx, spec);
+    let mut gas = calculate_initial_tx_gas_for_tx(&tx, spec, cpsb);
 
     if is_eip7623_disabled {
-        gas.floor_gas = 0
+        gas.set_floor_gas(0);
     }
 
     // Additional check to see if limit is big enough to cover initial gas.
-    if gas.initial_total_gas > tx.gas_limit() {
+    if gas.initial_total_gas() > tx.gas_limit() {
         return Err(InvalidTransaction::CallGasCostMoreThanGasLimit {
             gas_limit: tx.gas_limit(),
-            initial_gas: gas.initial_total_gas,
+            initial_gas: gas.initial_total_gas(),
         });
     }
 
     // EIP-7623: Increase calldata cost
     // floor gas should be less than gas limit.
-    if spec.is_enabled_in(SpecId::PRAGUE) && gas.floor_gas > tx.gas_limit() {
+    if spec.is_enabled_in(SpecId::PRAGUE) && gas.floor_gas() > tx.gas_limit() {
         return Err(InvalidTransaction::GasFloorMoreThanGasLimit {
-            gas_floor: gas.floor_gas,
+            gas_floor: gas.floor_gas(),
             gas_limit: tx.gas_limit(),
         });
     };
@@ -270,7 +271,7 @@ pub fn validate_initial_tx_gas(
     // Validate that both intrinsic regular gas and floor gas fit within the cap.
     // State gas is excluded — it uses its own reservoir.
     if is_amsterdam_eip8037_enabled && tx.gas_limit() > tx_gas_limit_cap {
-        let min_regular_gas = gas.initial_regular_gas().max(gas.floor_gas);
+        let min_regular_gas = gas.initial_regular_gas().max(gas.floor_gas());
         if min_regular_gas > tx_gas_limit_cap {
             return Err(InvalidTransaction::GasFloorMoreThanGasLimit {
                 gas_floor: min_regular_gas,
@@ -304,6 +305,7 @@ mod tests {
                     c.set_spec_and_mainnet_gas_params(spec_id);
                 }
             })
+            .modify_block_chained(|block| block.gas_limit = 100_000_000)
             .with_db(CacheDB::<EmptyDB>::default());
 
         let mut evm = ctx.build_mainnet();

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -243,8 +243,9 @@ pub fn validate_initial_tx_gas(
     is_amsterdam_eip8037_enabled: bool,
     tx_gas_limit_cap: u64,
     cpsb: u64,
+    eip2780: Option<context_interface::cfg::gas_params::Eip2780TxInfo>,
 ) -> Result<InitialAndFloorGas, InvalidTransaction> {
-    let mut gas = calculate_initial_tx_gas_for_tx(&tx, spec, cpsb);
+    let mut gas = calculate_initial_tx_gas_for_tx(&tx, spec, cpsb, eip2780);
 
     if is_eip7623_disabled {
         gas.set_floor_gas(0);

--- a/crates/inspector/CHANGELOG.md
+++ b/crates/inspector/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [20.0.0](https://github.com/bluealloy/revm/compare/revm-inspector-v19.0.0...revm-inspector-v20.0.0) - 2026-05-19
+## [21.0.0](https://github.com/bluealloy/revm/compare/revm-inspector-v19.0.0...revm-inspector-v21.0.0) - 2026-05-19
 
 ### Added
 

--- a/crates/inspector/CHANGELOG.md
+++ b/crates/inspector/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [20.0.0](https://github.com/bluealloy/revm/compare/revm-inspector-v19.0.0...revm-inspector-v20.0.0) - 2026-05-19
+
+### Added
+
+- *(eip8037)* Amsterdam bal-devnet-7 ([#3667](https://github.com/bluealloy/revm/pull/3667))
+
+### Fixed
+
+- *(inspector)* use build_result_gas in inspect_run_system_call ([#3637](https://github.com/bluealloy/revm/pull/3637))
+
+### Other
+
+- restructure `Journal` traits ([#3663](https://github.com/bluealloy/revm/pull/3663))
+- audit #[allow] attributes ([#3611](https://github.com/bluealloy/revm/pull/3611))
+- backport v107 release notes from branch ([#3617](https://github.com/bluealloy/revm/pull/3617))
+- [**breaking**] return Result from instruction functions ([#3558](https://github.com/bluealloy/revm/pull/3558))
+- enable and fix clippy::missing_const_for_fn ([#3592](https://github.com/bluealloy/revm/pull/3592))
+- *(interpreter)* separate instruction and gas tables ([#3561](https://github.com/bluealloy/revm/pull/3561))
+- pass reservoir into `first_frame_input` ([#3578](https://github.com/bluealloy/revm/pull/3578))
+- rm op-revm (migrated to ethereum-optimism/optimism) ([#3568](https://github.com/bluealloy/revm/pull/3568))
+
 ## [19.0.0](https://github.com/bluealloy/revm/compare/revm-inspector-v18.0.0...revm-inspector-v19.0.0) - 2026-04-17
 
 ### Other

--- a/crates/inspector/Cargo.toml
+++ b/crates/inspector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-inspector"
 description = "Revm inspector interface"
-version = "19.0.0"
+version = "20.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/inspector/Cargo.toml
+++ b/crates/inspector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-inspector"
 description = "Revm inspector interface"
-version = "20.0.0"
+version = "21.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/inspector/src/eip3155.rs
+++ b/crates/inspector/src/eip3155.rs
@@ -256,7 +256,10 @@ where
         self.mem_size = interp.memory.size();
         self.gas = interp.gas.remaining();
         self.reservoir = interp.gas.reservoir();
-        self.state_gas = interp.gas.state_gas_spent();
+        // Clamp to 0: EIP-8037 allows state_gas_spent to briefly go negative
+        // within a child frame (0→x→0 restoration); the tracer exposes it as a
+        // u64 counter.
+        self.state_gas = interp.gas.state_gas_spent().max(0) as u64;
         self.refunded = interp.gas.refunded();
     }
 

--- a/crates/inspector/src/gas.rs
+++ b/crates/inspector/src/gas.rs
@@ -6,7 +6,7 @@ use interpreter::{CallOutcome, CreateOutcome, Gas};
 pub struct GasInspector {
     gas_remaining: u64,
     last_gas_cost: u64,
-    state_gas_spent: u64,
+    state_gas_spent: i64,
     reservoir: u64,
 }
 
@@ -30,8 +30,12 @@ impl GasInspector {
     }
 
     /// Returns the state gas spent.
+    ///
+    /// Can be negative within a call frame (EIP-8037 issue #2): a child that
+    /// restores a slot set by its parent via 0→x→0 goes negative until the
+    /// frame returns and the parent's charge is reconciled.
     #[inline]
-    pub const fn state_gas_spent(&self) -> u64 {
+    pub const fn state_gas_spent(&self) -> i64 {
         self.state_gas_spent
     }
 
@@ -80,7 +84,7 @@ impl GasInspector {
     /// Spend all gas if call failed.
     #[inline]
     pub const fn call_end(&mut self, outcome: &mut CallOutcome) {
-        if outcome.result.result.is_error() {
+        if outcome.result.result.is_halt() {
             outcome.result.gas.spend_all();
             self.gas_remaining = 0;
         }
@@ -91,7 +95,7 @@ impl GasInspector {
     /// Spend all gas if create failed.
     #[inline]
     pub const fn create_end(&mut self, outcome: &mut CreateOutcome) {
-        if outcome.result.result.is_error() {
+        if outcome.result.result.is_halt() {
             outcome.result.gas.spend_all();
             self.gas_remaining = 0;
         }

--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -1,7 +1,8 @@
 use crate::{Inspector, InspectorEvmTr, JournalExt};
 use context::{result::ExecutionResult, Cfg, ContextTr, JournalEntry, JournalTr, Transaction};
 use handler::{
-    evm::FrameTr, post_execution::build_result_gas, EvmTr, FrameResult, Handler, ItemOrResult,
+    cache_cpsb_on_local, evm::FrameTr, post_execution::build_result_gas, EvmTr, FrameResult,
+    Handler, ItemOrResult,
 };
 use interpreter::{
     instructions::{GasTable, InstructionTable},
@@ -45,6 +46,9 @@ where
         &mut self,
         evm: &mut Self::Evm,
     ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
+        // Cache EIP-8037 cost_per_state_byte on the local context so the hot-path
+        // Host::cpsb is a single field read. Honors cfg.cpsb_override.
+        cache_cpsb_on_local(evm.ctx_mut());
         match self.inspect_run_without_catch_error(evm) {
             Ok(output) => Ok(output),
             Err(e) => self.catch_error(evm, e),
@@ -85,7 +89,6 @@ where
         let (gas_limit, reservoir) = init_and_floor_gas.initial_gas_and_reservoir(
             evm.ctx().tx().gas_limit(),
             evm.ctx().cfg().tx_gas_limit_cap(),
-            evm.ctx().cfg().is_amsterdam_eip8037_enabled(),
         );
         let first_frame_input = self.first_frame_input(evm, gas_limit, reservoir)?;
 
@@ -93,7 +96,7 @@ where
         let mut frame_result = self.inspect_run_exec_loop(evm, first_frame_input)?;
 
         // Handle last frame result
-        self.last_frame_result(evm, &mut frame_result)?;
+        self.last_frame_result(evm, reservoir, &mut frame_result)?;
         Ok(frame_result)
     }
 
@@ -149,6 +152,10 @@ where
         &mut self,
         evm: &mut Self::Evm,
     ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
+        // Cache EIP-8037 cost_per_state_byte on the local context. Inspector
+        // system calls skip validation/pre-execution but still execute
+        // interpreter code that reads Host::cpsb.
+        cache_cpsb_on_local(evm.ctx_mut());
         // dummy values that are not used.
         let init_and_floor_gas = InitialAndFloorGas::new(0, 0);
         // call execution with inspection and then output.
@@ -157,7 +164,7 @@ where
             .and_then(|exec_result| {
                 // System calls have no intrinsic gas; build ResultGas from frame result.
                 let gas = exec_result.gas();
-                let result_gas = build_result_gas(gas, init_and_floor_gas);
+                let result_gas = build_result_gas(false, gas, init_and_floor_gas);
                 self.execution_result(evm, exec_result, result_gas)
             }) {
             out @ Ok(_) => out,

--- a/crates/inspector/src/inspector_tests.rs
+++ b/crates/inspector/src/inspector_tests.rs
@@ -767,8 +767,8 @@ mod tests {
 
         // Sanity check: state_gas_spent should also agree.
         assert_eq!(
-            result_plain.gas().state_gas_spent(),
-            result_inspect.gas().state_gas_spent(),
+            result_plain.gas().state_gas_spent_final(),
+            result_inspect.gas().state_gas_spent_final(),
             "system_call state_gas_spent must match between inspect and non-inspect paths",
         );
     }

--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [36.0.0](https://github.com/bluealloy/revm/compare/revm-interpreter-v35.0.1...revm-interpreter-v36.0.0) - 2026-05-19
+
+### Added
+
+- *(eip8037)* Amsterdam bal-devnet-7 ([#3667](https://github.com/bluealloy/revm/pull/3667))
+
+### Fixed
+
+- *(bytecode)* mark `Bytecode::new_analyzed` as unsafe ([#3557](https://github.com/bluealloy/revm/pull/3557))
+
+### Other
+
+- change &mut self to &self for read-only methods ([#3669](https://github.com/bluealloy/revm/pull/3669))
+- *(interpreter)* cache init_code_hash in CreateInputs for inspector reuse ([#3664](https://github.com/bluealloy/revm/pull/3664))
+- *(interpreter)* unify call handlers ([#3626](https://github.com/bluealloy/revm/pull/3626))
+- rm unused MemoryExtensionResult ([#3646](https://github.com/bluealloy/revm/pull/3646))
+- remove unused spec ids ([#3649](https://github.com/bluealloy/revm/pull/3649))
+- audit #[allow] attributes ([#3611](https://github.com/bluealloy/revm/pull/3611))
+- backport v107 release notes from branch ([#3617](https://github.com/bluealloy/revm/pull/3617))
+- move memory_limit check into cold resize path ([#3599](https://github.com/bluealloy/revm/pull/3599))
+- [**breaking**] return Result from instruction functions ([#3558](https://github.com/bluealloy/revm/pull/3558))
+- enable and fix clippy::missing_const_for_fn ([#3592](https://github.com/bluealloy/revm/pull/3592))
+- *(interpreter)* separate instruction and gas tables ([#3561](https://github.com/bluealloy/revm/pull/3561))
+- thread reservoir through OOG constructors ([#3580](https://github.com/bluealloy/revm/pull/3580))
+- pass reservoir into `first_frame_input` ([#3578](https://github.com/bluealloy/revm/pull/3578))
+- *(interpreter)* dedup account loading across host instructions ([#3562](https://github.com/bluealloy/revm/pull/3562))
+- rm op-revm (migrated to ethereum-optimism/optimism) ([#3568](https://github.com/bluealloy/revm/pull/3568))
+- *(interpreter)* remove unused loop_control module ([#3555](https://github.com/bluealloy/revm/pull/3555))
+
 ## [35.0.1](https://github.com/bluealloy/revm/compare/revm-interpreter-v35.0.0...revm-interpreter-v35.0.1) - 2026-04-17
 
 ### Other

--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [36.0.0](https://github.com/bluealloy/revm/compare/revm-interpreter-v35.0.1...revm-interpreter-v36.0.0) - 2026-05-19
+## [37.0.0](https://github.com/bluealloy/revm/compare/revm-interpreter-v35.0.1...revm-interpreter-v37.0.0) - 2026-05-19
 
 ### Added
 

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-interpreter"
 description = "Revm Interpreter that executes bytecode."
-version = "35.0.1"
+version = "36.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-interpreter"
 description = "Revm Interpreter that executes bytecode."
-version = "36.0.0"
+version = "37.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/interpreter/src/gas.rs
+++ b/crates/interpreter/src/gas.rs
@@ -153,15 +153,39 @@ impl Gas {
     }
 
     /// Returns total state gas spent so far.
+    ///
+    /// Can be negative within a call frame when 0→x→0 storage restoration
+    /// refills more state gas than this frame charged (see
+    /// [`GasTracker::refill_reservoir`]).
     #[inline]
-    pub const fn state_gas_spent(&self) -> u64 {
+    pub const fn state_gas_spent(&self) -> i64 {
         self.tracker.state_gas_spent()
     }
 
     /// Sets the total state gas spent (used when propagating from child frame).
     #[inline]
-    pub const fn set_state_gas_spent(&mut self, val: u64) {
+    pub const fn set_state_gas_spent(&mut self, val: i64) {
         self.tracker.set_state_gas_spent(val);
+    }
+
+    /// Refills the reservoir with state gas returned by 0→x→0 storage restoration.
+    ///
+    /// See [`GasTracker::refill_reservoir`].
+    #[inline]
+    pub const fn refill_reservoir(&mut self, amount: u64) {
+        self.tracker.refill_reservoir(amount);
+    }
+
+    /// Returns the cumulative reservoir refill amount in this frame.
+    #[inline]
+    pub const fn refill_amount(&self) -> u64 {
+        self.tracker.refill_amount()
+    }
+
+    /// Sets the cumulative refill amount.
+    #[inline]
+    pub const fn set_refill_amount(&mut self, val: u64) {
+        self.tracker.set_refill_amount(val);
     }
 
     /// Erases a gas cost from remaining (returns gas from child frame).
@@ -399,6 +423,35 @@ mod tests {
         // On OOG, state_gas_spent is NOT incremented and reservoir is unchanged
         assert_eq!(gas.state_gas_spent(), 0);
         assert_eq!(gas.reservoir(), 20);
+    }
+
+    /// Refill reservoir restores state gas in-place (EIP-8037 0→x→0 restoration).
+    ///
+    /// The refill decrements `state_gas_spent` and may drive it negative if the
+    /// matching charge was made by a parent frame.
+    #[test]
+    fn test_refill_reservoir() {
+        // Simple case: charge then refill within the same frame.
+        let mut gas = Gas::new_with_regular_gas_and_reservoir(1000, 500);
+        assert!(gas.record_state_cost(200));
+        assert_eq!(
+            (gas.reservoir(), gas.remaining(), gas.state_gas_spent()),
+            (300, 1000, 200)
+        );
+        gas.refill_reservoir(200);
+        assert_eq!(
+            (gas.reservoir(), gas.remaining(), gas.state_gas_spent()),
+            (500, 1000, 0)
+        );
+
+        // Child-frame case: refill without a prior charge makes state_gas_spent
+        // negative. The parent's matching +charge is reconciled on return.
+        let mut gas = Gas::new_with_regular_gas_and_reservoir(1000, 100);
+        gas.refill_reservoir(300);
+        assert_eq!(
+            (gas.reservoir(), gas.remaining(), gas.state_gas_spent()),
+            (400, 1000, -300)
+        );
     }
 
     /// A.3: State gas with zero regular remaining but non-zero reservoir.

--- a/crates/interpreter/src/instruction_result.rs
+++ b/crates/interpreter/src/instruction_result.rs
@@ -236,7 +236,14 @@ impl InstructionResult {
 
     /// Returns whether the result is an error.
     #[inline]
+    #[deprecated(note = "use `is_halt` instead")]
     pub const fn is_error(self) -> bool {
+        self.is_halt()
+    }
+
+    /// Returns whether the result is a halt (error).
+    #[inline]
+    pub const fn is_halt(self) -> bool {
         matches!(self, return_error!())
     }
 }
@@ -403,7 +410,7 @@ mod tests {
         for result in ok_results {
             assert!(result.is_ok());
             assert!(!result.is_revert());
-            assert!(!result.is_error());
+            assert!(!result.is_halt());
         }
 
         let revert_results = [
@@ -414,7 +421,7 @@ mod tests {
         for result in revert_results {
             assert!(!result.is_ok());
             assert!(result.is_revert());
-            assert!(!result.is_error());
+            assert!(!result.is_halt());
         }
 
         let error_results = [
@@ -444,7 +451,7 @@ mod tests {
         for result in error_results {
             assert!(!result.is_ok());
             assert!(!result.is_revert());
-            assert!(result.is_error());
+            assert!(result.is_halt());
         }
     }
 }

--- a/crates/interpreter/src/instructions.rs
+++ b/crates/interpreter/src/instructions.rs
@@ -125,6 +125,25 @@ pub const fn gas_table_spec(spec: SpecId) -> GasTable {
         table[STATICCALL as usize] = gas::WARM_STORAGE_READ_COST as u16;
     }
 
+    if spec.is_enabled_in(AMSTERDAM) {
+        // EIP-8038: bump every warm/cold access base from 100 to 101.
+        // SLOAD / *CALL / BALANCE / EXTCODEHASH: a single WARM_ACCESS.
+        let warm = primitives::eip8038::WARM_ACCESS as u16;
+        table[SLOAD as usize] = warm;
+        table[BALANCE as usize] = warm;
+        table[EXTCODEHASH as usize] = warm;
+        table[CALL as usize] = warm;
+        table[CALLCODE as usize] = warm;
+        table[DELEGATECALL as usize] = warm;
+        table[STATICCALL as usize] = warm;
+        // EIP-8038 §"EXT* family update": EXTCODESIZE and EXTCODECOPY do two
+        // database reads, so the per-call access cost is `WARM_ACCESS` above
+        // the regular access cost. Bake the extra WARM_ACCESS into the static
+        // base; the dynamic cold premium is still added by `load_account`.
+        table[EXTCODESIZE as usize] = warm + warm;
+        table[EXTCODECOPY as usize] = warm + warm;
+    }
+
     table
 }
 

--- a/crates/interpreter/src/instructions/contract.rs
+++ b/crates/interpreter/src/instructions/contract.rs
@@ -86,11 +86,16 @@ pub fn create<const IS_CREATE2: bool, IT: ITy, H: Host + ?Sized>(
         CreateScheme::Create
     };
 
-    // State gas for account creation + contract metadata (EIP-8037)
+    // State gas for account creation + contract metadata (EIP-8037).
+    // Charged upfront on the parent's tracker; `return_create` refunds the same
+    // amount (derived from cfg) on entry and re-records it on a successful commit.
     if context.host.is_amsterdam_eip8037_enabled() {
         state_gas!(
             context.interpreter,
-            context.host.gas_params().create_state_gas()
+            context
+                .host
+                .gas_params()
+                .create_state_gas(context.host.cpsb())
         );
     }
 
@@ -160,7 +165,7 @@ pub fn call<const KIND: u8, IT: ITy, H: Host + ?Sized>(mut context: Ictx<'_, H, 
         get_memory_input_and_out_ranges(context.interpreter, context.host.gas_params())?;
 
     let is_call = KIND == CALL;
-    let (gas_limit, bytecode, bytecode_hash) =
+    let (gas_limit, bytecode, bytecode_hash, charged_new_account_state_gas) =
         load_acc_and_calc_gas(&mut context, to, has_transfer, is_call, local_gas_limit)?;
 
     let target_address = if matches!(KIND, CALLCODE | DELEGATECALL) {
@@ -204,6 +209,7 @@ pub fn call<const KIND: u8, IT: ITy, H: Host + ?Sized>(mut context: Ictx<'_, H, 
                 is_static,
                 return_memory_offset,
                 reservoir: context.interpreter.gas.reservoir(),
+                charged_new_account_state_gas,
             },
         ))));
     Err(InstructionResult::Suspend)

--- a/crates/interpreter/src/instructions/contract/call_helpers.rs
+++ b/crates/interpreter/src/instructions/contract/call_helpers.rs
@@ -51,6 +51,12 @@ pub fn resize_memory(
 }
 
 /// Calculates gas cost and limit for call instructions.
+///
+/// The trailing bool in the returned tuple is `charged_new_account_state_gas`:
+/// `true` iff this call upfront-charged EIP-8037 `new_account_state_gas`
+/// (transfers value into a previously-empty account). Callers should propagate
+/// it onto `CallInputs` so the parent can refund the charge if the resulting
+/// frame reverts/halts.
 #[inline(never)]
 pub fn load_acc_and_calc_gas<H: Host + ?Sized>(
     context: &mut Ictx<'_, H, impl ITy>,
@@ -58,7 +64,7 @@ pub fn load_acc_and_calc_gas<H: Host + ?Sized>(
     transfers_value: bool,
     create_empty_account: bool,
     stack_gas_limit: u64,
-) -> Result<(u64, Bytecode, B256), InstructionResult> {
+) -> Result<(u64, Bytecode, B256, bool), InstructionResult> {
     // Transfer value cost
     if transfers_value {
         gas!(
@@ -70,6 +76,7 @@ pub fn load_acc_and_calc_gas<H: Host + ?Sized>(
     // load account delegated and deduct dynamic gas.
     let (gas, state_gas_cost, bytecode, code_hash) =
         load_account_delegated_handle_error(context, to, transfers_value, create_empty_account)?;
+    let charged_new_account_state_gas = state_gas_cost > 0;
     let interpreter = &mut context.interpreter;
 
     // deduct dynamic gas.
@@ -98,7 +105,12 @@ pub fn load_acc_and_calc_gas<H: Host + ?Sized>(
         gas_limit = gas_limit.saturating_add(host.gas_params().call_stipend());
     }
 
-    Ok((gas_limit, bytecode, code_hash))
+    Ok((
+        gas_limit,
+        bytecode,
+        code_hash,
+        charged_new_account_state_gas,
+    ))
 }
 
 /// Loads accounts and its delegate account.
@@ -159,7 +171,7 @@ pub fn load_account_delegated<H: Host + ?Sized>(
             .gas_params()
             .new_account_cost(is_spurious_dragon, transfers_value);
         if host.is_amsterdam_eip8037_enabled() && transfers_value {
-            state_gas_cost += host.gas_params().new_account_state_gas();
+            state_gas_cost += host.gas_params().new_account_state_gas(host.cpsb());
         }
         return Ok((cost, state_gas_cost, bytecode, code_hash));
     }

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -234,10 +234,26 @@ pub fn sstore<IT: ITy, H: Host + ?Sized>(context: Ictx<'_, H, IT>) -> Result {
 
     // state gas for new slot creation (EIP-8037)
     if context.host.is_amsterdam_eip8037_enabled() {
+        let cpsb = context.host.cpsb();
         state_gas!(
             context.interpreter,
-            context.host.gas_params().sstore_state_gas(&state_load.data)
+            context
+                .host
+                .gas_params()
+                .sstore_state_gas(&state_load.data, cpsb)
         );
+
+        // EIP-8037 issue #2: 0→x→0 storage restoration refills the reservoir
+        // directly rather than routing the state gas through the capped refund
+        // counter. The regular-gas portion of the restoration still flows
+        // through `sstore_refund` below.
+        let refill = context
+            .host
+            .gas_params()
+            .sstore_state_gas_refill(&state_load.data, cpsb);
+        if refill > 0 {
+            context.interpreter.gas.refill_reservoir(refill);
+        }
     }
 
     // refund
@@ -348,7 +364,10 @@ pub fn selfdestruct<IT: ITy, H: Host + ?Sized>(context: Ictx<'_, H, IT>) -> Resu
     if context.host.is_amsterdam_eip8037_enabled() && should_charge_topup {
         state_gas!(
             context.interpreter,
-            context.host.gas_params().new_account_state_gas()
+            context
+                .host
+                .gas_params()
+                .new_account_state_gas(context.host.cpsb())
         );
     }
 

--- a/crates/interpreter/src/interpreter.rs
+++ b/crates/interpreter/src/interpreter.rs
@@ -399,9 +399,16 @@ impl InterpreterResult {
     }
 
     /// Returns whether the instruction result is an error.
+    #[deprecated(note = "use `is_halt` instead")]
     #[inline]
     pub const fn is_error(&self) -> bool {
-        self.result.is_error()
+        self.result.is_halt()
+    }
+
+    /// Returns whether the instruction result is a halt (error).
+    #[inline]
+    pub const fn is_halt(&self) -> bool {
+        self.result.is_halt()
     }
 }
 

--- a/crates/interpreter/src/interpreter_action/call_inputs.rs
+++ b/crates/interpreter/src/interpreter_action/call_inputs.rs
@@ -169,6 +169,11 @@ pub struct CallInputs {
     pub scheme: CallScheme,
     /// Whether the call is a static call, or is initiated inside a static call.
     pub is_static: bool,
+    /// EIP-8037: set when the CALL opcode upfront-charged `new_account_state_gas`
+    /// for creating an empty account at `target_address` via value transfer.
+    /// On revert/halt of the resulting frame the parent must refund this charge
+    /// to the reservoir, matching the CREATE pattern.
+    pub charged_new_account_state_gas: bool,
 }
 
 impl CallInputs {
@@ -346,6 +351,12 @@ mod tests {
         fn take_precompile_error_context(&mut self) -> Option<String> {
             None
         }
+
+        fn cpsb(&self) -> u64 {
+            0
+        }
+
+        fn set_cpsb(&mut self, _cpsb: u64) {}
     }
 
     #[test]

--- a/crates/interpreter/src/interpreter_action/call_outcome.rs
+++ b/crates/interpreter/src/interpreter_action/call_outcome.rs
@@ -25,6 +25,11 @@ pub struct CallOutcome {
     /// Precompile call logs. Needs as revert/halt would delete them from Journal.
     /// So they can't be accessed by inspector.
     pub precompile_call_logs: Vec<Log>,
+    /// EIP-8037: copied from `CallInputs::charged_new_account_state_gas`. Tells
+    /// the parent frame whether `new_account_state_gas` was upfront-charged on
+    /// the parent's tracker for this call, so the parent can refund it when
+    /// the call reverts/halts.
+    pub charged_new_account_state_gas: bool,
 }
 
 impl CallOutcome {
@@ -42,6 +47,7 @@ impl CallOutcome {
             memory_offset,
             was_precompile_called: false,
             precompile_call_logs: Vec::new(),
+            charged_new_account_state_gas: false,
         }
     }
 

--- a/crates/precompile/CHANGELOG.md
+++ b/crates/precompile/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [35.0.0](https://github.com/bluealloy/revm/compare/revm-precompile-v34.0.0...revm-precompile-v35.0.0) - 2026-05-19
+
+### Added
+
+- *(eip8037)* Amsterdam bal-devnet-7 ([#3667](https://github.com/bluealloy/revm/pull/3667))
+
+### Fixed
+
+- *(precompile)* tighten cfg on blake2 avx2 module ([#3613](https://github.com/bluealloy/revm/pull/3613))
+- *(precompile)* use SIGMA period 10 in blake2 portable path ([#3616](https://github.com/bluealloy/revm/pull/3616))
+- re-add PrecompileOutput::gas_refunded ([#3574](https://github.com/bluealloy/revm/pull/3574))
+
+### Other
+
+- remove unused spec ids ([#3649](https://github.com/bluealloy/revm/pull/3649))
+- audit #[allow] attributes ([#3611](https://github.com/bluealloy/revm/pull/3611))
+- backport v107 release notes from branch ([#3617](https://github.com/bluealloy/revm/pull/3617))
+- *(precompile)* vendor blake2b_simd for BLAKE2 compression ([#3609](https://github.com/bluealloy/revm/pull/3609))
+- *(precompile)* use static OnceLock array for Precompiles init ([#3602](https://github.com/bluealloy/revm/pull/3602))
+- enable and fix clippy::missing_const_for_fn ([#3592](https://github.com/bluealloy/revm/pull/3592))
+- rm op-revm (migrated to ethereum-optimism/optimism) ([#3568](https://github.com/bluealloy/revm/pull/3568))
+
 ## [34.0.0](https://github.com/bluealloy/revm/compare/revm-precompile-v33.0.0...revm-precompile-v34.0.0) - 2026-04-17
 
 ### Fixed

--- a/crates/precompile/CHANGELOG.md
+++ b/crates/precompile/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [35.0.0](https://github.com/bluealloy/revm/compare/revm-precompile-v34.0.0...revm-precompile-v35.0.0) - 2026-05-19
+## [36.0.0](https://github.com/bluealloy/revm/compare/revm-precompile-v34.0.0...revm-precompile-v36.0.0) - 2026-05-19
 
 ### Added
 

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-precompile"
 description = "Revm Precompiles - Ethereum compatible precompiled contracts"
-version = "34.0.0"
+version = "35.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-precompile"
 description = "Revm Precompiles - Ethereum compatible precompiled contracts"
-version = "35.0.0"
+version = "36.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/precompile/src/interface.rs
+++ b/crates/precompile/src/interface.rs
@@ -118,6 +118,9 @@ pub struct PrecompileOutput {
     pub state_gas_used: u64,
     /// Reservoir gas for EIP-8037.
     pub reservoir: u64,
+    /// Cumulative reservoir refill amount from 0→x→0 storage restorations
+    /// performed during precompile execution (EIP-8037).
+    pub refill_amount: u64,
     /// Output bytes.
     pub bytes: Bytes,
 }
@@ -138,6 +141,7 @@ impl PrecompileOutput {
             gas_refunded: 0,
             state_gas_used: 0,
             reservoir,
+            refill_amount: 0,
             bytes,
         }
     }
@@ -150,6 +154,7 @@ impl PrecompileOutput {
             gas_refunded: 0,
             state_gas_used: 0,
             reservoir,
+            refill_amount: 0,
             bytes: Bytes::new(),
         }
     }
@@ -162,6 +167,7 @@ impl PrecompileOutput {
             gas_refunded: 0,
             state_gas_used: 0,
             reservoir,
+            refill_amount: 0,
             bytes,
         }
     }

--- a/crates/primitives/CHANGELOG.md
+++ b/crates/primitives/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [24.0.0](https://github.com/bluealloy/revm/compare/revm-primitives-v23.0.0...revm-primitives-v24.0.0) - 2026-05-19
+
+### Added
+
+- *(eip8037)* Amsterdam bal-devnet-7 ([#3667](https://github.com/bluealloy/revm/pull/3667))
+
+### Other
+
+- remove unused spec ids ([#3649](https://github.com/bluealloy/revm/pull/3649))
+- audit #[allow] attributes ([#3611](https://github.com/bluealloy/revm/pull/3611))
+- *(precompile)* use static OnceLock array for Precompiles init ([#3602](https://github.com/bluealloy/revm/pull/3602))
+- *(primitives)* add SpecId::NEXT, drop num_enum dependency ([#3593](https://github.com/bluealloy/revm/pull/3593))
+- enable and fix clippy::missing_const_for_fn ([#3592](https://github.com/bluealloy/revm/pull/3592))
+- rm op-revm (migrated to ethereum-optimism/optimism) ([#3568](https://github.com/bluealloy/revm/pull/3568))
+
 ## [23.0.0](https://github.com/bluealloy/revm/compare/revm-primitives-v22.1.0...revm-primitives-v23.0.0) - 2026-04-10
 
 ### Added

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-primitives"
 description = "Revm primitives types"
-version = "23.0.0"
+version = "24.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/primitives/src/eip2780.rs
+++ b/crates/primitives/src/eip2780.rs
@@ -1,0 +1,21 @@
+//! EIP-2780: Reduce intrinsic transaction gas
+//!
+//! Replaces the legacy `21,000` intrinsic base with a decomposed model that
+//! prices ECDSA recovery, sender access + write, and additional `to`/`value`
+//! charges separately. Composes with EIP-8037 (state gas) and reuses the
+//! placeholder values from [`crate::eip8038`] for `ACCOUNT_WRITE`,
+//! `CREATE_ACCESS`, and `COLD_ACCOUNT_ACCESS`.
+
+/// Reduced intrinsic base cost charged to `tx.sender`.
+///
+/// Per the EIP, `TX_BASE_COST = GAS_PRECOMPILE_ECRECOVER + COLD_ACCOUNT_ACCESS + ACCOUNT_WRITE`.
+/// Kept at the literal `12_300` from the EIP-2780 reference table; the `+1`
+/// placeholder values in [`crate::eip8038`] would compute `12_302` instead.
+pub const TX_BASE_COST: u64 = 12_300;
+
+/// Regular gas cost of the EIP-7708 transfer log emitted for every nonzero-value
+/// transfer to a different account.
+///
+/// `TRANSFER_LOG_COST = GAS_LOG + 3 * GAS_LOG_TOPIC + 32 * GAS_LOG_DATA_PER_BYTE`
+/// = `375 + 1_125 + 256 = 1_756`.
+pub const TRANSFER_LOG_COST: u64 = 1_756;

--- a/crates/primitives/src/eip8037.rs
+++ b/crates/primitives/src/eip8037.rs
@@ -1,0 +1,36 @@
+//! EIP-8037: State Creation Gas Cost Increase
+//!
+//! Introduces a reservoir model that separates *state gas* (storage/code/account
+//! creation) from *regular* execution gas. State-gas charges are expressed as
+//! a number of "state bytes" that get multiplied by `cost_per_state_byte` (CPSB).
+//! In `bal-devnet-7` / Glamsterdam, CPSB is fixed at `1530`.
+
+/// Blocks per year at a 12-second block time (used by the CPSB formula).
+pub const BLOCKS_PER_YEAR: u64 = 2_628_000;
+
+/// Target yearly state growth budget, in bytes.
+pub const TARGET_STATE_GROWTH_PER_YEAR: u64 = 100 * 1024 * 1024 * 1024;
+
+/// Offset subtracted after rounding in the CPSB formula.
+pub const CPSB_OFFSET: u64 = 9578;
+
+/// Number of high-order bits retained when rounding CPSB.
+pub const CPSB_SIGNIFICANT_BITS: u32 = 5;
+
+/// State bytes charged per SSTORE 0→non-zero.
+pub const SSTORE_SET_BYTES: u64 = 64;
+
+/// State bytes charged when creating a new account.
+pub const NEW_ACCOUNT_BYTES: u64 = 120;
+
+/// State bytes charged per EIP-7702 authorization base cost.
+pub const AUTH_BASE_BYTES: u64 = 23;
+
+/// State bytes charged per byte of deployed code.
+pub const CODE_DEPOSIT_PER_BYTE: u64 = 1;
+
+/// Regular gas component of EIP-7702 `PER_EMPTY_ACCOUNT_COST` under EIP-8037.
+pub const EIP7702_PER_EMPTY_ACCOUNT_REGULAR: u64 = 7500;
+
+/// CPSB for Glamsterdam
+pub const CPSB_GLAMSTERDAM: u64 = 1530;

--- a/crates/primitives/src/eip8038.rs
+++ b/crates/primitives/src/eip8038.rs
@@ -1,0 +1,60 @@
+//! EIP-8038: State-Access Gas Cost Update
+//!
+//! Increases the gas cost of state-access operations to reflect Ethereum's
+//! larger state. All "TBD" values in the draft spec are filled in here as
+//! `previous_value + 1`.
+//!
+//! Active alongside EIP-7904 and EIP-8037 starting at the Amsterdam hardfork.
+
+/// Cold touch of an account (was 2,600 pre-EIP-8038).
+pub const COLD_ACCOUNT_ACCESS: u64 = 2_601;
+
+/// Surcharge for writing to an account that changes one account leaf value for
+/// the first time (was 6,700 pre-EIP-8038).
+pub const ACCOUNT_WRITE: u64 = 6_701;
+
+/// Cold touch of a storage slot (was 2,100 pre-EIP-8038).
+pub const COLD_STORAGE_ACCESS: u64 = 2_101;
+
+/// Surcharge for writing to a storage slot that changes its value for the
+/// first time (was 2,800 pre-EIP-8038).
+pub const STORAGE_WRITE: u64 = 2_801;
+
+/// Touch of an already-warm account or storage slot (was 100 pre-EIP-8038).
+pub const WARM_ACCESS: u64 = 101;
+
+/// Refund for clearing a storage slot (was 4,800 pre-EIP-8038).
+pub const STORAGE_CLEAR_REFUND: u64 = 4_801;
+
+/// State access cost for contract deployment (was 7,000 pre-EIP-8038).
+///
+/// Note: the spec also defines `CREATE_ACCESS = ACCOUNT_WRITE + COLD_STORAGE_ACCESS`,
+/// which does not exactly match the legacy decomposition. Per the user-supplied
+/// rule we keep this slot at the literal `previous + 1` value rather than the
+/// derived sum.
+pub const CREATE_ACCESS: u64 = 7_001;
+
+/// Gas charged per storage key included in a transaction's access list
+/// (was 1,900 pre-EIP-8038).
+pub const ACCESS_LIST_STORAGE_KEY_COST: u64 = 1_901;
+
+/// Gas charged per address included in a transaction's access list
+/// (was 2,400 pre-EIP-8038).
+pub const ACCESS_LIST_ADDRESS_COST: u64 = 2_401;
+
+/// Cold premium on top of `WARM_ACCESS` for account access.
+pub const COLD_ACCOUNT_ACCESS_ADDITIONAL: u64 = COLD_ACCOUNT_ACCESS - WARM_ACCESS;
+
+/// Cold premium on top of `WARM_ACCESS` for storage access.
+pub const COLD_STORAGE_ACCESS_ADDITIONAL: u64 = COLD_STORAGE_ACCESS - WARM_ACCESS;
+
+/// CALL value transfer cost: `ACCOUNT_WRITE + CALL_STIPEND` per the EIP.
+pub const CALL_VALUE: u64 = ACCOUNT_WRITE + 2_300;
+
+/// Regular-gas portion of EIP-7702 `PER_EMPTY_ACCOUNT_COST` under EIP-8038.
+///
+/// Equal to the pre-EIP-8038 value (`crate::eip8037::EIP7702_PER_EMPTY_ACCOUNT_REGULAR`)
+/// plus the delta from the modified primitives that appear in the per-auth
+/// breakdown (`ACCOUNT_WRITE` +1, `COLD_ACCOUNT_ACCESS` +1, two `WARM_ACCESS`
+/// occurrences +1 each — total +4).
+pub const EIP7702_PER_EMPTY_ACCOUNT_REGULAR: u64 = 7_504;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -25,6 +25,7 @@ pub mod eip7823;
 pub mod eip7825;
 pub mod eip7907;
 pub mod eip7954;
+pub mod eip8037;
 pub mod hardfork;
 pub mod hints_util;
 mod once_lock;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -26,6 +26,7 @@ pub mod eip7825;
 pub mod eip7907;
 pub mod eip7954;
 pub mod eip8037;
+pub mod eip8038;
 pub mod hardfork;
 pub mod hints_util;
 mod once_lock;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -17,6 +17,7 @@ extern crate alloc as std;
 
 pub mod constants;
 pub mod eip170;
+pub mod eip2780;
 pub mod eip3860;
 pub mod eip4844;
 pub mod eip7702;

--- a/crates/revm/CHANGELOG.md
+++ b/crates/revm/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [38.0.1](https://github.com/bluealloy/revm/compare/revm-v38.0.0...revm-v38.0.1) - 2026-05-19
+## [39.0.0](https://github.com/bluealloy/revm/compare/revm-v38.0.0...revm-v39.0.0) - 2026-05-19
 
 ### Other
 

--- a/crates/revm/CHANGELOG.md
+++ b/crates/revm/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [39.0.0](https://github.com/bluealloy/revm/compare/revm-v38.0.0...revm-v39.0.0) - 2026-05-19
+## [40.0.0](https://github.com/bluealloy/revm/compare/revm-v38.0.0...revm-v40.0.0) - 2026-05-19
 
 ### Other
 

--- a/crates/revm/CHANGELOG.md
+++ b/crates/revm/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [38.0.1](https://github.com/bluealloy/revm/compare/revm-v38.0.0...revm-v38.0.1) - 2026-05-19
+
+### Other
+
+- backport v107 release notes from branch ([#3617](https://github.com/bluealloy/revm/pull/3617))
+- rm op-revm (migrated to ethereum-optimism/optimism) ([#3568](https://github.com/bluealloy/revm/pull/3568))
+
 ## [38.0.0](https://github.com/bluealloy/revm/compare/revm-v37.0.0...revm-v38.0.0) - 2026-04-17
 
 ### Other

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm"
 description = "Revm - Rust Ethereum Virtual Machine"
-version = "38.0.0"
+version = "38.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm"
 description = "Revm - Rust Ethereum Virtual Machine"
-version = "39.0.0"
+version = "40.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm"
 description = "Revm - Rust Ethereum Virtual Machine"
-version = "38.0.1"
+version = "39.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/state/CHANGELOG.md
+++ b/crates/state/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [12.0.0](https://github.com/bluealloy/revm/compare/revm-state-v11.0.1...revm-state-v12.0.0) - 2026-05-19
+
+### Added
+
+- *(eip8037)* Amsterdam bal-devnet-7 ([#3667](https://github.com/bluealloy/revm/pull/3667))
+- add borrowed alloy BAL conversion ([#3670](https://github.com/bluealloy/revm/pull/3670))
+- *(state)* add Bal::try_from_alloy ([#3665](https://github.com/bluealloy/revm/pull/3665))
+- show address or slot in BAL error ([#3619](https://github.com/bluealloy/revm/pull/3619))
+- *(state)* Optimized index type for transaction ID using non-max ([#3610](https://github.com/bluealloy/revm/pull/3610))
+- *(account)* Optimized index type for account ID using `non-max` ([#3605](https://github.com/bluealloy/revm/pull/3605))
+
+### Fixed
+
+- *(state)* canonicalize BAL alloy ordering ([#3618](https://github.com/bluealloy/revm/pull/3618))
+- *(bal)* record storage writes to zero for selfdestructed accounts ([#3573](https://github.com/bluealloy/revm/pull/3573))
+
+### Other
+
+- expand `BalError` documentation ([#3666](https://github.com/bluealloy/revm/pull/3666))
+- update alloy-eip7928 to newer version ([#3627](https://github.com/bluealloy/revm/pull/3627))
+- audit #[allow] attributes ([#3611](https://github.com/bluealloy/revm/pull/3611))
+- backport v107 release notes from branch ([#3617](https://github.com/bluealloy/revm/pull/3617))
+- enable and fix clippy::missing_const_for_fn ([#3592](https://github.com/bluealloy/revm/pull/3592))
+- no alloc for empty accounts ([#3590](https://github.com/bluealloy/revm/pull/3590))
+- rm op-revm (migrated to ethereum-optimism/optimism) ([#3568](https://github.com/bluealloy/revm/pull/3568))
+
 ## [11.0.1](https://github.com/bluealloy/revm/compare/revm-state-v11.0.0...revm-state-v11.0.1) - 2026-04-17
 
 ### Fixed

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-state"
 description = "Revm state types"
-version = "11.0.1"
+version = "12.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/state/src/account_info.rs
+++ b/crates/state/src/account_info.rs
@@ -271,8 +271,7 @@ impl AccountInfo {
     /// - nonce is zero
     #[inline]
     pub fn is_empty(&self) -> bool {
-        let code_empty = self.is_empty_code_hash() || self.code_hash.is_zero();
-        code_empty && self.balance.is_zero() && self.nonce == 0
+        self.is_code_hash_empty_or_zero() && self.balance.is_zero() && self.nonce == 0
     }
 
     /// Optimization hint.
@@ -305,6 +304,12 @@ impl AccountInfo {
     #[inline]
     pub fn is_empty_code_hash(&self) -> bool {
         self.code_hash == KECCAK_EMPTY
+    }
+
+    /// Returns true if the code hash is the Keccak256 hash of the empty string `""` or is zero.
+    #[inline]
+    pub fn is_code_hash_empty_or_zero(&self) -> bool {
+        self.is_empty_code_hash() || self.code_hash.is_zero()
     }
 
     /// Takes bytecode from account.

--- a/crates/statetest-types/CHANGELOG.md
+++ b/crates/statetest-types/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [18.0.0](https://github.com/bluealloy/revm/compare/revm-statetest-types-v17.0.1...revm-statetest-types-v18.0.0) - 2026-05-19
+## [19.0.0](https://github.com/bluealloy/revm/compare/revm-statetest-types-v17.0.1...revm-statetest-types-v19.0.0) - 2026-05-19
 
 ### Other
 

--- a/crates/statetest-types/CHANGELOG.md
+++ b/crates/statetest-types/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [17.0.2](https://github.com/bluealloy/revm/compare/revm-statetest-types-v17.0.1...revm-statetest-types-v17.0.2) - 2026-05-19
+
+### Other
+
+- backport v107 release notes from branch ([#3617](https://github.com/bluealloy/revm/pull/3617))
+- rm op-revm (migrated to ethereum-optimism/optimism) ([#3568](https://github.com/bluealloy/revm/pull/3568))
+
 ## [17.0.1](https://github.com/bluealloy/revm/compare/revm-statetest-types-v17.0.0...revm-statetest-types-v17.0.1) - 2026-04-17
 
 ### Other

--- a/crates/statetest-types/CHANGELOG.md
+++ b/crates/statetest-types/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [17.0.2](https://github.com/bluealloy/revm/compare/revm-statetest-types-v17.0.1...revm-statetest-types-v17.0.2) - 2026-05-19
+## [18.0.0](https://github.com/bluealloy/revm/compare/revm-statetest-types-v17.0.1...revm-statetest-types-v18.0.0) - 2026-05-19
 
 ### Other
 

--- a/crates/statetest-types/Cargo.toml
+++ b/crates/statetest-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-statetest-types"
 description = "Statetest types for revme"
-version = "17.0.1"
+version = "17.0.2"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/statetest-types/Cargo.toml
+++ b/crates/statetest-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-statetest-types"
 description = "Statetest types for revme"
-version = "17.0.2"
+version = "18.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/statetest-types/Cargo.toml
+++ b/crates/statetest-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-statetest-types"
 description = "Statetest types for revme"
-version = "18.0.0"
+version = "19.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/examples/database_components/src/lib.rs
+++ b/examples/database_components/src/lib.rs
@@ -118,4 +118,8 @@ impl<S: DatabaseCommit, BH: BlockHashRef> DatabaseCommit for DatabaseComponents<
     fn commit(&mut self, changes: AddressMap<Account>) {
         self.state.commit(changes);
     }
+
+    fn commit_iter(&mut self, changes: &mut dyn Iterator<Item = (Address, Account)>) {
+        self.state.commit_iter(changes);
+    }
 }

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 
 # Version for the execution spec tests
 MAIN_VERSION="v5.4.0"
-DEVNET_VERSION="bal%40v5.4.0"
+DEVNET_VERSION="tests-bal%40v7.1.1"
 
 ### Directories ###
 FIXTURES_DIR="test-fixtures"
@@ -21,6 +21,7 @@ LEGACY_DIR="$FIXTURES_DIR/legacytests"
 
 ### URL and filenames ###
 FIXTURES_URL="https://github.com/ethereum/execution-spec-tests/releases/download"
+DEVNET_FIXTURES_URL="https://github.com/ethereum/execution-specs/releases/download"
 
 if [[ -n "${REVM_STATETEST_STABLE:-}" && "${REVM_STATETEST_STABLE:-}" != "0" ]]; then
     MAIN_DIR="$MAIN_STABLE_DIR"
@@ -118,9 +119,10 @@ download_and_extract() {
     local tar_file="$2"
     local label="$3"
     local version="$4"
+    local base_url="${5:-$FIXTURES_URL}"
 
     echo "Downloading ${label} fixtures..."
-    retry curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors "${FIXTURES_URL}/${version}/${tar_file}" -o "${FIXTURES_DIR}/${tar_file}"
+    retry curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors "${base_url}/${version}/${tar_file}" -o "${FIXTURES_DIR}/${tar_file}"
     echo "Extracting ${label} fixtures..."
      # strip-components=1 removes the first top level directory from the flepath
      # This is needed because when we extract the tar, it is placed under an
@@ -142,7 +144,7 @@ download_fixtures() {
     mkdir -p "$MAIN_DIR" "$DEVNET_DIR" "$LEGACY_DIR"
 
     download_and_extract "$MAIN_DIR" "$MAIN_TAR" "$MAIN_LABEL" "$MAIN_VERSION"
-    download_and_extract "$DEVNET_DIR" "$DEVNET_TAR" "devnet" "$DEVNET_VERSION"
+    download_and_extract "$DEVNET_DIR" "$DEVNET_TAR" "devnet" "$DEVNET_VERSION" "$DEVNET_FIXTURES_URL"
 
     # Clone legacytests repository
     echo "Cloning legacytests repository..."
@@ -177,8 +179,8 @@ run_tests() {
     echo "Running $MAIN_LABEL statetests..."
     $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest $KEEP_GOING_FLAG "$MAIN_DIR/state_tests"
 
-    echo "SKIP Running devnet statetests..."
-    #$RUST_RUNNER run $CARGO_OPTS -p revme -- statetest $KEEP_GOING_FLAG "$DEVNET_DIR/state_tests"
+    echo "Running devnet statetests..."
+    $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest $KEEP_GOING_FLAG "$DEVNET_DIR/state_tests"
 
     echo "Running legacy Cancun tests..."
     $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest $KEEP_GOING_FLAG "$LEGACY_DIR/Cancun/GeneralStateTests"


### PR DESCRIPTION
## Summary

Implements [EIP-8038](https://eips.ethereum.org/EIPS/eip-8038) (State-access gas cost update), gated at `AMSTERDAM` alongside the existing EIP-7904 / EIP-8037 work. Every \`TBD\` value in the draft is set to \`previous_value + 1\` per the rule provided.

| Parameter | Old | New |
| --- | --- | --- |
| `WARM_ACCESS` | 100 | **101** |
| `COLD_ACCOUNT_ACCESS` | 2,600 | **2,601** |
| `ACCOUNT_WRITE` | 6,700 | **6,701** |
| `COLD_STORAGE_ACCESS` | 2,100 | **2,101** |
| `STORAGE_WRITE` | 2,800 | **2,801** |
| `STORAGE_CLEAR_REFUND` | 4,800 | **4,801** |
| `CREATE_ACCESS` | 7,000 | **7,001** |
| `ACCESS_LIST_ADDRESS_COST` | 2,400 | **2,401** |
| `ACCESS_LIST_STORAGE_KEY_COST` | 1,900 | **1,901** |

### Changes
- New `primitives::eip8038` module exposing the parameter constants plus a few derived helpers (`COLD_*_ADDITIONAL`, `CALL_VALUE`, `EIP7702_PER_EMPTY_ACCOUNT_REGULAR`).
- `GasParams::new_spec_inner` AMSTERDAM branch overlays the new values onto every relevant slot: account access (`warm_storage_read_cost`, `cold_*_additional_cost`, `cold_storage_cost`), value-transfer/new-account regular surcharges (`transfer_value_cost`, `new_account_cost`, `new_account_cost_for_selfdestruct`), SSTORE (`sstore_static`, `sstore_set/reset_without_load_cost`, refunds, `sstore_clearing_slot_refund`), CREATE (`create`, `tx_create_cost`), access-list per-item costs (bumped base + existing EIP-7981 64 gas/byte), and EIP-7702 per-auth regular cost.
- `gas_table_spec` AMSTERDAM branch bumps all warm-access opcode bases from 100 → 101 and bakes the extra `WARM_ACCESS` into `EXTCODESIZE`/`EXTCODECOPY` (EIP "EXT* family update").
- One Amsterdam access-list unit test refreshed; `cargo insta accept` applied the new gas-spent values to 33 EIP-8037 snapshot tests (the CREATE_ACCESS 9000 → 7001 drop propagates as a ~2000-gas reduction).

Note: I kept `CREATE_ACCESS = 7001` (the literal "previous + 1" applied to the 7,000 in the EIP table) rather than the alternative `ACCOUNT_WRITE + COLD_STORAGE_ACCESS = 8802` formula; the EIP itself flags that those two definitions don't match.

## Test plan
- [x] `cargo nextest run --workspace` — 339/339 pass
- [x] `cargo nextest run --workspace --no-default-features` — 339/339 pass
- [x] `cargo clippy --workspace --all-targets --all-features` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `typos` — clean