### PR TITLE
refactor(eip8037): remove dead refill_amount tracking

### DIFF
--- a/crates/context/interface/src/cfg/gas.rs
+++ b/crates/context/interface/src/cfg/gas.rs
@@ -22,12 +22,6 @@ pub struct GasTracker {
     /// more state gas than the frame itself has charged (the parent previously
     /// charged the 0→x portion). The net is reconciled on frame return.
     state_gas_spent: i64,
-    /// Cumulative reservoir refill amount from 0→x→0 storage restorations
-    /// performed by this frame (EIP-8037 issue #2). Tracked so that on
-    /// revert/halt the parent can subtract this inflation when propagating
-    /// the child's reservoir, without confusing it with legitimate reservoir
-    /// growth from grandchild halt/revert refunds.
-    refill_amount: u64,
     /// Refunded gas. Used to refund the gas to the caller at the end of execution.
     refunded: i64,
 }
@@ -41,7 +35,6 @@ impl GasTracker {
             remaining,
             reservoir,
             state_gas_spent: 0,
-            refill_amount: 0,
             refunded: 0,
         }
     }
@@ -166,20 +159,6 @@ impl GasTracker {
     pub const fn refill_reservoir(&mut self, amount: u64) {
         self.reservoir = self.reservoir.saturating_add(amount);
         self.state_gas_spent = self.state_gas_spent.saturating_sub(amount as i64);
-        self.refill_amount = self.refill_amount.saturating_add(amount);
-    }
-
-    /// Returns cumulative reservoir refill amount from 0→x→0 restorations
-    /// performed in this frame.
-    #[inline]
-    pub const fn refill_amount(&self) -> u64 {
-        self.refill_amount
-    }
-
-    /// Sets the refill amount.
-    #[inline]
-    pub const fn set_refill_amount(&mut self, val: u64) {
-        self.refill_amount = val;
     }
 
     /// Records a refund value.

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -534,13 +534,10 @@ impl EthFrame<EthInterpreter> {
                 // this frame's tracker. When the child fails to deploy a contract
                 // (revert, halt, or early-fail paths that return `address == None`
                 // such as nonce overflow, depth, OutOfFunds), refund the upfront
-                // charge to the reservoir and undo it on `state_gas_spent`.
-                // The nonce-overflow path reports `InstructionResult::Return` (ok)
+                // charge to the reservoir and undo it on `state_gas_spent` via
+                // `refill_reservoir` (matching 0→x→0 storage restoration). The
+                // nonce-overflow path reports `InstructionResult::Return` (ok)
                 // with `address == None`, so gate on address rather than the result.
-                //
-                // Use `refill_reservoir` so that this refund is counted in
-                // `refill_amount` and gets unwound if the parent itself
-                // reverts/halts (matching 0→x→0 storage restoration).
                 let create_failed = outcome.address.is_none() || !instruction_result.is_ok();
 
                 if create_failed && ctx.cfg().is_amsterdam_eip8037_enabled() {
@@ -587,13 +584,6 @@ pub const fn handle_reservoir_remaining_gas(
             parent_gas
                 .state_gas_spent()
                 .saturating_add(child_gas.state_gas_spent()),
-        );
-        // Propagate child's 0→x→0 refill total so that if the parent
-        // later reverts/halts, the refill contribution can be unwound.
-        parent_gas.set_refill_amount(
-            parent_gas
-                .refill_amount()
-                .saturating_add(child_gas.refill_amount()),
         );
     } else {
         // On revert/halt: the child's state changes are rolled back, so any

--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -400,7 +400,6 @@ pub trait Handler {
         let refunded = gas.refunded();
         let reservoir = gas.reservoir();
         let state_gas_spent = gas.state_gas_spent();
-        let state_refill = gas.refill_amount();
 
         // Spend the gas limit. Gas is reimbursed when the tx returns successfully.
         *gas = Gas::new_spent_with_reservoir(evm.ctx().tx().gas_limit(), reservoir);
@@ -417,7 +416,6 @@ pub trait Handler {
         // return zero state gas on halt/revert.
         if instruction_result.is_ok() {
             gas.set_state_gas_spent(state_gas_spent);
-            gas.set_refill_amount(gas.refill_amount() + state_refill);
         } else {
             gas.set_state_gas_spent(0);
         }

--- a/crates/handler/src/precompile_provider.rs
+++ b/crates/handler/src/precompile_provider.rs
@@ -97,7 +97,6 @@ pub fn precompile_output_to_interpreter_result(
 
     // set state gas, reservoir is already set in the Gas constructor
     result.gas.set_state_gas_spent(output.state_gas_used as i64);
-    result.gas.set_refill_amount(output.refill_amount);
     result.gas.record_refund(output.gas_refunded);
 
     // spend used gas.
@@ -245,7 +244,6 @@ mod tests {
                     gas_refunded: 0,
                     state_gas_used: 0,
                     reservoir: inputs.reservoir,
-                    refill_amount: 0,
                     bytes: Bytes::from_static(b"unreliable"),
                 };
                 return Ok(Some(precompile_output_to_interpreter_result(

--- a/crates/interpreter/src/gas.rs
+++ b/crates/interpreter/src/gas.rs
@@ -176,18 +176,6 @@ impl Gas {
         self.tracker.refill_reservoir(amount);
     }
 
-    /// Returns the cumulative reservoir refill amount in this frame.
-    #[inline]
-    pub const fn refill_amount(&self) -> u64 {
-        self.tracker.refill_amount()
-    }
-
-    /// Sets the cumulative refill amount.
-    #[inline]
-    pub const fn set_refill_amount(&mut self, val: u64) {
-        self.tracker.set_refill_amount(val);
-    }
-
     /// Erases a gas cost from remaining (returns gas from child frame).
     #[inline]
     pub const fn erase_cost(&mut self, returned: u64) {

--- a/crates/precompile/src/interface.rs
+++ b/crates/precompile/src/interface.rs
@@ -118,9 +118,6 @@ pub struct PrecompileOutput {
     pub state_gas_used: u64,
     /// Reservoir gas for EIP-8037.
     pub reservoir: u64,
-    /// Cumulative reservoir refill amount from 0→x→0 storage restorations
-    /// performed during precompile execution (EIP-8037).
-    pub refill_amount: u64,
     /// Output bytes.
     pub bytes: Bytes,
 }
@@ -141,7 +138,6 @@ impl PrecompileOutput {
             gas_refunded: 0,
             state_gas_used: 0,
             reservoir,
-            refill_amount: 0,
             bytes,
         }
     }
@@ -154,7 +150,6 @@ impl PrecompileOutput {
             gas_refunded: 0,
             state_gas_used: 0,
             reservoir,
-            refill_amount: 0,
             bytes: Bytes::new(),
         }
     }
@@ -167,7 +162,6 @@ impl PrecompileOutput {
             gas_refunded: 0,
             state_gas_used: 0,
             reservoir,
-            refill_amount: 0,
             bytes,
         }
     }


### PR DESCRIPTION
## Summary
- Removes `GasTracker.refill_amount` and the parallel field on `PrecompileOutput`, plus the propagation lines that fed them. The field tracked cumulative reservoir refills from `refill_reservoir` calls (0→x→0 storage restoration, failed CREATE refunds), but the revert/halt unwinding it was meant to support is already covered by the signed-sum invariant `child.reservoir + child.state_gas_spent` — `refill_reservoir(r)` does `reservoir += r; state_gas_spent -= r`, so their sum is conserved across refills and recovers the pre-call value.
- Every read site (`last_frame_result` save/restore, `handle_reservoir_remaining_gas` success branch, `precompile_provider`) only fed the field back into itself. Nothing downstream — post-execution, refund finalization, or op-revm's `last_frame_result` override — consulted it.
- Net: **-56 / +3** across 6 files.

## Test plan
- [x] `cargo check --workspace --all-features` — clean.
- [x] `cargo nextest run -p revm-context-interface -p revm-handler -p revm-interpreter -p revm-precompile` — 122/122 passing.
- [x] `cargo clippy --workspace --all-targets --all-features` — clean.
- [x] `cargo fmt --all --check` — clean.
- [ ] Full `cargo nextest run --workspace`
- [ ] Conformance: re-run ee-tests with EIP-8037 enabled to confirm the reservoir/refill invariants hold.

## Notes
- `GasTracker` derives `serde::Serialize/Deserialize` under the `serde` feature, so removing the field is a **serialization-format break** for any external consumer that persists `GasTracker`.
- `PrecompileOutput` has no serde derive, so it's only a Rust ABI break there.