### PR TITLE
feat(eip7702): defer delegate code load via BytecodeLoad enum

### DIFF
--- a/crates/bytecode/src/bytecode/mod.rs
+++ b/crates/bytecode/src/bytecode/mod.rs
@@ -57,6 +57,48 @@ pub enum BytecodeKind {
     Eip7702,
 }
 
+/// Deferred bytecode reference produced when account loading is split from
+/// bytecode loading.
+///
+/// `Bytecode` carries an already-loaded [`Bytecode`]; `LoadFrom` carries an
+/// account [`Address`] whose code (and code hash) still needs to be fetched
+/// when the bytecode is actually required (e.g. on frame creation).
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum BytecodeLoad {
+    /// Code has not been loaded yet; load it from this address when needed.
+    LoadFrom(Address),
+    /// Code is already loaded.
+    Bytecode(Bytecode),
+}
+
+impl BytecodeLoad {
+    /// Returns the loaded bytecode if already available.
+    #[inline]
+    pub const fn as_bytecode(&self) -> Option<&Bytecode> {
+        match self {
+            Self::Bytecode(code) => Some(code),
+            Self::LoadFrom(_) => None,
+        }
+    }
+
+    /// Returns the address to load code from, if the load was deferred.
+    #[inline]
+    pub const fn load_from_address(&self) -> Option<Address> {
+        match self {
+            Self::LoadFrom(addr) => Some(*addr),
+            Self::Bytecode(_) => None,
+        }
+    }
+}
+
+impl From<Bytecode> for BytecodeLoad {
+    #[inline]
+    fn from(code: Bytecode) -> Self {
+        Self::Bytecode(code)
+    }
+}
+
 impl Default for Bytecode {
     #[inline]
     fn default() -> Self {

--- a/crates/bytecode/src/lib.rs
+++ b/crates/bytecode/src/lib.rs
@@ -21,7 +21,7 @@ pub mod utils;
 
 /// Re-export of bitvec crate, used to store legacy bytecode jump table.
 pub use bitvec;
-pub use bytecode::{Bytecode, BytecodeKind};
+pub use bytecode::{Bytecode, BytecodeKind, BytecodeLoad};
 pub use decode_errors::BytecodeDecodeError;
 pub use iter::BytecodeIterator;
 pub use legacy::JumpTable;

--- a/crates/context/interface/src/host.rs
+++ b/crates/context/interface/src/host.rs
@@ -147,6 +147,16 @@ pub trait Host {
         skip_cold_load: bool,
     ) -> Result<AccountInfoLoad<'_>, LoadError>;
 
+    /// Returns `true` if `address` is currently warm — i.e. it has already been
+    /// loaded in this transaction or appears in the warm-address set
+    /// (precompiles, coinbase, access list).
+    ///
+    /// This is a pure lookup: it never reads from the database and never
+    /// promotes a cold account to warm. Intended for paths where the caller
+    /// only needs the warm/cold decision (e.g. EIP-7702 delegate gas charging)
+    /// and wants to defer the actual account/code load to a later point.
+    fn is_account_warm(&self, address: Address) -> bool;
+
     /// Balance, calls `ContextTr::journal_mut().load_account(address)`
     #[inline]
     fn balance(&mut self, address: Address) -> Option<StateLoad<U256>> {
@@ -326,6 +336,10 @@ impl Host for DummyHost {
         _skip_cold_load: bool,
     ) -> Result<AccountInfoLoad<'_>, LoadError> {
         Ok(Default::default())
+    }
+
+    fn is_account_warm(&self, _address: Address) -> bool {
+        false
     }
 
     fn sstore_skip_cold_load(

--- a/crates/context/interface/src/host.rs
+++ b/crates/context/interface/src/host.rs
@@ -157,15 +157,26 @@ pub trait Host {
         skip_cold_load: bool,
     ) -> Result<AccountInfoLoad<'_>, LoadError>;
 
-    /// Returns `true` if `address` is currently warm — i.e. it has already been
-    /// loaded in this transaction or appears in the warm-address set
-    /// (precompiles, coinbase, access list).
+    /// Optionally warms `address` and reports whether it was cold prior to the
+    /// call, while avoiding a full DB-backed account load when possible.
     ///
-    /// This is a pure lookup: it never reads from the database and never
-    /// promotes a cold account to warm. Intended for paths where the caller
-    /// only needs the warm/cold decision (e.g. EIP-7702 delegate gas charging)
-    /// and wants to defer the actual account/code load to a later point.
-    fn is_account_warm(&self, address: Address) -> bool;
+    /// Behavior:
+    /// - If the address is cold and `skip_cold_load` is `true`, returns
+    ///   [`LoadError::ColdLoadSkipped`] without mutating any state.
+    /// - If the account already exists in the journal state map, marks it
+    ///   warm, loads its bytecode from the database if needed, and returns it
+    ///   in [`StateLoad::data`].
+    /// - If the account is not in the state map but is already warm via the
+    ///   access list (or is a precompile / coinbase), this is a no-op and
+    ///   `data` is `None`.
+    /// - Otherwise the address is inserted into the access list and a
+    ///   revert-only journal entry is pushed; `data` is `None`. The actual
+    ///   account/code load is deferred to a later point.
+    fn optional_account_warming(
+        &mut self,
+        address: Address,
+        skip_cold_load: bool,
+    ) -> Result<StateLoad<Option<Bytecode>>, LoadError>;
 
     /// Balance, calls `ContextTr::journal_mut().load_account(address)`
     #[inline]
@@ -352,8 +363,12 @@ impl Host for DummyHost {
         Ok(Default::default())
     }
 
-    fn is_account_warm(&self, _address: Address) -> bool {
-        false
+    fn optional_account_warming(
+        &mut self,
+        _address: Address,
+        _skip_cold_load: bool,
+    ) -> Result<StateLoad<Option<Bytecode>>, LoadError> {
+        Ok(StateLoad::new(None, true))
     }
 
     fn sstore_skip_cold_load(

--- a/crates/context/interface/src/host.rs
+++ b/crates/context/interface/src/host.rs
@@ -83,6 +83,16 @@ pub trait Host {
 
     /* Journal */
 
+    /// Returns the current call depth of the journal — i.e. the number of
+    /// nested checkpoints currently open.
+    ///
+    /// Used by CALL/CREATE opcodes to enforce the EIP-150 1024-frame stack
+    /// limit without going through a frame init that immediately fails. At
+    /// opcode dispatch time this equals `current_frame_depth + 1`, i.e. the
+    /// depth the next child frame would be created at, so the check is
+    /// `host.depth() > CALL_STACK_LIMIT`.
+    fn depth(&self) -> usize;
+
     /// Selfdestruct account, calls `ContextTr::journal_mut().selfdestruct(address, target)`
     fn selfdestruct(
         &mut self,
@@ -310,6 +320,10 @@ impl Host for DummyHost {
 
     fn block_hash(&mut self, _number: u64) -> Option<B256> {
         None
+    }
+
+    fn depth(&self) -> usize {
+        0
     }
 
     fn selfdestruct(

--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -338,14 +338,26 @@ pub trait JournalTr {
         _skip_cold_load: bool,
     ) -> Result<AccountInfoLoad<'_>, JournalLoadError<<Self::Database as Database>::Error>>;
 
-    /// Returns `true` if `address` is currently warm — already in the journal
-    /// (precompiles, coinbase, access list, or touched this transaction).
+    /// Optionally warms `address` and reports its cold/warm status, while
+    /// avoiding a full DB-backed account load when possible.
     ///
-    /// This is a pure lookup. It never touches the database, never promotes a
-    /// cold account to warm, and is intended for cases where the caller only
-    /// needs the warm/cold decision (e.g. EIP-7702 delegate gas charging) and
-    /// wants to defer the actual account/code load.
-    fn is_account_warm(&self, address: Address) -> bool;
+    /// Behavior:
+    /// - If the address is cold and `skip_cold_load` is `true`, returns
+    ///   [`JournalLoadError::ColdLoadSkipped`] without mutating any state.
+    /// - If the account already exists in the journal state map, marks it
+    ///   warm (journaling the warming), loads its bytecode from the database
+    ///   if needed, and returns it in [`StateLoad::data`].
+    /// - If the account is not in the state map but is already warm via the
+    ///   access list (or is a precompile / coinbase), this is a no-op and
+    ///   `data` is `None`.
+    /// - Otherwise the address is added to the access list and a revert-only
+    ///   journal entry is pushed; `data` is `None`. The actual account/code
+    ///   load is deferred to a later point.
+    fn optional_account_warming(
+        &mut self,
+        address: Address,
+        skip_cold_load: bool,
+    ) -> Result<StateLoad<Option<Bytecode>>, JournalLoadError<<Self::Database as Database>::Error>>;
 }
 
 /// Error that can happen when loading account info.

--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -337,6 +337,15 @@ pub trait JournalTr {
         _load_code: bool,
         _skip_cold_load: bool,
     ) -> Result<AccountInfoLoad<'_>, JournalLoadError<<Self::Database as Database>::Error>>;
+
+    /// Returns `true` if `address` is currently warm — already in the journal
+    /// (precompiles, coinbase, access list, or touched this transaction).
+    ///
+    /// This is a pure lookup. It never touches the database, never promotes a
+    /// cold account to warm, and is intended for cases where the caller only
+    /// needs the warm/cold decision (e.g. EIP-7702 delegate gas charging) and
+    /// wants to defer the actual account/code load.
+    fn is_account_warm(&self, address: Address) -> bool;
 }
 
 /// Error that can happen when loading account info.

--- a/crates/context/interface/src/journaled_state/entry.rs
+++ b/crates/context/interface/src/journaled_state/entry.rs
@@ -5,7 +5,9 @@
 //! They are created when there is change to the state from loading (making it warm), changes to the balance,
 //! or removal of the storage slot. Check [`JournalEntryTr`] for more details.
 
-use primitives::{Address, StorageKey, StorageValue, KECCAK_EMPTY, PRECOMPILE3, U256};
+use primitives::{
+    Address, AddressMap, HashSet, StorageKey, StorageValue, KECCAK_EMPTY, PRECOMPILE3, U256,
+};
 use state::{EvmState, TransientStorage};
 
 /// Trait for tracking and reverting state changes in the EVM.
@@ -13,6 +15,13 @@ use state::{EvmState, TransientStorage};
 pub trait JournalEntryTr {
     /// Creates a journal entry for when an account is accessed and marked as "warm" for gas metering
     fn account_warmed(address: Address) -> Self;
+
+    /// Creates a journal entry for when an account is warmed by adding it to the
+    /// per-transaction access list **without** inserting it into the journal state
+    /// map. Used by code paths that need to charge cold-access gas (and therefore
+    /// must remember the warming for revert) but want to defer the actual account
+    /// load to a later point.
+    fn account_warmed_in_access_list(address: Address) -> Self;
 
     /// Creates a journal entry for when an account is destroyed via SELFDESTRUCT
     /// Records the target address that received the destroyed account's balance,
@@ -86,6 +95,7 @@ pub trait JournalEntryTr {
         self,
         state: &mut EvmState,
         transient_storage: Option<&mut TransientStorage>,
+        access_list: &mut AddressMap<HashSet<StorageKey>>,
         is_spurious_dragon_enabled: bool,
     );
 }
@@ -117,6 +127,15 @@ pub enum JournalEntry {
     /// Revert: we will remove account from state.
     AccountWarmed {
         /// Address of warmed account.
+        address: Address,
+    },
+    /// Used to mark an account warm by adding it to the per-tx access list
+    /// without touching the journal state map.
+    ///
+    /// Action: insert address into the access list.
+    /// Revert: remove the address from the access list.
+    AccessListAccountWarmed {
+        /// Address that was warmed in the access list.
         address: Address,
     },
     /// Mark account to be destroyed and journal balance to be reverted
@@ -232,6 +251,10 @@ impl JournalEntryTr for JournalEntry {
         JournalEntry::AccountWarmed { address }
     }
 
+    fn account_warmed_in_access_list(address: Address) -> Self {
+        JournalEntry::AccessListAccountWarmed { address }
+    }
+
     fn account_destroyed(
         address: Address,
         target: Address,
@@ -311,11 +334,15 @@ impl JournalEntryTr for JournalEntry {
         self,
         state: &mut EvmState,
         transient_storage: Option<&mut TransientStorage>,
+        access_list: &mut AddressMap<HashSet<StorageKey>>,
         is_spurious_dragon_enabled: bool,
     ) {
         match self {
             JournalEntry::AccountWarmed { address } => {
                 state.get_mut(&address).unwrap().mark_cold();
+            }
+            JournalEntry::AccessListAccountWarmed { address } => {
+                access_list.remove(&address);
             }
             JournalEntry::AccountTouched { address } => {
                 if is_spurious_dragon_enabled && address == PRECOMPILE3 {

--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -12,6 +12,7 @@ use derive_where::derive_where;
 use primitives::{
     hardfork::SpecId, hints_util::cold_path, Address, Log, StorageKey, StorageValue, B256, U256,
 };
+use state::Bytecode;
 
 /// EVM context contains data that EVM needs for execution.
 #[derive_where(Clone, Debug; BLOCK, CFG, CHAIN, TX, DB, JOURNAL, <DB as Database>::Error, LOCAL)]
@@ -637,7 +638,24 @@ impl<
     }
 
     #[inline]
-    fn is_account_warm(&self, address: Address) -> bool {
-        self.journaled_state.is_account_warm(address)
+    fn optional_account_warming(
+        &mut self,
+        address: Address,
+        skip_cold_load: bool,
+    ) -> Result<StateLoad<Option<Bytecode>>, LoadError> {
+        match self
+            .journaled_state
+            .optional_account_warming(address, skip_cold_load)
+        {
+            Ok(a) => Ok(a),
+            Err(e) => {
+                cold_path();
+                let (ret, err) = e.into_parts();
+                if let Some(err) = err {
+                    self.error = Err(err.into());
+                }
+                Err(ret)
+            }
+        }
     }
 }

--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -630,4 +630,9 @@ impl<
             }
         }
     }
+
+    #[inline]
+    fn is_account_warm(&self, address: Address) -> bool {
+        self.journaled_state.is_account_warm(address)
+    }
 }

--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -533,6 +533,11 @@ impl<
 
     /* Journal */
 
+    #[inline]
+    fn depth(&self) -> usize {
+        self.journaled_state.depth()
+    }
+
     /// Gets the transient storage value of `address` at `index`.
     fn tload(&mut self, address: Address, index: StorageKey) -> StorageValue {
         self.journal_mut().tload(address, index)

--- a/crates/context/src/journal.rs
+++ b/crates/context/src/journal.rs
@@ -399,4 +399,9 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
                 AccountInfoLoad::new(&a.data.info, a.is_cold, a.state_clear_aware_is_empty(spec))
             })
     }
+
+    #[inline]
+    fn is_account_warm(&self, address: Address) -> bool {
+        self.inner.is_account_warm(address)
+    }
 }

--- a/crates/context/src/journal.rs
+++ b/crates/context/src/journal.rs
@@ -401,7 +401,13 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
     }
 
     #[inline]
-    fn is_account_warm(&self, address: Address) -> bool {
-        self.inner.is_account_warm(address)
+    fn optional_account_warming(
+        &mut self,
+        address: Address,
+        skip_cold_load: bool,
+    ) -> Result<StateLoad<Option<Bytecode>>, JournalLoadError<<Self::Database as Database>::Error>>
+    {
+        self.inner
+            .optional_account_warming(&mut self.database, address, skip_cold_load)
     }
 }

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -716,6 +716,23 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         })
     }
 
+    /// Returns `true` if `address` is currently warm in the journal — i.e. it
+    /// is either listed in the warm-address set (precompiles, coinbase, access
+    /// list) or has already been loaded in the current transaction.
+    ///
+    /// This is a pure lookup; it never reads from the database and never
+    /// promotes the account from cold to warm.
+    #[inline]
+    pub fn is_account_warm(&self, address: Address) -> bool {
+        if self.warm_addresses.is_warm(&address) {
+            return true;
+        }
+        match self.state.get(&address) {
+            Some(account) => !account.is_cold_transaction_id(self.transaction_id),
+            None => false,
+        }
+    }
+
     /// Loads account into memory. return if it is cold or warm accessed
     #[inline]
     pub fn load_account<'a, 'db, DB: Database>(

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -181,9 +181,10 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
             selfdestructed_addresses,
         } = self;
         let is_spurious_dragon_enabled = cfg.spec.is_enabled_in(SPURIOUS_DRAGON);
+        let access_list = warm_addresses.access_list_mut();
         // iterate over all journals entries and revert our global state
         journal.drain(..).rev().for_each(|entry| {
-            entry.revert(state, None, is_spurious_dragon_enabled);
+            entry.revert(state, None, access_list, is_spurious_dragon_enabled);
         });
         transient_storage.clear();
         *depth = 0;
@@ -594,8 +595,6 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
     #[inline]
     pub fn checkpoint_revert(&mut self, checkpoint: JournalCheckpoint) {
         let is_spurious_dragon_enabled = self.cfg.spec.is_enabled_in(SPURIOUS_DRAGON);
-        let state = &mut self.state;
-        let transient_storage = &mut self.transient_storage;
         self.depth = self.depth.saturating_sub(1);
         self.logs.truncate(checkpoint.log_i);
         // EIP-7708: Remove selfdestructed addresses added after checkpoint
@@ -604,11 +603,19 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
 
         // iterate over last N journals sets and revert our global state
         if checkpoint.journal_i < self.journal.len() {
+            let state = &mut self.state;
+            let transient_storage = &mut self.transient_storage;
+            let access_list = self.warm_addresses.access_list_mut();
             self.journal
                 .drain(checkpoint.journal_i..)
                 .rev()
                 .for_each(|entry| {
-                    entry.revert(state, Some(transient_storage), is_spurious_dragon_enabled);
+                    entry.revert(
+                        state,
+                        Some(transient_storage),
+                        access_list,
+                        is_spurious_dragon_enabled,
+                    );
                 });
         }
     }
@@ -716,20 +723,79 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         })
     }
 
