### PR TITLE
fix(eip2780): charge warm cost when tx.to or delegation target is in …

### DIFF
--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -1138,6 +1138,9 @@ impl GasParams {
             self.tx_create_access_cost()
         } else if to_is_self || info.to_is_precompile {
             0
+        } else if info.to_is_warm {
+            // EIP-2780: warmth from the access list overrides the cold cost.
+            self.warm_storage_read_cost()
         } else {
             eip8038::COLD_ACCOUNT_ACCESS
         };
@@ -1160,7 +1163,9 @@ impl GasParams {
 /// Carries the additional state needed to apply the decomposed intrinsic
 /// gas model: the sender address (for self-transfer detection), the `to`
 /// address (`None` for contract-creation transactions), the transferred
-/// value, and a flag indicating whether `to` resolves to a precompile.
+/// value, a flag indicating whether `to` resolves to a precompile, and a
+/// flag indicating whether `to` is already warm via the transaction access
+/// list.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Eip2780TxInfo {
     /// Transaction sender.
@@ -1171,6 +1176,12 @@ pub struct Eip2780TxInfo {
     pub value: U256,
     /// Whether `to` is a precompile under the active spec.
     pub to_is_precompile: bool,
+    /// Whether `to` appears in the transaction access list.
+    ///
+    /// Per EIP-2780, access-list warmth overrides the cold account cost:
+    /// the recipient is charged `WARM_STATE_READ` instead of
+    /// `COLD_ACCOUNT_ACCESS` when this flag is set.
+    pub to_is_warm: bool,
 }
 
 #[inline]

--- a/crates/ee-tests/src/eip2780.rs
+++ b/crates/ee-tests/src/eip2780.rs
@@ -11,11 +11,12 @@
 
 use revm::{
     context::TxEnv,
-    database::{BenchmarkDB, BENCH_CALLER},
+    context_interface::transaction::{AccessList, AccessListItem},
+    database::{BenchmarkDB, BENCH_CALLER, BENCH_TARGET},
     handler::{MainnetContext, MainnetEvm},
     primitives::{
-        address, eip2780, eip8037, eip8037::CPSB_GLAMSTERDAM, eip8038, hardfork::SpecId, TxKind,
-        U256,
+        self as primitives, address, eip2780, eip8037, eip8037::CPSB_GLAMSTERDAM, eip8038,
+        hardfork::SpecId, TxKind, U256,
     },
     state::Bytecode,
     Context, ExecuteEvm, MainBuilder, MainContext,
@@ -39,6 +40,20 @@ fn evm() -> MainEvm {
             cfg.tx_gas_limit_cap = Some(u64::MAX);
         })
         .with_db(BenchmarkDB::new_bytecode(Bytecode::new()))
+        .build_mainnet()
+}
+
+/// Builds an EVM at AMSTERDAM where BENCH_TARGET has EIP-7702 delegation to
+/// `delegation_target`. Used to test warm/cold charging of the delegation target.
+fn evm_with_7702_target(delegation_target: primitives::Address) -> MainEvm {
+    Context::mainnet()
+        .modify_cfg_chained(|cfg| {
+            cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
+            cfg.tx_gas_limit_cap = Some(u64::MAX);
+        })
+        .with_db(BenchmarkDB::new_bytecode(Bytecode::new_eip7702(
+            delegation_target,
+        )))
         .build_mainnet()
 }
 
@@ -171,4 +186,89 @@ fn test_eip2780_call_precompile_delta_vs_legacy() {
         g0.total_gas_spent() - g1.total_gas_spent(),
         LEGACY_BASE - eip2780::TX_BASE_COST,
     );
