### PR TITLE
perf(database): preserve commit_iter semantics

### DIFF
--- a/crates/database/interface/src/bal.rs
+++ b/crates/database/interface/src/bal.rs
@@ -388,4 +388,13 @@ impl<DB: DatabaseCommit> DatabaseCommit for BalDatabase<DB> {
         self.bal_state.commit(&changes);
         self.db.commit(changes);
     }
+
+    fn commit_iter(&mut self, changes: &mut dyn Iterator<Item = (Address, Account)>) {
+        let bal_state = &mut self.bal_state;
+        let mut changes = changes.map(|(address, account)| {
+            bal_state.commit_one(address, &account);
+            (address, account)
+        });
+        self.db.commit_iter(&mut changes);
+    }
 }

--- a/crates/database/interface/src/either.rs
+++ b/crates/database/interface/src/either.rs
@@ -68,6 +68,13 @@ where
             Self::Right(db) => db.commit(changes),
         }
     }
+
+    fn commit_iter(&mut self, changes: &mut dyn Iterator<Item = (Address, Account)>) {
+        match self {
+            Self::Left(db) => db.commit_iter(changes),
+            Self::Right(db) => db.commit_iter(changes),
+        }
+    }
 }
 
 impl<L, R> DatabaseRef for Either<L, R>

--- a/crates/database/interface/src/lib.rs
+++ b/crates/database/interface/src/lib.rs
@@ -223,6 +223,11 @@ impl<T: DatabaseRef + DatabaseCommit> DatabaseCommit for WrapDatabaseRef<T> {
     fn commit(&mut self, changes: AddressMap<Account>) {
         self.0.commit(changes)
     }
+
+    #[inline]
+    fn commit_iter(&mut self, changes: &mut dyn Iterator<Item = (Address, Account)>) {
+        self.0.commit_iter(changes)
+    }
 }
 
 impl<T: DatabaseRef> DatabaseRef for WrapDatabaseRef<T> {
@@ -380,5 +385,83 @@ mod tests {
             db_dyn.commit_from_iter(vec![]);
         }
         assert_eq!(db.commits.len(), 4);
+    }
+
+    #[test]
+    fn wrappers_forward_commit_iter() {
+        #[derive(Default)]
+        struct MockDb {
+            commits: usize,
+            commit_iters: usize,
+            committed_accounts: usize,
+        }
+
+        impl DatabaseCommit for MockDb {
+            fn commit(&mut self, changes: AddressMap<Account>) {
+                self.commits += 1;
+                self.committed_accounts += changes.len();
+            }
+
+            fn commit_iter(&mut self, changes: &mut dyn Iterator<Item = (Address, Account)>) {
+                self.commit_iters += 1;
+                self.committed_accounts += changes.count();
+            }
+        }
+
+        impl DatabaseRef for MockDb {
+            type Error = Infallible;
+
+            fn basic_ref(&self, _address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+                Ok(None)
+            }
+
+            fn code_by_hash_ref(&self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+                Ok(Bytecode::default())
+            }
+
+            fn storage_ref(
+                &self,
+                _address: Address,
+                _index: StorageKey,
+            ) -> Result<StorageValue, Self::Error> {
+                Ok(StorageValue::ZERO)
+            }
+
+            fn block_hash_ref(&self, _number: u64) -> Result<B256, Self::Error> {
+                Ok(B256::ZERO)
+            }
+        }
+
+        fn changes() -> Vec<(Address, Account)> {
+            vec![(Address::with_last_byte(1), Account::default())]
+        }
+
+        let mut db = WrapDatabaseRef(MockDb::default());
+        db.commit_iter(&mut changes().into_iter());
+        assert_eq!(db.0.commits, 0);
+        assert_eq!(db.0.commit_iters, 1);
+        assert_eq!(db.0.committed_accounts, 1);
+
+        let mut db: ::either::Either<MockDb, MockDb> = ::either::Either::Left(MockDb::default());
+        db.commit_iter(&mut changes().into_iter());
+        let ::either::Either::Left(db) = db else {
+            unreachable!()
+        };
+        assert_eq!(db.commits, 0);
+        assert_eq!(db.commit_iters, 1);
+        assert_eq!(db.committed_accounts, 1);
+
+        let address = Address::with_last_byte(2);
+        let mut account = Account::default();
+        account.mark_touch();
+
+        let mut db = bal::BalDatabase::new(MockDb::default()).with_bal_builder();
+        db.commit_iter(&mut [(address, account)].into_iter());
+        assert_eq!(db.db.commits, 0);
+        assert_eq!(db.db.commit_iters, 1);
+        assert_eq!(db.db.committed_accounts, 1);
+
+        let bal = db.bal_state.take_built_bal().expect("BAL should be built");
+        assert!(bal.accounts.get(&address).is_some());
     }
 }

--- a/crates/database/src/in_memory_db.rs
+++ b/crates/database/src/in_memory_db.rs
@@ -142,6 +142,40 @@ impl<ExtDB> CacheDB<ExtDB> {
         }
     }
 
