### PR TITLE
feat(eip8038): implement state-access gas cost update

### DIFF
--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use core::hash::{Hash, Hasher};
 use primitives::{
-    eip7702, eip8037,
+    eip7702, eip8037, eip8038,
     hardfork::SpecId::{self},
     OnceLock, U256,
 };
@@ -364,6 +364,64 @@ impl GasParams {
             table[GasId::tx_access_list_storage_key_cost().as_usize()] =
                 gas::ACCESS_LIST_STORAGE_KEY + 32 * 64;
             table[GasId::tx_access_list_floor_byte_multiplier().as_usize()] = 4;
+
+            // EIP-8038: State-access gas cost update. All TBD parameters are
+            // set to `previous_value + 1` per the user-supplied rule.
+            //   WARM_ACCESS                  100 -> 101
+            //   COLD_ACCOUNT_ACCESS        2,600 -> 2,601
+            //   ACCOUNT_WRITE              6,700 -> 6,701
+            //   COLD_STORAGE_ACCESS        2,100 -> 2,101
+            //   STORAGE_WRITE              2,800 -> 2,801
+            //   STORAGE_CLEAR_REFUND       4,800 -> 4,801
+            //   CREATE_ACCESS              7,000 -> 7,001
+            //   ACCESS_LIST_ADDRESS_COST   2,400 -> 2,401
+            //   ACCESS_LIST_STORAGE_KEY_COST 1,900 -> 1,901
+            //
+            // Account access table values.
+            table[GasId::warm_storage_read_cost().as_usize()] = eip8038::WARM_ACCESS;
+            table[GasId::cold_account_additional_cost().as_usize()] =
+                eip8038::COLD_ACCOUNT_ACCESS_ADDITIONAL;
+            table[GasId::cold_storage_additional_cost().as_usize()] =
+                eip8038::COLD_STORAGE_ACCESS_ADDITIONAL;
+            table[GasId::cold_storage_cost().as_usize()] = eip8038::COLD_STORAGE_ACCESS;
+            // CALL_VALUE = ACCOUNT_WRITE + CALL_STIPEND.
+            table[GasId::transfer_value_cost().as_usize()] = eip8038::CALL_VALUE;
+            // ACCOUNT_WRITE surcharge for first-time writes to an account: CALL
+            // to empty account, SELFDESTRUCT sending balance to empty account.
+            // Under EIP-8037 these were zeroed out (cost moved to state gas);
+            // EIP-8038 reintroduces a regular-gas surcharge.
+            table[GasId::new_account_cost().as_usize()] = eip8038::ACCOUNT_WRITE;
+            table[GasId::new_account_cost_for_selfdestruct().as_usize()] = eip8038::ACCOUNT_WRITE;
+
+            // SSTORE table values.
+            //   warm-base       = WARM_ACCESS         (sstore_static)
+            //   write surcharge = STORAGE_WRITE       (sstore_set / sstore_reset dynamic)
+            //   refunds         = STORAGE_WRITE / STORAGE_CLEAR_REFUND
+            table[GasId::sstore_static().as_usize()] = eip8038::WARM_ACCESS;
+            table[GasId::sstore_set_without_load_cost().as_usize()] = eip8038::STORAGE_WRITE;
+            table[GasId::sstore_reset_without_cold_load_cost().as_usize()] = eip8038::STORAGE_WRITE;
+            table[GasId::sstore_set_refund().as_usize()] = eip8038::STORAGE_WRITE;
+            table[GasId::sstore_reset_refund().as_usize()] = eip8038::STORAGE_WRITE;
+            table[GasId::sstore_clearing_slot_refund().as_usize()] = eip8038::STORAGE_CLEAR_REFUND;
+
+            // CREATE / CREATE2 regular-gas access cost.
+            //   `create` slot is the regular-gas portion charged at the
+            //   CREATE/CREATE2 opcodes and for create-kind txns.
+            table[GasId::create().as_usize()] = eip8038::CREATE_ACCESS;
+            table[GasId::tx_create_cost().as_usize()] = eip8038::CREATE_ACCESS;
+
+            // Access-list per-item costs: bump the base by +1 each, keeping the
+            // EIP-7981 64 gas/byte data charge on top.
+            table[GasId::tx_access_list_address_cost().as_usize()] =
+                eip8038::ACCESS_LIST_ADDRESS_COST + 20 * 64;
+            table[GasId::tx_access_list_storage_key_cost().as_usize()] =
+                eip8038::ACCESS_LIST_STORAGE_KEY_COST + 32 * 64;
+
+            // EIP-7702: regular-gas portion of the per-auth cost shifts with
+            // ACCOUNT_WRITE / COLD_ACCOUNT_ACCESS / WARM_ACCESS (see
+            // [`eip8038::EIP7702_PER_EMPTY_ACCOUNT_REGULAR`]).
+            table[GasId::tx_eip7702_per_empty_account_cost().as_usize()] =
+                eip8038::EIP7702_PER_EMPTY_ACCOUNT_REGULAR;
         }
 
         Self::new(Arc::new(table))