+}
+
+/// Per-address access-list cost at AMSTERDAM: base (2401) + data bytes (20 × 64).
+const ACCESS_LIST_ADDR_COST: u64 = eip8038::ACCESS_LIST_ADDRESS_COST + 20 * 64;
+
+#[test]
+fn test_eip2780_to_in_access_list_uses_warm_cost() {
+    // When tx.to is listed in the transaction access list, EIP-2780 must charge
+    // WARM_ACCESS instead of COLD_ACCOUNT_ACCESS for the recipient.
+    let to = address!("0x00000000000000000000000000000000000000cc");
+
+    let warm_tx = TxEnv::builder_for_bench()
+        .tx_type(None)
+        .kind(TxKind::Call(to))
+        .value(U256::ZERO)
+        .gas_price(0)
+        .gas_limit(TX_GAS_LIMIT)
+        .access_list(AccessList(vec![AccessListItem {
+            address: to,
+            storage_keys: vec![],
+        }]))
+        .build_fill();
+
+    let mut warm_evm = evm();
+    let warm_gas = *warm_evm.transact_one(warm_tx).unwrap().gas();
+
+    // to_cost = WARM_ACCESS; access-list entry itself costs ACCESS_LIST_ADDR_COST.
+    let expected = eip2780::TX_BASE_COST + eip8038::WARM_ACCESS + ACCESS_LIST_ADDR_COST;
+    assert_eq!(warm_gas.total_gas_spent(), expected);
+
+    // Cold baseline (fresh EVM, no access list): to_cost = COLD_ACCOUNT_ACCESS.
+    let mut cold_evm = evm();
+    let cold_gas = run(&mut cold_evm, TxKind::Call(to), U256::ZERO);
+    assert_eq!(
+        cold_gas.total_gas_spent(),
+        eip2780::TX_BASE_COST + eip8038::COLD_ACCOUNT_ACCESS
+    );
+}
+
+#[test]
+fn test_eip2780_7702_delegation_target_warm_vs_cold() {
+    // At depth 0, a 7702-delegated recipient causes an extra access charge for
+    // its delegation target.  The charge must be COLD_ACCOUNT_ACCESS when the
+    // target is cold, and WARM_ACCESS when it has been pre-warmed via the
+    // access list.
+    let delegation_target = address!("0x00000000000000000000000000000000000000dd");
+
+    // BENCH_TARGET carries EIP-7702 bytecode delegating to `delegation_target`.
+    let mut evm = evm_with_7702_target(delegation_target);
+
+    // Cold case: delegation target not in access list.
+    let cold_tx = TxEnv::builder_for_bench()
+        .kind(TxKind::Call(BENCH_TARGET))
+        .value(U256::ZERO)
+        .gas_price(0)
+        .gas_limit(TX_GAS_LIMIT)
+        .build_fill();
+    let cold_gas = *evm.transact_one(cold_tx).unwrap().gas();
+    // Intrinsic: TX_BASE_COST + COLD_ACCOUNT_ACCESS (for BENCH_TARGET)
+    // Depth-0 charge: COLD_ACCOUNT_ACCESS (cold delegation target)
+    let cold_expected =
+        eip2780::TX_BASE_COST + eip8038::COLD_ACCOUNT_ACCESS + eip8038::COLD_ACCOUNT_ACCESS;
+    assert_eq!(cold_gas.total_gas_spent(), cold_expected);
+
+    // Warm case: delegation target in access list.
+    let warm_tx = TxEnv::builder_for_bench()
+        .tx_type(None)
+        .kind(TxKind::Call(BENCH_TARGET))
+        .value(U256::ZERO)
+        .gas_price(0)
+        .gas_limit(TX_GAS_LIMIT)
+        .access_list(AccessList(vec![AccessListItem {
+            address: delegation_target,
+            storage_keys: vec![],
+        }]))
+        .build_fill();
+    let mut evm2 = evm_with_7702_target(delegation_target);
+    let warm_gas = *evm2.transact_one(warm_tx).unwrap().gas();
+    // Intrinsic: TX_BASE_COST + COLD_ACCOUNT_ACCESS (for BENCH_TARGET) + ACCESS_LIST_ADDR_COST
+    // Depth-0 charge: WARM_ACCESS (warm delegation target)
+    let warm_expected = eip2780::TX_BASE_COST
+        + eip8038::COLD_ACCOUNT_ACCESS
+        + ACCESS_LIST_ADDR_COST
+        + eip8038::WARM_ACCESS;
+    assert_eq!(warm_gas.total_gas_spent(), warm_expected);
 }

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -7,7 +7,8 @@ use context_interface::{
     context::{take_error, ContextError},
     journaled_state::{account::JournaledAccountTr, JournalCheckpoint, JournalTr},
     local::{FrameToken, OutFrame},
-    Cfg, ContextTr, Database,
+    transaction::{AccessListItemTr, TransactionType},
+    Cfg, ContextTr, Database, Transaction,
 };
 use core::cmp::min;
 use derive_where::derive_where;
