### PR TITLE
chore: v111 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
 
+# v111
+date: 22.05.2026
+
+Maintenance release. Adds `is_fatal` to `DBErrorMarker` ([#3704](https://github.com/bluealloy/revm/pull/3704)). All transitively dependent crates bumped accordingly.
+
+* `revm-database-interface`: 12.0.0 -> 12.1.0 (✓ API compatible changes)
+* `revm-context-interface`: 19.0.1 -> 19.0.2 (✓ dependency bump)
+* `revm-context`: 18.0.1 -> 18.0.2 (✓ dependency bump)
+* `revm-database`: 15.0.0 -> 15.0.1 (✓ dependency bump)
+* `revm-interpreter`: 37.0.1 -> 37.0.2 (✓ dependency bump)
+* `revm-precompile`: 36.0.1 -> 36.0.2 (✓ dependency bump)
+* `revm-handler`: 20.0.1 -> 20.0.2 (✓ dependency bump)
+* `revm-inspector`: 21.0.1 -> 21.0.2 (✓ dependency bump)
+* `revm-statetest-types`: 19.0.1 -> 19.0.2 (✓ dependency bump)
+* `revm`: 40.0.1 -> 40.0.2 (✓ dependency bump)
+* `revme`: 17.0.1 -> 17.0.2 (✓ dependency bump)
+
 # v110
 date: 21.05.2026
 


### PR DESCRIPTION
## Summary
- Add v111 entry to `CHANGELOG.md` for the maintenance release auto-prepared in #3705.
- Headline change: `is_fatal` added to `DBErrorMarker` (#3704). All transitively dependent crates patch-bumped.

## Test plan
- [ ] CI green
- [ ] CHANGELOG entry matches versions published from #3705