### PR TITLE
docs(api): clarify replay uses current context tx

### DIFF
--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -42,10 +42,10 @@ And [`Context`](https://docs.rs/revm-context/latest/revm_context/context/struct.
 
 REVM provides four ways to execute transactions through traits (API):
 
-* `transact(tx)` and `replay()` are functions of [`ExecuteEvm`](https://docs.rs/revm-handler/latest/revm_handler/api/trait.ExecuteEvm.html) trait that allow execution transactions. They return the status of execution with reason, changed state and in case of failed execution an error.
+* `transact(tx)` and `replay()` are functions of [`ExecuteEvm`](https://docs.rs/revm-handler/latest/revm_handler/api/trait.ExecuteEvm.html) trait that allow transaction execution with finalized state output. `replay()` executes the transaction currently stored in context (`ctx.tx()`), while `transact(tx)` executes the provided transaction argument.
 * `transact_commit(tx)` and `replay_commit()` are part of [`ExecuteCommitEvm`](https://docs.rs/revm-handler/latest/revm_handler/api/trait.ExecuteCommitEvm.html) that internally commits the state diff to the database and returns status of execution. Database is required to support `DatabaseCommit` trait.
-* `inspect()`, `inspect_replay(tx)` and a few others are part of [`InspectEvm`](https://docs.rs/revm-inspector/latest/revm_inspector/trait.InspectEvm.html) trait that allow execution with inspection. This is how tracers are called.
-* `inspect_commit()`, `inspect_replay_commit(tx)` are part of the [`InspectCommitEvm`](https://docs.rs/revm-inspector/latest/revm_inspector/trait.InspectCommitEvm.html) trait that extends `InspectEvm` to allow committing state diff after tracing.
+* `inspect_tx(tx)`, `inspect(tx, inspector)`, and related helpers are part of [`InspectEvm`](https://docs.rs/revm-inspector/latest/revm_inspector/trait.InspectEvm.html) trait that allow execution with inspection. This is how tracers are called.
+* `inspect_tx_commit(tx)` and `inspect_commit(tx, inspector)` are part of the [`InspectCommitEvm`](https://docs.rs/revm-inspector/latest/revm_inspector/trait.InspectCommitEvm.html) trait that extends `InspectEvm` to allow committing state diff after tracing.
 
 For inspection API to be enabled, [`Evm`](https://docs.rs/revm-context/1.0.0/revm_context/evm/struct.Evm.html) needs to be created with inspector.
 

--- a/crates/handler/src/api.rs
+++ b/crates/handler/src/api.rs
@@ -118,7 +118,12 @@ pub trait ExecuteEvm {
         Ok(ExecResultAndState::new(result, state))
     }
 
-    /// Execute previous transaction and finalize it.
+    /// Execute the transaction currently stored in context and finalize it.
+    ///
+    /// This method does not pull a "previous transaction" from history.
+    /// It re-runs the transaction that is currently present in `ctx.tx()`.
+    /// If another API (for example a system call helper) overwrote `ctx.tx()`,
+    /// `replay` will execute that updated transaction.
     fn replay(
         &mut self,
     ) -> Result<ExecResultAndState<Self::ExecutionResult, Self::State>, Self::Error>;
@@ -159,7 +164,7 @@ pub trait ExecuteCommitEvm: ExecuteEvm {
         Ok(outputs)
     }
 
-    /// Replay the transaction and commit to the state.
+    /// Replay the transaction currently stored in context and commit to the state.
     ///
     /// Internally calls `replay` and `commit` functions.
     #[inline]

--- a/crates/inspector/src/inspect.rs
+++ b/crates/inspector/src/inspect.rs
@@ -57,7 +57,7 @@ pub trait InspectEvm: ExecuteEvm {
 ///
 /// Functions return CommitOutput from [`ExecuteCommitEvm`] trait.
 pub trait InspectCommitEvm: InspectEvm + ExecuteCommitEvm {
-    /// Inspect the EVM with the current inspector and previous transaction by replaying, similar to [`InspectEvm::inspect_tx`]
+    /// Inspect the EVM with the current inspector and given transaction, similar to [`InspectEvm::inspect_tx`]
     /// and commit the state diff to the database.
     fn inspect_tx_commit(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
         let output = self.inspect_one_tx(tx)?;


### PR DESCRIPTION
This change aligns replay-related API docs with runtime behavior, clarifying that replay executes the transaction currently stored in context.