### PR TITLE
feat: add async database fiber support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1483,6 +1483,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "corosensei"
+version = "0.3.3"
+source = "git+https://github.com/Amanieu/corosensei?rev=3a122508ab1d7c25e4dee8b2b4b4c47046c3c3d8#3a122508ab1d7c25e4dee8b2b4b4c47046c3c3d8"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "libc",
+ "scopeguard",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3789,6 +3801,7 @@ name = "revm-database-interface"
 version = "12.1.0"
 dependencies = [
  "auto_impl",
+ "corosensei",
  "either",
  "revm-primitives",
  "revm-state",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1484,8 +1484,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "corosensei"
-version = "0.3.3"
-source = "git+https://github.com/Amanieu/corosensei?rev=3a122508ab1d7c25e4dee8b2b4b4c47046c3c3d8#3a122508ab1d7c25e4dee8b2b4b4c47046c3c3d8"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6886a0c0f263965933c438626e7179139a62b978a33aa18281cbf0cd5a975f34"
 dependencies = [
  "autocfg",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,9 +112,7 @@ serde_json = { version = "1.0", default-features = false }
 auto_impl = "1.3.0"
 bitflags = { version = "2.10", default-features = false }
 cfg-if = { version = "1.0", default-features = false }
-# Uses public `Coroutine::with_stack_unchecked`.
-# https://github.com/Amanieu/corosensei/pull/74
-corosensei = { version = "0.3.3", git = "https://github.com/Amanieu/corosensei", rev = "3a122508ab1d7c25e4dee8b2b4b4c47046c3c3d8", default-features = false, features = [
+corosensei = { version = "0.3.4", default-features = false, features = [
     "default-stack",
     "unwind",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,12 @@ serde_json = { version = "1.0", default-features = false }
 auto_impl = "1.3.0"
 bitflags = { version = "2.10", default-features = false }
 cfg-if = { version = "1.0", default-features = false }
+# Uses public `Coroutine::with_stack_unchecked`.
+# https://github.com/Amanieu/corosensei/pull/74
+corosensei = { version = "0.3.3", git = "https://github.com/Amanieu/corosensei", rev = "3a122508ab1d7c25e4dee8b2b4b4c47046c3c3d8", default-features = false, features = [
+    "default-stack",
+    "unwind",
+] }
 derive-where = { version = "1.6", default-features = false }
 rand = "0.9"
 tokio = "1.47"

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -70,6 +70,7 @@ dev = [
 	"optional_priority_fee_check",
 	"optional_fee_charge",
 ]
+asyncdb = ["std", "database-interface/asyncdb"]
 memory_limit = []
 optional_balance_check = []
 optional_block_gas_limit = []

--- a/crates/context/src/evm.rs
+++ b/crates/context/src/evm.rs
@@ -22,6 +22,9 @@ pub struct Evm<CTX, INSP, I, P, F> {
     pub precompiles: P,
     /// Frame that is going to be executed.
     pub frame_stack: FrameStack<F>,
+    /// Reusable async execution stack.
+    #[cfg(feature = "asyncdb")]
+    pub async_stack: database_interface::async_db::FiberStack,
 }
 
 impl<CTX, I, P, F: Default> Evm<CTX, (), I, P, F> {
@@ -35,6 +38,8 @@ impl<CTX, I, P, F: Default> Evm<CTX, (), I, P, F> {
             instruction,
             precompiles,
             frame_stack: FrameStack::new_prealloc(8),
+            #[cfg(feature = "asyncdb")]
+            async_stack: database_interface::async_db::FiberStack::default(),
         }
     }
 }
@@ -48,6 +53,8 @@ impl<CTX, I, INSP, P, F: Default> Evm<CTX, INSP, I, P, F> {
             instruction,
             precompiles,
             frame_stack: FrameStack::new_prealloc(8),
+            #[cfg(feature = "asyncdb")]
+            async_stack: database_interface::async_db::FiberStack::default(),
         }
     }
 }
@@ -62,6 +69,8 @@ impl<CTX, INSP, I, P, F> Evm<CTX, INSP, I, P, F> {
             instruction: self.instruction,
             precompiles: self.precompiles,
             frame_stack: self.frame_stack,
+            #[cfg(feature = "asyncdb")]
+            async_stack: self.async_stack,
         }
     }
 
@@ -73,6 +82,8 @@ impl<CTX, INSP, I, P, F> Evm<CTX, INSP, I, P, F> {
             instruction: self.instruction,
             precompiles,
             frame_stack: self.frame_stack,
+            #[cfg(feature = "asyncdb")]
+            async_stack: self.async_stack,
         }
     }
 

--- a/crates/database/interface/Cargo.toml
+++ b/crates/database/interface/Cargo.toml
@@ -32,6 +32,7 @@ serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
 # asyncdb
 tokio = { workspace = true, optional = true }
+corosensei = { workspace = true, optional = true }
 
 [dev-dependencies]
 
@@ -45,4 +46,4 @@ std = [
     "thiserror/std",
 ]
 serde = ["dep:serde", "primitives/serde", "state/serde", "either/serde"]
-asyncdb = ["dep:tokio", "tokio/rt-multi-thread"]
+asyncdb = ["std", "dep:tokio", "tokio/rt-multi-thread", "dep:corosensei"]

--- a/crates/database/interface/src/async_db.rs
+++ b/crates/database/interface/src/async_db.rs
@@ -1,17 +1,474 @@
 //! Async database interface.
-use crate::{DBErrorMarker, Database, DatabaseRef};
-use core::future::Future;
-use primitives::{Address, StorageKey, StorageValue, B256};
-use state::{AccountId, AccountInfo, Bytecode};
-use tokio::runtime::{Handle, Runtime};
+use crate::{DBErrorMarker, Database, DatabaseCommit, DatabaseRef};
+use core::{
+    convert::Infallible,
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    ptr::NonNull,
+    task::{Context, Poll},
+};
+use corosensei::{stack::DefaultStack, Coroutine, CoroutineResult, Yielder};
+use primitives::{Address, AddressMap, StorageKey, StorageValue, B256};
+use state::{Account, AccountId, AccountInfo, Bytecode};
+use std::{cell::Cell, fmt, io};
+use tokio::{
+    runtime::{Handle, Runtime},
+    task,
+};
 
-/// The async EVM database interface
+type Resume = AsyncResult<NonNull<Context<'static>>>;
+type Yield = ();
+type Complete<R> = AsyncResult<R>;
+type DatabaseFiber<R> = Coroutine<Resume, Yield, Complete<R>, DefaultStack>;
+
+const DEFAULT_STACK_SIZE: usize = 1024 * 1024;
+
+/// Reusable async EVM fiber stack storage.
+#[derive(Default)]
+pub struct FiberStack {
+    stack: Option<DefaultStack>,
+}
+
+impl Clone for FiberStack {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
+impl fmt::Debug for FiberStack {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FiberStack").finish_non_exhaustive()
+    }
+}
+
+impl FiberStack {
+    #[inline]
+    fn take_or_new(&mut self) -> AsyncResult<DefaultStack> {
+        match self.stack.take() {
+            Some(stack) => Ok(stack),
+            None => DefaultStack::new(DEFAULT_STACK_SIZE).map_err(AsyncError::Io),
+        }
+    }
+
+    #[inline]
+    fn put(&mut self, stack: DefaultStack) {
+        debug_assert!(self.stack.is_none());
+        self.stack = Some(stack);
+    }
+}
+
+thread_local! {
+    static CURRENT: Cell<Option<NonNull<CurrentFiber>>> = const { Cell::new(None) };
+}
+
+/// Result type used by async database execution helpers.
+pub type AsyncResult<T, E = Infallible> = Result<T, AsyncError<E>>;
+
+/// Error returned by async database execution helpers.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum AsyncError<E = Infallible> {
+    /// The async EVM fiber was cancelled before execution completed.
+    #[error("async EVM execution was cancelled")]
+    Cancelled,
+    /// An async host operation was called outside an async EVM fiber.
+    #[error("async host operation requires EVM async fiber execution")]
+    NotOnFiber,
+    /// Blocking async I/O was requested outside a supported Tokio runtime.
+    #[error("async host operation requires a Tokio multi-thread runtime")]
+    Runtime,
+    /// Async fiber stack setup failed.
+    #[error(transparent)]
+    Io(io::Error),
+    /// The wrapped operation returned an error.
+    #[error(transparent)]
+    Inner(#[from] E),
+}
+
+impl AsyncError {
+    fn with_inner_error<E>(self) -> AsyncError<E> {
+        match self {
+            Self::Cancelled => AsyncError::Cancelled,
+            Self::NotOnFiber => AsyncError::NotOnFiber,
+            Self::Runtime => AsyncError::Runtime,
+            Self::Io(error) => AsyncError::Io(error),
+            Self::Inner(error) => match error {},
+        }
+    }
+}
+
+impl<E: DBErrorMarker> DBErrorMarker for AsyncError<E> {
+    #[inline]
+    fn is_fatal(&self) -> bool {
+        match self {
+            Self::Inner(error) => error.is_fatal(),
+            _ => true,
+        }
+    }
+}
+
+struct CurrentFiber {
+    suspend: NonNull<Yielder<Resume, Yield>>,
+    future_cx: NonNull<Context<'static>>,
+    cancelled: bool,
+}
+
+impl CurrentFiber {
+    #[inline]
+    fn context(&mut self) -> &mut Context<'_> {
+        unsafe { restore_context_lifetime(self.future_cx.as_mut()) }
+    }
+
+    #[inline]
+    fn suspend(&mut self) -> AsyncResult<()> {
+        match unsafe { self.suspend.as_ref() }.suspend(()) {
+            Ok(cx) => {
+                self.future_cx = cx;
+                Ok(())
+            }
+            Err(error) => {
+                self.cancelled = true;
+                Err(error)
+            }
+        }
+    }
+
+    #[inline]
+    const fn is_cancelled(&self) -> bool {
+        self.cancelled
+    }
+}
+
+struct ResetCurrentFiber(Option<NonNull<CurrentFiber>>);
+
+impl Drop for ResetCurrentFiber {
+    fn drop(&mut self) {
+        CURRENT.set(self.0);
+    }
+}
+
+/// Runs `func` on a native fiber and awaits its completion.
+///
+/// Synchronous code running inside `func` may call [`block_on_current`] to wait for async host
+/// operations without blocking the executor thread.
+#[cfg(test)]
+pub(crate) fn on_fiber_result<'a, R, E>(
+    func: impl FnOnce() -> Result<R, E> + 'a,
+) -> impl Future<Output = AsyncResult<R, E>> + Send + 'a
+where
+    R: Send + 'a,
+    E: Send + 'a,
+{
+    OnFiber::new(func)
+}
+
+/// Runs `func` on a native fiber backed by a reusable EVM stack slot.
+///
+/// # Safety
+///
+/// `stack` must point to valid stack storage for the lifetime of the returned future. That storage
+/// must not be accessed by anything else until the returned future is dropped.
+pub unsafe fn on_fiber_result_with_stack<'a, R, E>(
+    stack: NonNull<FiberStack>,
+    func: impl FnOnce() -> Result<R, E> + 'a,
+) -> impl Future<Output = AsyncResult<R, E>> + Send + 'a
+where
+    R: Send + 'a,
+    E: Send + 'a,
+{
+    OnFiber::with_stack(stack, func)
+}
+
+#[cfg(test)]
+pub(crate) fn on_fiber<'a, R>(
+    func: impl FnOnce() -> R + 'a,
+) -> impl Future<Output = AsyncResult<R>> + Send + 'a
+where
+    R: Send + 'a,
+{
+    on_fiber_result(move || Ok::<_, Infallible>(func()))
+}
+
+/// Runs `func` on a native fiber backed by a reusable EVM stack slot.
+///
+/// # Safety
+///
+/// See [`on_fiber_result_with_stack`].
+pub unsafe fn on_fiber_with_stack<'a, R>(
+    stack: NonNull<FiberStack>,
+    func: impl FnOnce() -> R + 'a,
+) -> impl Future<Output = AsyncResult<R>> + Send + 'a
+where
+    R: Send + 'a,
+{
+    unsafe { on_fiber_result_with_stack(stack, move || Ok::<_, Infallible>(func())) }
+}
+
+enum OnFiber<'a, R, E> {
+    Running(FiberFuture<'a, Result<R, E>>),
+    Error(Option<AsyncError>),
+    Done,
+}
+
+impl<'a, R, E> OnFiber<'a, R, E> {
+    #[cfg(test)]
+    fn new(func: impl FnOnce() -> Result<R, E> + 'a) -> Self {
+        Self::new_inner(None, func)
+    }
+
+    fn with_stack(stack: NonNull<FiberStack>, func: impl FnOnce() -> Result<R, E> + 'a) -> Self {
+        Self::new_inner(Some(stack), func)
+    }
+
+    fn new_inner(
+        stack: Option<NonNull<FiberStack>>,
+        func: impl FnOnce() -> Result<R, E> + 'a,
+    ) -> Self {
+        match FiberFuture::new(stack, func) {
+            Ok(fiber) => Self::Running(fiber),
+            Err(error) => Self::Error(Some(error)),
+        }
+    }
+}
+
+impl<R, E> Future for OnFiber<'_, R, E> {
+    type Output = AsyncResult<R, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        match this {
+            Self::Running(fiber) => match Pin::new(fiber).poll(cx) {
+                Poll::Ready(Ok(Ok(value))) => {
+                    *this = Self::Done;
+                    Poll::Ready(Ok(value))
+                }
+                Poll::Ready(Ok(Err(error))) => {
+                    *this = Self::Done;
+                    Poll::Ready(Err(AsyncError::Inner(error)))
+                }
+                Poll::Ready(Err(error)) => {
+                    *this = Self::Done;
+                    Poll::Ready(Err(error.with_inner_error()))
+                }
+                Poll::Pending => Poll::Pending,
+            },
+            Self::Error(error) => {
+                let error = error
+                    .take()
+                    .expect("async EVM fiber error already returned");
+                Poll::Ready(Err(error.with_inner_error()))
+            }
+            Self::Done => panic!("async EVM fiber polled after completion"),
+        }
+    }
+}
+
+struct FiberFuture<'a, R> {
+    fiber: Option<DatabaseFiber<R>>,
+    stack: Option<NonNull<FiberStack>>,
+    _marker: PhantomData<&'a ()>,
+}
+
+// SAFETY: The future may move between polls, but the coroutine stack itself is heap allocated and
+// is only resumed through `poll` with a fresh task context. Values that can remain on the coroutine
+// stack across suspension are required to be `Send` by the blocking boundary.
+unsafe impl<R: Send> Send for FiberFuture<'_, R> {}
+
+impl<'a, R> FiberFuture<'a, R> {
+    fn new(
+        mut stack: Option<NonNull<FiberStack>>,
+        func: impl FnOnce() -> R + 'a,
+    ) -> AsyncResult<Self> {
+        let fiber_stack = match &mut stack {
+            Some(stack) => unsafe { stack.as_mut() }.take_or_new()?,
+            None => DefaultStack::new(DEFAULT_STACK_SIZE).map_err(AsyncError::Io)?,
+        };
+        let body = move |suspend: &Yielder<Resume, Yield>, resume| {
+            let future_cx = resume?;
+            let mut current = CurrentFiber {
+                suspend: NonNull::from(suspend),
+                future_cx,
+                cancelled: false,
+            };
+            let current = NonNull::from(&mut current);
+            let previous = CURRENT.replace(Some(current));
+            let _reset = ResetCurrentFiber(previous);
+            Ok(func())
+        };
+        // SAFETY: The coroutine is stored inside `FiberFuture<'a, R>`, which is tied to the
+        // borrowed state lifetime and dropped before those borrows can expire.
+        let fiber = unsafe { Coroutine::with_stack_unchecked(fiber_stack, body) };
+        Ok(Self {
+            fiber: Some(fiber),
+            stack,
+            _marker: PhantomData,
+        })
+    }
+
+    fn recycle_stack(&mut self) {
+        let Some(fiber) = self.fiber.take() else {
+            return;
+        };
+        debug_assert!(fiber.done());
+        let stack = fiber.into_stack();
+        if let Some(mut slot) = self.stack {
+            unsafe { slot.as_mut() }.put(stack);
+        }
+    }
+}
+
+impl<R> Future for FiberFuture<'_, R> {
+    type Output = AsyncResult<R>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        let cx = NonNull::from(unsafe { change_context_lifetime(cx) });
+        let fiber = this
+            .fiber
+            .as_mut()
+            .expect("async EVM fiber polled after completion");
+        match fiber.resume(Ok(cx)) {
+            CoroutineResult::Return(result) => {
+                this.recycle_stack();
+                Poll::Ready(result)
+            }
+            CoroutineResult::Yield(()) => Poll::Pending,
+        }
+    }
+}
+
+impl<R> Drop for FiberFuture<'_, R> {
+    fn drop(&mut self) {
+        let Some(fiber) = self.fiber.as_mut() else {
+            return;
+        };
+        if fiber.done() {
+            self.recycle_stack();
+        } else if matches!(
+            fiber.resume(Err(AsyncError::Cancelled)),
+            CoroutineResult::Yield(())
+        ) {
+            // SAFETY: Cancellation already gave the coroutine a chance to return normally. If it
+            // yields again, the stack is no longer useful to this future.
+            unsafe { fiber.force_reset() };
+        } else {
+            self.recycle_stack();
+        }
+    }
+}
+
+/// Polls `future` to completion from inside an async EVM fiber.
+///
+/// If `future` returns `Poll::Pending`, the current EVM fiber is suspended and the outer async EVM
+/// future returns `Poll::Pending`. When the executor wakes and polls the outer future again, the
+/// EVM fiber resumes and continues polling `future`.
+///
+/// # Errors
+///
+/// Returns [`AsyncError::NotOnFiber`] if called outside async EVM execution, or
+/// [`AsyncError::Cancelled`] if the outer async EVM execution was dropped.
+pub fn block_on_current<F: Future>(future: F) -> AsyncResult<F::Output> {
+    let mut future = core::pin::pin!(future);
+    loop {
+        match with_current(|current| {
+            if current.is_cancelled() {
+                return Err(AsyncError::Cancelled);
+            }
+            let poll = future.as_mut().poll(current.context());
+            if poll.is_pending() {
+                current.suspend()?;
+            }
+            Ok(poll)
+        })? {
+            Poll::Ready(value) => return Ok(value),
+            Poll::Pending => {}
+        }
+    }
+}
+
+fn current_tokio_handle() -> Option<Handle> {
+    match Handle::try_current() {
+        Ok(handle) => match handle.runtime_flavor() {
+            tokio::runtime::RuntimeFlavor::CurrentThread => None,
+            _ => Some(handle),
+        },
+        Err(_) => None,
+    }
+}
+
+fn block_on_handle<F>(handle: &Handle, future: F) -> F::Output
+where
+    F: Future + Send,
+    F::Output: Send,
+{
+    let should_use_block_in_place = Handle::try_current()
+        .ok()
+        .map(|current| {
+            !matches!(
+                current.runtime_flavor(),
+                tokio::runtime::RuntimeFlavor::CurrentThread
+            )
+        })
+        .unwrap_or(false);
+
+    if should_use_block_in_place {
+        task::block_in_place(move || handle.block_on(future))
+    } else {
+        handle.block_on(future)
+    }
+}
+
+fn block_on_runtime<F>(runtime: Option<&Handle>, future: F) -> AsyncResult<F::Output>
+where
+    F: Future + Send,
+    F::Output: Send,
+{
+    if CURRENT.get().is_some() {
+        return block_on_current(future);
+    }
+
+    if let Some(runtime) = runtime {
+        return Ok(block_on_handle(runtime, future));
+    }
+
+    Err(AsyncError::Runtime)
+}
+
+fn block_on_runtime_result<F, T, E>(runtime: Option<&Handle>, future: F) -> AsyncResult<T, E>
+where
+    F: Future<Output = Result<T, E>> + Send,
+    T: Send,
+    E: Send,
+{
+    match block_on_runtime(runtime, future).map_err(AsyncError::with_inner_error)? {
+        Ok(value) => Ok(value),
+        Err(error) => Err(AsyncError::Inner(error)),
+    }
+}
+
+fn with_current<R>(f: impl FnOnce(&mut CurrentFiber) -> AsyncResult<R>) -> AsyncResult<R> {
+    let mut current = CURRENT.get().ok_or(AsyncError::NotOnFiber)?;
+    f(unsafe { current.as_mut() })
+}
+
+unsafe fn change_context_lifetime<'a>(cx: &'a mut Context<'_>) -> &'a mut Context<'static> {
+    unsafe { core::mem::transmute::<&'a mut Context<'_>, &'a mut Context<'static>>(cx) }
+}
+
+unsafe fn restore_context_lifetime<'a>(cx: &'a mut Context<'static>) -> &'a mut Context<'a> {
+    unsafe { core::mem::transmute::<&'a mut Context<'static>, &'a mut Context<'a>>(cx) }
+}
+
+/// The async EVM database interface.
 ///
 /// Contains the same methods as [Database], but it returns [Future] type instead.
 ///
