### PR TITLE
refactor: use get instead of get_mut in test code

### DIFF
--- a/crates/database/src/states/bundle_state.rs
+++ b/crates/database/src/states/bundle_state.rs
@@ -1093,7 +1093,7 @@ mod tests {
         b2.state.get_mut(&account1()).unwrap().status = AccountStatus::Changed;
         b1.extend(b2);
         assert_eq!(
-            b1.state.get_mut(&account1()).unwrap().status,
+            b1.state.get(&account1()).unwrap().status,
             AccountStatus::DestroyedChanged
         );
 
@@ -1108,7 +1108,7 @@ mod tests {
         b2.reverts[0][0].1.wipe_storage = true;
         b1.extend(b2);
         assert_eq!(
-            b1.state.get_mut(&account1()).unwrap().status,
+            b1.state.get(&account1()).unwrap().status,
             AccountStatus::Destroyed
         );
 
@@ -1137,7 +1137,7 @@ mod tests {
         b2.state.get_mut(&account1()).unwrap().status = AccountStatus::Changed;
         b1.extend(b2);
         assert_eq!(
-            b1.state.get_mut(&account1()).unwrap().status,
+            b1.state.get(&account1()).unwrap().status,
             AccountStatus::InMemoryChange
         );
     }

--- a/crates/ee-tests/src/revm_tests.rs
+++ b/crates/ee-tests/src/revm_tests.rs
@@ -31,7 +31,7 @@ fn test_selfdestruct_multi_tx() {
         .transact_one(TxEnv::builder_for_bench().build_fill())
         .unwrap();
 
-    let destroyed_acc = evm.ctx.journal_mut().state.get_mut(&BENCH_TARGET).unwrap();
+    let destroyed_acc = evm.ctx.journal_mut().state.get(&BENCH_TARGET).unwrap();
 
     // balance got transferred to 0x0000..00FFFF
     assert_eq!(destroyed_acc.info.balance, U256::ZERO);
@@ -46,7 +46,7 @@ fn test_selfdestruct_multi_tx() {
         .transact_one(TxEnv::builder_for_bench().nonce(1).build_fill())
         .unwrap();
 
-    let destroyed_acc = evm.ctx.journal_mut().state.get_mut(&BENCH_TARGET).unwrap();
+    let destroyed_acc = evm.ctx.journal_mut().state.get(&BENCH_TARGET).unwrap();
 
     assert_eq!(destroyed_acc.info.code_hash, KECCAK_EMPTY);
     assert_eq!(destroyed_acc.info.nonce, 0);
@@ -85,7 +85,7 @@ fn test_multi_tx_create() {
         .ctx
         .journal_mut()
         .state
-        .get_mut(&created_address)
+        .get(&created_address)
         .unwrap();
 
     assert_eq!(
@@ -109,7 +109,7 @@ fn test_multi_tx_create() {
         .ctx
         .journal_mut()
         .state
-        .get_mut(&created_address)
+        .get(&created_address)
         .unwrap();
 
     // reset nonce to trigger create on same address.
@@ -149,7 +149,7 @@ fn test_multi_tx_create() {
         .ctx
         .journal_mut()
         .state
-        .get_mut(&created_address)
+        .get(&created_address)
         .unwrap();
 
     assert_eq!(


### PR DESCRIPTION
Replaced `get_mut` with `get` in 8 test code locations where the result was only read, not mutated.