### PR TITLE
chore: v110 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
 
+# v110
+date: 21.05.2026
+
+Maintenance release. Removes the dead `refill_amount` tracking field from `GasTracker` and `PrecompileOutput` ([#3699](https://github.com/bluealloy/revm/pull/3699)). All transitively dependent crates bumped accordingly.
+
+* `revm-context-interface`: 19.0.0 -> 19.0.1 (✓ API compatible changes)
+* `revm-context`: 18.0.0 -> 18.0.1 (✓ dependency bump)
+* `revm-interpreter`: 37.0.0 -> 37.0.1 (✓ API compatible changes)
+* `revm-precompile`: 36.0.0 -> 36.0.1 (✓ API compatible changes)
+* `revm-handler`: 20.0.0 -> 20.0.1 (✓ API compatible changes)
+* `revm-inspector`: 21.0.0 -> 21.0.1 (✓ dependency bump)
+* `revm-statetest-types`: 19.0.0 -> 19.0.1 (✓ dependency bump)
+* `revm`: 40.0.0 -> 40.0.1 (✓ dependency bump)
+* `revme`: 17.0.0 -> 17.0.1 (✓ dependency bump)
+
 # v109
 date: 20.05.2026
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "20.0.0"
+version = "19.0.1"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3844,7 +3844,7 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "38.0.0"
+version = "37.0.1"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "37.0.0"
+version = "36.0.1"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "revme"
-version = "17.0.0"
+version = "17.0.1"
 dependencies = [
  "alloy-rlp",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,12 +47,12 @@ bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "11.
 database = { path = "crates/database", package = "revm-database", version = "15.0.0", default-features = false }
 database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "12.0.0", default-features = false }
 state = { path = "crates/state", package = "revm-state", version = "12.0.0", default-features = false }
-interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "38.0.0", default-features = false }
+interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "37.0.1", default-features = false }
 inspector = { path = "crates/inspector", package = "revm-inspector", version = "21.0.1", default-features = false }
-precompile = { path = "crates/precompile", package = "revm-precompile", version = "37.0.0", default-features = false }
+precompile = { path = "crates/precompile", package = "revm-precompile", version = "36.0.1", default-features = false }
 statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "19.0.1", default-features = false }
 context = { path = "crates/context", package = "revm-context", version = "18.0.1", default-features = false }
-context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "20.0.0", default-features = false }
+context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "19.0.1", default-features = false }
 handler = { path = "crates/handler", package = "revm-handler", version = "20.0.1", default-features = false }
 ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "0.3.0", default-features = false }
 

--- a/bins/revme/CHANGELOG.md
+++ b/bins/revme/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [17.0.1](https://github.com/bluealloy/revm/compare/revme-v17.0.0...revme-v17.0.1) - 2026-05-21
+
+### Other
+
+- updated the following local packages: revm
+
 ## [17.0.0](https://github.com/bluealloy/revm/compare/revme-v15.0.0...revme-v17.0.0) - 2026-05-19
 
 ### Other

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revme"
 description = "Rust Ethereum Virtual Machine Executable"
-version = "17.0.0"
+version = "17.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/context/interface/CHANGELOG.md
+++ b/crates/context/interface/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [20.0.0](https://github.com/bluealloy/revm/compare/revm-context-interface-v19.0.0...revm-context-interface-v20.0.0) - 2026-05-21
+## [19.0.1](https://github.com/bluealloy/revm/compare/revm-context-interface-v19.0.0...revm-context-interface-v19.0.1) - 2026-05-21
 
 ### Other
 

--- a/crates/context/interface/Cargo.toml
+++ b/crates/context/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-context-interface"
 description = "Revm context interface crates"
-version = "20.0.0"
+version = "19.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [38.0.0](https://github.com/bluealloy/revm/compare/revm-interpreter-v37.0.0...revm-interpreter-v38.0.0) - 2026-05-21
+## [37.0.1](https://github.com/bluealloy/revm/compare/revm-interpreter-v37.0.0...revm-interpreter-v37.0.1) - 2026-05-21
 
 ### Other
 

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-interpreter"
 description = "Revm Interpreter that executes bytecode."
-version = "38.0.0"
+version = "37.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/precompile/CHANGELOG.md
+++ b/crates/precompile/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [37.0.0](https://github.com/bluealloy/revm/compare/revm-precompile-v36.0.0...revm-precompile-v37.0.0) - 2026-05-21
+## [36.0.1](https://github.com/bluealloy/revm/compare/revm-precompile-v36.0.0...revm-precompile-v36.0.1) - 2026-05-21
 
 ### Other
 

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-precompile"
 description = "Revm Precompiles - Ethereum compatible precompiled contracts"
-version = "37.0.0"
+version = "36.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
## Summary

Maintenance release. Patch-bump all crates affected by #3699 (removal of dead `refill_amount` tracking from `GasTracker` and `PrecompileOutput`).

Bumps (from v109):
- `revm-context-interface`: 19.0.0 -> 19.0.1
- `revm-context`: 18.0.0 -> 18.0.1
- `revm-interpreter`: 37.0.0 -> 37.0.1
- `revm-precompile`: 36.0.0 -> 36.0.1
- `revm-handler`: 20.0.0 -> 20.0.1
- `revm-inspector`: 21.0.0 -> 21.0.1
- `revm-statetest-types`: 19.0.0 -> 19.0.1
- `revm`: 40.0.0 -> 40.0.1
- `revme`: 17.0.0 -> 17.0.1

Unchanged: `revm-primitives`, `revm-bytecode`, `revm-database`, `revm-database-interface`, `revm-state`, `revm-ee-tests` (no code changes since v109).

## Test plan

- [x] `cargo check --workspace` clean