-/// Use [WrapDatabaseAsync] to provide [Database] implementation for a type that only implements this trait.
+/// Use [AsyncDb] to provide [Database] implementation for a type that only implements this trait.
 pub trait DatabaseAsync {
-    /// The database error type
+    /// The database error type.
     type Error: DBErrorMarker;
 
     /// Gets basic account information.
@@ -54,13 +511,13 @@ pub trait DatabaseAsync {
     ) -> impl Future<Output = Result<B256, Self::Error>> + Send;
 }
 
-/// The async EVM database interface
+/// The async EVM database interface.
 ///
 /// Contains the same methods as [DatabaseRef], but it returns [Future] type instead.
 ///
-/// Use [WrapDatabaseAsync] to provide [DatabaseRef] implementation for a type that only implements this trait.
+/// Use [AsyncDb] to provide [DatabaseRef] implementation for a type that only implements this trait.
 pub trait DatabaseAsyncRef {
-    /// The database error type
+    /// The database error type.
     type Error: DBErrorMarker;
 
     /// Gets basic account information.
@@ -103,61 +560,92 @@ pub trait DatabaseAsyncRef {
     ) -> impl Future<Output = Result<B256, Self::Error>> + Send;
 }
 
-/// Wraps a [DatabaseAsync] or [DatabaseAsyncRef] to provide a [`Database`] implementation.
+/// Adapter that exposes an async database through the synchronous [`Database`] interface.
 #[derive(Debug)]