@@ -174,14 +175,32 @@ impl EthFrame<EthInterpreter> {
                 .map(|a| a.info.clone());
 
             if let Some(info) = acc_info {
-                // 7702 delegation: additional COLD_ACCOUNT_ACCESS regular gas.
-                let is_7702_delegated = info
-                    .code
-                    .as_ref()
-                    .and_then(Bytecode::eip7702_address)
-                    .is_some();
-                if is_7702_delegated && !gas.record_regular_cost(eip8038::COLD_ACCOUNT_ACCESS) {
-                    early_halt = Some(InstructionResult::OutOfGas);
+                // 7702 delegation: additional access cost for the delegation target.
+                // Charge COLD_ACCOUNT_ACCESS if the target is cold, WARM_ACCESS if
+                // it was already warmed (e.g. via the transaction access list or a
+                // prior auth-list load during pre-execution).
+                if let Some(delegation_target) =
+                    info.code.as_ref().and_then(Bytecode::eip7702_address)
+                {
+                    // Warmth is based on whether the delegation target was pre-warmed
+                    // by the transaction access list. We cannot rely on journal warmth
+                    // because create_init_frame already loads the delegation target
+                    // before this depth-0 check runs.
+                    let tx = ctx.tx();
+                    let is_warm = tx.tx_type() != TransactionType::Legacy as u8
+                        && tx
+                            .access_list()
+                            .into_iter()
+                            .flatten()
+                            .any(|item| *item.address() == delegation_target);
+                    let charge = if is_warm {
+                        eip8038::WARM_ACCESS
+                    } else {
+                        eip8038::COLD_ACCOUNT_ACCESS
+                    };
+                    if !gas.record_regular_cost(charge) {
+                        early_halt = Some(InstructionResult::OutOfGas);
+                    }
                 }
 
                 // Empty recipient + nonzero value: charge `new_account_state_gas`.

--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -13,6 +13,7 @@ use context_interface::{
     cfg::gas_params,
     context::{take_error, ContextError},
     result::{HaltReasonTr, InvalidHeader, InvalidTransaction, ResultGas},
+    transaction::AccessListItemTr,
     Cfg, ContextTr, Database, JournalTr, Transaction,
 };
 use interpreter::{interpreter_action::FrameInit, Gas, InitialAndFloorGas, SharedMemory};
@@ -321,11 +322,18 @@ pub trait Handler {
                 TxKind::Create => (None, false),
                 TxKind::Call(addr) => (Some(addr), precompiles.contains(&addr)),
             };
+            let to_is_warm = to.is_some_and(|addr| {
+                tx.access_list()
+                    .into_iter()
+                    .flatten()
+                    .any(|item| *item.address() == addr)
+            });
             Some(gas_params::Eip2780TxInfo {
                 sender: tx.caller(),
                 to,
                 value: tx.value(),
                 to_is_precompile,
+                to_is_warm,
             })
         } else {
             None


### PR DESCRIPTION
Per EIP-2780 [1]:

  "Warmth discovered through an access list still applies and overrides
   the cold cost."

  "The delegation target incurs an additional COLD_ACCOUNT_COST_CODE
   if cold, or WARM_STATE_READ if already warm (e.g., if it appeared
   in the access list)."

Two bugs fixed that violated the above rules:

**Bug 1 — Recipient warm override**
`eip2780_base_to_value_gas` always charged `COLD_ACCOUNT_ACCESS` for `tx.to` even when `tx.to` appeared in the transaction access list.

Fix: add `to_is_warm: bool` to `Eip2780TxInfo` and populate it by scanning `tx.access_list()` in `validate_initial_tx_gas`. When set, `eip2780_base_to_value_gas` charges `warm_storage_read_cost` instead of `COLD_ACCOUNT_ACCESS` for the recipient.

**Bug 2 — EIP-7702 delegation target warm/cold**
The depth-0 extra access charge for EIP-7702-delegated recipients always used `COLD_ACCOUNT_ACCESS` regardless of whether the delegation target had been pre-warmed by the access list.

The original implementation tried to check journal warmth at `make_call_frame` time, but `create_init_frame` (execution.rs) loads the delegation target unconditionally before `make_call_frame` runs, making the journal always report it as warm.

Fix: check the transaction access list directly (same approach as `to_is_warm`) instead of querying journal state. This correctly distinguishes addresses pre-warmed by the access list from those warmed incidentally during frame setup.

Tests added to `crates/ee-tests/src/eip2780.rs` covering both fixes.

[1] https://eip.tools/eip/2780