### PR TITLE
feat(database): add is_fatal to DBErrorMarker

### DIFF
--- a/crates/database/interface/src/bal.rs
+++ b/crates/database/interface/src/bal.rs
@@ -297,7 +297,14 @@ impl<ERROR> From<BalError> for EvmDatabaseError<ERROR> {
     }
 }
 
-impl<ERROR: core::error::Error + Send + Sync + 'static> DBErrorMarker for EvmDatabaseError<ERROR> {}
+impl<ERROR: core::error::Error + Send + Sync + 'static> DBErrorMarker for EvmDatabaseError<ERROR> {
+    fn is_fatal(&self) -> bool {
+        match self {
+            Self::Bal(_) => false,
+            Self::Database(_) => true,
+        }
+    }
+}
 
 impl<ERROR: Display> Display for EvmDatabaseError<ERROR> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/crates/database/interface/src/lib.rs
+++ b/crates/database/interface/src/lib.rs
@@ -45,7 +45,14 @@ pub use erased_error::ErasedError;
 pub use try_commit::{ArcUpgradeError, TryDatabaseCommit};
 
 /// Database error marker is needed to implement From conversion for Error type.
-pub trait DBErrorMarker: core::error::Error + Send + Sync + 'static {}
+pub trait DBErrorMarker: core::error::Error + Send + Sync + 'static {
+    /// Returns `true` if the error is fatal and execution cannot recover from it.
+    ///
+    /// Defaults to `true`. Implementors can override this to signal recoverable errors.
+    fn is_fatal(&self) -> bool {
+        true
+    }
+}
 
 /// Implement marker for `()`.
 impl DBErrorMarker for Infallible {}


### PR DESCRIPTION
## Summary
- Add `is_fatal(&self) -> bool` to `DBErrorMarker` with a default of `true`, so existing implementors keep their fail-stop behavior.
- Override on `EvmDatabaseError` so the `Database(_)` variant is fatal and the `Bal(_)` variant is non-fatal — letting callers distinguish BAL validation issues from underlying database failures.

## Test plan
- [ ] `cargo check -p revm-database-interface`
- [ ] `cargo clippy --workspace --all-targets --all-features`