-pub struct WrapDatabaseAsync<T> {
+pub struct AsyncDb<T> {
     db: T,
-    rt: HandleOrRuntime,
+    rt: Option<HandleOrRuntime>,
 }
 
-impl<T> WrapDatabaseAsync<T> {
-    /// Wraps a [DatabaseAsync] or [DatabaseAsyncRef] instance.
+impl<T> AsyncDb<T> {
+    /// Creates a new async database adapter.
     ///
-    /// Returns `None` if no tokio runtime is available or if the current runtime is a current-thread runtime.
-    pub fn new(db: T) -> Option<Self> {
-        let rt = match Handle::try_current() {
-            Ok(handle) => match handle.runtime_flavor() {
-                tokio::runtime::RuntimeFlavor::CurrentThread => return None,
-                _ => HandleOrRuntime::Handle(handle),
-            },
-            Err(_) => return None,
-        };
-        Some(Self { db, rt })
+    /// This captures the current Tokio runtime handle when one is available.
+    #[inline]
+    pub fn new(db: T) -> Self {
+        Self {
+            db,
+            rt: current_tokio_handle().map(HandleOrRuntime::Handle),
+        }
     }
 
-    /// Wraps a [DatabaseAsync] or [DatabaseAsyncRef] instance, with a runtime.
+    /// Creates a new async database adapter using the current Tokio runtime handle.
     ///
-    /// Refer to [tokio::runtime::Builder] on how to create a runtime if you are in synchronous world.
-    ///
-    /// If you are already using something like [tokio::main], call [`WrapDatabaseAsync::new`] instead.
+    /// Returns `None` if no Tokio runtime is available or the current runtime is current-threaded.
+    #[inline]
+    pub fn blocking(db: T) -> Option<Self> {
+        Some(Self {
+            db,
+            rt: Some(HandleOrRuntime::Handle(current_tokio_handle()?)),
+        })
+    }
+
+    /// Creates a new async database adapter with a Tokio runtime.
+    #[inline]
     pub const fn with_runtime(db: T, runtime: Runtime) -> Self {
-        let rt = HandleOrRuntime::Runtime(runtime);
-        Self { db, rt }
+        Self {
+            db,
+            rt: Some(HandleOrRuntime::Runtime(runtime)),
+        }
     }
 
-    /// Wraps a [DatabaseAsync] or [DatabaseAsyncRef] instance, with a runtime handle.
-    ///
-    /// This generally allows you to pass any valid runtime handle, refer to [tokio::runtime::Handle] on how
-    /// to obtain a handle.
-    ///
-    /// If you are already in asynchronous world, like [tokio::main], use [`WrapDatabaseAsync::new`] instead.
+    /// Creates a new async database adapter with a Tokio runtime handle.
+    #[inline]
     pub const fn with_handle(db: T, handle: Handle) -> Self {
-        let rt = HandleOrRuntime::Handle(handle);
-        Self { db, rt }
+        Self {
+            db,
+            rt: Some(HandleOrRuntime::Handle(handle)),
+        }
+    }
+
+    /// Returns the wrapped database.
+    #[inline]
+    pub const fn inner(&self) -> &T {
+        &self.db
+    }
+
+    /// Returns the wrapped database mutably.
+    #[inline]
+    pub const fn inner_mut(&mut self) -> &mut T {
+        &mut self.db
+    }
+
+    /// Consumes the adapter and returns the wrapped database.
+    #[inline]
+    pub fn into_inner(self) -> T {
+        self.db
     }
 }
 
-impl<T: DatabaseAsync> Database for WrapDatabaseAsync<T> {
-    type Error = T::Error;
+impl<T: DatabaseAsync> Database for AsyncDb<T> {
+    type Error = AsyncError<T::Error>;
 
     #[inline]
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
-        self.rt.block_on(self.db.basic_async(address))
+        let Self { db, rt } = self;
+        block_on_runtime_result(
+            rt.as_ref().map(HandleOrRuntime::handle),
+            db.basic_async(address),
+        )
     }
 
     #[inline]
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
-        self.rt.block_on(self.db.code_by_hash_async(code_hash))
+        let Self { db, rt } = self;
+        block_on_runtime_result(
+            rt.as_ref().map(HandleOrRuntime::handle),
+            db.code_by_hash_async(code_hash),
+        )
     }
 
     #[inline]
@@ -166,12 +654,13 @@ impl<T: DatabaseAsync> Database for WrapDatabaseAsync<T> {
         address: Address,
         index: StorageKey,
     ) -> Result<StorageValue, Self::Error> {
-        self.rt.block_on(self.db.storage_async(address, index))
+        let Self { db, rt } = self;
+        block_on_runtime_result(
+            rt.as_ref().map(HandleOrRuntime::handle),
+            db.storage_async(address, index),
+        )
     }
 
-    /// Gets storage value of account by its id.
-    ///
-    /// Wraps [`DatabaseAsync::storage_by_account_id_async`] in a blocking call.
     #[inline]
     fn storage_by_account_id(
         &mut self,
@@ -179,29 +668,40 @@ impl<T: DatabaseAsync> Database for WrapDatabaseAsync<T> {
         account_id: AccountId,
         storage_key: StorageKey,
     ) -> Result<StorageValue, Self::Error> {
-        self.rt.block_on(
-            self.db
-                .storage_by_account_id_async(address, account_id, storage_key),
+        let Self { db, rt } = self;
+        block_on_runtime_result(
+            rt.as_ref().map(HandleOrRuntime::handle),
+            db.storage_by_account_id_async(address, account_id, storage_key),
         )
     }
 
     #[inline]
     fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error> {
-        self.rt.block_on(self.db.block_hash_async(number))
+        let Self { db, rt } = self;
+        block_on_runtime_result(
+            rt.as_ref().map(HandleOrRuntime::handle),
+            db.block_hash_async(number),
+        )
     }
 }
 
-impl<T: DatabaseAsyncRef> DatabaseRef for WrapDatabaseAsync<T> {
-    type Error = T::Error;
+impl<T: DatabaseAsyncRef> DatabaseRef for AsyncDb<T> {
+    type Error = AsyncError<T::Error>;
 
     #[inline]
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
-        self.rt.block_on(self.db.basic_async_ref(address))
+        block_on_runtime_result(
+            self.rt.as_ref().map(HandleOrRuntime::handle),
+            self.db.basic_async_ref(address),
+        )
     }
 
     #[inline]
     fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error> {
-        self.rt.block_on(self.db.code_by_hash_async_ref(code_hash))
+        block_on_runtime_result(
+            self.rt.as_ref().map(HandleOrRuntime::handle),
+            self.db.code_by_hash_async_ref(code_hash),
+        )
     }
 
     #[inline]
@@ -210,7 +710,10 @@ impl<T: DatabaseAsyncRef> DatabaseRef for WrapDatabaseAsync<T> {
         address: Address,
         index: StorageKey,
     ) -> Result<StorageValue, Self::Error> {
-        self.rt.block_on(self.db.storage_async_ref(address, index))
+        block_on_runtime_result(
+            self.rt.as_ref().map(HandleOrRuntime::handle),
+            self.db.storage_async_ref(address, index),
+        )
     }
 
     #[inline]
@@ -220,7 +723,8 @@ impl<T: DatabaseAsyncRef> DatabaseRef for WrapDatabaseAsync<T> {
         account_id: AccountId,
         storage_key: StorageKey,
     ) -> Result<StorageValue, Self::Error> {
-        self.rt.block_on(
+        block_on_runtime_result(
+            self.rt.as_ref().map(HandleOrRuntime::handle),
             self.db
                 .storage_by_account_id_async_ref(address, account_id, storage_key),
         )
@@ -228,11 +732,169 @@ impl<T: DatabaseAsyncRef> DatabaseRef for WrapDatabaseAsync<T> {
 
     #[inline]
     fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
-        self.rt.block_on(self.db.block_hash_async_ref(number))
+        block_on_runtime_result(
+            self.rt.as_ref().map(HandleOrRuntime::handle),
+            self.db.block_hash_async_ref(number),
+        )
     }
 }
 
-// Hold a tokio runtime handle or full runtime
+impl<T: DatabaseAsync + DatabaseCommit> DatabaseCommit for AsyncDb<T> {
+    #[inline]
+    fn commit(&mut self, changes: AddressMap<Account>) {
+        self.db.commit(changes);
+    }
+
+    #[inline]
+    fn commit_iter(&mut self, changes: &mut dyn Iterator<Item = (Address, Account)>) {
+        self.db.commit_iter(changes);
+    }
+}
+
+/// Wraps a [DatabaseAsync] or [DatabaseAsyncRef] to provide a [`Database`] implementation.
+#[derive(Debug)]
+pub struct WrapDatabaseAsync<T>(AsyncDb<T>);
+
+impl<T> WrapDatabaseAsync<T> {
+    /// Wraps a [DatabaseAsync] or [DatabaseAsyncRef] instance.
+    ///
+    /// Returns `None` if no tokio runtime is available or if the current runtime is a current-thread runtime.
+    #[inline]
+    pub fn new(db: T) -> Option<Self> {
+        AsyncDb::blocking(db).map(Self)
+    }
+
+    /// Wraps a [DatabaseAsync] or [DatabaseAsyncRef] instance, with a runtime.
+    ///
+    /// Refer to [tokio::runtime::Builder] on how to create a runtime if you are in synchronous world.
+    ///
+    /// If you are already using something like [tokio::main], call [`WrapDatabaseAsync::new`] instead.
+    #[inline]
+    pub const fn with_runtime(db: T, runtime: Runtime) -> Self {
+        Self(AsyncDb::with_runtime(db, runtime))
+    }
+
+    /// Wraps a [DatabaseAsync] or [DatabaseAsyncRef] instance, with a runtime handle.
+    ///
+    /// This generally allows you to pass any valid runtime handle, refer to [tokio::runtime::Handle] on how
+    /// to obtain a handle.
+    ///
+    /// If you are already in asynchronous world, like [tokio::main], use [`WrapDatabaseAsync::new`] instead.
+    #[inline]
+    pub const fn with_handle(db: T, handle: Handle) -> Self {
+        Self(AsyncDb::with_handle(db, handle))
+    }
+
+    /// Returns the wrapped database.
+    #[inline]
+    pub const fn inner(&self) -> &T {
+        self.0.inner()
+    }
+
+    /// Returns the wrapped database mutably.
+    #[inline]
+    pub const fn inner_mut(&mut self) -> &mut T {
+        self.0.inner_mut()
+    }
+
+    /// Consumes the adapter and returns the wrapped database.
+    #[inline]
+    pub fn into_inner(self) -> T {
+        self.0.into_inner()
+    }
+}
+
+impl<T: DatabaseAsync> Database for WrapDatabaseAsync<T> {
+    type Error = AsyncError<T::Error>;
+
+    #[inline]
+    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        self.0.basic(address)
+    }
+
+    #[inline]
+    fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        self.0.code_by_hash(code_hash)
+    }
+
+    #[inline]
+    fn storage(
+        &mut self,
+        address: Address,
+        index: StorageKey,
+    ) -> Result<StorageValue, Self::Error> {
+        self.0.storage(address, index)
+    }
+
+    #[inline]
+    fn storage_by_account_id(
+        &mut self,
+        address: Address,
+        account_id: AccountId,
+        storage_key: StorageKey,
+    ) -> Result<StorageValue, Self::Error> {
+        self.0
+            .storage_by_account_id(address, account_id, storage_key)
+    }
+
+    #[inline]
+    fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error> {
+        self.0.block_hash(number)
+    }
+}
+
+impl<T: DatabaseAsyncRef> DatabaseRef for WrapDatabaseAsync<T> {
+    type Error = AsyncError<T::Error>;
+
+    #[inline]
+    fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        self.0.basic_ref(address)
+    }
+
+    #[inline]
+    fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        self.0.code_by_hash_ref(code_hash)
+    }
+
+    #[inline]
+    fn storage_ref(
+        &self,
+        address: Address,
+        index: StorageKey,
+    ) -> Result<StorageValue, Self::Error> {
+        self.0.storage_ref(address, index)
+    }
+
+    #[inline]
+    fn storage_by_account_id_ref(
+        &self,
+        address: Address,
+        account_id: AccountId,
+        storage_key: StorageKey,
+    ) -> Result<StorageValue, Self::Error> {
+        self.0
+            .storage_by_account_id_ref(address, account_id, storage_key)
+    }
+
+    #[inline]
+    fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
+        self.0.block_hash_ref(number)
+    }
+}
+
+impl<T: DatabaseAsync + DatabaseCommit> DatabaseCommit for WrapDatabaseAsync<T> {
+    #[inline]
+    fn commit(&mut self, changes: AddressMap<Account>) {
+        self.0.commit(changes);
+    }
+
+    #[inline]
+    fn commit_iter(&mut self, changes: &mut dyn Iterator<Item = (Address, Account)>) {
+        self.0.commit_iter(changes);
+    }
+}
+
+// Hold a tokio runtime handle or full runtime.
 #[derive(Debug)]
 enum HandleOrRuntime {
     Handle(Handle),
@@ -241,48 +903,346 @@ enum HandleOrRuntime {
 
 impl HandleOrRuntime {
     #[inline]
-    fn block_on<F>(&self, f: F) -> F::Output
-    where
-        F: Future + Send,
-        F::Output: Send,
-    {
+    fn handle(&self) -> &Handle {
         match self {
-            Self::Handle(handle) => {
-                // We use a conservative approach: if we're currently in a multi-threaded
-                // tokio runtime context, we use block_in_place. This works because:
-                // 1. If we're in the SAME runtime, block_in_place prevents deadlock
-                // 2. If we're in a DIFFERENT runtime, block_in_place still works safely
-                //    (it just moves the work off the current worker thread before blocking)
-                //
-                // This approach is compatible with all tokio versions and doesn't require
-                // runtime identity comparison (Handle::id() is unstable feature).
-                let should_use_block_in_place = Handle::try_current()
-                    .ok()
-                    .map(|current| {
-                        // Only use block_in_place for multi-threaded runtimes
-                        // (block_in_place panics on current-thread runtime)
-                        !matches!(
-                            current.runtime_flavor(),
-                            tokio::runtime::RuntimeFlavor::CurrentThread
-                        )
-                    })
-                    .unwrap_or(false);
-
-                if should_use_block_in_place {
-                    // We're in a multi-threaded runtime context.
-                    // Use block_in_place to:
-                    // 1. Move the blocking operation off the async worker thread
-                    // 2. Prevent potential deadlock if this is the same runtime
-                    // 3. Allow other tasks to continue executing
-                    tokio::task::block_in_place(move || handle.block_on(f))
-                } else {
-                    // Safe to call block_on directly in these cases:
-                    // - We're outside any runtime context
-                    // - We're in a current-thread runtime (where block_in_place doesn't work)
-                    handle.block_on(f)
-                }
-            }
-            Self::Runtime(rt) => rt.block_on(f),
+            Self::Handle(handle) => handle,
+            Self::Runtime(runtime) => runtime.handle(),
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{block_on_current, on_fiber, AsyncDb, AsyncError, DatabaseAsync};
+    use crate::Database;
+    use core::{convert::Infallible, fmt, future::Future, pin::Pin, task::Poll};
+    use primitives::{Address, StorageKey, StorageValue, B256};
+    use state::{AccountInfo, Bytecode};
+    use std::task::{Context, Waker};
+
+    #[test]
+    fn block_on_requires_fiber() {
+        assert!(matches!(
+            block_on_current(core::future::ready(())),
+            Err(AsyncError::NotOnFiber)
+        ));
+    }
+
+    #[test]
+    fn fiber_suspends_and_resumes_pending_future() {
+        let mut state = 1;
+        let mut future = core::pin::pin!(on_fiber(|| {
+            state += block_on_current(PendingOnce { pending: true }).unwrap();
+            state
+        }));
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(waker);
+
+        assert!(matches!(future.as_mut().poll(&mut cx), Poll::Pending));
+        assert!(matches!(future.as_mut().poll(&mut cx), Poll::Ready(Ok(3))));
+    }
+
+    #[test]
+    fn fiber_reuses_stack_slot() {
+        let mut stack = super::FiberStack::default();
+        let stack_ptr = core::ptr::NonNull::from(&mut stack);
+
+        poll_ready(unsafe {
+            super::on_fiber_result_with_stack(stack_ptr, || Ok::<_, Infallible>(1))
+        })
+        .unwrap();
+        assert!(stack.stack.is_some());
+        poll_ready(unsafe {
+            super::on_fiber_result_with_stack(stack_ptr, || Ok::<_, Infallible>(2))
+        })
+        .unwrap();
+        assert!(stack.stack.is_some());
+    }
+
+    #[test]
+    fn async_database_adapts_to_database() {
+        let mut db = AsyncDb::new(TestDb);
+
+        let value = poll_ready(on_fiber(|| {
+            Database::storage(&mut db, Address::ZERO, StorageKey::from(7)).unwrap()
+        }))
+        .unwrap();
+
+        assert_eq!(value, StorageValue::from(9));
+    }
+
+    #[test]
+    fn async_database_suspends_until_ready() {
+        let mut db = AsyncDb::new(PendingDb { pending: true });
+        let mut future = core::pin::pin!(on_fiber(|| {
+            Database::storage(&mut db, Address::ZERO, StorageKey::from(7)).unwrap()
+        }));
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(waker);
+
+        assert!(matches!(future.as_mut().poll(&mut cx), Poll::Pending));
+        assert!(
+            matches!(future.as_mut().poll(&mut cx), Poll::Ready(Ok(value)) if value == StorageValue::from(9))
+        );
+    }
+
+    #[test]
+    fn async_database_returns_database_error() {
+        let mut db = AsyncDb::new(FailingDb);
+        let result = poll_ready(on_fiber(|| {
+            Database::storage(&mut db, Address::ZERO, StorageKey::from(7))
+        }));
+
+        assert!(matches!(result, Ok(Err(AsyncError::Inner(TestError)))));
+    }
+
+    #[test]
+    fn synchronous_database_blocks_with_current_tokio_runtime() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _guard = runtime.enter();
+        let mut db = AsyncDb::new(TokioDb);
+
+        let value = Database::storage(&mut db, Address::ZERO, StorageKey::from(7)).unwrap();
+
+        assert_eq!(value, StorageValue::from(9));
+    }
+
+    #[test]
+    fn blocking_constructor_uses_current_tokio_runtime() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _guard = runtime.enter();
+        let mut db = AsyncDb::blocking(TokioDb).unwrap();
+
+        let value = Database::storage(&mut db, Address::ZERO, StorageKey::from(7)).unwrap();
+
+        assert_eq!(value, StorageValue::from(9));
+    }
+
+    #[test]
+    fn synchronous_database_blocks_with_stored_tokio_handle() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let mut db = AsyncDb::with_handle(TokioDb, runtime.handle().clone());
+
+        let value = Database::storage(&mut db, Address::ZERO, StorageKey::from(7)).unwrap();
+
+        assert_eq!(value, StorageValue::from(9));
+    }
+
+    #[test]
+    fn synchronous_database_requires_runtime_handle() {
+        let mut db = AsyncDb::new(TestDb);
+
+        let result = Database::storage(&mut db, Address::ZERO, StorageKey::from(7));
+
+        assert!(matches!(result, Err(AsyncError::Runtime)));
+    }
+
+    #[test]
+    fn dropping_fiber_cancels_blocked_future() {
+        let mut saw_cancel = false;
+        {
+            let mut future = core::pin::pin!(on_fiber(|| {
+                saw_cancel = matches!(block_on_current(PendingForever), Err(AsyncError::Cancelled));
+            }));
+            let waker = Waker::noop();
+            let mut cx = Context::from_waker(waker);
+
+            assert!(matches!(future.as_mut().poll(&mut cx), Poll::Pending));
+        }
+        assert!(saw_cancel);
+    }
+
+    fn poll_ready<F: Future + Send>(future: F) -> F::Output {
+        let mut future = core::pin::pin!(future);
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(waker);
+
+        match future.as_mut().poll(&mut cx) {
+            Poll::Ready(value) => value,
+            Poll::Pending => panic!("future unexpectedly pending"),
+        }
+    }
+
+    struct PendingOnce {
+        pending: bool,
+    }
+
+    impl Future for PendingOnce {
+        type Output = i32;
+
+        fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+            if self.pending {
+                self.pending = false;
+                Poll::Pending
+            } else {
+                Poll::Ready(2)
+            }
+        }
+    }
+
+    struct PendingForever;
+
+    impl Future for PendingForever {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+            Poll::Pending
+        }
+    }
+
+    struct TestDb;
+
+    impl DatabaseAsync for TestDb {
+        type Error = Infallible;
+
+        async fn basic_async(
+            &mut self,
+            _address: Address,
+        ) -> Result<Option<AccountInfo>, Self::Error> {
+            Ok(None)
+        }
+
+        async fn code_by_hash_async(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            Ok(Bytecode::default())
+        }
+
+        async fn storage_async(
+            &mut self,
+            _address: Address,
+            _index: StorageKey,
+        ) -> Result<StorageValue, Self::Error> {
+            Ok(StorageValue::from(9))
+        }
+
+        async fn block_hash_async(&mut self, _number: u64) -> Result<B256, Self::Error> {
+            Ok(B256::ZERO)
+        }
+    }
+
+    struct PendingDb {
+        pending: bool,
+    }
+
+    impl DatabaseAsync for PendingDb {
+        type Error = Infallible;
+
+        async fn basic_async(
+            &mut self,
+            _address: Address,
+        ) -> Result<Option<AccountInfo>, Self::Error> {
+            Ok(None)
+        }
+
+        async fn code_by_hash_async(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            Ok(Bytecode::default())
+        }
+
+        async fn storage_async(
+            &mut self,
+            _address: Address,
+            _index: StorageKey,
+        ) -> Result<StorageValue, Self::Error> {
+            PendingStorage {
+                pending: &mut self.pending,
+            }
+            .await;
+            Ok(StorageValue::from(9))
+        }
+
+        async fn block_hash_async(&mut self, _number: u64) -> Result<B256, Self::Error> {
+            Ok(B256::ZERO)
+        }
+    }
+
+    struct PendingStorage<'a> {
+        pending: &'a mut bool,
+    }
+
+    impl Future for PendingStorage<'_> {
+        type Output = ();
+
+        fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+            if *self.pending {
+                *self.pending = false;
+                Poll::Pending
+            } else {
+                Poll::Ready(())
+            }
+        }
+    }
+
+    struct FailingDb;
+
+    impl DatabaseAsync for FailingDb {
+        type Error = TestError;
+
+        async fn basic_async(
+            &mut self,
+            _address: Address,
+        ) -> Result<Option<AccountInfo>, Self::Error> {
+            Ok(None)
+        }
+
+        async fn code_by_hash_async(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            Ok(Bytecode::default())
+        }
+
+        async fn storage_async(
+            &mut self,
+            _address: Address,
+            _index: StorageKey,
+        ) -> Result<StorageValue, Self::Error> {
+            Err(TestError)
+        }
+
+        async fn block_hash_async(&mut self, _number: u64) -> Result<B256, Self::Error> {
+            Ok(B256::ZERO)
+        }
+    }
+
+    struct TokioDb;
+
+    impl DatabaseAsync for TokioDb {
+        type Error = Infallible;
+
+        async fn basic_async(
+            &mut self,
+            _address: Address,
+        ) -> Result<Option<AccountInfo>, Self::Error> {
+            tokio::task::yield_now().await;
+            Ok(None)
+        }
+
+        async fn code_by_hash_async(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            tokio::task::yield_now().await;
+            Ok(Bytecode::default())
+        }
+
+        async fn storage_async(
+            &mut self,
+            _address: Address,
+            _index: StorageKey,
+        ) -> Result<StorageValue, Self::Error> {
+            tokio::task::yield_now().await;
+            Ok(StorageValue::from(9))
+        }
+
+        async fn block_hash_async(&mut self, _number: u64) -> Result<B256, Self::Error> {
+            tokio::task::yield_now().await;
+            Ok(B256::ZERO)
+        }
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct TestError;
+
+    impl fmt::Display for TestError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("storage read failed")
+        }
+    }
+
+    impl core::error::Error for TestError {}
+
+    impl crate::DBErrorMarker for TestError {}
 }

