### PR TITLE
chore(bytecode): mark RETURN and REVERT as memory-modifying

### DIFF
--- a/crates/bytecode/src/opcode.rs
+++ b/crates/bytecode/src/opcode.rs
@@ -191,6 +191,8 @@ impl OpCode {
                 | OpCode::LOG2
                 | OpCode::LOG3
                 | OpCode::LOG4
+                | OpCode::RETURN
+                | OpCode::REVERT
                 | OpCode::CREATE
                 | OpCode::CREATE2
         )
@@ -785,6 +787,8 @@ mod tests {
         assert!(OpCode::new(LOG2).unwrap().modifies_memory());
         assert!(OpCode::new(LOG3).unwrap().modifies_memory());
         assert!(OpCode::new(LOG4).unwrap().modifies_memory());
+        assert!(OpCode::new(RETURN).unwrap().modifies_memory());
+        assert!(OpCode::new(REVERT).unwrap().modifies_memory());
         assert!(OpCode::new(CREATE).unwrap().modifies_memory());
         assert!(OpCode::new(CREATE2).unwrap().modifies_memory());
     }


### PR DESCRIPTION
## Summary

- Mark RETURN and REVERT as memory-modifying opcodes because their shared return path expands memory for non-zero output ranges.
- Add coverage to `test_modifies_memory` for both terminating opcodes.