@@ -1604,13 +1662,15 @@ mod tests {
     fn test_eip7981_access_list_cost_amsterdam() {
         // EIP-7981 folds a 64 gas/byte data charge into the per-item access-list cost
         // and adds 4 floor tokens per access-list byte on top of the EIP-7976 floor.
+        // EIP-8038 bumps the per-item base by +1 (ACCESS_LIST_ADDRESS_COST 2400 ->
+        // 2401, ACCESS_LIST_STORAGE_KEY_COST 1900 -> 1901).
         let params = GasParams::new_spec(SpecId::AMSTERDAM);
 
         // Per-item intrinsic cost: base + bytes * 64
-        assert_eq!(params.tx_access_list_address_cost(), 2400 + 20 * 64);
-        assert_eq!(params.tx_access_list_storage_key_cost(), 1900 + 32 * 64);
-        assert_eq!(params.tx_access_list_cost(1, 0), 2400 + 20 * 64);
-        assert_eq!(params.tx_access_list_cost(0, 1), 1900 + 32 * 64);
+        assert_eq!(params.tx_access_list_address_cost(), 2401 + 20 * 64);
+        assert_eq!(params.tx_access_list_storage_key_cost(), 1901 + 32 * 64);
+        assert_eq!(params.tx_access_list_cost(1, 0), 2401 + 20 * 64);
+        assert_eq!(params.tx_access_list_cost(0, 1), 1901 + 32 * 64);
 
         // Floor multiplier activates at AMSTERDAM.
         assert_eq!(params.tx_access_list_floor_byte_multiplier(), 4);

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_block_gas_limit_enforced_with_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_block_gas_limit_enforced_with_state_gas.snap
@@ -6,7 +6,7 @@ expression: "&result_fits"
   "Success": {
     "reason": "Stop",
     "gas": {
-      "gas_spent": 226006,
+      "gas_spent": 226009,
       "state_gas_spent": 200000,
       "gas_refunded": 0,
       "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_propagates.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_propagates.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 35525,
+        "gas_spent": 33530,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 571531,
+        "gas_spent": 569536,
         "state_gas_spent": 536000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_reverts.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_reverts.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 35747,
+        "gas_spent": 33752,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 375753,
+        "gas_spent": 373758,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_existing_account.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_existing_account.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 27822,
+        "gas_spent": 27824,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -32,7 +32,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 27822,
+        "gas_spent": 27824,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 30322,
+        "gas_spent": 37025,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -32,7 +32,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 280322,
+        "gas_spent": 287025,
         "state_gas_spent": 250000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account_no_value.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account_no_value.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 23622,
+        "gas_spent": 23623,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 23622,
+        "gas_spent": 23623,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create2_with_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create2_with_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 30079,
+        "gas_spent": 28080,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 370085,
+        "gas_spent": 368086,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -37,7 +37,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 370076,
+        "gas_spent": 368077,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_child_propagates.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_child_propagates.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 35121,
+        "gas_spent": 33125,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 566127,
+        "gas_spent": 564131,
         "state_gas_spent": 531000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_code_deposit_state_gas_oog.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_code_deposit_state_gas_oog.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, baseline_tight_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 30079,
+        "gas_spent": 28080,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, baseline_tight_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 30079,
+        "gas_spent": 28080,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -39,7 +39,7 @@ expression: "&(baseline_result, baseline_tight_result, result)"
         "OutOfGas": "Basic"
       },
       "gas": {
-        "gas_spent": 30080,
+        "gas_spent": 28081,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_empty_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_empty_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 30067,
+        "gas_spent": 28068,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 360067,
+        "gas_spent": 358068,
         "state_gas_spent": 330000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_large_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_large_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 30088,
+        "gas_spent": 28089,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 560130,
+        "gas_spent": 558131,
         "state_gas_spent": 530000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 30070,
+        "gas_spent": 28071,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 370076,
+        "gas_spent": 368077,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_sstore.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 35121,
+        "gas_spent": 33125,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 566127,
+        "gas_spent": 564131,
         "state_gas_spent": 531000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_nested_call_create_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_nested_call_create_sstore.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 35525,
+        "gas_spent": 33530,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 571531,
+        "gas_spent": 569536,
         "state_gas_spent": 536000,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -37,7 +37,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 366076,
+        "gas_spent": 364077,
         "state_gas_spent": 336000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_parent_sstore_after_child_revert.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_parent_sstore_after_child_revert.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 40753,
+        "gas_spent": 38761,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 580759,
+        "gas_spent": 578767,
         "state_gas_spent": 540000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_precompile_no_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_precompile_no_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 21137,
+        "gas_spent": 21138,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 21137,
+        "gas_spent": 21138,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_causes_oog.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_causes_oog.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_sufficient.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_sufficient.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226006,
+        "gas_spent": 226009,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_state_gas_less.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_state_gas_less.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_vs_revert_difference.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_vs_revert_difference.snap
@@ -20,7 +20,7 @@ expression: "&(result_halt, result_revert)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 26012,
+        "gas_spent": 26015,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_less.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_less.snap
@@ -6,7 +6,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 26012,
+        "gas_spent": 26015,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -18,7 +18,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 26012,
+        "gas_spent": 26015,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_more.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_more.snap
@@ -6,7 +6,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 31018,
+        "gas_spent": 31024,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -18,7 +18,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 31018,
+        "gas_spent": 31024,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reverted_create_child.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reverted_create_child.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 35118,
+        "gas_spent": 33122,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 35118,
+        "gas_spent": 33122,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_selfdestruct_new_account.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_selfdestruct_new_account.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "SelfDestruct",
       "gas": {
-        "gas_spent": 28603,
+        "gas_spent": 35305,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -32,7 +32,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "SelfDestruct",
       "gas": {
-        "gas_spent": 278603,
+        "gas_spent": 285305,
         "state_gas_spent": 250000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_multiple_new_slots.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_multiple_new_slots.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 36018,
+        "gas_spent": 36027,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 636018,
+        "gas_spent": 636027,
         "state_gas_spent": 600000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_new_slot.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_new_slot.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226006,
+        "gas_spent": 226009,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_overwrite_no_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_overwrite_no_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26112,
+        "gas_spent": 26116,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226112,
+        "gas_spent": 226116,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_set_then_clear_refund.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_set_then_clear_refund.snap
@@ -7,9 +7,9 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26112,
+        "gas_spent": 26116,
         "state_gas_spent": 0,
-        "gas_refunded": 2800,
+        "gas_refunded": 2801,
         "floor_gas": 21000
       },
       "logs": [],
@@ -22,9 +22,9 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26112,
+        "gas_spent": 26116,
         "state_gas_spent": 0,
-        "gas_refunded": 2800,
+        "gas_refunded": 2801,
         "floor_gas": 21000
       },
       "logs": [],

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_zero_to_zero_no_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_zero_to_zero_no_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 23206,
+        "gas_spent": 23208,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 23206,
+        "gas_spent": 23208,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_does_not_reduce_regular_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_does_not_reduce_regular_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226006,
+        "gas_spent": 226009,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_oog_remaining.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_oog_remaining.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_spent_final_in_result.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_spent_final_in_result.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226006,
+        "gas_spent": 226009,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_selfdestruct_after_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_selfdestruct_after_sstore.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Return",
       "gas": {
-        "gas_spent": 40431,
+        "gas_spent": 38435,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 22728
@@ -25,7 +25,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Return",
       "gas": {
-        "gas_spent": 240551,
+        "gas_spent": 238555,
         "state_gas_spent": 200120,
         "gas_refunded": 0,
         "floor_gas": 22728

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_limit_cap_not_enforced_with_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_limit_cap_not_enforced_with_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226006,
+        "gas_spent": 226009,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/interpreter/src/instructions.rs
+++ b/crates/interpreter/src/instructions.rs
@@ -125,6 +125,25 @@ pub const fn gas_table_spec(spec: SpecId) -> GasTable {
         table[STATICCALL as usize] = gas::WARM_STORAGE_READ_COST as u16;
     }
 
+    if spec.is_enabled_in(AMSTERDAM) {
+        // EIP-8038: bump every warm/cold access base from 100 to 101.
+        // SLOAD / *CALL / BALANCE / EXTCODEHASH: a single WARM_ACCESS.
+        let warm = primitives::eip8038::WARM_ACCESS as u16;
+        table[SLOAD as usize] = warm;
+        table[BALANCE as usize] = warm;
+        table[EXTCODEHASH as usize] = warm;
+        table[CALL as usize] = warm;
+        table[CALLCODE as usize] = warm;
+        table[DELEGATECALL as usize] = warm;
+        table[STATICCALL as usize] = warm;
+        // EIP-8038 §"EXT* family update": EXTCODESIZE and EXTCODECOPY do two
+        // database reads, so the per-call access cost is `WARM_ACCESS` above
+        // the regular access cost. Bake the extra WARM_ACCESS into the static
+        // base; the dynamic cold premium is still added by `load_account`.
+        table[EXTCODESIZE as usize] = warm + warm;
+        table[EXTCODECOPY as usize] = warm + warm;
+    }
+
     table
 }
 

--- a/crates/primitives/src/eip8038.rs
+++ b/crates/primitives/src/eip8038.rs
@@ -1,0 +1,60 @@
+//! EIP-8038: State-Access Gas Cost Update
+//!
+//! Increases the gas cost of state-access operations to reflect Ethereum's
+//! larger state. All "TBD" values in the draft spec are filled in here as
+//! `previous_value + 1`.
+//!
+//! Active alongside EIP-7904 and EIP-8037 starting at the Amsterdam hardfork.
+
+/// Cold touch of an account (was 2,600 pre-EIP-8038).
+pub const COLD_ACCOUNT_ACCESS: u64 = 2_601;
+
+/// Surcharge for writing to an account that changes one account leaf value for
+/// the first time (was 6,700 pre-EIP-8038).
+pub const ACCOUNT_WRITE: u64 = 6_701;
+
+/// Cold touch of a storage slot (was 2,100 pre-EIP-8038).
+pub const COLD_STORAGE_ACCESS: u64 = 2_101;
+
+/// Surcharge for writing to a storage slot that changes its value for the
+/// first time (was 2,800 pre-EIP-8038).
+pub const STORAGE_WRITE: u64 = 2_801;
+
+/// Touch of an already-warm account or storage slot (was 100 pre-EIP-8038).
+pub const WARM_ACCESS: u64 = 101;
+
+/// Refund for clearing a storage slot (was 4,800 pre-EIP-8038).
+pub const STORAGE_CLEAR_REFUND: u64 = 4_801;
+
+/// State access cost for contract deployment (was 7,000 pre-EIP-8038).
+///
+/// Note: the spec also defines `CREATE_ACCESS = ACCOUNT_WRITE + COLD_STORAGE_ACCESS`,
+/// which does not exactly match the legacy decomposition. Per the user-supplied
+/// rule we keep this slot at the literal `previous + 1` value rather than the
+/// derived sum.
+pub const CREATE_ACCESS: u64 = 7_001;
+
+/// Gas charged per storage key included in a transaction's access list
+/// (was 1,900 pre-EIP-8038).
+pub const ACCESS_LIST_STORAGE_KEY_COST: u64 = 1_901;
+
+/// Gas charged per address included in a transaction's access list
+/// (was 2,400 pre-EIP-8038).
+pub const ACCESS_LIST_ADDRESS_COST: u64 = 2_401;
+
+/// Cold premium on top of `WARM_ACCESS` for account access.
+pub const COLD_ACCOUNT_ACCESS_ADDITIONAL: u64 = COLD_ACCOUNT_ACCESS - WARM_ACCESS;
+
+/// Cold premium on top of `WARM_ACCESS` for storage access.
+pub const COLD_STORAGE_ACCESS_ADDITIONAL: u64 = COLD_STORAGE_ACCESS - WARM_ACCESS;
+
+/// CALL value transfer cost: `ACCOUNT_WRITE + CALL_STIPEND` per the EIP.
+pub const CALL_VALUE: u64 = ACCOUNT_WRITE + 2_300;
+
+/// Regular-gas portion of EIP-7702 `PER_EMPTY_ACCOUNT_COST` under EIP-8038.
+///
+/// Equal to the pre-EIP-8038 value (`crate::eip8037::EIP7702_PER_EMPTY_ACCOUNT_REGULAR`)
+/// plus the delta from the modified primitives that appear in the per-auth
+/// breakdown (`ACCOUNT_WRITE` +1, `COLD_ACCOUNT_ACCESS` +1, two `WARM_ACCESS`
+/// occurrences +1 each — total +4).
+pub const EIP7702_PER_EMPTY_ACCOUNT_REGULAR: u64 = 7_504;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -26,6 +26,7 @@ pub mod eip7825;
 pub mod eip7907;
 pub mod eip7954;
 pub mod eip8037;
+pub mod eip8038;
 pub mod hardfork;
 pub mod hints_util;
 mod once_lock;


### PR DESCRIPTION
## Summary
- Implements EIP-8038 state-access gas cost update on top of `glam-devnet-5`.
- Overrides regular-gas slots (WARM_ACCESS, COLD_ACCOUNT_ACCESS, ACCOUNT_WRITE, COLD_STORAGE_ACCESS, STORAGE_WRITE, STORAGE_CLEAR_REFUND, CREATE_ACCESS, ACCESS_LIST_*) at the AMSTERDAM activation in `gas_params.rs`, sourcing values from the new `primitives::eip8038` module.
- Recomputes the EIP-7702 regular-gas per-auth cost from the shifted ACCOUNT_WRITE / COLD_ACCOUNT_ACCESS / WARM_ACCESS values.
- Merges latest `origin/glam-devnet-5`; the only conflict was in `gas_params.rs` (EIP-8038 overrides + EIP-2780 intrinsic-gas entries land in adjacent blocks of the same `if AMSTERDAM` body — kept both).

## Test plan
- [x] `cargo check --workspace`
- [x] `cargo nextest run -p revm-context-interface` — all 11 tests pass, including `test_gas_id_name_and_from_str_coverage` (49 GasIds) and `test_eip7981_access_list_cost_amsterdam` (verifies the 2401 / 1901 EIP-8038-bumped access-list values).
- [ ] Full workspace `cargo nextest run --workspace`
- [ ] EIP-8038 conformance tests (ee-tests)