### PR TITLE
chore: v108 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
 
+# v108
+date: 19.05.2026
+
+Prep for Amsteradam, bal-devnet-7 version (EIP-8037)
+
+* `revm-primitives`: 23.0.0 -> 24.0.0 (⚠ API breaking changes)
+* `revm-bytecode`: 10.0.0 -> 11.0.0 (⚠ API breaking changes)
+* `revm-state`: 11.0.1 -> 12.0.0 (⚠ API breaking changes)
+* `revm-database-interface`: 11.0.1 -> 11.1.0 (✓ API compatible changes)
+* `revm-context-interface`: 17.0.1 -> 18.0.0 (⚠ API breaking changes)
+* `revm-context`: 16.0.1 -> 17.0.0 (⚠ API breaking changes)
+* `revm-database`: 13.0.1 -> 14.0.0 (✓ API compatible changes)
+* `revm-interpreter`: 35.0.1 -> 36.0.0 (⚠ API breaking changes)
+* `revm-precompile`: 34.0.0 -> 35.0.0 (⚠ API breaking changes)
+* `revm-handler`: 18.1.0 -> 19.0.0 (⚠ API breaking changes)
+* `revm-inspector`: 19.0.0 -> 20.0.0 (⚠ API breaking changes)
+* `revm-statetest-types`: 17.0.1 -> 18.0.0 (✓ API compatible changes)
+* `revm`: 38.0.0 -> 39.0.0 (✓ API compatible changes)
+* `revme`: 15.0.0 -> 16.0.0 (✓ API compatible changes)
+
 # v107
 date: 17.04.2026
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3706,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "38.0.1"
+version = "39.0.0"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "13.1.0"
+version = "14.0.0"
 dependencies = [
  "alloy-eips",
  "alloy-provider",
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "revm-statetest-types"
-version = "17.0.2"
+version = "18.0.0"
 dependencies = [
  "alloy-eip7928 0.4.0",
  "k256",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "revme"
-version = "15.0.1"
+version = "16.0.0"
 dependencies = [
  "alloy-rlp",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,16 +41,16 @@ default-members = ["crates/revm"]
 
 [workspace.dependencies]
 # revm
-revm = { path = "crates/revm", version = "38.0.1", default-features = false }
+revm = { path = "crates/revm", version = "39.0.0", default-features = false }
 primitives = { path = "crates/primitives", package = "revm-primitives", version = "24.0.0", default-features = false }
 bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "11.0.0", default-features = false }
-database = { path = "crates/database", package = "revm-database", version = "13.1.0", default-features = false }
+database = { path = "crates/database", package = "revm-database", version = "14.0.0", default-features = false }
 database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "11.1.0", default-features = false }
 state = { path = "crates/state", package = "revm-state", version = "12.0.0", default-features = false }
 interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "36.0.0", default-features = false }
 inspector = { path = "crates/inspector", package = "revm-inspector", version = "20.0.0", default-features = false }
 precompile = { path = "crates/precompile", package = "revm-precompile", version = "35.0.0", default-features = false }
-statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "17.0.2", default-features = false }
+statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "18.0.0", default-features = false }
 context = { path = "crates/context", package = "revm-context", version = "17.0.0", default-features = false }
 context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "18.0.0", default-features = false }
 handler = { path = "crates/handler", package = "revm-handler", version = "19.0.0", default-features = false }

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,4 +1,58 @@
 