--- a/crates/database/interface/src/lib.rs
+++ b/crates/database/interface/src/lib.rs
@@ -39,7 +39,7 @@ pub mod erased_error;
 pub mod try_commit;
 
 #[cfg(feature = "asyncdb")]
-pub use async_db::{DatabaseAsync, WrapDatabaseAsync};
+pub use async_db::{AsyncDb, AsyncError, AsyncResult, DatabaseAsync, WrapDatabaseAsync};
 pub use empty_db::{EmptyDB, EmptyDBTyped};
 pub use erased_error::ErasedError;
 pub use try_commit::{ArcUpgradeError, TryDatabaseCommit};

--- a/crates/database/src/states/bundle_account.rs
+++ b/crates/database/src/states/bundle_account.rs
@@ -372,6 +372,6 @@ impl BundleAccount {
             }
         };
 
-        account_revert.and_then(|acc| if acc.is_empty() { None } else { Some(acc) })
+        account_revert.filter(|acc| !acc.is_empty())
     }
 }

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -65,6 +65,7 @@ serde = [
 	"interpreter/serde",
 	"derive-where/serde",
 ]
+asyncdb = ["std", "context/asyncdb", "database-interface/asyncdb"]
 
 # Deprecated, please use `serde` feature instead.
 serde-json = ["serde"]