+    fn commit_account(&mut self, address: Address, mut account: Account) {
+        if !account.is_touched() {
+            return;
+        }
+        if account.is_selfdestructed() {
+            let db_account = self.cache.accounts.entry(address).or_default();
+            db_account.storage.clear();
+            db_account.account_state = AccountState::NotExisting;
+            db_account.info = AccountInfo::default();
+            return;
+        }
+        let is_newly_created = account.is_created();
+        self.insert_contract(&mut account.info);
+
+        let db_account = self.cache.accounts.entry(address).or_default();
+        db_account.info = account.info;
+
+        db_account.account_state = if is_newly_created {
+            db_account.storage.clear();
+            AccountState::StorageCleared
+        } else if db_account.account_state.is_storage_cleared() {
+            // Preserve old account state if it already exists
+            AccountState::StorageCleared
+        } else {
+            AccountState::Touched
+        };
+        db_account.storage.extend(
+            account
+                .storage
+                .into_iter()
+                .map(|(key, value)| (key, value.present_value())),
+        );
+    }
+
     /// Wraps the cache in a [CacheDB], creating a nested cache.
     pub fn nest(self) -> CacheDB<Self> {
         CacheDB::new(self)
@@ -281,38 +315,14 @@ impl<ExtDB: DatabaseRef> CacheDB<ExtDB> {
 
 impl<ExtDB> DatabaseCommit for CacheDB<ExtDB> {
     fn commit(&mut self, changes: AddressMap<Account>) {
-        for (address, mut account) in changes {
-            if !account.is_touched() {
-                continue;
-            }
-            if account.is_selfdestructed() {
-                let db_account = self.cache.accounts.entry(address).or_default();
-                db_account.storage.clear();
-                db_account.account_state = AccountState::NotExisting;
-                db_account.info = AccountInfo::default();
-                continue;
-            }
-            let is_newly_created = account.is_created();
-            self.insert_contract(&mut account.info);
+        for (address, account) in changes {
+            self.commit_account(address, account);
+        }
+    }
 
-            let db_account = self.cache.accounts.entry(address).or_default();
-            db_account.info = account.info;
-
-            db_account.account_state = if is_newly_created {
-                db_account.storage.clear();
-                AccountState::StorageCleared
-            } else if db_account.account_state.is_storage_cleared() {
-                // Preserve old account state if it already exists
-                AccountState::StorageCleared
-            } else {
-                AccountState::Touched
-            };
-            db_account.storage.extend(
-                account
-                    .storage
-                    .into_iter()
-                    .map(|(key, value)| (key, value.present_value())),
-            );
+    fn commit_iter(&mut self, changes: &mut dyn Iterator<Item = (Address, Account)>) {
+        for (address, account) in changes {
+            self.commit_account(address, account);
         }
     }
 }
@@ -587,9 +597,9 @@ impl Database for BenchmarkDB {
 #[cfg(test)]
 mod tests {
     use super::{CacheDB, EmptyDB};
-    use database_interface::Database;
+    use database_interface::{Database, DatabaseCommit};
     use primitives::{Address, HashMap, StorageKey, StorageValue};
-    use state::AccountInfo;
+    use state::{Account, AccountInfo, EvmStorageSlot, TransactionId};
 
     #[test]
     fn test_insert_account_storage() {
@@ -641,6 +651,37 @@ mod tests {
         assert_eq!(new_state.basic(account).unwrap().unwrap().nonce, nonce);
         assert_eq!(new_state.storage(account, key0), Ok(StorageValue::ZERO));
         assert_eq!(new_state.storage(account, key1), Ok(value1));
+    }
+
+    #[test]
+    fn commit_iter_applies_repeated_account_updates_in_order() {
+        let address = Address::with_last_byte(42);
+        let key = StorageKey::from(123);
+        let value = StorageValue::from(456);
+        let mut db = CacheDB::new(EmptyDB::default());
+
+        let first = Account::from(AccountInfo {
+            nonce: 1,
+            ..Default::default()
+        })
+        .with_touched_mark()
+        .with_storage(
+            [(
+                key,
+                EvmStorageSlot::new_changed(StorageValue::ZERO, value, TransactionId::ZERO),
+            )]
+            .into_iter(),
+        );
+        let second = Account::from(AccountInfo {
+            nonce: 2,
+            ..Default::default()
+        })
+        .with_touched_mark();
+
+        db.commit_iter(&mut [(address, first), (address, second)].into_iter());
+
+        assert_eq!(db.basic(address).unwrap().unwrap().nonce, 2);
+        assert_eq!(db.storage(address, key), Ok(value));
     }
 
     #[cfg(feature = "std")]

--- a/examples/database_components/src/lib.rs
+++ b/examples/database_components/src/lib.rs
@@ -118,4 +118,8 @@ impl<S: DatabaseCommit, BH: BlockHashRef> DatabaseCommit for DatabaseComponents<
     fn commit(&mut self, changes: AddressMap<Account>) {
         self.state.commit(changes);
     }
+
+    fn commit_iter(&mut self, changes: &mut dyn Iterator<Item = (Address, Account)>) {
+        self.state.commit_iter(changes);
+    }
 }


### PR DESCRIPTION
# Summary

This PR forwards `DatabaseCommit::commit_iter` through database wrappers instead of falling back to the default collect-then-commit path.

# Problem

`commit_iter` exists for callers that already have an iterator of state changes, but `CacheDB`, `BalDatabase`, `Either`, and `WrapDatabaseRef` currently lose that path. `CacheDB` also collapses repeated addresses when the default implementation collects into an `AddressMap`.

# Solution

- add a streaming `CacheDB::commit_iter` implementation shared with `commit`
- forward `commit_iter` through database wrappers
- add regression coverage for wrapper forwarding and repeated `CacheDB` account updates