-    /// Returns `true` if `address` is currently warm in the journal — i.e. it
-    /// is either listed in the warm-address set (precompiles, coinbase, access
-    /// list) or has already been loaded in the current transaction.
+    /// Optionally warms `address` and reports whether it was cold prior to the
+    /// call.
     ///
-    /// This is a pure lookup; it never reads from the database and never
-    /// promotes the account from cold to warm.
+    /// Behavior:
+    /// - If `skip_cold_load` is `true` and the address is cold, returns
+    ///   [`JournalLoadError::ColdLoadSkipped`] without mutating any state.
+    /// - If the account is already in the journal state map, marks it warm
+    ///   (journaling the warming via [`JournalEntryTr::account_warmed`]),
+    ///   loads its bytecode from the database if not already loaded, and
+    ///   returns the bytecode in [`StateLoad::data`].
+    /// - If the account is not in the state map but is already warm in the
+    ///   access list (or is a precompile / coinbase), it's a no-op and
+    ///   `data` is `None`.
+    /// - If the account is not in the state map and not warm, it is inserted
+    ///   into the access list and an
+    ///   [`JournalEntryTr::account_warmed_in_access_list`] entry is pushed so
+    ///   the warming can be reverted; `data` is `None`.
     #[inline]
-    pub fn is_account_warm(&self, address: Address) -> bool {
-        if self.warm_addresses.is_warm(&address) {
-            return true;
-        }
-        match self.state.get(&address) {
-            Some(account) => !account.is_cold_transaction_id(self.transaction_id),
-            None => false,
+    pub fn optional_account_warming<DB: Database>(
+        &mut self,
+        db: &mut DB,
+        address: Address,
+        skip_cold_load: bool,
+    ) -> Result<StateLoad<Option<Bytecode>>, JournalLoadError<DB::Error>> {
+        match self.state.entry(address) {
+            Entry::Occupied(entry) => {
+                let account = entry.into_mut();
+                let mut is_cold = account.is_cold_transaction_id(self.transaction_id);
+
+                if unlikely(is_cold) {
+                    is_cold = self
+                        .warm_addresses
+                        .check_is_cold(&address, skip_cold_load)?;
+
+                    account.mark_warm_with_transaction_id(self.transaction_id);
+
+                    if account.is_selfdestructed_locally() {
+                        account.selfdestruct();
+                        account.unmark_selfdestructed_locally();
+                    }
+                    account.set_current_info_as_original();
+                    account.unmark_created_locally();
+
+                    self.journal.push(ENTRY::account_warmed(address));
+                }
+
+                if account.info.code.is_none() {
+                    let hash = account.info.code_hash;
+                    let code = if hash == KECCAK_EMPTY {
+                        Bytecode::default()
+                    } else {
+                        db.code_by_hash(hash).map_err(JournalLoadError::DBError)?
+                    };
+                    account.info.code = Some(code);
+                }
+
+                Ok(StateLoad::new(account.info.code.clone(), is_cold))
+            }
+            Entry::Vacant(_) => {
+                if self.warm_addresses.is_warm(&address) {
+                    return Ok(StateLoad::new(None, false));
+                }
+
+                if skip_cold_load {
+                    return Err(JournalLoadError::ColdLoadSkipped);
+                }
+
+                self.warm_addresses.add_address_to_access_list(address);
+                self.journal
+                    .push(ENTRY::account_warmed_in_access_list(address));
+
+                Ok(StateLoad::new(None, true))
+            }
         }
     }
 

--- a/crates/context/src/journal/warm_addresses.rs
+++ b/crates/context/src/journal/warm_addresses.rs
@@ -99,6 +99,21 @@ impl WarmAddresses {
         &self.access_list
     }
 
+    /// Returns a mutable reference to the access list.
+    #[inline]
+    pub const fn access_list_mut(&mut self) -> &mut AddressMap<HashSet<StorageKey>> {
+        &mut self.access_list
+    }
+
+    /// Inserts `address` into the access list with an empty storage key set,
+    /// marking the account warm without touching the journal state map.
+    ///
+    /// No-op if the address is already in the access list.
+    #[inline]
+    pub fn add_address_to_access_list(&mut self, address: Address) {
+        self.access_list.entry(address).or_default();
+    }
+
     /// Clear the coinbase address.
     #[inline]
     pub const fn clear_coinbase(&mut self) {

--- a/crates/handler/src/execution.rs
+++ b/crates/handler/src/execution.rs
@@ -4,7 +4,7 @@ use interpreter::{
     CallInput, CallInputs, CallScheme, CallValue, CreateInputs, CreateScheme, FrameInput,
 };
 use primitives::TxKind;
-use state::Bytecode;
+use state::{Bytecode, BytecodeLoad};
 use std::boxed::Box;
 
 /// Creates the first [`FrameInput`] from the transaction, spec and gas limit.
@@ -27,12 +27,12 @@ pub fn create_init_frame<CTX: ContextTr>(
                 let account = &journal.load_account_with_code(delegated_address)?.info;
                 (
                     account.code_hash(),
-                    account.code.clone().unwrap_or_default(),
+                    BytecodeLoad::Bytecode(account.code.clone().unwrap_or_default()),
                 )
             } else {
                 (
                     account.code_hash(),
-                    account.code.clone().unwrap_or_default(),
+                    BytecodeLoad::Bytecode(account.code.clone().unwrap_or_default()),
                 )
             };
             Ok(FrameInput::Call(Box::new(CallInputs {

--- a/crates/handler/src/execution.rs
+++ b/crates/handler/src/execution.rs
@@ -4,7 +4,7 @@ use interpreter::{
     CallInput, CallInputs, CallScheme, CallValue, CreateInputs, CreateScheme, FrameInput,
 };
 use primitives::TxKind;
-use state::{Bytecode, BytecodeLoad};
+use state::Bytecode;
 use std::boxed::Box;
 
 /// Creates the first [`FrameInput`] from the transaction, spec and gas limit.
@@ -27,12 +27,12 @@ pub fn create_init_frame<CTX: ContextTr>(
                 let account = &journal.load_account_with_code(delegated_address)?.info;
                 (
                     account.code_hash(),
-                    BytecodeLoad::Bytecode(account.code.clone().unwrap_or_default()),
+                    account.code.clone().unwrap_or_default(),
                 )
             } else {
                 (
                     account.code_hash(),
-                    BytecodeLoad::Bytecode(account.code.clone().unwrap_or_default()),
+                    account.code.clone().unwrap_or_default(),
                 )
             };
             Ok(FrameInput::Call(Box::new(CallInputs {

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -329,15 +329,12 @@ impl EthFrame<EthInterpreter> {
             })))
         };
 
-        // Fetch balance of caller.
+        // The CREATE opcode already verified the caller balance and applied
+        // the depth gate, so we can proceed straight to the nonce bump. The
+        // actual balance decrement is performed in `create_account_checkpoint`
+        // below.
         let journal = context.journal_mut();
         let mut caller_info = journal.load_account_mut(inputs.caller())?;
-
-        // Check if caller has enough balance to send to the created contract.
-        // decrement of balance is done in the create_account_checkpoint.
-        if *caller_info.balance() < inputs.value() {
-            return return_error(InstructionResult::OutOfFunds);
-        }
 
         // Increase nonce of caller and check if it overflows
         let old_nonce = caller_info.nonce();
@@ -573,12 +570,13 @@ impl EthFrame<EthInterpreter> {
 
                 // EIP-8037: The CREATE opcode charged `create_state_gas` upfront on
                 // this frame's tracker. When the child fails to deploy a contract
-                // (revert, halt, or early-fail paths that return `address == None`
-                // such as nonce overflow, depth, OutOfFunds), refund the upfront
-                // charge to the reservoir and undo it on `state_gas_spent` via
-                // `refill_reservoir` (matching 0→x→0 storage restoration). The
-                // nonce-overflow path reports `InstructionResult::Return` (ok)
-                // with `address == None`, so gate on address rather than the result.
+                // (revert, halt, or the nonce-overflow early-fail that returns
+                // `address == None`), refund the upfront charge to the reservoir
+                // and undo it on `state_gas_spent` via `refill_reservoir`
+                // (matching 0→x→0 storage restoration). The nonce-overflow path
+                // reports `InstructionResult::Return` (ok) with `address == None`,
+                // so gate on address rather than the result. Depth and OutOfFunds
+                // are now handled at the opcode and never suspend into this frame.
                 let create_failed = outcome.address.is_none() || !instruction_result.is_ok();
 
                 if create_failed && ctx.cfg().is_amsterdam_eip8037_enabled() {

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -25,7 +25,7 @@ use primitives::{
     hardfork::SpecId::{self, HOMESTEAD, LONDON, SPURIOUS_DRAGON},
     Address, Bytes, U256,
 };
-use state::Bytecode;
+use state::{Bytecode, BytecodeLoad};
 use std::{borrow::ToOwned, boxed::Box, vec::Vec};
 
 /// Frame implementation for Ethereum.
@@ -226,6 +226,21 @@ impl EthFrame<EthInterpreter> {
             return return_result(InstructionResult::CallTooDeep);
         }
 
+        // Resolve EIP-7702 deferred bytecode load BEFORE the checkpoint so the
+        // delegate account's warmth (and code load) is not rolled back if the
+        // child frame later reverts. The CALL helper already charged gas for
+        // the access and we must honor it regardless of outcome.
+        let (bytecode_hash, bytecode) = match inputs.known_bytecode.clone() {
+            (hash, BytecodeLoad::Bytecode(code)) => (hash, code),
+            (_, BytecodeLoad::LoadFrom(delegate_address)) => {
+                let info = &ctx
+                    .journal_mut()
+                    .load_account_with_code(delegate_address)?
+                    .info;
+                (info.code_hash(), info.code.clone().unwrap_or_default())
+            }
+        };
+
         // Create subroutine checkpoint
         let checkpoint = ctx.journal_mut().checkpoint();
 
@@ -272,9 +287,6 @@ impl EthFrame<EthInterpreter> {
                 charged_new_account_state_gas,
             })));
         }
-
-        // Get bytecode and hash - either from known_bytecode or load from account
-        let (bytecode_hash, bytecode) = inputs.known_bytecode.clone();
 
         // Returns success if bytecode is empty.
         if bytecode.is_empty() {

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -20,7 +20,6 @@ use interpreter::{
     InterpreterResult, InterpreterTypes, SharedMemory,
 };
 use primitives::{
-    constants::CALL_STACK_LIMIT,
     eip8038,
     hardfork::SpecId::{self, HOMESTEAD, LONDON, SPURIOUS_DRAGON},
     Address, Bytes, U256,
@@ -221,11 +220,6 @@ impl EthFrame<EthInterpreter> {
             return return_result(halt);
         }
 
-        // Check depth
-        if depth > CALL_STACK_LIMIT as usize {
-            return return_result(InstructionResult::CallTooDeep);
-        }
-
         // Resolve EIP-7702 deferred bytecode load BEFORE the checkpoint so the
         // delegate account's warmth (and code load) is not rolled back if the
         // child frame later reverts. The CALL helper already charged gas for
@@ -344,11 +338,6 @@ impl EthFrame<EthInterpreter> {
                 address: None,
             })))
         };
-
-        // Check depth
-        if depth > CALL_STACK_LIMIT as usize {
-            return return_error(InstructionResult::CallTooDeep);
-        }
 
         // Fetch balance of caller.
         let journal = context.journal_mut();

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -24,7 +24,7 @@ use primitives::{
     hardfork::SpecId::{self, HOMESTEAD, LONDON, SPURIOUS_DRAGON},
     Address, Bytes, U256,
 };
-use state::{Bytecode, BytecodeLoad};
+use state::Bytecode;
 use std::{borrow::ToOwned, boxed::Box, vec::Vec};
 
 /// Frame implementation for Ethereum.
@@ -220,20 +220,10 @@ impl EthFrame<EthInterpreter> {
             return return_result(halt);
         }
 
-        // Resolve EIP-7702 deferred bytecode load BEFORE the checkpoint so the
-        // delegate account's warmth (and code load) is not rolled back if the
-        // child frame later reverts. The CALL helper already charged gas for
-        // the access and we must honor it regardless of outcome.
-        let (bytecode_hash, bytecode) = match inputs.known_bytecode.clone() {
-            (hash, BytecodeLoad::Bytecode(code)) => (hash, code),
-            (_, BytecodeLoad::LoadFrom(delegate_address)) => {
-                let info = &ctx
-                    .journal_mut()
-                    .load_account_with_code(delegate_address)?
-                    .info;
-                (info.code_hash(), info.code.clone().unwrap_or_default())
-            }
-        };
+        // The CALL opcode has already resolved any EIP-7702 deferred load,
+        // verified caller balance for value transfers and applied the depth
+        // gate, so `known_bytecode` is a concrete `(hash, code)` pair here.
+        let (bytecode_hash, bytecode) = inputs.known_bytecode.clone();
 
         // Create subroutine checkpoint
         let checkpoint = ctx.journal_mut().checkpoint();

--- a/crates/inspector/src/gas.rs
+++ b/crates/inspector/src/gas.rs
@@ -263,16 +263,12 @@ mod tests {
             opcode::DUP1,
             opcode::ADDRESS,
             opcode::CALL,
-            opcode::PUSH1,
-            0x01,
+            // CREATE with value=0 so the caller-balance gate doesn't
+            // short-circuit before the inspector override fires.
             opcode::PUSH1,
             0x0,
             opcode::DUP1,
             opcode::DUP1,
-            opcode::DUP1,
-            opcode::DUP1,
-            opcode::DUP1,
-            opcode::ADDRESS,
             opcode::CREATE,
             opcode::STOP,
         ]);

--- a/crates/interpreter/src/instructions/contract.rs
+++ b/crates/interpreter/src/instructions/contract.rs
@@ -1,9 +1,9 @@
 mod call_helpers;
 
 pub use call_helpers::{
-    check_call_depth, check_caller_balance, check_create_depth, get_memory_input_and_out_ranges,
-    load_acc_and_calc_gas, load_account_delegated, load_account_delegated_handle_error,
-    resize_memory, resolve_bytecode_load,
+    check_call_depth, check_caller_balance, check_create_caller_balance, check_create_depth,
+    get_memory_input_and_out_ranges, load_acc_and_calc_gas, load_account_delegated,
+    load_account_delegated_handle_error, resize_memory, resolve_bytecode_load,
 };
 
 use crate::{
@@ -118,9 +118,21 @@ pub fn create<const IS_CREATE2: bool, IT: ITy, H: Host + ?Sized>(
         return Ok(());
     }
 
+    let caller = context.interpreter.input.target_address();
+
+    // Balance check for the value being moved into the to-be-created contract:
+    // if the caller can't cover the transfer, the CREATE fails immediately
+    // (same shape as a depth overflow) — refund allocated gas + EIP-8037
+    // state gas, push 0, and continue without ever spawning a frame.
+    if !value.is_zero()
+        && check_create_caller_balance(context.interpreter, context.host, caller, value, gas_limit)?
+    {
+        return Ok(());
+    }
+
     // Call host to interact with target contract
     let create_inputs = CreateInputs::new(
-        context.interpreter.input.target_address(),
+        caller,
         scheme,
         value,
         code,

--- a/crates/interpreter/src/instructions/contract.rs
+++ b/crates/interpreter/src/instructions/contract.rs
@@ -1,8 +1,9 @@
 mod call_helpers;
 
 pub use call_helpers::{
-    check_call_depth, check_create_depth, get_memory_input_and_out_ranges, load_acc_and_calc_gas,
-    load_account_delegated, load_account_delegated_handle_error, resize_memory,
+    check_call_depth, check_caller_balance, check_create_depth, get_memory_input_and_out_ranges,
+    load_acc_and_calc_gas, load_account_delegated, load_account_delegated_handle_error,
+    resize_memory, resolve_bytecode_load,
 };
 
 use crate::{
@@ -169,7 +170,7 @@ pub fn call<const KIND: u8, IT: ITy, H: Host + ?Sized>(mut context: Ictx<'_, H, 
         get_memory_input_and_out_ranges(context.interpreter, context.host.gas_params())?;
 
     let is_call = KIND == CALL;
-    let (gas_limit, bytecode, bytecode_hash, charged_new_account_state_gas) =
+    let (gas_limit, bytecode_load, bytecode_hash, charged_new_account_state_gas) =
         load_acc_and_calc_gas(&mut context, to, has_transfer, is_call, local_gas_limit)?;
 
     let target_address = if matches!(KIND, CALLCODE | DELEGATECALL) {
@@ -181,11 +182,6 @@ pub fn call<const KIND: u8, IT: ITy, H: Host + ?Sized>(mut context: Ictx<'_, H, 
         context.interpreter.input.caller_address()
     } else {
         context.interpreter.input.target_address()
-    };
-    let value = if KIND == DELEGATECALL {
-        CallValue::Apparent(context.interpreter.input.call_value())
-    } else {
-        CallValue::Transfer(value)
     };
     let scheme = match KIND {
         CALL => CallScheme::Call,
@@ -199,6 +195,30 @@ pub fn call<const KIND: u8, IT: ITy, H: Host + ?Sized>(mut context: Ictx<'_, H, 
     if check_call_depth(context.interpreter, context.host, gas_limit) {
         return Ok(());
     }
+
+    // Balance check for value-transferring calls: if the caller can't cover the
+    // transfer, the call fails immediately just like a depth overflow — refund
+    // the allocated gas, push 0, and continue without ever spawning a frame.
+    // The transfer source is `caller` for CALL and `context.interpreter.input
+    // .target_address()` (self-transfer) for CALLCODE; both are captured by
+    // the `caller` binding above.
+    if has_transfer
+        && check_caller_balance(context.interpreter, context.host, caller, value, gas_limit)?
+    {
+        return Ok(());
+    }
+
+    let value = if KIND == DELEGATECALL {
+        CallValue::Apparent(context.interpreter.input.call_value())
+    } else {
+        CallValue::Transfer(value)
+    };
+
+    // All gas/depth/balance checks passed — resolve any EIP-7702 deferred code
+    // load now so the spawned frame receives a concrete bytecode and the
+    // delegate account is warmed before the child checkpoint is created.
+    let (bytecode_hash, bytecode) =
+        resolve_bytecode_load(context.host, bytecode_hash, bytecode_load)?;
 
     // Call host to interact with target contract
     context

--- a/crates/interpreter/src/instructions/contract.rs
+++ b/crates/interpreter/src/instructions/contract.rs
@@ -1,8 +1,8 @@
 mod call_helpers;
 
 pub use call_helpers::{
-    get_memory_input_and_out_ranges, load_acc_and_calc_gas, load_account_delegated,
-    load_account_delegated_handle_error, resize_memory,
+    check_call_depth, check_create_depth, get_memory_input_and_out_ranges, load_acc_and_calc_gas,
+    load_account_delegated, load_account_delegated_handle_error, resize_memory,
 };
 
 use crate::{
@@ -113,6 +113,10 @@ pub fn create<const IS_CREATE2: bool, IT: ITy, H: Host + ?Sized>(
     }
     gas!(context.interpreter, gas_limit);
 
+    if check_create_depth(context.interpreter, context.host, gas_limit) {
+        return Ok(());
+    }
+
     // Call host to interact with target contract
     let create_inputs = CreateInputs::new(
         context.interpreter.input.target_address(),
@@ -191,6 +195,10 @@ pub fn call<const KIND: u8, IT: ITy, H: Host + ?Sized>(mut context: Ictx<'_, H, 
         _ => unreachable!(),
     };
     let is_static = context.interpreter.runtime_flag.is_static() || KIND == STATICCALL;
+
+    if check_call_depth(context.interpreter, context.host, gas_limit) {
+        return Ok(());
+    }
 
     // Call host to interact with target contract
     context

--- a/crates/interpreter/src/instructions/contract/call_helpers.rs
+++ b/crates/interpreter/src/instructions/contract/call_helpers.rs
@@ -212,6 +212,9 @@ pub fn load_account_delegated<H: Host + ?Sized>(
         let load = host.optional_account_warming(delegate_address, skip_cold_load)?;
         if load.is_cold {
             cost += additional_cold_cost;
+            if cost > remaining_gas {
+                return Err(LoadError::ColdLoadSkipped);
+            }
         }
         let bytecode_load = match load.data {
             Some(code) => BytecodeLoad::Bytecode(code),

--- a/crates/interpreter/src/instructions/contract/call_helpers.rs
+++ b/crates/interpreter/src/instructions/contract/call_helpers.rs
@@ -152,7 +152,7 @@ pub fn load_account_delegated_handle_error<H: Host + ?Sized>(
 /// `state_gas_cost` is non-zero only when creating a new empty account (EIP-8037).
 ///
 /// For EIP-7702 delegations the delegate account is **not** loaded here —
-/// only its warm/cold status is checked via [`Host::is_account_warm`] in
+/// only its warm/cold status is checked via [`Host::is_account_cold`] in
 /// order to charge the correct gas. The actual bytecode load is deferred to
 /// frame creation, signalled by returning `BytecodeLoad::LoadFrom(address)`.
 #[inline]
@@ -195,9 +195,11 @@ pub fn load_account_delegated<H: Host + ?Sized>(
         ));
     }
 
-    // EIP-7702 delegation: the delegated account is never cold-loaded here.
-    // We only consult its warm/cold status to compute gas; the actual code
-    // load is deferred to frame creation via `BytecodeLoad::LoadFrom`.
+    // EIP-7702 delegation: the delegate is warmed eagerly so the cold/warm gas
+    // charge can be computed correctly, but its bytecode is only loaded here
+    // when the account is already present in the journal state map. Otherwise
+    // the bytecode load is deferred to frame creation via
+    // `BytecodeLoad::LoadFrom`.
     if let Some(delegate_address) = account.code.as_ref().and_then(Bytecode::eip7702_address) {
         // EIP-7702 is enabled after berlin hardfork.
         cost += warm_storage_read_cost;
@@ -205,21 +207,17 @@ pub fn load_account_delegated<H: Host + ?Sized>(
             return Err(LoadError::ColdLoadSkipped);
         }
 
-        let is_warm = host.is_account_warm(delegate_address);
-        if !is_warm {
-            // Charging the cold-access surcharge requires the caller to have
-            // enough gas to actually load the delegate later.
-            if remaining_gas < cost + additional_cold_cost {
-                return Err(LoadError::ColdLoadSkipped);
-            }
+        // Skip the cold load if the caller cannot afford the cold surcharge.
+        let skip_cold_load = remaining_gas < cost + additional_cold_cost;
+        let load = host.optional_account_warming(delegate_address, skip_cold_load)?;
+        if load.is_cold {
             cost += additional_cold_cost;
         }
-        return Ok((
-            cost,
-            state_gas_cost,
-            BytecodeLoad::LoadFrom(delegate_address),
-            B256::ZERO,
-        ));
+        let bytecode_load = match load.data {
+            Some(code) => BytecodeLoad::Bytecode(code),
+            None => BytecodeLoad::LoadFrom(delegate_address),
+        };
+        return Ok((cost, state_gas_cost, bytecode_load, B256::ZERO));
     }
 
     Ok((

--- a/crates/interpreter/src/instructions/contract/call_helpers.rs
+++ b/crates/interpreter/src/instructions/contract/call_helpers.rs
@@ -322,6 +322,41 @@ pub fn check_caller_balance<IT: ITy, H: Host + ?Sized>(
     Ok(true)
 }
 
+/// Caller-balance check for CREATE/CREATE2.
+///
+/// Returns `true` when the caller cannot afford to transfer `value` into the
+/// to-be-created contract: the allocated child gas is reimbursed, the
+/// EIP-8037 `create_state_gas` (if any) is returned to the reservoir, the
+/// return-data buffer is cleared, `U256::ZERO` is pushed, and the caller
+/// should return `Ok(())` to continue execution — matching the
+/// [`check_create_depth`] short-circuit.
+///
+/// Returns `false` when the caller has enough balance; the caller should
+/// proceed to dispatch the child frame.
+#[inline]
+pub fn check_create_caller_balance<IT: ITy, H: Host + ?Sized>(
+    interpreter: &mut Interpreter<IT>,
+    host: &mut H,
+    caller: Address,
+    value: U256,
+    gas_limit: u64,
+) -> Result<bool, InstructionResult> {
+    let balance = host
+        .balance(caller)
+        .ok_or(InstructionResult::FatalExternalError)?;
+    if balance.data >= value {
+        return Ok(false);
+    }
+    interpreter.gas.erase_cost(gas_limit);
+    if host.is_amsterdam_eip8037_enabled() {
+        let state_gas = host.gas_params().create_state_gas(host.cpsb());
+        interpreter.gas.refill_reservoir(state_gas);
+    }
+    interpreter.return_data.clear();
+    let _ = interpreter.stack.push(U256::ZERO);
+    Ok(true)
+}
+
 /// Resolve a [`BytecodeLoad`] produced by [`load_acc_and_calc_gas`] into the
 /// final `(code_hash, bytecode)` pair used to build [`crate::CallInputs`].
 ///

--- a/crates/interpreter/src/instructions/contract/call_helpers.rs
+++ b/crates/interpreter/src/instructions/contract/call_helpers.rs
@@ -6,6 +6,7 @@ use crate::{
 use context_interface::{cfg::GasParams, host::LoadError, Host};
 use core::{cmp::min, ops::Range};
 use primitives::{
+    constants::CALL_STACK_LIMIT,
     hardfork::SpecId::{self, *},
     Address, B256, U256,
 };
@@ -227,4 +228,55 @@ pub fn load_account_delegated<H: Host + ?Sized>(
         BytecodeLoad::Bytecode(bytecode),
         code_hash,
     ))
+}
+
+/// EIP-150 call-stack depth check for the CALL family.
+///
+/// Returns `true` and short-circuits the opcode when creating a child frame
+/// would exceed [`CALL_STACK_LIMIT`]. The full `gas_limit` (already including
+/// the call stipend for value-transferring calls) is reimbursed to the
+/// parent's tracker — matching the EVM spec where the stipend on a failed
+/// immediate call is effectively returned to the caller — `U256::ZERO` is
+/// pushed and the caller should return `Ok(())` to continue execution.
+///
+/// Returns `false` when the depth check passes; the caller should proceed to
+/// dispatch the child frame.
+#[inline]
+pub fn check_call_depth<IT: ITy, H: Host + ?Sized>(
+    interpreter: &mut Interpreter<IT>,
+    host: &H,
+    gas_limit: u64,
+) -> bool {
+    if host.depth() <= CALL_STACK_LIMIT as usize {
+        return false;
+    }
+    interpreter.gas.erase_cost(gas_limit);
+    // Safe to push without stack-overflow check: each CALL family opcode pops
+    // at least two stack items before reaching this point.
+    let _ = interpreter.stack.push(U256::ZERO);
+    true
+}
+
+/// EIP-150 call-stack depth check for CREATE/CREATE2.
+///
+/// Returns `true` when the depth check fails: the allocated child gas is
+/// reimbursed to the parent, the EIP-8037 `create_state_gas` (if any) is
+/// returned to the reservoir, `U256::ZERO` is pushed, and the caller should
+/// return `Ok(())` to continue execution.
+#[inline]
+pub fn check_create_depth<IT: ITy, H: Host + ?Sized>(
+    interpreter: &mut Interpreter<IT>,
+    host: &H,
+    gas_limit: u64,
+) -> bool {
+    if host.depth() <= CALL_STACK_LIMIT as usize {
+        return false;
+    }
+    interpreter.gas.erase_cost(gas_limit);
+    if host.is_amsterdam_eip8037_enabled() {
+        let state_gas = host.gas_params().create_state_gas(host.cpsb());
+        interpreter.gas.refill_reservoir(state_gas);
+    }
+    let _ = interpreter.stack.push(U256::ZERO);
+    true
 }

--- a/crates/interpreter/src/instructions/contract/call_helpers.rs
+++ b/crates/interpreter/src/instructions/contract/call_helpers.rs
@@ -1,6 +1,6 @@
 use crate::{
     interpreter::Interpreter,
-    interpreter_types::{InterpreterTypes as ITy, MemoryTr, RuntimeFlag, StackTr},
+    interpreter_types::{InterpreterTypes as ITy, MemoryTr, ReturnData, RuntimeFlag, StackTr},
     InstructionContext as Ictx, InstructionResult,
 };
 use context_interface::{cfg::GasParams, host::LoadError, Host};
@@ -251,6 +251,9 @@ pub fn check_call_depth<IT: ITy, H: Host + ?Sized>(
         return false;
     }
     interpreter.gas.erase_cost(gas_limit);
+    // EIP-211: a failed call exposes an empty return data buffer to the
+    // caller's subsequent RETURNDATASIZE/RETURNDATACOPY.
+    interpreter.return_data.clear();
     // Safe to push without stack-overflow check: each CALL family opcode pops
     // at least two stack items before reaching this point.
     let _ = interpreter.stack.push(U256::ZERO);
@@ -277,6 +280,68 @@ pub fn check_create_depth<IT: ITy, H: Host + ?Sized>(
         let state_gas = host.gas_params().create_state_gas(host.cpsb());
         interpreter.gas.refill_reservoir(state_gas);
     }
+    // A non-reverted CREATE failure clears the caller's return data buffer
+    // (the spec only preserves it for the CREATE revert path).
+    interpreter.return_data.clear();
     let _ = interpreter.stack.push(U256::ZERO);
     true
+}
+
+/// Caller-balance check for value-transferring CALL/CALLCODE.
+///
+/// Returns `true` when the caller cannot afford the value transfer: the
+/// allocated child gas (already including the call stipend) is reimbursed to
+/// the parent, `U256::ZERO` is pushed, and the caller should return `Ok(())`
+/// to continue execution — the same short-circuit shape used for the depth
+/// check.
+///
+/// Returns `false` when the caller has enough balance; the caller should
+/// proceed to dispatch the child frame.
+#[inline]
+pub fn check_caller_balance<IT: ITy, H: Host + ?Sized>(
+    interpreter: &mut Interpreter<IT>,
+    host: &mut H,
+    caller: Address,
+    value: U256,
+    gas_limit: u64,
+) -> Result<bool, InstructionResult> {
+    let balance = host
+        .balance(caller)
+        .ok_or(InstructionResult::FatalExternalError)?;
+    if balance.data >= value {
+        return Ok(false);
+    }
+    interpreter.gas.erase_cost(gas_limit);
+    // EIP-211: a failed call exposes an empty return data buffer to the
+    // caller's subsequent RETURNDATASIZE/RETURNDATACOPY.
+    interpreter.return_data.clear();
+    // Safe to push without stack-overflow check: each CALL family opcode pops
+    // at least two stack items before reaching this point.
+    let _ = interpreter.stack.push(U256::ZERO);
+    Ok(true)
+}
+
+/// Resolve a [`BytecodeLoad`] produced by [`load_acc_and_calc_gas`] into the
+/// final `(code_hash, bytecode)` pair used to build [`crate::CallInputs`].
+///
+/// `BytecodeLoad::Bytecode` is returned as-is (the main account's code was
+/// already loaded). `BytecodeLoad::LoadFrom(delegate)` triggers a fetch of
+/// the delegate account's code via [`Host::load_account_info_skip_cold_load`]
+/// (with `skip_cold_load = false`) — by the time this helper is invoked the
+/// CALL opcode has charged the access cost in [`load_account_delegated`] and
+/// passed the depth/balance gates, so this is the right moment to actually
+/// warm and read the delegate.
+#[inline]
+pub fn resolve_bytecode_load<H: Host + ?Sized>(
+    host: &mut H,
+    bytecode_hash: B256,
+    bytecode_load: BytecodeLoad,
+) -> Result<(B256, Bytecode), InstructionResult> {
+    match bytecode_load {
+        BytecodeLoad::Bytecode(code) => Ok((bytecode_hash, code)),
+        BytecodeLoad::LoadFrom(addr) => {
+            let info = host.load_account_info_skip_cold_load(addr, true, false)?;
+            Ok((info.code_hash(), info.code.clone().unwrap_or_default()))
+        }
+    }
 }

--- a/crates/interpreter/src/instructions/contract/call_helpers.rs
+++ b/crates/interpreter/src/instructions/contract/call_helpers.rs
@@ -9,7 +9,7 @@ use primitives::{
     hardfork::SpecId::{self, *},
     Address, B256, U256,
 };
-use state::Bytecode;
+use state::{Bytecode, BytecodeLoad};
 
 /// Gets memory input and output ranges for call instructions.
 #[inline]
@@ -64,7 +64,7 @@ pub fn load_acc_and_calc_gas<H: Host + ?Sized>(
     transfers_value: bool,
     create_empty_account: bool,
     stack_gas_limit: u64,
-) -> Result<(u64, Bytecode, B256, bool), InstructionResult> {
+) -> Result<(u64, BytecodeLoad, B256, bool), InstructionResult> {
     // Transfer value cost
     if transfers_value {
         gas!(
@@ -115,14 +115,22 @@ pub fn load_acc_and_calc_gas<H: Host + ?Sized>(
 
 /// Loads accounts and its delegate account.
 ///
-/// Returns `(regular_gas_cost, state_gas_cost, bytecode, code_hash)`.
+/// Returns `(regular_gas_cost, state_gas_cost, bytecode_load, code_hash)`.
+///
+/// `bytecode_load` is `BytecodeLoad::Bytecode(_)` when the bytecode for the
+/// frame is already known (non-delegated path), and
+/// `BytecodeLoad::LoadFrom(delegate_address)` when the call target is an
+/// EIP-7702 delegation — in that case the delegate account is not loaded here,
+/// only its warm/cold status is consulted to charge gas, and `code_hash` is
+/// returned as [`B256::ZERO`] (the real hash is fetched when the deferred
+/// load is resolved at frame creation).
 #[inline]
 pub fn load_account_delegated_handle_error<H: Host + ?Sized>(
     context: &mut Ictx<'_, H, impl ITy>,
     to: Address,
     transfers_value: bool,
     create_empty_account: bool,
-) -> Result<(u64, u64, Bytecode, B256), InstructionResult> {
+) -> Result<(u64, u64, BytecodeLoad, B256), InstructionResult> {
     // move this to static gas.
     let remaining_gas = context.interpreter.gas.remaining();
     Ok(load_account_delegated(
@@ -139,8 +147,13 @@ pub fn load_account_delegated_handle_error<H: Host + ?Sized>(
 ///
 /// Assumption is that warm gas is already deducted.
 ///
-/// Returns `(regular_gas_cost, state_gas_cost, bytecode, code_hash)`.
+/// Returns `(regular_gas_cost, state_gas_cost, bytecode_load, code_hash)`.
 /// `state_gas_cost` is non-zero only when creating a new empty account (EIP-8037).
+///
+/// For EIP-7702 delegations the delegate account is **not** loaded here —
+/// only its warm/cold status is checked via [`Host::is_account_warm`] in
+/// order to charge the correct gas. The actual bytecode load is deferred to
+/// frame creation, signalled by returning `BytecodeLoad::LoadFrom(address)`.
 #[inline]
 pub fn load_account_delegated<H: Host + ?Sized>(
     host: &mut H,
@@ -149,7 +162,7 @@ pub fn load_account_delegated<H: Host + ?Sized>(
     address: Address,
     transfers_value: bool,
     create_empty_account: bool,
-) -> Result<(u64, u64, Bytecode, B256), LoadError> {
+) -> Result<(u64, u64, BytecodeLoad, B256), LoadError> {
     let mut cost = 0;
     let mut state_gas_cost = 0;
     let is_berlin = spec.is_enabled_in(SpecId::BERLIN);
@@ -163,8 +176,8 @@ pub fn load_account_delegated<H: Host + ?Sized>(
     if is_berlin && account.is_cold {
         cost += additional_cold_cost;
     }
-    let mut bytecode = account.code.clone().unwrap_or_default();
-    let mut code_hash = account.code_hash();
+    let bytecode = account.code.clone().unwrap_or_default();
+    let code_hash = account.code_hash();
     // New account cost, as account is empty there is no delegated account and we can return early.
     if create_empty_account && account.is_empty {
         cost += host
@@ -173,28 +186,45 @@ pub fn load_account_delegated<H: Host + ?Sized>(
         if host.is_amsterdam_eip8037_enabled() && transfers_value {
             state_gas_cost += host.gas_params().new_account_state_gas(host.cpsb());
         }
-        return Ok((cost, state_gas_cost, bytecode, code_hash));
+        return Ok((
+            cost,
+            state_gas_cost,
+            BytecodeLoad::Bytecode(bytecode),
+            code_hash,
+        ));
     }
 
-    // load delegate code if account is EIP-7702
-    if let Some(address) = account.code.as_ref().and_then(Bytecode::eip7702_address) {
+    // EIP-7702 delegation: the delegated account is never cold-loaded here.
+    // We only consult its warm/cold status to compute gas; the actual code
+    // load is deferred to frame creation via `BytecodeLoad::LoadFrom`.
+    if let Some(delegate_address) = account.code.as_ref().and_then(Bytecode::eip7702_address) {
         // EIP-7702 is enabled after berlin hardfork.
         cost += warm_storage_read_cost;
         if cost > remaining_gas {
             return Err(LoadError::ColdLoadSkipped);
         }
 
-        // skip cold load if there is enough gas to cover the cost.
-        let skip_cold_load = remaining_gas < cost + additional_cold_cost;
-        let delegate_account =
-            host.load_account_info_skip_cold_load(address, true, skip_cold_load)?;
-
-        if delegate_account.is_cold {
+        let is_warm = host.is_account_warm(delegate_address);
+        if !is_warm {
+            // Charging the cold-access surcharge requires the caller to have
+            // enough gas to actually load the delegate later.
+            if remaining_gas < cost + additional_cold_cost {
+                return Err(LoadError::ColdLoadSkipped);
+            }
             cost += additional_cold_cost;
         }
-        bytecode = delegate_account.code.clone().unwrap_or_default();
-        code_hash = delegate_account.code_hash();
+        return Ok((
+            cost,
+            state_gas_cost,
+            BytecodeLoad::LoadFrom(delegate_address),
+            B256::ZERO,
+        ));
     }
 
-    Ok((cost, state_gas_cost, bytecode, code_hash))
+    Ok((
+        cost,
+        state_gas_cost,
+        BytecodeLoad::Bytecode(bytecode),
+        code_hash,
+    ))
 }

--- a/crates/interpreter/src/interpreter_action/call_inputs.rs
+++ b/crates/interpreter/src/interpreter_action/call_inputs.rs
@@ -2,7 +2,7 @@ use crate::interpreter_types::MemoryTr;
 use context_interface::{ContextTr, LocalContextTr};
 use core::ops::Range;
 use primitives::{Address, Bytes, B256, U256};
-use state::Bytecode;
+use state::BytecodeLoad;
 
 /// Input enum for a call.
 ///
@@ -145,10 +145,14 @@ pub struct CallInputs {
     ///
     /// Previously `context.code_address`.
     pub bytecode_address: Address,
-    /// Known bytecode and its hash.
-    /// If None, bytecode will be loaded from the account at `bytecode_address`.
-    /// If Some((hash, bytecode)), the provided bytecode and hash will be used.
-    pub known_bytecode: (B256, Bytecode),
+    /// Known bytecode (or a deferred load) and its hash.
+    ///
+    /// `known_bytecode.0` is the code hash. It is meaningful when
+    /// `known_bytecode.1` is `BytecodeLoad::Bytecode`; for
+    /// `BytecodeLoad::LoadFrom`, the hash is unknown at this point and the
+    /// field is set to `B256::ZERO` — frame creation resolves the load and
+    /// uses the freshly loaded account's hash.
+    pub known_bytecode: (B256, BytecodeLoad),
     /// Target address, this account storage is going to be modified.
     ///
     /// Previously `context.address`.

--- a/crates/interpreter/src/interpreter_action/call_inputs.rs
+++ b/crates/interpreter/src/interpreter_action/call_inputs.rs
@@ -2,7 +2,7 @@ use crate::interpreter_types::MemoryTr;
 use context_interface::{ContextTr, LocalContextTr};
 use core::ops::Range;
 use primitives::{Address, Bytes, B256, U256};
-use state::BytecodeLoad;
+use state::Bytecode;
 
 /// Input enum for a call.
 ///
@@ -145,14 +145,12 @@ pub struct CallInputs {
     ///
     /// Previously `context.code_address`.
     pub bytecode_address: Address,
-    /// Known bytecode (or a deferred load) and its hash.
+    /// Known bytecode and its hash for the call's target.
     ///
-    /// `known_bytecode.0` is the code hash. It is meaningful when
-    /// `known_bytecode.1` is `BytecodeLoad::Bytecode`; for
-    /// `BytecodeLoad::LoadFrom`, the hash is unknown at this point and the
-    /// field is set to `B256::ZERO` — frame creation resolves the load and
-    /// uses the freshly loaded account's hash.
-    pub known_bytecode: (B256, BytecodeLoad),
+    /// For EIP-7702 delegations this is the delegated account's code (the
+    /// CALL opcode resolves the deferred load before building this struct);
+    /// otherwise it is the target account's own code.
+    pub known_bytecode: (B256, Bytecode),
     /// Target address, this account storage is going to be modified.
     ///
     /// Previously `context.address`.

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -12,7 +12,7 @@ mod types;
 pub use bytecode;
 
 pub use account_info::{AccountId, AccountInfo};
-pub use bytecode::Bytecode;
+pub use bytecode::{Bytecode, BytecodeLoad};
 pub use primitives;
 pub use types::{EvmState, EvmStorage, TransientStorage};
 

--- a/examples/cheatcode_inspector/src/main.rs
+++ b/examples/cheatcode_inspector/src/main.rs
@@ -315,6 +315,10 @@ impl JournalTr for Backend {
             .load_account_info_skip_cold_load(address, load_code, skip_cold_load)
     }
 
+    fn is_account_warm(&self, address: Address) -> bool {
+        self.journaled_state.is_account_warm(address)
+    }
+
     fn load_account_mut_optional_code(
         &mut self,
         address: Address,

--- a/examples/cheatcode_inspector/src/main.rs
+++ b/examples/cheatcode_inspector/src/main.rs
@@ -315,8 +315,13 @@ impl JournalTr for Backend {
             .load_account_info_skip_cold_load(address, load_code, skip_cold_load)
     }
 
-    fn is_account_warm(&self, address: Address) -> bool {
-        self.journaled_state.is_account_warm(address)
+    fn optional_account_warming(
+        &mut self,
+        address: Address,
+        skip_cold_load: bool,
+    ) -> Result<StateLoad<Option<Bytecode>>, JournalLoadError<Infallible>> {
+        self.journaled_state
+            .optional_account_warming(address, skip_cold_load)
     }
 
     fn load_account_mut_optional_code(


### PR DESCRIPTION
## Summary

- For an EIP-7702 delegated call target, the delegate account is no longer eagerly cold-loaded in the CALL helper. The warm/cold decision now drives gas charging only, and the actual code fetch is deferred to frame creation.
- Introduces a new `BytecodeLoad { LoadFrom(Address), Bytecode(Bytecode) }` enum (`state::BytecodeLoad`, re-exported from `bytecode`) that lets `load_account_delegated` return either an already-loaded bytecode or a pointer to "load from this address later".
- Adds `Host::is_account_warm(&self, address) -> bool` — a pure warm-set lookup that never reads from the DB and never promotes a cold account to warm. Mirrored on `JournalTr`, implemented in `JournalInner` (precompile/coinbase/access-list set + in-memory account's `is_cold_transaction_id`), and wired through `Journal`, `Context`, and the cheatcode_inspector example.
- `CallInputs.known_bytecode` becomes `(B256, BytecodeLoad)`. `make_call_frame` resolves a `LoadFrom` by calling `journal.load_account_with_code(addr)` **before** the child checkpoint is created, so the delegate's warmth survives if the child frame reverts (this caught a state-root regression on `test_pointer_reverts` during development).

## Test plan

- [x] `cargo check --workspace` (default features)
- [x] `cargo check --workspace --all-features`
- [x] `cargo check --workspace --no-default-features`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo fmt --all --check`
- [x] `cargo nextest run --workspace` — 327 passed
- [x] `cargo run --release -p revme -- statetest test-fixtures/main/develop/state_tests` — all 2710 tests pass, including the EIP-7702 `test_pointer_reverts` cases that exercise the warm-on-revert path