--- a/crates/handler/src/api.rs
+++ b/crates/handler/src/api.rs
@@ -8,9 +8,13 @@ use context::{
     },
     Block, ContextSetters, ContextTr, Database, Evm, JournalTr, Transaction,
 };
+#[cfg(feature = "asyncdb")]
+use database_interface::async_db::{on_fiber_result_with_stack, AsyncResult};
 use database_interface::DatabaseCommit;
 use interpreter::{interpreter::EthInterpreter, InterpreterResult};
 use state::EvmState;
+#[cfg(feature = "asyncdb")]
+use std::ptr::NonNull;
 use std::vec::Vec;
 
 /// Type alias for the result of transact_many_finalize to reduce type complexity.
@@ -170,6 +174,25 @@ pub trait ExecuteCommitEvm: ExecuteEvm {
     }
 }
 
+/// Async extension of the [`ExecuteEvm`] trait that runs execution on an async fiber.
+#[cfg(feature = "asyncdb")]
+pub trait ExecuteEvmAsync: ExecuteEvm {
+    /// Execute transaction and store state inside journal on an async fiber.
+    fn transact_one_async(
+        &mut self,
+        tx: Self::Tx,
+    ) -> impl core::future::Future<Output = AsyncResult<Self::ExecutionResult, Self::Error>> + Send + '_;
+
+    /// Transact the given transaction and finalize in a single operation on an async fiber.
+    fn transact_async(
+        &mut self,
+        tx: Self::Tx,
+    ) -> impl core::future::Future<
+        Output = AsyncResult<ExecResultAndState<Self::ExecutionResult, Self::State>, Self::Error>,
+    > + Send
+           + '_;
+}
+
 impl<CTX, INSP, INST, PRECOMPILES> ExecuteEvm
     for Evm<CTX, INSP, INST, PRECOMPILES, EthFrame<EthInterpreter>>
 where