+# v108 tag (revm v39.0.0)
+
+### EIP-8037 Amsterdam — bal-devnet-7 ([#3667](https://github.com/bluealloy/revm/pull/3667))
+* `Cfg`, `Host`, `LocalContextTr` gained required `cpsb()`. `LocalContextTr` also gained `set_cpsb`.
+* `InitialAndFloorGas`: `initial_total_gas` / `eip7702_reservoir_refund` removed; `initial_regular_gas` / `state_refund` added.
+* `ResultGas::state_gas_spent` removed — use `state_gas_spent_final`.
+* New struct fields (break literal construction): `LocalContext.cpsb`, `CallInputs.charged_new_account_state_gas`, `CallOutcome.charged_new_account_state_gas`, `PrecompileOutput.refill_amount`.
+* `GasParams` accessors (`sstore_state_gas`, `new_account_state_gas`, `code_deposit_state_gas`, `create_state_gas`, `tx_eip7702_per_empty_account_cost`, `tx_eip7702_auth_refund`, `initial_tx_gas`) each gained one CPSB param. `tx_eip7702_per_auth_state_gas` and `split_eip7702_refund` removed (also dropped from `GasId`).
+* `calculate_initial_tx_gas` 6→7 params; `calculate_initial_tx_gas_for_tx` 2→3; `validate_initial_tx_gas` 5→6; `build_result_gas` 2→3; `apply_auth_list` 4→3; `initial_gas_and_reservoir` 2→3.
+* `Handler::last_frame_result` trait method 2→3 params. `return_create` 5→4 params and 2→1 generics.
+
+### JournalTr restructure ([#3663](https://github.com/bluealloy/revm/pull/3663))
+* New required methods `db_and_state` / `db_and_state_mut` (no default).
+* `JournalExt` now requires `JournalTr` as supertrait and is no longer dyn-compatible. `evm_state` / `evm_state_mut` removed.
+
+### Instructions return `Result` ([#3558](https://github.com/bluealloy/revm/pull/3558))
+* Opcode fns now return `InstructionExecResult` instead of `()`.
+* New `InstructionResult::Suspend` variant (update exhaustive matches).
+* `InstructionResult::is_error` / `InterpreterResult::is_error` deprecated.
+
+### Split instruction & gas tables ([#3561](https://github.com/bluealloy/revm/pull/3561))
+* `Instruction::new` 2→1 param; `Instruction::static_gas` removed.
+* `InstructionProvider` gained required `gas_table(&self) -> &GasTable`.
+* `EthInstructions`: no longer struct-literal constructible (`instruction_table` field removed). `new` 2→3 params; `insert_instruction` 2→3.
+* `Interpreter::step` / `run_plain` / `run_plain_as_output` 2→3 params; `inspect_instructions` 4→5.
+* `interpreter::instruction_table_gas_changes_spec` removed.
+
+### Reservoir in OOG constructors ([#3580](https://github.com/bluealloy/revm/pull/3580))
+* `Gas::new_spent` removed.
+* `InterpreterResult::new_oog`, `CallOutcome::new_oog`, `CreateOutcome::new_oog`, `FrameResult::new_call_oog`, `FrameResult::new_create_oog` each gained a trailing `reservoir` param.
+
+### SpecId cleanup ([#3593](https://github.com/bluealloy/revm/pull/3593), [#3649](https://github.com/bluealloy/revm/pull/3649))
+* `num_enum` dropped — use the manual `TryFrom<u8>`. New `SpecId::NEXT` constant.
+* Variants removed: `FRONTIER_THAWING`, `DAO_FORK`, `CONSTANTINOPLE`, `MUIR_GLACIER`, `ARROW_GLACIER`, `GRAY_GLACIER` (with their `name::*` consts).
+* Discriminants of the remaining variants shifted (e.g. `HOMESTEAD` 2→1, `AMSTERDAM` 20→14) — fix any `as u8` / pointer-cast usage.
+
+### `op-revm` removed ([#3568](https://github.com/bluealloy/revm/pull/3568))
+Moved to `ethereum-optimism/optimism` (`rust/op-revm`). Update dependency paths.
+
+### Other
+* `Bytecode::new_analyzed` is now `unsafe` ([#3557](https://github.com/bluealloy/revm/pull/3557)) — no PUSH-padding validation.
+* `OpCode::new_unchecked` deprecated ([#3566](https://github.com/bluealloy/revm/pull/3566)).
+* `BalError` ([#3619](https://github.com/bluealloy/revm/pull/3619)): `AccountNotFound` / `SlotNotFound` are now struct variants; new `InvalidAccountId` variant; discriminants no longer stable.
+* `StorageBal::get` 2→3 params; `get_bal_writes` 1→2.
+* `Account.original_info` pub field removed (now private — use accessors) ([#3590](https://github.com/bluealloy/revm/pull/3590)).
+* `MemoryTr::limit_reached` 2→1 param ([#3599](https://github.com/bluealloy/revm/pull/3599)).
+* CALL handlers unified ([#3626](https://github.com/bluealloy/revm/pull/3626)): `contract::call_code` / `delegate_call` / `static_call` removed — use `contract::call::<KIND, _, _>`. `contract::create` swapped const-generic / type-generic order.
+* `MemoryExtensionResult` enum removed ([#3646](https://github.com/bluealloy/revm/pull/3646)).
+* Removed: `Stack::pop_unsafe`, `Stack::top_unsafe`, `Interpreter::step_dummy`.
+* Macros removed: `resize_memory!`, `as_usize_or_fail_ret!`, `as_isize_saturated!`, `berlin_load_account!`.
+* `LoadError` variant discriminants swapped (`DBError` 0→1, `ColdLoadSkipped` 1→0).
+* `GasParams::get` and `log_cost` no longer `const fn` ([#3608](https://github.com/bluealloy/revm/pull/3608)).
+* `revm_precompile::blake2::algo` module + `SIGMA` / `IV` consts removed ([#3609](https://github.com/bluealloy/revm/pull/3609)).
+
 # v107 tag (revm v38.0.0)
 
 * `Handler::first_frame_input` ([#3578](https://github.com/bluealloy/revm/pull/3578)): `init_and_floor_gas: &InitialAndFloorGas` param replaced by `reservoir: u64`. Compute via `InitialAndFloorGas::initial_gas_and_reservoir(tx_gas_limit, tx_gas_limit_cap, is_eip8037) -> (gas_limit, reservoir)`.

--- a/bins/revme/CHANGELOG.md
+++ b/bins/revme/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [15.0.1](https://github.com/bluealloy/revm/compare/revme-v15.0.0...revme-v15.0.1) - 2026-05-19
+## [16.0.0](https://github.com/bluealloy/revm/compare/revme-v15.0.0...revme-v16.0.0) - 2026-05-19
 
 ### Other
 

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revme"
 description = "Rust Ethereum Virtual Machine Executable"
-version = "15.0.1"
+version = "16.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/database/CHANGELOG.md
+++ b/crates/database/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [13.1.0](https://github.com/bluealloy/revm/compare/revm-database-v13.0.1...revm-database-v13.1.0) - 2026-05-19
+## [14.0.0](https://github.com/bluealloy/revm/compare/revm-database-v13.0.1...revm-database-v14.0.0) - 2026-05-19
 
 ### Added
 

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-database"
 description = "Revm Database implementations"
-version = "13.1.0"
+version = "14.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/revm/CHANGELOG.md
+++ b/crates/revm/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [38.0.1](https://github.com/bluealloy/revm/compare/revm-v38.0.0...revm-v38.0.1) - 2026-05-19
+## [39.0.0](https://github.com/bluealloy/revm/compare/revm-v38.0.0...revm-v39.0.0) - 2026-05-19
 
 ### Other
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm"
 description = "Revm - Rust Ethereum Virtual Machine"
-version = "38.0.1"
+version = "39.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/statetest-types/CHANGELOG.md
+++ b/crates/statetest-types/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [17.0.2](https://github.com/bluealloy/revm/compare/revm-statetest-types-v17.0.1...revm-statetest-types-v17.0.2) - 2026-05-19
+## [18.0.0](https://github.com/bluealloy/revm/compare/revm-statetest-types-v17.0.1...revm-statetest-types-v18.0.0) - 2026-05-19
 
 ### Other
 

--- a/crates/statetest-types/Cargo.toml
+++ b/crates/statetest-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-statetest-types"
 description = "Statetest types for revme"
-version = "17.0.2"
+version = "18.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
## Summary

- Bump crate versions for the v108 (revm v39.0.0) release, prepping for Amsterdam bal-devnet-7 (EIP-8037).
- Add v108 entry to `CHANGELOG.md` and a condensed v108 breaking-changes section to `MIGRATION_GUIDE.md` (sourced from the `cargo-semver-checks` report on #3679).

Crate bumps:
- `revm-primitives` 23.0.0 → 24.0.0 (⚠)
- `revm-bytecode` 10.0.0 → 11.0.0 (⚠)
- `revm-state` 11.0.1 → 12.0.0 (⚠)
- `revm-database-interface` 11.0.1 → 11.1.0
- `revm-context-interface` 17.0.1 → 18.0.0 (⚠)
- `revm-context` 16.0.1 → 17.0.0 (⚠)
- `revm-database` 13.0.1 → 14.0.0
- `revm-interpreter` 35.0.1 → 36.0.0 (⚠)
- `revm-precompile` 34.0.0 → 35.0.0 (⚠)
- `revm-handler` 18.1.0 → 19.0.0 (⚠)
- `revm-inspector` 19.0.0 → 20.0.0 (⚠)
- `revm-statetest-types` 17.0.1 → 18.0.0
- `revm` 38.0.0 → 39.0.0
- `revme` 15.0.0 → 16.0.0

## Test plan

- [ ] `cargo build --workspace`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo fmt --all --check`
- [ ] Spot-check MIGRATION_GUIDE.md renders cleanly on GitHub