### PR TITLE
chore: v109 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
 
+# v109
+date: 20.05.2026
+
+Bump revm-database-interface major version. All dependent crates bumped accordingly.
+
+* `revm-database-interface`: 11.1.0 -> 12.0.0 (⚠ API breaking changes)
+* `revm-context-interface`: 18.0.0 -> 19.0.0 (⚠ dependency bump)
+* `revm-database`: 14.0.0 -> 15.0.0 (⚠ dependency bump)
+* `revm-context`: 17.0.0 -> 18.0.0 (⚠ dependency bump)
+* `revm-interpreter`: 36.0.0 -> 37.0.0 (⚠ dependency bump)
+* `revm-precompile`: 35.0.0 -> 36.0.0 (⚠ dependency bump)
+* `revm-handler`: 19.0.0 -> 20.0.0 (⚠ dependency bump)
+* `revm-inspector`: 20.0.0 -> 21.0.0 (⚠ dependency bump)
+* `revm-statetest-types`: 18.0.0 -> 19.0.0 (⚠ dependency bump)
+* `revm`: 39.0.0 -> 40.0.0 (⚠ dependency bump)
+* `revm-ee-tests`: 0.2.0 -> 0.3.0 (⚠ dependency bump)
+* `revme`: 16.0.0 -> 17.0.0 (⚠ dependency bump)
+
 # v108
 date: 19.05.2026
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3706,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "39.0.0"
+version = "40.0.0"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "18.0.0"
+version = "19.0.0"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "14.0.0"
+version = "15.0.0"
 dependencies = [
  "alloy-eips",
  "alloy-provider",
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "11.1.0"
+version = "12.0.0"
 dependencies = [
  "auto_impl",
  "either",
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "revm-ee-tests"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "insta",
  "revm",
@@ -3807,7 +3807,7 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "alloy-signer",
  "alloy-signer-local",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "20.0.0"
+version = "21.0.0"
 dependencies = [
  "auto_impl",
  "either",
@@ -3844,7 +3844,7 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "revm-statetest-types"
-version = "18.0.0"
+version = "19.0.0"
 dependencies = [
  "alloy-eip7928 0.4.0",
  "k256",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "revme"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "alloy-rlp",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,20 +41,20 @@ default-members = ["crates/revm"]
 
 [workspace.dependencies]
 # revm
-revm = { path = "crates/revm", version = "39.0.0", default-features = false }
+revm = { path = "crates/revm", version = "40.0.0", default-features = false }
 primitives = { path = "crates/primitives", package = "revm-primitives", version = "24.0.0", default-features = false }
 bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "11.0.0", default-features = false }
-database = { path = "crates/database", package = "revm-database", version = "14.0.0", default-features = false }
-database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "11.1.0", default-features = false }
+database = { path = "crates/database", package = "revm-database", version = "15.0.0", default-features = false }
+database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "12.0.0", default-features = false }
 state = { path = "crates/state", package = "revm-state", version = "12.0.0", default-features = false }
-interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "36.0.0", default-features = false }
-inspector = { path = "crates/inspector", package = "revm-inspector", version = "20.0.0", default-features = false }
-precompile = { path = "crates/precompile", package = "revm-precompile", version = "35.0.0", default-features = false }
-statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "18.0.0", default-features = false }
-context = { path = "crates/context", package = "revm-context", version = "17.0.0", default-features = false }
-context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "18.0.0", default-features = false }
-handler = { path = "crates/handler", package = "revm-handler", version = "19.0.0", default-features = false }
-ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "0.2.0", default-features = false }
+interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "37.0.0", default-features = false }
+inspector = { path = "crates/inspector", package = "revm-inspector", version = "21.0.0", default-features = false }
+precompile = { path = "crates/precompile", package = "revm-precompile", version = "36.0.0", default-features = false }
+statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "19.0.0", default-features = false }
+context = { path = "crates/context", package = "revm-context", version = "18.0.0", default-features = false }
+context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "19.0.0", default-features = false }
+handler = { path = "crates/handler", package = "revm-handler", version = "20.0.0", default-features = false }
+ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "0.3.0", default-features = false }
 
 # alloy
 alloy-eip2930 = { version = "0.2.3", default-features = false }