@@ -205,6 +228,45 @@ where
             let state = self.finalize();
             ResultAndState::new(result, state)
         })
+    }
+}
+
+#[cfg(feature = "asyncdb")]
+impl<CTX, INSP, INST, PRECOMPILES> ExecuteEvmAsync
+    for Evm<CTX, INSP, INST, PRECOMPILES, EthFrame<EthInterpreter>>
+where
+    CTX: ContextTr<Journal: JournalTr<State = EvmState>> + ContextSetters,
+    INST: InstructionProvider<Context = CTX, InterpreterTypes = EthInterpreter>,
+    PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
+    ExecutionResult<HaltReason>: Send,
+    EvmState: Send,
+    EVMError<<CTX::Db as Database>::Error, InvalidTransaction>: Send,
+    <CTX as ContextTr>::Tx: Send,
+{
+    #[inline]
+    fn transact_one_async(
+        &mut self,
+        tx: Self::Tx,
+    ) -> impl core::future::Future<Output = AsyncResult<Self::ExecutionResult, Self::Error>> + Send + '_
+    {
+        let stack = NonNull::from(&mut self.async_stack);
+        // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
+        // access the EVM stack slot until that future is dropped.
+        unsafe { on_fiber_result_with_stack(stack, move || self.transact_one(tx)) }
+    }
+
+    #[inline]
+    fn transact_async(
+        &mut self,
+        tx: Self::Tx,
+    ) -> impl core::future::Future<
+        Output = AsyncResult<ExecResultAndState<Self::ExecutionResult, Self::State>, Self::Error>,
+    > + Send
+           + '_ {
+        let stack = NonNull::from(&mut self.async_stack);
+        // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
+        // access the EVM stack slot until that future is dropped.
+        unsafe { on_fiber_result_with_stack(stack, move || self.transact(tx)) }
     }
 }
 

