### PR TITLE
feat(glam-devnet-5): EIP-2780 + EIP-8038 + EIP-8037 integration

### DIFF
--- a/crates/context/interface/src/cfg.rs
+++ b/crates/context/interface/src/cfg.rs
@@ -95,6 +95,15 @@ pub trait Cfg {
     /// `cost_per_state_byte` and adds a hash cost for deployed bytecode.
     fn is_amsterdam_eip8037_enabled(&self) -> bool;
 
+    /// Returns whether EIP-2780 (Amsterdam) reduced intrinsic transaction gas
+    /// is enabled.
+    ///
+    /// When enabled, the legacy `21,000` intrinsic base is replaced with the
+    /// decomposed `TX_BASE_COST + to-based + value-based` model and top-level
+    /// execution charges are applied for empty recipients with value and
+    /// EIP-7702-delegated recipients.
+    fn is_amsterdam_eip2780_enabled(&self) -> bool;
+
     /// Returns the EIP-8037 `cost_per_state_byte` (CPSB).
     ///
     /// When [`Cfg::is_amsterdam_eip8037_enabled`] is `false` this returns `0`.

--- a/crates/context/interface/src/cfg.rs
+++ b/crates/context/interface/src/cfg.rs
@@ -73,14 +73,17 @@ pub trait Cfg {
     /// Returns whether EIP-7708 (ETH transfers emit logs) is disabled.
     fn is_eip7708_disabled(&self) -> bool;
 
-    /// Returns whether EIP-7708 delayed burn logging is disabled.
+    /// Returns whether the EIP-8246 delayed clearing of self-destructed accounts is disabled.
     ///
-    /// When enabled, revm tracks all self-destructed addresses and emits logs for
-    /// accounts that still have remaining balance at the end of the transaction.
-    /// This can be disabled for performance reasons as it requires storing and
-    /// iterating over all self-destructed accounts. When disabled, the logging
-    /// can be done outside of revm when applying accounts to database state.
-    fn is_eip7708_delayed_burn_disabled(&self) -> bool;
+    /// When enabled, revm tracks all self-destructed addresses and, at the end of the
+    /// transaction, clears the code, storage and nonce of any that still have a remaining
+    /// balance while preserving the balance ([EIP-8246]). This can be disabled for performance
+    /// reasons as it requires storing and iterating over all self-destructed accounts. When
+    /// disabled, this clearing can be done outside of revm when applying accounts to database
+    /// state.
+    ///
+    /// [EIP-8246]: https://eips.ethereum.org/EIPS/eip-8246
+    fn is_eip8246_delayed_clear_disabled(&self) -> bool;
 
     /// Returns the limit in bytes for the memory buffer.
     fn memory_limit(&self) -> u64;

--- a/crates/context/interface/src/cfg/gas.rs
+++ b/crates/context/interface/src/cfg/gas.rs
@@ -1,6 +1,10 @@
 //! Gas constants and functions for gas calculation.
 
-use crate::{cfg::GasParams, transaction::AccessListItemTr as _, Transaction, TransactionType};
+use crate::{
+    cfg::{gas_params, GasParams},
+    transaction::AccessListItemTr as _,
+    Transaction, TransactionType,
+};
 use primitives::hardfork::SpecId;
 
 /// Tracker for gas during execution.
@@ -488,6 +492,7 @@ impl InitialAndFloorGas {
 ///
 /// - Intrinsic gas
 /// - Number of tokens in calldata
+#[allow(clippy::too_many_arguments)]
 pub fn calculate_initial_tx_gas(
     spec_id: SpecId,
     input: &[u8],
@@ -496,6 +501,7 @@ pub fn calculate_initial_tx_gas(
     access_list_storages: u64,
     authorization_list_num: u64,
     cpsb: u64,
+    eip2780: Option<gas_params::Eip2780TxInfo>,
 ) -> InitialAndFloorGas {
     GasParams::new_spec(spec_id).initial_tx_gas(
         input,
@@ -504,6 +510,7 @@ pub fn calculate_initial_tx_gas(
         access_list_storages,
         authorization_list_num,
         cpsb,
+        eip2780,
     )
 }
 
@@ -518,6 +525,7 @@ pub fn calculate_initial_tx_gas_for_tx(
     tx: impl Transaction,
     spec: SpecId,
     cpsb: u64,
+    eip2780: Option<gas_params::Eip2780TxInfo>,
 ) -> InitialAndFloorGas {
     let mut accounts = 0;
     let mut storages = 0;
@@ -544,6 +552,7 @@ pub fn calculate_initial_tx_gas_for_tx(
         storages as u64,
         tx.authorization_list_len() as u64,
         cpsb,
+        eip2780,
     )
 }
 

--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use core::hash::{Hash, Hasher};
 use primitives::{
-    eip7702, eip8037,
+    eip2780, eip7702, eip8037, eip8038,
     hardfork::SpecId::{self},
     OnceLock, U256,
 };
@@ -364,6 +364,15 @@ impl GasParams {
             table[GasId::tx_access_list_storage_key_cost().as_usize()] =
                 gas::ACCESS_LIST_STORAGE_KEY + 32 * 64;
             table[GasId::tx_access_list_floor_byte_multiplier().as_usize()] = 4;
+
+            // EIP-2780: Intrinsic gas decomposition. The new path uses
+            // `eip2780::TX_BASE_COST` directly for the sender base and these
+            // entries for the additional `to`- and `value`-based charges.
+            // ACCOUNT_WRITE / CREATE_ACCESS source from `eip8038` so a single
+            // change to the placeholder TBD values propagates everywhere.
+            table[GasId::tx_transfer_log_cost().as_usize()] = eip2780::TRANSFER_LOG_COST;
+            table[GasId::tx_account_write_cost().as_usize()] = eip8038::ACCOUNT_WRITE;
+            table[GasId::tx_create_access_cost().as_usize()] = eip8038::CREATE_ACCESS;
         }
 
         Self::new(Arc::new(table))
@@ -933,6 +942,29 @@ impl GasParams {
         self.get(GasId::tx_base_stipend())
     }
 
+    /// EIP-2780: regular gas cost of the EIP-7708 transfer log emitted on
+    /// every nonzero-value transfer to a different account. Zero before AMSTERDAM.
+    #[inline]
+    pub fn tx_transfer_log_cost(&self) -> u64 {
+        self.get(GasId::tx_transfer_log_cost())
+    }
+
+    /// EIP-2780/EIP-8038: regular gas cost of an account-leaf write, added
+    /// when `tx.value > 0` and the recipient differs from the sender.
+    /// Zero before AMSTERDAM.
+    #[inline]
+    pub fn tx_account_write_cost(&self) -> u64 {
+        self.get(GasId::tx_account_write_cost())
+    }
+
+    /// EIP-2780/EIP-8038: regular gas cost of a top-level CREATE access,
+    /// in addition to [`Self::tx_base_stipend`] and the EIP-8037 state gas.
+    /// Zero before AMSTERDAM.
+    #[inline]
+    pub fn tx_create_access_cost(&self) -> u64 {
+        self.get(GasId::tx_create_access_cost())
+    }
+
     /// Used in [GasParams::initial_tx_gas] to calculate the create cost.
     ///
     /// Similar to the [`Self::create_cost`] method but it got activated in different fork,
@@ -957,12 +989,18 @@ impl GasParams {
     /// - EIP-7702 auth list state gas (per-auth account creation + metadata costs)
     /// - For CREATE transactions: `create_state_gas` (account creation + contract metadata)
     ///
+    /// When `eip2780` is `Some`, the legacy `21,000`-style base + create-cost
+    /// stipend is replaced with the EIP-2780 decomposition
+    /// (`TX_BASE_COST + to-based + value-based`). Calldata, access list, and
+    /// authorization-list costs are unchanged.
+    ///
     /// Note: `code_deposit_state_gas` is not included since deployed code size is unknown at validation time.
     ///
     /// # Returns
     ///
     /// - Intrinsic gas (including state gas for CREATE)
     /// - Number of tokens in calldata
+    #[allow(clippy::too_many_arguments)]
     pub fn initial_tx_gas(
         &self,
         input: &[u8],
@@ -971,6 +1009,7 @@ impl GasParams {
         access_list_storages: u64,
         authorization_list_num: u64,
         cpsb: u64,
+        eip2780: Option<Eip2780TxInfo>,
     ) -> InitialAndFloorGas {
         // Initdate stipend
         let tokens_in_calldata =
@@ -984,12 +1023,24 @@ impl GasParams {
 
         let auth_regular_cost = auth_total_cost - auth_state_gas;
 
+        let base_and_to_and_value_gas = match eip2780 {
+            None => {
+                let mut base = self.tx_base_stipend();
+                if is_create {
+                    // EIP-2: Homestead Hard-fork Changes
+                    base += self.tx_create_cost();
+                }
+                base
+            }
+            Some(info) => self.eip2780_base_to_value_gas(is_create, &info),
+        };
+
         let mut initial_regular_gas = tokens_in_calldata * self.tx_token_cost()
             // before berlin tx_access_list_address_cost will be zero
             + access_list_accounts * self.tx_access_list_address_cost()
             // before berlin tx_access_list_storage_key_cost will be zero
             + access_list_storages * self.tx_access_list_storage_key_cost()
-            + self.tx_base_stipend()
+            + base_and_to_and_value_gas
             // EIP-7702: Only the regular portion of auth list cost
             + auth_regular_cost;
 
@@ -997,9 +1048,6 @@ impl GasParams {
         let mut initial_state_gas = auth_state_gas;
 
         if is_create {
-            // EIP-2: Homestead Hard-fork Changes
-            initial_regular_gas += self.tx_create_cost();
-
             // EIP-3860: Limit and meter initcode
             initial_regular_gas += self.tx_initcode_cost(input.len());
 
@@ -1020,6 +1068,47 @@ impl GasParams {
             .with_initial_state_gas(initial_state_gas)
             .with_floor_gas(floor_gas)
     }
+
+    /// EIP-2780: sum of the sender base, `tx.to`-based, and `tx.value`-based
+    /// regular-gas charges. Excludes calldata, access list, authorizations,
+    /// and initcode/state-gas pieces which are added by the caller.
+    ///
+    /// The self-transfer and precompile zero-charge edge cases from the
+    /// current EIP-2780 draft are not implemented — a future revision is
+    /// expected to drop those carve-outs, so self-transfers and precompile
+    /// transfers pay the same `to`/`value` charges as any other recipient.
+    fn eip2780_base_to_value_gas(&self, is_create: bool, info: &Eip2780TxInfo) -> u64 {
+        // tx.to charge
+        let to_cost = if is_create {
+            self.tx_create_access_cost()
+        } else {
+            eip8038::COLD_ACCOUNT_ACCESS
+        };
+
+        // tx.value charge
+        let value_cost = if info.value.is_zero() {
+            0
+        } else if is_create {
+            self.tx_transfer_log_cost()
+        } else {
+            self.tx_transfer_log_cost() + self.tx_account_write_cost()
+        };
+
+        eip2780::TX_BASE_COST + to_cost + value_cost
+    }
+}
+
+/// EIP-2780 inputs to [`GasParams::initial_tx_gas`].
+///
+/// Only carries the transferred value — the decomposed intrinsic model only
+/// branches on `is_create` (already passed to `initial_tx_gas`) and whether
+/// `tx.value` is zero. The self-transfer and precompile carve-outs in the
+/// current draft are intentionally not implemented; see
+/// [`GasParams::eip2780_base_to_value_gas`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Eip2780TxInfo {
+    /// Transferred value.
+    pub value: U256,
 }
 
 #[inline]
@@ -1131,6 +1220,9 @@ impl GasId {
             x if x == Self::tx_access_list_floor_byte_multiplier().as_u8() => {
                 "tx_access_list_floor_byte_multiplier"
             }
+            x if x == Self::tx_transfer_log_cost().as_u8() => "tx_transfer_log_cost",
+            x if x == Self::tx_account_write_cost().as_u8() => "tx_account_write_cost",
+            x if x == Self::tx_create_access_cost().as_u8() => "tx_create_access_cost",
             _ => "unknown",
         }
     }
@@ -1202,6 +1294,9 @@ impl GasId {
             "tx_access_list_floor_byte_multiplier" => {
                 Some(Self::tx_access_list_floor_byte_multiplier())
             }
+            "tx_transfer_log_cost" => Some(Self::tx_transfer_log_cost()),
+            "tx_account_write_cost" => Some(Self::tx_account_write_cost()),
+            "tx_create_access_cost" => Some(Self::tx_create_access_cost()),
             _ => None,
         }
     }
@@ -1451,6 +1546,26 @@ impl GasId {
     pub const fn tx_access_list_floor_byte_multiplier() -> GasId {
         Self::new(46)
     }
+
+    /// EIP-2780: regular gas cost of the EIP-7708 transfer log emitted on every
+    /// nonzero-value transfer to a different account. Zero before AMSTERDAM.
+    pub const fn tx_transfer_log_cost() -> GasId {
+        Self::new(47)
+    }
+
+    /// EIP-2780/EIP-8038: regular gas cost of an account-leaf write at the
+    /// intrinsic level (added when `tx.value > 0` and the recipient differs
+    /// from the sender). Zero before AMSTERDAM.
+    pub const fn tx_account_write_cost() -> GasId {
+        Self::new(48)
+    }
+
+    /// EIP-2780/EIP-8038: regular gas cost of a top-level CREATE access, in
+    /// addition to [`Self::tx_base_stipend`] and the EIP-8037 state gas.
+    /// Zero before AMSTERDAM.
+    pub const fn tx_create_access_cost() -> GasId {
+        Self::new(49)
+    }
 }
 
 #[cfg(test)]
@@ -1521,11 +1636,11 @@ mod tests {
             "Not all unique names are resolvable via from_str"
         );
 
-        // We should have exactly 46 known GasIds (based on the indices 1-46 used)
+        // We should have exactly 49 known GasIds (based on the indices 1-49 used)
         assert_eq!(
             unique_names.len(),
-            46,
-            "Expected 46 unique GasIds, found {}",
+            49,
+            "Expected 49 unique GasIds, found {}",
             unique_names.len()
         );
     }
@@ -1576,7 +1691,7 @@ mod tests {
         let cpsb = eip8037::CPSB_GLAMSTERDAM;
 
         // Test CREATE transaction (is_create = true)
-        let create_gas = gas_params.initial_tx_gas(b"", true, 0, 0, 0, cpsb);
+        let create_gas = gas_params.initial_tx_gas(b"", true, 0, 0, 0, cpsb, None);
         let expected_state_gas = gas_params.create_state_gas(cpsb);
 
         assert_eq!(create_gas.initial_state_gas_final(), expected_state_gas);
@@ -1594,7 +1709,7 @@ mod tests {
         );
 
         // Test CALL transaction (is_create = false)
-        let call_gas = gas_params.initial_tx_gas(b"", false, 0, 0, 0, cpsb);
+        let call_gas = gas_params.initial_tx_gas(b"", false, 0, 0, 0, cpsb, None);
         assert_eq!(call_gas.initial_state_gas_final(), 0);
         // initial_gas should be unchanged for calls
         assert_eq!(call_gas.initial_total_gas(), gas_params.tx_base_stipend());
@@ -1618,7 +1733,7 @@ mod tests {
         assert_eq!(params.tx_floor_tokens_in_access_list(2, 3), (40 + 96) * 4);
 
         // Floor gas includes both calldata (empty here) and access-list contribution.
-        let gas = params.initial_tx_gas(b"", false, 2, 3, 0, 0);
+        let gas = params.initial_tx_gas(b"", false, 2, 3, 0, 0, None);
         let expected_al_floor = (40 + 96) * 4 * params.tx_floor_cost_per_token();
         assert_eq!(
             gas.floor_gas(),
@@ -1629,7 +1744,7 @@ mod tests {
         let prague = GasParams::new_spec(SpecId::PRAGUE);
         assert_eq!(prague.tx_access_list_floor_byte_multiplier(), 0);
         assert_eq!(prague.tx_floor_tokens_in_access_list(2, 3), 0);
-        let prague_gas = prague.initial_tx_gas(b"", false, 2, 3, 0, 0);
+        let prague_gas = prague.initial_tx_gas(b"", false, 2, 3, 0, 0, None);
         assert_eq!(prague_gas.floor_gas(), prague.tx_floor_cost_base_gas());
     }
 }

--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use core::hash::{Hash, Hasher};
 use primitives::{
-    eip7702, eip8037,
+    eip7702, eip8037, eip8038,
     hardfork::SpecId::{self},
     OnceLock, U256,
 };
@@ -364,6 +364,64 @@ impl GasParams {
             table[GasId::tx_access_list_storage_key_cost().as_usize()] =
                 gas::ACCESS_LIST_STORAGE_KEY + 32 * 64;
             table[GasId::tx_access_list_floor_byte_multiplier().as_usize()] = 4;
+
+            // EIP-8038: State-access gas cost update. All TBD parameters are
+            // set to `previous_value + 1` per the user-supplied rule.
+            //   WARM_ACCESS                  100 -> 101
+            //   COLD_ACCOUNT_ACCESS        2,600 -> 2,601
+            //   ACCOUNT_WRITE              6,700 -> 6,701
+            //   COLD_STORAGE_ACCESS        2,100 -> 2,101
+            //   STORAGE_WRITE              2,800 -> 2,801
+            //   STORAGE_CLEAR_REFUND       4,800 -> 4,801
+            //   CREATE_ACCESS              7,000 -> 7,001
+            //   ACCESS_LIST_ADDRESS_COST   2,400 -> 2,401
+            //   ACCESS_LIST_STORAGE_KEY_COST 1,900 -> 1,901
+            //
+            // Account access table values.
+            table[GasId::warm_storage_read_cost().as_usize()] = eip8038::WARM_ACCESS;
+            table[GasId::cold_account_additional_cost().as_usize()] =
+                eip8038::COLD_ACCOUNT_ACCESS_ADDITIONAL;
+            table[GasId::cold_storage_additional_cost().as_usize()] =
+                eip8038::COLD_STORAGE_ACCESS_ADDITIONAL;
+            table[GasId::cold_storage_cost().as_usize()] = eip8038::COLD_STORAGE_ACCESS;
+            // CALL_VALUE = ACCOUNT_WRITE + CALL_STIPEND.
+            table[GasId::transfer_value_cost().as_usize()] = eip8038::CALL_VALUE;
+            // ACCOUNT_WRITE surcharge for first-time writes to an account: CALL
+            // to empty account, SELFDESTRUCT sending balance to empty account.
+            // Under EIP-8037 these were zeroed out (cost moved to state gas);
+            // EIP-8038 reintroduces a regular-gas surcharge.
+            table[GasId::new_account_cost().as_usize()] = eip8038::ACCOUNT_WRITE;
+            table[GasId::new_account_cost_for_selfdestruct().as_usize()] = eip8038::ACCOUNT_WRITE;
+
+            // SSTORE table values.
+            //   warm-base       = WARM_ACCESS         (sstore_static)
+            //   write surcharge = STORAGE_WRITE       (sstore_set / sstore_reset dynamic)
+            //   refunds         = STORAGE_WRITE / STORAGE_CLEAR_REFUND
+            table[GasId::sstore_static().as_usize()] = eip8038::WARM_ACCESS;
+            table[GasId::sstore_set_without_load_cost().as_usize()] = eip8038::STORAGE_WRITE;
+            table[GasId::sstore_reset_without_cold_load_cost().as_usize()] = eip8038::STORAGE_WRITE;
+            table[GasId::sstore_set_refund().as_usize()] = eip8038::STORAGE_WRITE;
+            table[GasId::sstore_reset_refund().as_usize()] = eip8038::STORAGE_WRITE;
+            table[GasId::sstore_clearing_slot_refund().as_usize()] = eip8038::STORAGE_CLEAR_REFUND;
+
+            // CREATE / CREATE2 regular-gas access cost.
+            //   `create` slot is the regular-gas portion charged at the
+            //   CREATE/CREATE2 opcodes and for create-kind txns.
+            table[GasId::create().as_usize()] = eip8038::CREATE_ACCESS;
+            table[GasId::tx_create_cost().as_usize()] = eip8038::CREATE_ACCESS;
+
+            // Access-list per-item costs: bump the base by +1 each, keeping the
+            // EIP-7981 64 gas/byte data charge on top.
+            table[GasId::tx_access_list_address_cost().as_usize()] =
+                eip8038::ACCESS_LIST_ADDRESS_COST + 20 * 64;
+            table[GasId::tx_access_list_storage_key_cost().as_usize()] =
+                eip8038::ACCESS_LIST_STORAGE_KEY_COST + 32 * 64;
+
+            // EIP-7702: regular-gas portion of the per-auth cost shifts with
+            // ACCOUNT_WRITE / COLD_ACCOUNT_ACCESS / WARM_ACCESS (see
+            // [`eip8038::EIP7702_PER_EMPTY_ACCOUNT_REGULAR`]).
+            table[GasId::tx_eip7702_per_empty_account_cost().as_usize()] =
+                eip8038::EIP7702_PER_EMPTY_ACCOUNT_REGULAR;
         }
 
         Self::new(Arc::new(table))
@@ -1604,13 +1662,15 @@ mod tests {
     fn test_eip7981_access_list_cost_amsterdam() {
         // EIP-7981 folds a 64 gas/byte data charge into the per-item access-list cost
         // and adds 4 floor tokens per access-list byte on top of the EIP-7976 floor.
+        // EIP-8038 bumps the per-item base by +1 (ACCESS_LIST_ADDRESS_COST 2400 ->
+        // 2401, ACCESS_LIST_STORAGE_KEY_COST 1900 -> 1901).
         let params = GasParams::new_spec(SpecId::AMSTERDAM);
 
         // Per-item intrinsic cost: base + bytes * 64
-        assert_eq!(params.tx_access_list_address_cost(), 2400 + 20 * 64);
-        assert_eq!(params.tx_access_list_storage_key_cost(), 1900 + 32 * 64);
-        assert_eq!(params.tx_access_list_cost(1, 0), 2400 + 20 * 64);
-        assert_eq!(params.tx_access_list_cost(0, 1), 1900 + 32 * 64);
+        assert_eq!(params.tx_access_list_address_cost(), 2401 + 20 * 64);
+        assert_eq!(params.tx_access_list_storage_key_cost(), 1901 + 32 * 64);
+        assert_eq!(params.tx_access_list_cost(1, 0), 2401 + 20 * 64);
+        assert_eq!(params.tx_access_list_cost(0, 1), 1901 + 32 * 64);
 
         // Floor multiplier activates at AMSTERDAM.
         assert_eq!(params.tx_access_list_floor_byte_multiplier(), 4);

--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -139,16 +139,17 @@ pub trait JournalTr {
     /// Sets the spec id.
     fn set_spec_id(&mut self, spec_id: SpecId);
 
-    /// Sets EIP-7708 configuration flags.
+    /// Sets EIP-7708 and EIP-8246 configuration flags.
     ///
     /// - `disabled`: Whether EIP-7708 (ETH transfers emit logs) is completely disabled.
-    /// - `delayed_burn_disabled`: Whether delayed burn logging is disabled. When enabled,
-    ///   revm tracks all self-destructed addresses and emits logs for accounts that still
-    ///   have remaining balance at the end of the transaction. This can be disabled for
-    ///   performance reasons as it requires storing and iterating over all self-destructed
-    ///   accounts. When disabled, the logging can be done outside of revm when applying
-    ///   accounts to database state.
-    fn set_eip7708_config(&mut self, disabled: bool, delayed_burn_disabled: bool);
+    /// - `eip8246_delayed_clear_disabled`: Whether the EIP-8246 delayed clearing of
+    ///   self-destructed accounts is disabled. When enabled, revm tracks all self-destructed
+    ///   addresses and, at the end of the transaction, clears the code, storage and nonce of
+    ///   any that still have a remaining balance while preserving the balance. This can be
+    ///   disabled for performance reasons as it requires storing and iterating over all
+    ///   self-destructed accounts. When disabled, this clearing can be done outside of revm
+    ///   when applying accounts to database state.
+    fn set_eip7708_config(&mut self, disabled: bool, eip8246_delayed_clear_disabled: bool);
 
     /// Touches the account.
     fn touch_account(&mut self, address: Address);

--- a/crates/context/interface/src/result.rs
+++ b/crates/context/interface/src/result.rs
@@ -63,7 +63,8 @@ impl<R, S> ExecResultAndState<R, S> {
 /// ## Derived values
 ///
 /// - [`tx_gas_used()`](ResultGas::tx_gas_used) = `max(total_gas_spent − refunded, floor_gas)` (the value that goes into receipts)
-/// - [`block_regular_gas_used()`](ResultGas::block_regular_gas_used) = `max(total_gas_spent − state_gas_spent, floor_gas)`
+/// - [`block_regular_gas_used()`](ResultGas::block_regular_gas_used) = `total_gas_spent − state_gas_spent`
+///   (EIP-8037 + EIP-7778: pre-refund; refund and floor only affect `tx_gas_used`, not block-level regular gas)
 /// - [`block_state_gas_used()`](ResultGas::block_state_gas_used) = `state_gas_spent`
 /// - [`spent_sub_refunded()`](ResultGas::spent_sub_refunded) = `total_gas_spent − refunded` (before floor gas check)
 /// - [`final_refunded()`](ResultGas::final_refunded) = `refunded` when floor gas is inactive, `0` when floor gas kicks in
@@ -267,13 +268,15 @@ impl ResultGas {
         max(tx_gas_refunded, self.floor_gas())
     }
 
-    /// Returns the regular gas used by the block.
+    /// Returns the regular gas used by the block per EIP-8037 + EIP-7778.
+    ///
+    /// `total_gas_spent - state_gas_spent` (pre-refund). Refund and floor are
+    /// applied to the combined pre-refund total and only affect `tx_gas_used`
+    /// (the receipt value), not the block-level regular component.
     #[inline]
     pub const fn block_regular_gas_used(&self) -> u64 {
-        let execution_gas_spent = self
-            .total_gas_spent()
-            .saturating_sub(self.state_gas_spent_final());
-        max(execution_gas_spent, self.floor_gas())
+        self.total_gas_spent()
+            .saturating_sub(self.state_gas_spent_final())
     }
 
     /// Returns the state gas used by the block.
@@ -1383,5 +1386,45 @@ mod tests {
             .with_floor_gas(40000);
         assert_eq!(gas.tx_gas_used(), 40000);
         assert_eq!(gas.final_refunded(), 10000);
+    }
+
+    #[test]
+    fn test_block_regular_gas_used_no_floor_no_refund() {
+        // block_regular_gas_used = total_gas_spent - state_gas_spent.
+        // Refund and floor only affect tx_gas_used, never block_regular.
+
+        // No state, no refund, no floor.
+        let gas = ResultGas::default().with_total_gas_spent(100_000);
+        assert_eq!(gas.block_regular_gas_used(), 100_000);
+
+        // With state gas.
+        let gas = ResultGas::default()
+            .with_total_gas_spent(100_000)
+            .with_state_gas_spent(30_000);
+        assert_eq!(gas.block_regular_gas_used(), 70_000);
+        assert_eq!(gas.block_state_gas_used(), 30_000);
+
+        // Refund present: tx_gas_used drops, block_regular does not.
+        let gas = ResultGas::default()
+            .with_total_gas_spent(100_000)
+            .with_refunded(10_000)
+            .with_state_gas_spent(30_000);
+        assert_eq!(gas.tx_gas_used(), 90_000);
+        assert_eq!(gas.block_regular_gas_used(), 70_000);
+
+        // Floor active: tx_gas_used floors up, block_regular does not.
+        let gas = ResultGas::default()
+            .with_total_gas_spent(100_000)
+            .with_refunded(90_000)
+            .with_floor_gas(50_000)
+            .with_state_gas_spent(30_000);
+        assert_eq!(gas.tx_gas_used(), 50_000);
+        assert_eq!(gas.block_regular_gas_used(), 70_000);
+
+        // State gas exceeds total → saturates to 0.
+        let gas = ResultGas::default()
+            .with_total_gas_spent(20_000)
+            .with_state_gas_spent(30_000);
+        assert_eq!(gas.block_regular_gas_used(), 0);
     }
 }

--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -158,16 +158,19 @@ pub struct CfgEnv<SPEC = SpecId> {
     ///
     /// By default, it is set to `false`.
     pub amsterdam_eip7708_disabled: bool,
-    /// Disables EIP-7708 delayed burn logging.
+    /// Disables the EIP-8246 delayed clearing of self-destructed accounts.
     ///
-    /// When enabled, revm tracks all self-destructed addresses and emits logs for
-    /// accounts that still have remaining balance at the end of the transaction.
-    /// This can be disabled for performance reasons as it requires storing and
-    /// iterating over all self-destructed accounts. When disabled, the logging
-    /// can be done outside of revm when applying accounts to database state.
+    /// When enabled, revm tracks all self-destructed addresses and, at the end of the
+    /// transaction, clears the code, storage and nonce of any that still have a remaining
+    /// balance while preserving the balance ([EIP-8246]). This can be disabled for performance
+    /// reasons as it requires storing and iterating over all self-destructed accounts. When
+    /// disabled, this clearing can be done outside of revm when applying accounts to database
+    /// state.
     ///
     /// By default, it is set to `false`.
-    pub amsterdam_eip7708_delayed_burn_disabled: bool,
+    ///
+    /// [EIP-8246]: https://eips.ethereum.org/EIPS/eip-8246
+    pub amsterdam_eip8246_delayed_clear_disabled: bool,
 }
 
 impl CfgEnv {
@@ -287,7 +290,7 @@ impl<SPEC> CfgEnv<SPEC> {
             enable_amsterdam_eip8037: self.enable_amsterdam_eip8037,
             enable_amsterdam_eip2780: self.enable_amsterdam_eip2780,
             amsterdam_eip7708_disabled: self.amsterdam_eip7708_disabled,
-            amsterdam_eip7708_delayed_burn_disabled: self.amsterdam_eip7708_delayed_burn_disabled,
+            amsterdam_eip8246_delayed_clear_disabled: self.amsterdam_eip8246_delayed_clear_disabled,
         }
     }
 
@@ -379,7 +382,7 @@ impl<SPEC: Into<SpecId> + Clone> CfgEnv<SPEC> {
             enable_amsterdam_eip8037: is_amsterdam,
             enable_amsterdam_eip2780: is_amsterdam,
             amsterdam_eip7708_disabled: false,
-            amsterdam_eip7708_delayed_burn_disabled: false,
+            amsterdam_eip8246_delayed_clear_disabled: false,
         }
     }
 
@@ -578,8 +581,8 @@ impl<SPEC: Into<SpecId> + Clone> Cfg for CfgEnv<SPEC> {
         self.amsterdam_eip7708_disabled
     }
 
-    fn is_eip7708_delayed_burn_disabled(&self) -> bool {
-        self.amsterdam_eip7708_delayed_burn_disabled
+    fn is_eip8246_delayed_clear_disabled(&self) -> bool {
+        self.amsterdam_eip8246_delayed_clear_disabled
     }
 
     fn memory_limit(&self) -> u64 {

--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -145,6 +145,15 @@ pub struct CfgEnv<SPEC = SpecId> {
     ///
     /// By default, it is set to `false`.
     pub enable_amsterdam_eip8037: bool,
+    /// Enables EIP-2780 (Amsterdam) reduced intrinsic transaction gas.
+    ///
+    /// Replaces the legacy 21,000 base with the decomposed
+    /// `TX_BASE_COST + to-based + value-based` model and adds top-level
+    /// execution charges for empty recipients with value (state gas) and
+    /// EIP-7702-delegated recipients (extra cold access).
+    ///
+    /// By default, it is set to `false`.
+    pub enable_amsterdam_eip2780: bool,
     /// Disables EIP-7708 (ETH transfers emit logs).
     ///
     /// By default, it is set to `false`.
@@ -223,15 +232,17 @@ impl<SPEC> CfgEnv<SPEC> {
 
     /// Sets the spec for the `CfgEnv` and the gas params to the mainnet gas params.
     ///
-    /// Automatically enables EIP-8037 for AMSTERDAM and later.
+    /// Automatically enables EIP-8037 and EIP-2780 for AMSTERDAM and later.
     pub fn with_spec_and_mainnet_gas_params<OSPEC: Into<SpecId> + Clone>(
         self,
         spec: OSPEC,
     ) -> CfgEnv<OSPEC> {
         let is_amsterdam = spec.clone().into().is_enabled_in(SpecId::AMSTERDAM);
         let enable_amsterdam_eip8037 = self.enable_amsterdam_eip8037 || is_amsterdam;
+        let enable_amsterdam_eip2780 = self.enable_amsterdam_eip2780 || is_amsterdam;
         let mut cfg = self.with_spec_and_gas_params(spec.clone(), GasParams::new_spec(spec.into()));
         cfg.enable_amsterdam_eip8037 = enable_amsterdam_eip8037;
+        cfg.enable_amsterdam_eip2780 = enable_amsterdam_eip2780;
         cfg
     }
 
@@ -274,6 +285,7 @@ impl<SPEC> CfgEnv<SPEC> {
             #[cfg(feature = "optional_fee_charge")]
             disable_fee_charge: self.disable_fee_charge,
             enable_amsterdam_eip8037: self.enable_amsterdam_eip8037,
+            enable_amsterdam_eip2780: self.enable_amsterdam_eip2780,
             amsterdam_eip7708_disabled: self.amsterdam_eip7708_disabled,
             amsterdam_eip7708_delayed_burn_disabled: self.amsterdam_eip7708_delayed_burn_disabled,
         }
@@ -321,6 +333,13 @@ impl<SPEC> CfgEnv<SPEC> {
         self.enable_amsterdam_eip8037 = enable;
         self
     }
+
+    /// Sets the enable EIP-2780 (Amsterdam) reduced intrinsic transaction
+    /// gas flag.
+    pub const fn with_enable_amsterdam_eip2780(mut self, enable: bool) -> Self {
+        self.enable_amsterdam_eip2780 = enable;
+        self
+    }
 }
 
 impl<SPEC: Into<SpecId> + Clone> CfgEnv<SPEC> {
@@ -358,6 +377,7 @@ impl<SPEC: Into<SpecId> + Clone> CfgEnv<SPEC> {
             #[cfg(feature = "optional_fee_charge")]
             disable_fee_charge: false,
             enable_amsterdam_eip8037: is_amsterdam,
+            enable_amsterdam_eip2780: is_amsterdam,
             amsterdam_eip7708_disabled: false,
             amsterdam_eip7708_delayed_burn_disabled: false,
         }
@@ -398,14 +418,15 @@ impl<SPEC: Into<SpecId> + Clone> CfgEnv<SPEC> {
 
     /// Sets the spec for the `CfgEnv` and the gas params to the mainnet gas params.
     ///
-    /// Automatically enables EIP-8037 for AMSTERDAM and later.
+    /// Automatically enables EIP-8037 and EIP-2780 for AMSTERDAM and later.
     #[inline]
     pub fn set_spec_and_mainnet_gas_params(&mut self, spec: SPEC) {
         self.spec = spec.clone();
         self.set_gas_params(GasParams::new_spec(spec.clone().into()));
-        // EIP-8037: Enable EIP-8037 for AMSTERDAM and later
+        // EIP-8037/EIP-2780: Enable for AMSTERDAM and later
         if spec.into().is_enabled_in(SpecId::AMSTERDAM) {
             self.enable_amsterdam_eip8037 = true;
+            self.enable_amsterdam_eip2780 = true;
         }
     }
 }
@@ -578,6 +599,10 @@ impl<SPEC: Into<SpecId> + Clone> Cfg for CfgEnv<SPEC> {
 
     fn is_amsterdam_eip8037_enabled(&self) -> bool {
         self.enable_amsterdam_eip8037
+    }
+
+    fn is_amsterdam_eip2780_enabled(&self) -> bool {
+        self.enable_amsterdam_eip2780
     }
 
     #[inline]

--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -45,7 +45,7 @@ fn sync_cfg_to_journal<CFG: Cfg, JOURNAL: JournalTr>(cfg: &CFG, journal: &mut JO
     journal.set_spec_id(cfg.spec().into());
     journal.set_eip7708_config(
         cfg.is_eip7708_disabled(),
-        cfg.is_eip7708_delayed_burn_disabled(),
+        cfg.is_eip8246_delayed_clear_disabled(),
     );
 }
 

--- a/crates/context/src/journal.rs
+++ b/crates/context/src/journal.rs
@@ -203,9 +203,9 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
     }
 
     #[inline]
-    fn set_eip7708_config(&mut self, disabled: bool, delayed_burn_disabled: bool) {
+    fn set_eip7708_config(&mut self, disabled: bool, eip8246_delayed_clear_disabled: bool) {
         self.inner
-            .set_eip7708_config(disabled, delayed_burn_disabled);
+            .set_eip7708_config(disabled, eip8246_delayed_clear_disabled);
     }
 
     #[inline]

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -12,7 +12,7 @@ use context_interface::{
 use core::mem;
 use database_interface::Database;
 use primitives::{
-    eip7708::{BURN_LOG_TOPIC, ETH_TRANSFER_LOG_ADDRESS, ETH_TRANSFER_LOG_TOPIC},
+    eip7708::{ETH_TRANSFER_LOG_ADDRESS, ETH_TRANSFER_LOG_TOPIC},
     hardfork::SpecId::{self, *},
     hash_map::Entry,
     hints_util::unlikely,
@@ -42,14 +42,17 @@ pub struct JournalCfg {
     pub spec: SpecId,
     /// Whether EIP-7708 (ETH transfers emit logs) is disabled.
     pub eip7708_disabled: bool,
-    /// Whether EIP-7708 delayed burn logging is disabled.
+    /// Whether the EIP-8246 delayed clearing of self-destructed accounts is disabled.
     ///
-    /// When enabled, revm tracks all self-destructed addresses and emits logs for
-    /// accounts that still have remaining balance at the end of the transaction.
-    /// This can be disabled for performance reasons as it requires storing and
-    /// iterating over all self-destructed accounts. When disabled, the logging
-    /// can be done outside of revm when applying accounts to database state.
-    pub eip7708_delayed_burn_disabled: bool,
+    /// When enabled, revm tracks all self-destructed addresses and, at the end of the
+    /// transaction, clears the code, storage and nonce of any that still have a remaining
+    /// balance while preserving the balance (see [EIP-8246]). This can be disabled for
+    /// performance reasons as it requires storing and iterating over all self-destructed
+    /// accounts. When disabled, this clearing can be done outside of revm when applying
+    /// accounts to database state.
+    ///
+    /// [EIP-8246]: https://eips.ethereum.org/EIPS/eip-8246
+    pub eip8246_delayed_clear_disabled: bool,
 }
 /// Inner journal state that contains journal and state changes.
 ///
@@ -81,13 +84,13 @@ pub struct JournalInner<ENTRY> {
     pub warm_addresses: WarmAddresses,
     /// Addresses that were self-destructed for the first time in this transaction.
     ///
-    /// This is used by [EIP-7708] to emit logs for self-destructed accounts that still
-    /// have balance at the end of the transaction.
+    /// This is used by [EIP-8246] to clear (code, storage and nonce) self-destructed accounts
+    /// that still have balance at the end of the transaction, preserving their balance.
     ///
     /// The vec is indexed by checkpoint - on revert, entries added after the checkpoint
     /// are removed.
     ///
-    /// [EIP-7708]: https://eips.ethereum.org/EIPS/eip-7708
+    /// [EIP-8246]: https://eips.ethereum.org/EIPS/eip-8246
     pub selfdestructed_addresses: Vec<Address>,
 }
 
@@ -118,12 +121,13 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
 
     /// Returns the logs.
     ///
-    /// Before returning, this function emits EIP-7708 logs for any self-destructed
-    /// accounts that still have a non-zero balance.
+    /// Before returning, this function applies EIP-8246 to any self-destructed
+    /// accounts that still have a non-zero balance, clearing their code, storage and
+    /// nonce while preserving the balance.
     #[inline]
     pub fn take_logs(&mut self) -> Vec<Log> {
-        // EIP-7708: Emit logs for self-destructed accounts with remaining balance
-        self.eip7708_emit_burn_remaining_balance_logs();
+        // EIP-8246: clear self-destructed accounts that still hold a balance.
+        self.eip8246_clear_selfdestructed_accounts();
         mem::take(&mut self.logs)
     }
 
@@ -254,45 +258,53 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         state
     }
 
-    /// Emit EIP-7708 logs for self-destructed accounts that still have balance.
+    /// Apply [EIP-8246] to self-destructed accounts that still have a balance.
     ///
     /// This should be called before `take_logs()` at the end of transaction execution.
-    /// It checks all accounts that were self-destructed in this transaction and emits
-    /// a `Burn` log for any that still have a non-zero balance.
+    /// It iterates over all accounts that were self-destructed in this transaction and,
+    /// for any that still hold a non-zero balance, clears the rest of the account instead
+    /// of letting the balance be burned: the nonce is reset to `0`, the code and storage are
+    /// cleared, the balance is left unchanged and the self-destruct flag is removed so the
+    /// account is preserved in state as a balance-only account.
     ///
-    /// This can happen when an account receives ETH after being self-destructed
-    /// in the same transaction.
+    /// A non-zero balance can remain when an account receives ETH after being self-destructed
+    /// in the same transaction, or when a contract created in the same transaction
+    /// self-destructs to itself (see [`Self::selfdestruct`]).
     ///
-    /// Logs are emitted sorted by address in ascending order.
+    /// Accounts with a zero balance keep their self-destruct flag and are removed from state as
+    /// before (they are *empty* and deleted by [EIP-161]).
     ///
-    /// [EIP-7708](https://eips.ethereum.org/EIPS/eip-7708)
+    /// Self-destructed accounts can only reach this point if they were created in the same
+    /// transaction (EIP-6780 is always active alongside EIP-8246), so they never have storage
+    /// stored in the database and clearing the in-memory storage is sufficient.
+    ///
+    /// [EIP-8246]: https://eips.ethereum.org/EIPS/eip-8246
+    /// [EIP-161]: https://eips.ethereum.org/EIPS/eip-161
     #[inline]
-    pub fn eip7708_emit_burn_remaining_balance_logs(&mut self) {
-        if !self.cfg.spec.is_enabled_in(AMSTERDAM)
-            || self.cfg.eip7708_disabled
-            || self.cfg.eip7708_delayed_burn_disabled
-        {
+    pub fn eip8246_clear_selfdestructed_accounts(&mut self) {
+        if !self.cfg.spec.is_enabled_in(AMSTERDAM) || self.cfg.eip8246_delayed_clear_disabled {
             return;
         }
 
-        // Collect addresses with non-zero balance and sort by address
-        let mut addresses_with_balance: Vec<(Address, U256)> = self
-            .selfdestructed_addresses
-            .iter()
-            .filter_map(|address| {
-                self.state
-                    .get(address)
-                    .filter(|account| !account.info.balance.is_zero())
-                    .map(|account| (*address, account.info.balance))
-            })
-            .collect();
+        for address in &self.selfdestructed_addresses {
+            let Some(account) = self.state.get_mut(address) else {
+                continue;
+            };
 
-        // Sort by address (ascending)
-        addresses_with_balance.sort_by_key(|(addr, _)| *addr);
+            // Zero-balance accounts stay self-destructed and are removed from state (EIP-161).
+            if account.info.balance.is_zero() {
+                continue;
+            }
 
-        // Emit logs in sorted order
-        for (address, balance) in addresses_with_balance {
-            self.eip7708_burn_log(address, balance);
+            // EIP-8246: keep the balance but clear the rest of the account.
+            account.info.nonce = 0;
+            account.info.code_hash = KECCAK_EMPTY;
+            account.info.code = Some(Bytecode::default());
+            account.storage.clear();
+
+            // Remove the self-destruct flags so the account is preserved instead of destroyed.
+            account.unmark_selfdestruct();
+            account.unmark_selfdestructed_locally();
         }
     }
 
@@ -308,11 +320,15 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         self.cfg.spec = spec;
     }
 
-    /// Sets EIP-7708 configuration flags.
+    /// Sets EIP-7708 and EIP-8246 configuration flags.
     #[inline]
-    pub const fn set_eip7708_config(&mut self, disabled: bool, delayed_burn_disabled: bool) {
+    pub const fn set_eip7708_config(
+        &mut self,
+        disabled: bool,
+        eip8246_delayed_clear_disabled: bool,
+    ) {
         self.cfg.eip7708_disabled = disabled;
-        self.cfg.eip7708_delayed_burn_disabled = delayed_burn_disabled;
+        self.cfg.eip8246_delayed_clear_disabled = eip8246_delayed_clear_disabled;
     }
 
     /// Mark account as touched as only touched accounts will be added to state.
@@ -662,30 +678,41 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
 
         // EIP-6780 (Cancun hard-fork): selfdestruct only if contract is created in the same tx
         let journal_entry = if acc.is_created_locally() || !is_cancun_enabled {
-            // EIP-7708: Track first self-destruction for remaining balance log.
-            // Only track when account is actually destroyed and delayed burn is not disabled.
+            // EIP-8246: Track first self-destruction so the account can be cleared (code, storage
+            // and nonce) while preserving its balance at finalization.
+            // Only track when account is actually destroyed and delayed clearing is not disabled.
             if destroyed_status == SelfdestructionRevertStatus::GloballySelfdestroyed
-                && !self.cfg.eip7708_delayed_burn_disabled
+                && !self.cfg.eip8246_delayed_clear_disabled
             {
                 self.selfdestructed_addresses.push(address);
             }
 
             acc.mark_selfdestructed_locally();
-            acc.info.balance = U256::ZERO;
 
-            // EIP-7708: emit appropriate log for selfdestruct
-            if target != address {
-                // Transfer log for balance transferred to different address
+            // `had_balance` records the balance that left the account so it can be restored
+            // on revert.
+            let had_balance = if target != address {
+                // Balance was transferred to target above; zero out the source.
+                acc.info.balance = U256::ZERO;
+                // EIP-7708: transfer log for balance moved to a different address.
                 self.eip7708_transfer_log(address, target, balance);
+                balance
+            } else if spec.is_enabled_in(AMSTERDAM) {
+                // EIP-8246: self-destruct to self no longer burns the balance. The balance is
+                // kept and the account is cleared at finalization
+                // (see `eip8246_clear_selfdestructed_accounts`).
+                U256::ZERO
             } else {
-                // Burn log for selfdestruct to self
-                self.eip7708_burn_log(address, balance);
-            }
+                // Pre-EIP-8246: self-destruct to self burns the balance.
+                acc.info.balance = U256::ZERO;
+                balance
+            };
+
             Some(ENTRY::account_destroyed(
                 address,
                 target,
                 destroyed_status,
-                balance,
+                had_balance,
             ))
         } else if address != target {
             acc.info.balance = U256::ZERO;
@@ -1106,34 +1133,6 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         self.logs.push(Log {
             address: ETH_TRANSFER_LOG_ADDRESS,
             data: LogData::new(topics, data).expect("3 topics is valid"),
-        });
-    }
-
-    /// Creates and pushes an EIP-7708 burn log.
-    ///
-    /// This emits a LOG2 when a contract self-destructs to itself or when a
-    /// self-destructed account still has remaining balance at end of transaction.
-    /// Only emitted if EIP-7708 is enabled (Amsterdam and later) and balance is non-zero.
-    ///
-    /// [EIP-7708](https://eips.ethereum.org/EIPS/eip-7708)
-    #[inline]
-    pub fn eip7708_burn_log(&mut self, address: Address, balance: U256) {
-        // Only emit log if EIP-7708 is enabled and balance is non-zero
-        if !self.cfg.spec.is_enabled_in(AMSTERDAM) || self.cfg.eip7708_disabled || balance.is_zero()
-        {
-            return;
-        }
-
-        // Create LOG2 with Burn(address,uint256) event signature
-        // Topic[0]: Burn event signature
-        // Topic[1]: account address (zero-padded to 32 bytes)
-        // Data: amount in wei (big-endian uint256)
-        let topics = std::vec![BURN_LOG_TOPIC, B256::left_padding_from(address.as_slice()),];
-        let data = Bytes::copy_from_slice(&balance.to_be_bytes::<32>());
-
-        self.logs.push(Log {
-            address: ETH_TRANSFER_LOG_ADDRESS,
-            data: LogData::new(topics, data).expect("2 topics is valid"),
         });
     }
 }

--- a/crates/ee-tests/src/eip2780.rs
+++ b/crates/ee-tests/src/eip2780.rs
@@ -1,0 +1,147 @@
+//! EIP-2780 integration tests.
+//!
+//! Verifies the decomposed intrinsic gas model (`TX_BASE_COST` + to-based +
+//! value-based) and the top-level execution charges (state gas for empty
+//! recipient with value, extra cold access for EIP-7702-delegated recipients).
+//!
+//! The self-transfer and precompile zero-charge edge cases in the current
+//! EIP-2780 draft are intentionally not implemented (a future revision is
+//! expected to drop them), so the tests below treat self-transfers and
+//! precompile transfers as regular recipients.
+
+use revm::{
+    context::TxEnv,
+    database::{BenchmarkDB, BENCH_CALLER},
+    handler::{MainnetContext, MainnetEvm},
+    primitives::{
+        address, eip2780, eip8037, eip8037::CPSB_GLAMSTERDAM, eip8038, hardfork::SpecId, TxKind,
+        U256,
+    },
+    state::Bytecode,
+    Context, ExecuteEvm, MainBuilder, MainContext,
+};
+
+type MainEvm = MainnetEvm<MainnetContext<BenchmarkDB>>;
+
+const TX_GAS_LIMIT: u64 = 1_000_000;
+
+/// Pre-EIP-2780 legacy intrinsic base.
+const LEGACY_BASE: u64 = 21_000;
+
+/// State gas for new-account creation under Glamsterdam CPSB (120 × 1530 = 183_600).
+const STATE_BYTES_PER_NEW_ACCOUNT: u64 = eip8037::NEW_ACCOUNT_BYTES * CPSB_GLAMSTERDAM;
+
+/// Builds an EVM at AMSTERDAM with EIP-2780 enabled.
+fn evm() -> MainEvm {
+    Context::mainnet()
+        .modify_cfg_chained(|cfg| {
+            cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
+            cfg.tx_gas_limit_cap = Some(u64::MAX);
+        })
+        .with_db(BenchmarkDB::new_bytecode(Bytecode::new()))
+        .build_mainnet()
+}
+
+/// Builds an EVM at AMSTERDAM with EIP-2780 disabled (legacy 21k base).
+fn evm_no_eip2780() -> MainEvm {
+    Context::mainnet()
+        .modify_cfg_chained(|cfg| {
+            cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
+            cfg.enable_amsterdam_eip2780 = false;
+            cfg.tx_gas_limit_cap = Some(u64::MAX);
+        })
+        .with_db(BenchmarkDB::new_bytecode(Bytecode::new()))
+        .build_mainnet()
+}
+
+fn tx(kind: TxKind, value: U256) -> TxEnv {
+    TxEnv::builder_for_bench()
+        .kind(kind)
+        .value(value)
+        .gas_price(0)
+        .gas_limit(TX_GAS_LIMIT)
+        .build_fill()
+}
+
+fn run(evm: &mut MainEvm, kind: TxKind, value: U256) -> revm::context_interface::result::ResultGas {
+    *evm.transact_one(tx(kind, value)).unwrap().gas()
+}
+
+/// Helper: regular gas spent (`total_gas_spent` minus the state-gas portion).
+fn regular_spent(gas: &revm::context_interface::result::ResultGas) -> u64 {
+    gas.total_gas_spent()
+        .saturating_sub(gas.state_gas_spent_final())
+}
+
+#[test]
+fn test_eip2780_self_transfer() {
+    let mut evm = evm();
+    let gas = run(&mut evm, TxKind::Call(BENCH_CALLER), U256::ZERO);
+    // Self-transfer is not special-cased: pays TX_BASE_COST + COLD_ACCOUNT_ACCESS.
+    assert_eq!(
+        gas.total_gas_spent(),
+        eip2780::TX_BASE_COST + eip8038::COLD_ACCOUNT_ACCESS
+    );
+    assert_eq!(gas.state_gas_spent_final(), 0);
+}
+
+#[test]
+fn test_eip2780_call_eoa_no_value() {
+    let mut evm = evm();
+    // Cold EOA (not a precompile, not self).
+    let to = address!("0x00000000000000000000000000000000000000aa");
+    let gas = run(&mut evm, TxKind::Call(to), U256::ZERO);
+    // Intrinsic: TX_BASE_COST + COLD_ACCOUNT_ACCESS = 14_900.
+    assert_eq!(
+        gas.total_gas_spent(),
+        eip2780::TX_BASE_COST + eip8038::COLD_ACCOUNT_ACCESS
+    );
+    assert_eq!(gas.state_gas_spent_final(), 0);
+}
+
+#[test]
+fn test_eip2780_call_empty_with_value() {
+    let mut evm = evm();
+    let to = address!("0x00000000000000000000000000000000000000ab");
+    let gas = run(&mut evm, TxKind::Call(to), U256::from(1u64));
+    // Intrinsic regular: TX_BASE_COST + COLD_ACCOUNT_ACCESS + ACCOUNT_WRITE + TRANSFER_LOG_COST = 23_356.
+    // Top-level state gas: STATE_BYTES_PER_NEW_ACCOUNT × CPSB = 183_600.
+    let expected_regular = eip2780::TX_BASE_COST
+        + eip8038::COLD_ACCOUNT_ACCESS
+        + eip8038::ACCOUNT_WRITE
+        + eip2780::TRANSFER_LOG_COST;
+    assert_eq!(regular_spent(&gas), expected_regular);
+    assert_eq!(gas.state_gas_spent_final(), STATE_BYTES_PER_NEW_ACCOUNT);
+}
+
+#[test]
+fn test_eip2780_create_no_value() {
+    let mut evm = evm();
+    let gas = run(&mut evm, TxKind::Create, U256::ZERO);
+    // Intrinsic regular: TX_BASE_COST + CREATE_ACCESS = 21_600.
+    // Intrinsic state gas: STATE_BYTES_PER_NEW_ACCOUNT × CPSB = 183_600.
+    let expected_regular = eip2780::TX_BASE_COST + eip8038::CREATE_ACCESS;
+    assert_eq!(regular_spent(&gas), expected_regular);
+    assert_eq!(gas.state_gas_spent_final(), STATE_BYTES_PER_NEW_ACCOUNT);
+}
+
+#[test]
+fn test_eip2780_create_with_value() {
+    let mut evm = evm();
+    let gas = run(&mut evm, TxKind::Create, U256::from(1u64));
+    // Intrinsic regular: TX_BASE_COST + CREATE_ACCESS + TRANSFER_LOG_COST.
+    // Intrinsic state gas: STATE_BYTES_PER_NEW_ACCOUNT × CPSB.
+    let expected_regular =
+        eip2780::TX_BASE_COST + eip8038::CREATE_ACCESS + eip2780::TRANSFER_LOG_COST;
+    assert_eq!(regular_spent(&gas), expected_regular);
+    assert_eq!(gas.state_gas_spent_final(), STATE_BYTES_PER_NEW_ACCOUNT);
+}
+
+#[test]
+fn test_eip2780_legacy_base_when_disabled() {
+    // With EIP-2780 disabled, the legacy 21,000 stipend applies.
+    let mut evm = evm_no_eip2780();
+    let to = address!("0x00000000000000000000000000000000000000aa");
+    let gas = run(&mut evm, TxKind::Call(to), U256::ZERO);
+    assert_eq!(gas.total_gas_spent(), LEGACY_BASE);
+}

--- a/crates/ee-tests/src/eip8037.rs
+++ b/crates/ee-tests/src/eip8037.rs
@@ -36,6 +36,10 @@ fn state_gas_evm(bytecode: Bytecode, cap: u64) -> MainEvm {
     Context::mainnet()
         .modify_cfg_chained(|cfg| {
             cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
+            // EIP-2780 changes intrinsic gas independently of the EIP-8037
+            // reservoir model this test file exercises; disable it here to
+            // keep the comparisons focused on state-gas behaviour.
+            cfg.enable_amsterdam_eip2780 = false;
             cfg.tx_gas_limit_cap = Some(cap);
             cfg.cpsb_override = Some(1);
             cfg.gas_params.override_gas([
@@ -55,6 +59,7 @@ fn baseline_evm(bytecode: Bytecode) -> MainEvm {
         .modify_cfg_chained(|cfg| {
             cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
             cfg.enable_amsterdam_eip8037 = false;
+            cfg.enable_amsterdam_eip2780 = false;
             cfg.tx_gas_limit_cap = Some(u64::MAX);
         })
         .with_db(BenchmarkDB::new_bytecode(bytecode))
@@ -1047,6 +1052,7 @@ fn test_eip8037_block_gas_limit_enforced_with_state_gas() {
     let mut evm = Context::mainnet()
         .modify_cfg_chained(|cfg| {
             cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
+            cfg.enable_amsterdam_eip2780 = false;
             cfg.tx_gas_limit_cap = Some(u64::MAX);
             cfg.cpsb_override = Some(1);
             cfg.gas_params.override_gas([
@@ -1081,6 +1087,7 @@ fn test_eip8037_block_gas_limit_enforced_with_state_gas() {
     let mut evm_no_state = Context::mainnet()
         .modify_cfg_chained(|cfg| {
             cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
+            cfg.enable_amsterdam_eip2780 = false;
             cfg.tx_gas_limit_cap = Some(u64::MAX);
         })
         .modify_block_chained(|block| {
@@ -2266,6 +2273,7 @@ fn test_eip8037_tx_create_collision() {
         .modify_cfg_chained(|cfg| {
             cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
             cfg.enable_amsterdam_eip8037 = false;
+            cfg.enable_amsterdam_eip2780 = false;
             cfg.tx_gas_limit_cap = Some(u64::MAX);
         })
         .with_db(build_db())
@@ -2277,6 +2285,7 @@ fn test_eip8037_tx_create_collision() {
     let mut evm = Context::mainnet()
         .modify_cfg_chained(|cfg| {
             cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
+            cfg.enable_amsterdam_eip2780 = false;
             cfg.cpsb_override = Some(1);
             cfg.gas_params.override_gas([
                 (GasId::sstore_set_state_gas(), STATE_GAS_SSTORE_SET),

--- a/crates/ee-tests/src/lib.rs
+++ b/crates/ee-tests/src/lib.rs
@@ -19,4 +19,7 @@ macro_rules! assert_sorted_json_snapshot {
 mod revm_tests;
 
 #[cfg(test)]
+mod eip2780;
+
+#[cfg(test)]
 mod eip8037;

--- a/crates/ee-tests/src/revm_tests.rs
+++ b/crates/ee-tests/src/revm_tests.rs
@@ -279,12 +279,15 @@ fn test_eip7708_transfer_log_tx_value() {
 
     let tx_value = U256::from(1_000_000_000_000_000u128); // 0.001 ETH (within balance)
 
+    // ETH transfer creating new account costs ~207k gas under EIP-2780
+    // (TX_BASE_COST + COLD_ACCOUNT_ACCESS + ACCOUNT_WRITE + TRANSFER_LOG_COST
+    //  + STATE_BYTES_PER_NEW_ACCOUNT × CPSB at top-level execution).
     let result = evm
         .transact_one(
             TxEnv::builder_for_bench()
                 .to(recipient)
                 .value(tx_value)
-                .gas_limit(100_000)
+                .gas_limit(300_000)
                 .gas_price(0) // Zero gas price to avoid balance issues
                 .build_fill(),
         )

--- a/crates/ee-tests/src/revm_tests.rs
+++ b/crates/ee-tests/src/revm_tests.rs
@@ -435,11 +435,12 @@ const SELFDESTRUCT_TO_SELF_INIT_CODE: &[u8] = &[
     opcode::SELFDESTRUCT,
 ];
 
-/// Test EIP-7708 selfdestruct-to-self log emission
-/// This test creates a contract with value that selfdestructs to itself during construction,
-/// which should emit a SelfBalanceLog since the contract is created in the same tx.
+/// Test EIP-8246 selfdestruct-to-self balance preservation.
+/// This test creates a contract with value that selfdestructs to itself during construction.
+/// Before EIP-8246 this burned the balance and emitted a `Burn` log; with EIP-8246 the balance
+/// is preserved and the account is kept with cleared code, storage and nonce.
 #[test]
-fn test_eip7708_selfdestruct_to_self() {
+fn test_eip8246_selfdestruct_to_self_preserves_balance() {
     let mut evm = Context::mainnet()
         .with_cfg(CfgEnv::new_with_spec(SpecId::AMSTERDAM))
         .modify_block_chained(|block| block.gas_limit = 100_000_000)
@@ -463,21 +464,29 @@ fn test_eip7708_selfdestruct_to_self() {
 
     assert!(result.is_success(), "Transaction should succeed");
 
-    // Find the burn log
+    // EIP-8246: self-destruct to self no longer burns the balance, so no `Burn` log is emitted.
     let logs = result.logs();
     let burn_log = logs
         .iter()
         .find(|log| log.data.topics().len() == 2 && log.data.topics()[0] == BURN_LOG_TOPIC);
-
     assert!(
-        burn_log.is_some(),
-        "Expected burn log, got logs: {:?}",
-        logs
+        burn_log.is_none(),
+        "Expected no burn log, got logs: {logs:?}"
     );
-    let log = burn_log.unwrap();
-    assert_eq!(log.address, ETH_TRANSFER_LOG_ADDRESS);
-    // The log data should contain the create value
-    assert_eq!(log.data.data.as_ref(), &create_value.to_be_bytes::<32>());
+
+    // The created account keeps its balance, while its code, storage and nonce are cleared
+    // and it is no longer marked self-destructed.
+    let created_address = result.created_address().unwrap();
+    let account = evm
+        .ctx
+        .journal_mut()
+        .state
+        .get(&created_address)
+        .expect("self-destructed account should be preserved");
+    assert_eq!(account.info.balance, create_value);
+    assert_eq!(account.info.nonce, 0);
+    assert_eq!(account.info.code_hash, KECCAK_EMPTY);
+    assert!(!account.is_selfdestructed());
 }
 
 /// Bytecode that performs a CALL with value to a specific address

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_block_gas_limit_enforced_with_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_block_gas_limit_enforced_with_state_gas.snap
@@ -6,7 +6,7 @@ expression: "&result_fits"
   "Success": {
     "reason": "Stop",
     "gas": {
-      "gas_spent": 226006,
+      "gas_spent": 226009,
       "state_gas_spent": 200000,
       "gas_refunded": 0,
       "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_propagates.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_propagates.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 35525,
+        "gas_spent": 33530,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 571531,
+        "gas_spent": 569536,
         "state_gas_spent": 536000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_reverts.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_reverts.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 35747,
+        "gas_spent": 33752,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 375753,
+        "gas_spent": 373758,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_existing_account.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_existing_account.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 27822,
+        "gas_spent": 27824,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -32,7 +32,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 27822,
+        "gas_spent": 27824,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 30322,
+        "gas_spent": 37025,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -32,7 +32,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 280322,
+        "gas_spent": 287025,
         "state_gas_spent": 250000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account_no_value.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account_no_value.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 23622,
+        "gas_spent": 23623,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 23622,
+        "gas_spent": 23623,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create2_with_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create2_with_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 30079,
+        "gas_spent": 28080,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 370085,
+        "gas_spent": 368086,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -37,7 +37,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 370076,
+        "gas_spent": 368077,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_child_propagates.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_child_propagates.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 35121,
+        "gas_spent": 33125,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 566127,
+        "gas_spent": 564131,
         "state_gas_spent": 531000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_code_deposit_state_gas_oog.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_code_deposit_state_gas_oog.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, baseline_tight_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 30079,
+        "gas_spent": 28080,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, baseline_tight_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 30079,
+        "gas_spent": 28080,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -39,7 +39,7 @@ expression: "&(baseline_result, baseline_tight_result, result)"
         "OutOfGas": "Basic"
       },
       "gas": {
-        "gas_spent": 30080,
+        "gas_spent": 28081,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_empty_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_empty_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 30067,
+        "gas_spent": 28068,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 360067,
+        "gas_spent": 358068,
         "state_gas_spent": 330000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_large_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_large_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 30088,
+        "gas_spent": 28089,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 560130,
+        "gas_spent": 558131,
         "state_gas_spent": 530000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 30070,
+        "gas_spent": 28071,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 370076,
+        "gas_spent": 368077,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_sstore.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 35121,
+        "gas_spent": 33125,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 566127,
+        "gas_spent": 564131,
         "state_gas_spent": 531000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_nested_call_create_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_nested_call_create_sstore.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 35525,
+        "gas_spent": 33530,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 571531,
+        "gas_spent": 569536,
         "state_gas_spent": 536000,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -37,7 +37,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 366076,
+        "gas_spent": 364077,
         "state_gas_spent": 336000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_parent_sstore_after_child_revert.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_parent_sstore_after_child_revert.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 40753,
+        "gas_spent": 38761,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 580759,
+        "gas_spent": 578767,
         "state_gas_spent": 540000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_precompile_no_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_precompile_no_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 21137,
+        "gas_spent": 21138,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 21137,
+        "gas_spent": 21138,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_causes_oog.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_causes_oog.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_sufficient.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_sufficient.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226006,
+        "gas_spent": 226009,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_state_gas_less.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_state_gas_less.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_vs_revert_difference.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_vs_revert_difference.snap
@@ -20,7 +20,7 @@ expression: "&(result_halt, result_revert)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 26012,
+        "gas_spent": 26015,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_less.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_less.snap
@@ -6,7 +6,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 26012,
+        "gas_spent": 26015,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -18,7 +18,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 26012,
+        "gas_spent": 26015,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_more.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_more.snap
@@ -6,7 +6,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 31018,
+        "gas_spent": 31024,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -18,7 +18,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 31018,
+        "gas_spent": 31024,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reverted_create_child.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reverted_create_child.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 35118,
+        "gas_spent": 33122,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 35118,
+        "gas_spent": 33122,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_selfdestruct_new_account.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_selfdestruct_new_account.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "SelfDestruct",
       "gas": {
-        "gas_spent": 28603,
+        "gas_spent": 35305,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -32,7 +32,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "SelfDestruct",
       "gas": {
-        "gas_spent": 278603,
+        "gas_spent": 285305,
         "state_gas_spent": 250000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_multiple_new_slots.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_multiple_new_slots.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 36018,
+        "gas_spent": 36027,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 636018,
+        "gas_spent": 636027,
         "state_gas_spent": 600000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_new_slot.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_new_slot.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226006,
+        "gas_spent": 226009,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_overwrite_no_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_overwrite_no_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26112,
+        "gas_spent": 26116,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226112,
+        "gas_spent": 226116,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_set_then_clear_refund.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_set_then_clear_refund.snap
@@ -7,9 +7,9 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26112,
+        "gas_spent": 26116,
         "state_gas_spent": 0,
-        "gas_refunded": 2800,
+        "gas_refunded": 2801,
         "floor_gas": 21000
       },
       "logs": [],
@@ -22,9 +22,9 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26112,
+        "gas_spent": 26116,
         "state_gas_spent": 0,
-        "gas_refunded": 2800,
+        "gas_refunded": 2801,
         "floor_gas": 21000
       },
       "logs": [],

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_zero_to_zero_no_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_zero_to_zero_no_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 23206,
+        "gas_spent": 23208,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 23206,
+        "gas_spent": 23208,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_does_not_reduce_regular_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_does_not_reduce_regular_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226006,
+        "gas_spent": 226009,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_oog_remaining.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_oog_remaining.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_spent_final_in_result.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_spent_final_in_result.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226006,
+        "gas_spent": 226009,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_selfdestruct_after_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_selfdestruct_after_sstore.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Return",
       "gas": {
-        "gas_spent": 40431,
+        "gas_spent": 38435,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 22728
@@ -25,7 +25,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Return",
       "gas": {
-        "gas_spent": 240551,
+        "gas_spent": 238555,
         "state_gas_spent": 200120,
         "gas_refunded": 0,
         "floor_gas": 22728

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_limit_cap_not_enforced_with_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_limit_cap_not_enforced_with_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26006,
+        "gas_spent": 26009,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226006,
+        "gas_spent": 226009,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -695,7 +695,7 @@ pub fn return_create<CTX: ContextTr>(
     }
 
     // EIP-170: Contract code size limit to 0x6000 (~25kb)
-    // EIP-7954 increased this limit to 0x8000 (~32kb).
+    // EIP-7954 increased this limit to 0x10000 (64kb).
     // This must be checked BEFORE charging state gas for code deposit,
     // so that oversized code does not incur storage gas costs.
     if spec_id.is_enabled_in(SPURIOUS_DRAGON) && interpreter_result.output.len() > max_code_size {

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -21,6 +21,7 @@ use interpreter::{
 };
 use primitives::{
     constants::CALL_STACK_LIMIT,
+    eip8038,
     hardfork::SpecId::{self, HOMESTEAD, LONDON, SPURIOUS_DRAGON},
     Address, Bytes, U256,
 };
@@ -154,9 +155,54 @@ impl EthFrame<EthInterpreter> {
         inputs: Box<CallInputs>,
     ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR> {
         let reservoir_remaining_gas = inputs.reservoir;
-        let charged_new_account_state_gas = inputs.charged_new_account_state_gas;
-        let gas =
+        let mut charged_new_account_state_gas = inputs.charged_new_account_state_gas;
+        let mut gas =
             Gas::new_with_regular_gas_and_reservoir(inputs.gas_limit, reservoir_remaining_gas);
+
+        // EIP-2780 top-level execution charges. Applied before any state changes
+        // so the recipient's pre-call state determines the charge.
+        let mut early_halt: Option<InstructionResult> = None;
+        if depth == 0
+            && ctx.cfg().is_amsterdam_eip2780_enabled()
+            && !precompiles.contains(&inputs.target_address)
+        {
+            // Load the (already-cached) recipient account.
+            let acc_info = ctx
+                .journal_mut()
+                .load_account(inputs.target_address)
+                .ok()
+                .map(|a| a.info.clone());
+
+            if let Some(info) = acc_info {
+                // 7702 delegation: additional COLD_ACCOUNT_ACCESS regular gas.
+                let is_7702_delegated = info
+                    .code
+                    .as_ref()
+                    .and_then(Bytecode::eip7702_address)
+                    .is_some();
+                if is_7702_delegated && !gas.record_regular_cost(eip8038::COLD_ACCOUNT_ACCESS) {
+                    early_halt = Some(InstructionResult::OutOfGas);
+                }
+
+                // Empty recipient + nonzero value: charge `new_account_state_gas`.
+                // Refunded on revert via the existing `state_gas_spent`/reservoir
+                // reconciliation in `last_frame_result`.
+                if early_halt.is_none() {
+                    if let CallValue::Transfer(value) = inputs.value {
+                        if !value.is_zero() && info.is_empty() {
+                            let cpsb = ctx.cfg().cpsb();
+                            let charge = ctx.cfg().gas_params().new_account_state_gas(cpsb);
+                            if !gas.record_state_cost(charge) {
+                                early_halt = Some(InstructionResult::OutOfGas);
+                            } else {
+                                charged_new_account_state_gas = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         let return_result = |instruction_result: InstructionResult| {
             Ok(ItemOrResult::Result(FrameResult::Call(CallOutcome {
                 result: InterpreterResult {
@@ -170,6 +216,10 @@ impl EthFrame<EthInterpreter> {
                 charged_new_account_state_gas,
             })))
         };
+
+        if let Some(halt) = early_halt {
+            return return_result(halt);
+        }
 
         // Check depth
         if depth > CALL_STACK_LIMIT as usize {

--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -10,12 +10,13 @@ use context::{
     LocalContextTr,
 };
 use context_interface::{
+    cfg::gas_params,
     context::{take_error, ContextError},
     result::{HaltReasonTr, InvalidHeader, InvalidTransaction, ResultGas},
     Cfg, ContextTr, Database, JournalTr, Transaction,
 };
 use interpreter::{interpreter_action::FrameInit, Gas, InitialAndFloorGas, SharedMemory};
-use primitives::U256;
+use primitives::{hardfork::SpecId, U256};
 
 /// Trait for errors that can occur during EVM execution.
 ///
@@ -306,14 +307,25 @@ pub trait Handler {
         &self,
         evm: &mut Self::Evm,
     ) -> Result<InitialAndFloorGas, Self::Error> {
-        let ctx = evm.ctx_ref();
+        let ctx = evm.ctx();
+        let cfg = ctx.cfg();
+        let spec: SpecId = cfg.spec().into();
+        let is_eip7623_disabled = cfg.is_eip7623_disabled();
+        let is_amsterdam_eip8037_enabled = cfg.is_amsterdam_eip8037_enabled();
+        let is_amsterdam_eip2780_enabled = cfg.is_amsterdam_eip2780_enabled();
+        let tx_gas_limit_cap = cfg.tx_gas_limit_cap();
+        let cpsb = cfg.cpsb();
+        let tx = ctx.tx();
+        let eip2780 =
+            is_amsterdam_eip2780_enabled.then(|| gas_params::Eip2780TxInfo { value: tx.value() });
         let gas = validation::validate_initial_tx_gas(
-            ctx.tx(),
-            ctx.cfg().spec().into(),
-            ctx.cfg().is_eip7623_disabled(),
-            ctx.cfg().is_amsterdam_eip8037_enabled(),
-            ctx.cfg().tx_gas_limit_cap(),
-            ctx.cfg().cpsb(),
+            tx,
+            spec,
+            is_eip7623_disabled,
+            is_amsterdam_eip8037_enabled,
+            tx_gas_limit_cap,
+            cpsb,
+            eip2780,
         )?;
 
         Ok(gas)

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -243,8 +243,9 @@ pub fn validate_initial_tx_gas(
     is_amsterdam_eip8037_enabled: bool,
     tx_gas_limit_cap: u64,
     cpsb: u64,
+    eip2780: Option<context_interface::cfg::gas_params::Eip2780TxInfo>,
 ) -> Result<InitialAndFloorGas, InvalidTransaction> {
-    let mut gas = calculate_initial_tx_gas_for_tx(&tx, spec, cpsb);
+    let mut gas = calculate_initial_tx_gas_for_tx(&tx, spec, cpsb, eip2780);
 
     if is_eip7623_disabled {
         gas.set_floor_gas(0);

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -363,7 +363,7 @@ mod tests {
 
     #[test]
     fn test_eip7954_initcode_between_old_and_new_limit() {
-        // Size between old limit (0xC000) and new limit (0x10000):
+        // Size between old limit (0xC000) and new limit (0x20000):
         // should fail pre-Amsterdam, succeed at Amsterdam
         let size = eip3860::MAX_INITCODE_SIZE + 1; // 0xC001
         let large_bytecode = vec![opcode::STOP; size];
@@ -386,13 +386,13 @@ mod tests {
 
     #[test]
     fn test_eip7954_code_size_limit_failure() {
-        // EIP-7954: MAX_CODE_SIZE = 0x8000
-        // use the simplest method to return a contract code size greater than 0x8000
-        // PUSH3 0x8001 (greater than 0x8000) - return size
+        // EIP-7954: MAX_CODE_SIZE = 0x10000
+        // use the simplest method to return a contract code size greater than 0x10000
+        // PUSH3 0x10001 (greater than 0x10000) - return size
         // PUSH1 0x00 - memory position 0
         // RETURN - return uninitialized memory, will be filled with 0
         let init_code = vec![
-            0x62, 0x00, 0x80, 0x01, // PUSH3 0x8001 (greater than 0x8000)
+            0x62, 0x01, 0x00, 0x01, // PUSH3 0x10001 (greater than 0x10000)
             0x60, 0x00, // PUSH1 0
             0xf3, // RETURN
         ];

--- a/crates/interpreter/src/instructions.rs
+++ b/crates/interpreter/src/instructions.rs
@@ -125,6 +125,25 @@ pub const fn gas_table_spec(spec: SpecId) -> GasTable {
         table[STATICCALL as usize] = gas::WARM_STORAGE_READ_COST as u16;
     }
 
+    if spec.is_enabled_in(AMSTERDAM) {
+        // EIP-8038: bump every warm/cold access base from 100 to 101.
+        // SLOAD / *CALL / BALANCE / EXTCODEHASH: a single WARM_ACCESS.
+        let warm = primitives::eip8038::WARM_ACCESS as u16;
+        table[SLOAD as usize] = warm;
+        table[BALANCE as usize] = warm;
+        table[EXTCODEHASH as usize] = warm;
+        table[CALL as usize] = warm;
+        table[CALLCODE as usize] = warm;
+        table[DELEGATECALL as usize] = warm;
+        table[STATICCALL as usize] = warm;
+        // EIP-8038 §"EXT* family update": EXTCODESIZE and EXTCODECOPY do two
+        // database reads, so the per-call access cost is `WARM_ACCESS` above
+        // the regular access cost. Bake the extra WARM_ACCESS into the static
+        // base; the dynamic cold premium is still added by `load_account`.
+        table[EXTCODESIZE as usize] = warm + warm;
+        table[EXTCODECOPY as usize] = warm + warm;
+    }
+
     table
 }
 

--- a/crates/primitives/src/eip2780.rs
+++ b/crates/primitives/src/eip2780.rs
@@ -1,0 +1,21 @@
+//! EIP-2780: Reduce intrinsic transaction gas
+//!
+//! Replaces the legacy `21,000` intrinsic base with a decomposed model that
+//! prices ECDSA recovery, sender access + write, and additional `to`/`value`
+//! charges separately. Composes with EIP-8037 (state gas) and reuses the
+//! placeholder values from [`crate::eip8038`] for `ACCOUNT_WRITE`,
+//! `CREATE_ACCESS`, and `COLD_ACCOUNT_ACCESS`.
+
+/// Reduced intrinsic base cost charged to `tx.sender`.
+///
+/// Per the EIP, `TX_BASE_COST = GAS_PRECOMPILE_ECRECOVER + COLD_ACCOUNT_ACCESS + ACCOUNT_WRITE`.
+/// Kept at the literal `12_300` from the EIP-2780 reference table; the `+1`
+/// placeholder values in [`crate::eip8038`] would compute `12_302` instead.
+pub const TX_BASE_COST: u64 = 12_300;
+
+/// Regular gas cost of the EIP-7708 transfer log emitted for every nonzero-value
+/// transfer to a different account.
+///
+/// `TRANSFER_LOG_COST = GAS_LOG + 3 * GAS_LOG_TOPIC + 32 * GAS_LOG_DATA_PER_BYTE`
+/// = `375 + 1_125 + 256 = 1_756`.
+pub const TRANSFER_LOG_COST: u64 = 1_756;

--- a/crates/primitives/src/eip7954.rs
+++ b/crates/primitives/src/eip7954.rs
@@ -2,8 +2,8 @@
 //!
 //! Increases the contract code size limit and initcode size limit.
 
-/// EIP-7954: Maximum contract code size: 32,768 bytes (0x8000).
-pub const MAX_CODE_SIZE: usize = 0x8000;
+/// EIP-7954: Maximum contract code size: 65,536 bytes (0x10000).
+pub const MAX_CODE_SIZE: usize = 0x10000;
 
-/// EIP-7954: Maximum initcode size: 65,536 bytes (0x10000).
-pub const MAX_INITCODE_SIZE: usize = 0x10000;
+/// EIP-7954: Maximum initcode size: 131,072 bytes (0x20000).
+pub const MAX_INITCODE_SIZE: usize = 0x20000;

--- a/crates/primitives/src/eip8038.rs
+++ b/crates/primitives/src/eip8038.rs
@@ -1,0 +1,60 @@
+//! EIP-8038: State-Access Gas Cost Update
+//!
+//! Increases the gas cost of state-access operations to reflect Ethereum's
+//! larger state. All "TBD" values in the draft spec are filled in here as
+//! `previous_value + 1`.
+//!
+//! Active alongside EIP-7904 and EIP-8037 starting at the Amsterdam hardfork.
+
+/// Cold touch of an account (was 2,600 pre-EIP-8038).
+pub const COLD_ACCOUNT_ACCESS: u64 = 2_601;
+
+/// Surcharge for writing to an account that changes one account leaf value for
+/// the first time (was 6,700 pre-EIP-8038).
+pub const ACCOUNT_WRITE: u64 = 6_701;
+
+/// Cold touch of a storage slot (was 2,100 pre-EIP-8038).
+pub const COLD_STORAGE_ACCESS: u64 = 2_101;
+
+/// Surcharge for writing to a storage slot that changes its value for the
+/// first time (was 2,800 pre-EIP-8038).
+pub const STORAGE_WRITE: u64 = 2_801;
+
+/// Touch of an already-warm account or storage slot (was 100 pre-EIP-8038).
+pub const WARM_ACCESS: u64 = 101;
+
+/// Refund for clearing a storage slot (was 4,800 pre-EIP-8038).
+pub const STORAGE_CLEAR_REFUND: u64 = 4_801;
+
+/// State access cost for contract deployment (was 7,000 pre-EIP-8038).
+///
+/// Note: the spec also defines `CREATE_ACCESS = ACCOUNT_WRITE + COLD_STORAGE_ACCESS`,
+/// which does not exactly match the legacy decomposition. Per the user-supplied
+/// rule we keep this slot at the literal `previous + 1` value rather than the
+/// derived sum.
+pub const CREATE_ACCESS: u64 = 7_001;
+
+/// Gas charged per storage key included in a transaction's access list
+/// (was 1,900 pre-EIP-8038).
+pub const ACCESS_LIST_STORAGE_KEY_COST: u64 = 1_901;
+
+/// Gas charged per address included in a transaction's access list
+/// (was 2,400 pre-EIP-8038).
+pub const ACCESS_LIST_ADDRESS_COST: u64 = 2_401;
+
+/// Cold premium on top of `WARM_ACCESS` for account access.
+pub const COLD_ACCOUNT_ACCESS_ADDITIONAL: u64 = COLD_ACCOUNT_ACCESS - WARM_ACCESS;
+
+/// Cold premium on top of `WARM_ACCESS` for storage access.
+pub const COLD_STORAGE_ACCESS_ADDITIONAL: u64 = COLD_STORAGE_ACCESS - WARM_ACCESS;
+
+/// CALL value transfer cost: `ACCOUNT_WRITE + CALL_STIPEND` per the EIP.
+pub const CALL_VALUE: u64 = ACCOUNT_WRITE + 2_300;
+
+/// Regular-gas portion of EIP-7702 `PER_EMPTY_ACCOUNT_COST` under EIP-8038.
+///
+/// Equal to the pre-EIP-8038 value (`crate::eip8037::EIP7702_PER_EMPTY_ACCOUNT_REGULAR`)
+/// plus the delta from the modified primitives that appear in the per-auth
+/// breakdown (`ACCOUNT_WRITE` +1, `COLD_ACCOUNT_ACCESS` +1, two `WARM_ACCESS`
+/// occurrences +1 each — total +4).
+pub const EIP7702_PER_EMPTY_ACCOUNT_REGULAR: u64 = 7_504;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -26,6 +26,7 @@ pub mod eip7825;
 pub mod eip7907;
 pub mod eip7954;
 pub mod eip8037;
+pub mod eip8038;
 pub mod hardfork;
 pub mod hints_util;
 mod once_lock;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -17,6 +17,7 @@ extern crate alloc as std;
 
 pub mod constants;
 pub mod eip170;
+pub mod eip2780;
 pub mod eip3860;
 pub mod eip4844;
 pub mod eip7702;

--- a/examples/cheatcode_inspector/src/main.rs
+++ b/examples/cheatcode_inspector/src/main.rs
@@ -137,9 +137,9 @@ impl JournalTr for Backend {
         self.journaled_state.set_spec_id(spec_id);
     }
 
-    fn set_eip7708_config(&mut self, disabled: bool, delayed_burn_disabled: bool) {
+    fn set_eip7708_config(&mut self, disabled: bool, eip8246_delayed_clear_disabled: bool) {
         self.journaled_state
-            .set_eip7708_config(disabled, delayed_burn_disabled);
+            .set_eip7708_config(disabled, eip8246_delayed_clear_disabled);
     }
 
     fn touch_account(&mut self, address: Address) {


### PR DESCRIPTION
## Summary

Glamsterdam devnet-5 EIP bundle. Status of included EIPs:

- [ ] **EIP-2780** — Reduce intrinsic transaction gas.
  - #3682 — feat(eip2780): reduce intrinsic transaction gas
- [x] **EIP-8038** — State access gas cost update (numbers pending final spec).
  - #3697 — feat(eip8038): implement state-access gas cost update
- [x] **EIP-7954** — Increase max contract size to 64 KiB (initcode 128 KiB).
  - #3707 — feat(eip7954): bump max code size to 64 KiB and initcode to 128 KiB
- [x] **EIP-8246** — Remove SELFDESTRUCT burn.
  - #3717 — feat(context): implement EIP-8246 (remove SELFDESTRUCT burn)
- [ ] **EIP-8037** — State-gas reservoir fixes.
  - [ ] - Pending changes from https://github.com/ethereum/EIPs/pull/11706/changes
  - [x] - https://github.com/bluealloy/revm/pull/3719 floor gas removed from block regular gas calc
  - [ ] - eip7702 gas optimization on double delegate in list.
- [ ] **BAL** - Pending vote on how to handle balance and call stack check with loading of target in CALLs
   - [ ] PR https://github.com/ethereum/EIPs/compare/master...nerolation:EIPs:toni/state-access
   - #3720 — feat(eip7702): defer delegate code load via BytecodeLoad enum

> **Note:** **EIP-7997** (Deterministic factory predeploy) is being implemented in alloy/evm: https://github.com/alloy-rs/evm/pull/368

## Test plan
- [x] `cargo check --workspace`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo fmt --all --check`
