### PR TITLE
feat(eip7954): bump max code size to 64 KiB and initcode to 128 KiB

### DIFF
--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -695,7 +695,7 @@ pub fn return_create<CTX: ContextTr>(
     }
 
     // EIP-170: Contract code size limit to 0x6000 (~25kb)
-    // EIP-7954 increased this limit to 0x8000 (~32kb).
+    // EIP-7954 increased this limit to 0x10000 (64kb).
     // This must be checked BEFORE charging state gas for code deposit,
     // so that oversized code does not incur storage gas costs.
     if spec_id.is_enabled_in(SPURIOUS_DRAGON) && interpreter_result.output.len() > max_code_size {

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -363,7 +363,7 @@ mod tests {
 
     #[test]
     fn test_eip7954_initcode_between_old_and_new_limit() {
-        // Size between old limit (0xC000) and new limit (0x10000):
+        // Size between old limit (0xC000) and new limit (0x20000):
         // should fail pre-Amsterdam, succeed at Amsterdam
         let size = eip3860::MAX_INITCODE_SIZE + 1; // 0xC001
         let large_bytecode = vec![opcode::STOP; size];
@@ -386,13 +386,13 @@ mod tests {
 
     #[test]
     fn test_eip7954_code_size_limit_failure() {
-        // EIP-7954: MAX_CODE_SIZE = 0x8000
-        // use the simplest method to return a contract code size greater than 0x8000
-        // PUSH3 0x8001 (greater than 0x8000) - return size
+        // EIP-7954: MAX_CODE_SIZE = 0x10000
+        // use the simplest method to return a contract code size greater than 0x10000
+        // PUSH3 0x10001 (greater than 0x10000) - return size
         // PUSH1 0x00 - memory position 0
         // RETURN - return uninitialized memory, will be filled with 0
         let init_code = vec![
-            0x62, 0x00, 0x80, 0x01, // PUSH3 0x8001 (greater than 0x8000)
+            0x62, 0x01, 0x00, 0x01, // PUSH3 0x10001 (greater than 0x10000)
             0x60, 0x00, // PUSH1 0
             0xf3, // RETURN
         ];

--- a/crates/primitives/src/eip7954.rs
+++ b/crates/primitives/src/eip7954.rs
@@ -2,8 +2,8 @@
 //!
 //! Increases the contract code size limit and initcode size limit.
 
-/// EIP-7954: Maximum contract code size: 32,768 bytes (0x8000).
-pub const MAX_CODE_SIZE: usize = 0x8000;
+/// EIP-7954: Maximum contract code size: 65,536 bytes (0x10000).
+pub const MAX_CODE_SIZE: usize = 0x10000;
 
-/// EIP-7954: Maximum initcode size: 65,536 bytes (0x10000).
-pub const MAX_INITCODE_SIZE: usize = 0x10000;
+/// EIP-7954: Maximum initcode size: 131,072 bytes (0x20000).
+pub const MAX_INITCODE_SIZE: usize = 0x20000;


### PR DESCRIPTION
## Summary
- Raises EIP-7954 `MAX_CODE_SIZE` from `0x8000` (32 KiB) to `0x10000` (64 KiB).
- Raises EIP-7954 `MAX_INITCODE_SIZE` from `0x10000` (64 KiB) to `0x20000` (128 KiB).
- Updates `test_eip7954_code_size_limit_failure` to push the new oversize threshold (PUSH3 `0x10001`) and refreshes related comments in `frame.rs` and `validation.rs`.

## Test plan
- [x] `cargo build -p revm-primitives -p revm-context -p revm-handler`
- [x] `cargo nextest run -p revm-handler validation::` (14 passed)