--- a/crates/handler/src/lib.rs
+++ b/crates/handler/src/lib.rs
@@ -41,6 +41,8 @@ pub use primitives;
 pub use state;
 
 // Public exports
+#[cfg(feature = "asyncdb")]
+pub use api::ExecuteEvmAsync;
 pub use api::{ExecuteCommitEvm, ExecuteEvm};
 pub use evm::{EvmTr, FrameTr};
 pub use frame::{handle_reservoir_remaining_gas, return_create, ContextTrDbError, EthFrame};
@@ -52,4 +54,6 @@ pub use mainnet_handler::MainnetHandler;
 pub use precompile_provider::{
     precompile_output_to_interpreter_result, EthPrecompiles, PrecompileProvider,
 };
+#[cfg(feature = "asyncdb")]
+pub use system_call::SystemCallEvmAsync;
 pub use system_call::{SystemCallCommitEvm, SystemCallEvm, SystemCallTx, SYSTEM_ADDRESS};

--- a/crates/handler/src/mainnet_builder.rs
+++ b/crates/handler/src/mainnet_builder.rs
@@ -43,6 +43,8 @@ where
             instruction: EthInstructions::new_mainnet_with_spec(spec),
             precompiles: EthPrecompiles::new(spec),
             frame_stack: FrameStack::new_prealloc(8),
+            #[cfg(feature = "asyncdb")]
+            async_stack: database_interface::async_db::FiberStack::default(),
         }
     }
 
@@ -57,6 +59,8 @@ where
             instruction: EthInstructions::new_mainnet_with_spec(spec),
             precompiles: EthPrecompiles::new(spec),
             frame_stack: FrameStack::new_prealloc(8),
+            #[cfg(feature = "asyncdb")]
+            async_stack: database_interface::async_db::FiberStack::default(),
         }
     }
 }

--- a/crates/handler/src/precompile_provider.rs
+++ b/crates/handler/src/precompile_provider.rs
@@ -282,6 +282,8 @@ mod tests {
             instruction: EthInstructions::<EthInterpreter, _>::new_mainnet_with_spec(spec),
             precompiles: OverspendingPrecompiles::new(spec),
             frame_stack: FrameStack::new_prealloc(8),
+            #[cfg(feature = "asyncdb")]
+            async_stack: database_interface::async_db::FiberStack::default(),
         };
 
         let tx = TxEnv::builder()

--- a/crates/handler/src/system_call.rs
+++ b/crates/handler/src/system_call.rs
@@ -24,10 +24,14 @@ use crate::{
     MainnetHandler, PrecompileProvider,
 };
 use context::{result::ExecResultAndState, ContextSetters, ContextTr, Evm, JournalTr, TxEnv};