--- a/bins/revme/CHANGELOG.md
+++ b/bins/revme/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [16.0.0](https://github.com/bluealloy/revm/compare/revme-v15.0.0...revme-v16.0.0) - 2026-05-19
+## [17.0.0](https://github.com/bluealloy/revm/compare/revme-v15.0.0...revme-v17.0.0) - 2026-05-19
 
 ### Other
 

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revme"
 description = "Rust Ethereum Virtual Machine Executable"
-version = "16.0.0"
+version = "17.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/context/CHANGELOG.md
+++ b/crates/context/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [17.0.0](https://github.com/bluealloy/revm/compare/revm-context-v16.0.1...revm-context-v17.0.0) - 2026-05-19
+## [18.0.0](https://github.com/bluealloy/revm/compare/revm-context-v16.0.1...revm-context-v18.0.0) - 2026-05-19
 
 ### Added
 

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-context"
 description = "Revm context crates"
-version = "17.0.0"
+version = "18.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/context/interface/CHANGELOG.md
+++ b/crates/context/interface/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [18.0.0](https://github.com/bluealloy/revm/compare/revm-context-interface-v17.0.1...revm-context-interface-v18.0.0) - 2026-05-19
+## [19.0.0](https://github.com/bluealloy/revm/compare/revm-context-interface-v17.0.1...revm-context-interface-v19.0.0) - 2026-05-19
 
 ### Added
 

--- a/crates/context/interface/Cargo.toml
+++ b/crates/context/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-context-interface"
 description = "Revm context interface crates"
-version = "18.0.0"
+version = "19.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/database/CHANGELOG.md
+++ b/crates/database/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [14.0.0](https://github.com/bluealloy/revm/compare/revm-database-v13.0.1...revm-database-v14.0.0) - 2026-05-19
+## [15.0.0](https://github.com/bluealloy/revm/compare/revm-database-v13.0.1...revm-database-v15.0.0) - 2026-05-19
 
 ### Added
 

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-database"
 description = "Revm Database implementations"
-version = "14.0.0"
+version = "15.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/database/interface/CHANGELOG.md
+++ b/crates/database/interface/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.1.0](https://github.com/bluealloy/revm/compare/revm-database-interface-v11.0.1...revm-database-interface-v11.1.0) - 2026-05-19
+## [12.0.0](https://github.com/bluealloy/revm/compare/revm-database-interface-v11.0.1...revm-database-interface-v12.0.0) - 2026-05-19
 
 ### Added
 

--- a/crates/database/interface/Cargo.toml
+++ b/crates/database/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-database-interface"
 description = "Revm Database interface"
-version = "11.1.0"
+version = "12.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/ee-tests/CHANGELOG.md
+++ b/crates/ee-tests/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0](https://github.com/bluealloy/revm/compare/revm-ee-tests-v0.1.0...revm-ee-tests-v0.2.0) - 2026-03-04
+## [0.3.0](https://github.com/bluealloy/revm/compare/revm-ee-tests-v0.1.0...revm-ee-tests-v0.3.0) - 2026-03-04
 
 ### Other
 

--- a/crates/ee-tests/Cargo.toml
+++ b/crates/ee-tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-ee-tests"
 description = "Common test utilities for REVM crates"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/handler/CHANGELOG.md
+++ b/crates/handler/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [19.0.0](https://github.com/bluealloy/revm/compare/revm-handler-v18.1.0...revm-handler-v19.0.0) - 2026-05-19
+## [20.0.0](https://github.com/bluealloy/revm/compare/revm-handler-v18.1.0...revm-handler-v20.0.0) - 2026-05-19
 
 ### Added
 

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-handler"
 description = "Revm handler crates"
-version = "19.0.0"
+version = "20.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/inspector/CHANGELOG.md
+++ b/crates/inspector/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [20.0.0](https://github.com/bluealloy/revm/compare/revm-inspector-v19.0.0...revm-inspector-v20.0.0) - 2026-05-19
+## [21.0.0](https://github.com/bluealloy/revm/compare/revm-inspector-v19.0.0...revm-inspector-v21.0.0) - 2026-05-19
 
 ### Added
 

--- a/crates/inspector/Cargo.toml
+++ b/crates/inspector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-inspector"
 description = "Revm inspector interface"
-version = "20.0.0"
+version = "21.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [36.0.0](https://github.com/bluealloy/revm/compare/revm-interpreter-v35.0.1...revm-interpreter-v36.0.0) - 2026-05-19
+## [37.0.0](https://github.com/bluealloy/revm/compare/revm-interpreter-v35.0.1...revm-interpreter-v37.0.0) - 2026-05-19
 
 ### Added
 

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-interpreter"
 description = "Revm Interpreter that executes bytecode."
-version = "36.0.0"
+version = "37.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/precompile/CHANGELOG.md
+++ b/crates/precompile/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [35.0.0](https://github.com/bluealloy/revm/compare/revm-precompile-v34.0.0...revm-precompile-v35.0.0) - 2026-05-19
+## [36.0.0](https://github.com/bluealloy/revm/compare/revm-precompile-v34.0.0...revm-precompile-v36.0.0) - 2026-05-19
 
 ### Added
 

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-precompile"
 description = "Revm Precompiles - Ethereum compatible precompiled contracts"
-version = "35.0.0"
+version = "36.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/revm/CHANGELOG.md
+++ b/crates/revm/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [39.0.0](https://github.com/bluealloy/revm/compare/revm-v38.0.0...revm-v39.0.0) - 2026-05-19
+## [40.0.0](https://github.com/bluealloy/revm/compare/revm-v38.0.0...revm-v40.0.0) - 2026-05-19
 
 ### Other
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm"
 description = "Revm - Rust Ethereum Virtual Machine"
-version = "39.0.0"
+version = "40.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/statetest-types/CHANGELOG.md
+++ b/crates/statetest-types/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [18.0.0](https://github.com/bluealloy/revm/compare/revm-statetest-types-v17.0.1...revm-statetest-types-v18.0.0) - 2026-05-19
+## [19.0.0](https://github.com/bluealloy/revm/compare/revm-statetest-types-v17.0.1...revm-statetest-types-v19.0.0) - 2026-05-19
 
 ### Other
 

--- a/crates/statetest-types/Cargo.toml
+++ b/crates/statetest-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-statetest-types"
 description = "Statetest types for revme"
-version = "18.0.0"
+version = "19.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
## Summary
- Bump `revm-database-interface` 11.1.0 → 12.0.0 (major) and cascade major bumps to all transitively dependent libraries.
- Follow the v105 precedent for a database-interface major bump.

## Version bumps
- `revm-database-interface`: 11.1.0 → 12.0.0 (⚠ API breaking changes)
- `revm-context-interface`: 18.0.0 → 19.0.0 (⚠ dependency bump)
- `revm-database`: 14.0.0 → 15.0.0 (⚠ dependency bump)
- `revm-context`: 17.0.0 → 18.0.0 (⚠ dependency bump)
- `revm-interpreter`: 36.0.0 → 37.0.0 (⚠ dependency bump)
- `revm-precompile`: 35.0.0 → 36.0.0 (⚠ dependency bump)
- `revm-handler`: 19.0.0 → 20.0.0 (⚠ dependency bump)
- `revm-inspector`: 20.0.0 → 21.0.0 (⚠ dependency bump)
- `revm-statetest-types`: 18.0.0 → 19.0.0 (⚠ dependency bump)
- `revm`: 39.0.0 → 40.0.0 (⚠ dependency bump)
- `revm-ee-tests`: 0.2.0 → 0.3.0 (⚠ dependency bump)
- `revme`: 16.0.0 → 17.0.0 (⚠ dependency bump)

## Test plan
- [x] `cargo check --workspace` passes
- [ ] CI green