### PR TITLE
docs: clarify BAL database API docs

### DIFF
--- a/crates/database/interface/src/bal.rs
+++ b/crates/database/interface/src/bal.rs
@@ -281,13 +281,19 @@ impl<DB> BalDatabase<DB> {
     }
 }
 
-/// Error type from database.
+/// Error returned by [`BalDatabase`] when a lookup can fail either in the BAL
+/// layer or in the wrapped database.
+///
+/// BAL misses are reported as [`EvmDatabaseError::Bal`] when the configured
+/// [`Bal`] is missing an account, storage slot, or positional account id that
+/// execution expected to be available. Errors from the underlying database are
+/// preserved as [`EvmDatabaseError::Database`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum EvmDatabaseError<ERROR> {
-    /// BAL error.
+    /// The configured BAL did not contain data needed by the current lookup.
     Bal(BalError),
-    /// External database error.
+    /// Error returned by the wrapped external database.
     Database(ERROR),
 }
 
@@ -311,9 +317,13 @@ impl<ERROR: Display> Display for EvmDatabaseError<ERROR> {
 impl<ERROR: Error> Error for EvmDatabaseError<ERROR> {}
 
 impl<ERROR> EvmDatabaseError<ERROR> {
-    /// Convert BAL database error to database error.
+    /// Convert this wrapper into the external database error.
     ///
-    /// Panics if BAL error is present.
+    /// # Panics
+    ///
+    /// Panics if this value is [`EvmDatabaseError::Bal`], because BAL lookup
+    /// failures are produced by the wrapper layer and cannot be converted back
+    /// into the wrapped database's error type.
     pub fn into_external_error(self) -> ERROR {
         match self {
             Self::Bal(_) => panic!("Expected database error, got BAL error"),

--- a/crates/state/src/account_info.rs
+++ b/crates/state/src/account_info.rs
@@ -7,7 +7,15 @@ use primitives::{B256, KECCAK_EMPTY, U256};
 
 use nonmax::NonMaxU32;
 
-/// Account ID is a custom type that wraps a `NonMaxU32`
+/// Opaque account handle returned by database and BAL lookups.
+///
+/// `AccountId` is a positional index into the account collection that produced
+/// it. It is intended as a fast path for repeated storage access through
+/// `storage_by_account_id` methods, and is only meaningful for the same
+/// database or BAL instance that issued it.
+///
+/// Wraps a [`NonMaxU32`] so that `Option<AccountId>` benefits from niche
+/// optimization.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AccountId(NonMaxU32);


### PR DESCRIPTION
## Summary

- Expands the `EvmDatabaseError` docs in `crates/database/interface/src/bal.rs` to explain when the BAL wrapper reports a BAL miss versus preserving an error from the wrapped database.
- Clarifies that `into_external_error` only succeeds for wrapped database errors and panics for BAL-layer lookup failures.
- Documents `AccountId` as an opaque positional handle issued by a database or BAL instance for `storage_by_account_id` fast paths.

Pure documentation change -- no behavior or API changes.