+#[cfg(feature = "asyncdb")]
+use database_interface::async_db::{on_fiber_result_with_stack, AsyncResult};
 use database_interface::DatabaseCommit;
 use interpreter::{interpreter::EthInterpreter, InterpreterResult};
 use primitives::{address, eip8037, Address, Bytes, TxKind};
 use state::EvmState;
+#[cfg(feature = "asyncdb")]
+use std::ptr::NonNull;
 
 /// The system address used for system calls.
 pub const SYSTEM_ADDRESS: Address = address!("0xfffffffffffffffffffffffffffffffffffffffe");
@@ -227,6 +231,51 @@ pub trait SystemCallCommitEvm: SystemCallEvm + ExecuteCommitEvm {
     }
 }
 
+/// Async extension of the [`SystemCallEvm`] trait that runs execution on an async fiber.
+#[cfg(feature = "asyncdb")]
+pub trait SystemCallEvmAsync: SystemCallEvm {
+    /// System call executed on an async fiber.
+    fn system_call_one_with_caller_async(
+        &mut self,
+        caller: Address,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> impl core::future::Future<Output = AsyncResult<Self::ExecutionResult, Self::Error>> + Send + '_;
+
+    /// System call executed on an async fiber.
+    fn system_call_one_async(
+        &mut self,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> impl core::future::Future<Output = AsyncResult<Self::ExecutionResult, Self::Error>> + Send + '_
+    {
+        self.system_call_one_with_caller_async(SYSTEM_ADDRESS, system_contract_address, data)
+    }
+
+    /// System call executed and finalized on an async fiber.
+    fn system_call_with_caller_async(
+        &mut self,
+        caller: Address,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> impl core::future::Future<
+        Output = AsyncResult<ExecResultAndState<Self::ExecutionResult, Self::State>, Self::Error>,
+    > + Send
+           + '_;
+
+    /// System call executed and finalized on an async fiber.
+    fn system_call_async(
+        &mut self,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> impl core::future::Future<
+        Output = AsyncResult<ExecResultAndState<Self::ExecutionResult, Self::State>, Self::Error>,
+    > + Send
+           + '_ {
+        self.system_call_with_caller_async(SYSTEM_ADDRESS, system_contract_address, data)
+    }
+}
+
 impl<CTX, INSP, INST, PRECOMPILES> SystemCallEvm
     for Evm<CTX, INSP, INST, PRECOMPILES, EthFrame<EthInterpreter>>
 where
@@ -248,6 +297,57 @@ where
         ));
         // create handler
         MainnetHandler::default().run_system_call(self)
+    }
+}
+
+#[cfg(feature = "asyncdb")]
+impl<CTX, INSP, INST, PRECOMPILES> SystemCallEvmAsync
+    for Evm<CTX, INSP, INST, PRECOMPILES, EthFrame<EthInterpreter>>
+where
+    CTX: ContextTr<Journal: JournalTr<State = EvmState>, Tx: SystemCallTx> + ContextSetters,
+    INST: InstructionProvider<Context = CTX, InterpreterTypes = EthInterpreter>,
+    PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
+    Self: ExecuteEvm,
+    <Self as ExecuteEvm>::ExecutionResult: Send,
+    <Self as ExecuteEvm>::State: Send,
+    <Self as ExecuteEvm>::Error: Send,
+{
+    #[inline]
+    fn system_call_one_with_caller_async(
+        &mut self,
+        caller: Address,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> impl core::future::Future<Output = AsyncResult<Self::ExecutionResult, Self::Error>> + Send + '_
+    {
+        let stack = NonNull::from(&mut self.async_stack);
+        // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
+        // access the EVM stack slot until that future is dropped.
+        unsafe {
+            on_fiber_result_with_stack(stack, move || {
+                self.system_call_one_with_caller(caller, system_contract_address, data)
+            })
+        }
+    }
+
+    #[inline]
+    fn system_call_with_caller_async(
+        &mut self,
+        caller: Address,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> impl core::future::Future<
+        Output = AsyncResult<ExecResultAndState<Self::ExecutionResult, Self::State>, Self::Error>,
+    > + Send
+           + '_ {
+        let stack = NonNull::from(&mut self.async_stack);
+        // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
+        // access the EVM stack slot until that future is dropped.
+        unsafe {
+            on_fiber_result_with_stack(stack, move || {
+                self.system_call_with_caller(caller, system_contract_address, data)
+            })
+        }
     }
 }
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -70,7 +70,12 @@ serde = [
 arbitrary = ["primitives/arbitrary"]
 asm-keccak = ["primitives/asm-keccak"]
 sha3-keccak = ["primitives/sha3-keccak"]
-asyncdb = ["database-interface/asyncdb"]
+asyncdb = [
+	"std",
+	"context/asyncdb",
+	"database-interface/asyncdb",
+	"handler/asyncdb",
+]
 
 # Enables alloydb inside database crate
 alloydb = ["database/alloydb"]

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -36,10 +36,14 @@ pub use context::{
     journal::{Journal, JournalEntry},
     Context,
 };
+#[cfg(feature = "asyncdb")]
+pub use database_interface::{AsyncDb, AsyncError, AsyncResult, DatabaseAsync, WrapDatabaseAsync};
 pub use database_interface::{Database, DatabaseCommit, DatabaseRef};
 pub use handler::{
     ExecuteCommitEvm, ExecuteEvm, MainBuilder, MainContext, MainnetEvm, SystemCallCommitEvm,
     SystemCallEvm,
 };
+#[cfg(feature = "asyncdb")]
+pub use handler::{ExecuteEvmAsync, SystemCallEvmAsync};
 pub use inspector::{InspectCommitEvm, InspectEvm, InspectSystemCallEvm, Inspector};
 pub use precompile::install_crypto;

--- a/examples/custom_precompile_journal/Cargo.toml
+++ b/examples/custom_precompile_journal/Cargo.toml
@@ -13,3 +13,6 @@ rust-version.workspace = true
 [dependencies]
 revm = { path = "../../crates/revm", features = ["optional_eip3607"] }
 anyhow = "1.0"
+
+[features]
+asyncdb = ["revm/asyncdb"]

--- a/examples/custom_precompile_journal/src/custom_evm.rs
+++ b/examples/custom_precompile_journal/src/custom_evm.rs
@@ -54,6 +54,8 @@ where
             instruction: EthInstructions::new_mainnet_with_spec(SpecId::CANCUN),
             precompiles: CustomPrecompileProvider::new_with_spec(SpecId::CANCUN),
             frame_stack: FrameStack::new(),
+            #[cfg(feature = "asyncdb")]
+            async_stack: revm::database_interface::async_db::FiberStack::default(),
         })
     }
 }

--- a/examples/my_evm/Cargo.toml
+++ b/examples/my_evm/Cargo.toml
@@ -19,3 +19,6 @@ workspace = true
 
 [dependencies]
 revm = { workspace = true }
+
+[features]
+asyncdb = ["revm/asyncdb"]

--- a/examples/my_evm/src/evm.rs
+++ b/examples/my_evm/src/evm.rs
@@ -51,6 +51,8 @@ impl<CTX: ContextTr, INSP> MyEvm<CTX, INSP> {
             instruction: EthInstructions::new_mainnet_with_spec(SpecId::default()),
             precompiles: EthPrecompiles::new(SpecId::default()),
             frame_stack: FrameStack::new(),
+            #[cfg(feature = "asyncdb")]
+            async_stack: revm::database_interface::async_db::FiberStack::default(),
         })
     }
 }


### PR DESCRIPTION
Adds a fiber-backed async database adapter that lets synchronous EVM execution yield while host database futures are pending. The asyncdb feature now wires the fiber stack through the EVM container and exposes async transaction and system-call extension traits while preserving the existing blocking wrapper constructor shape.