### PR TITLE
feat: add `OnStateHook` for `State<DB>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3775,6 +3775,7 @@ dependencies = [
  "alloy-eips",
  "alloy-provider",
  "alloy-transport",
+ "derive_more",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ auto_impl = "1.3.0"
 bitflags = { version = "2.10", default-features = false }
 cfg-if = { version = "1.0", default-features = false }
 derive-where = { version = "1.6", default-features = false }
+derive_more = { version = "2.0", default-features = false, features = ["debug"] }
 rand = "0.9"
 tokio = "1.47"
 either = { version = "1.15.0", default-features = false }

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -22,6 +22,7 @@ state.workspace = true
 primitives.workspace = true
 database-interface.workspace = true
 bytecode.workspace = true
+derive_more.workspace = true
 
 # Optional
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
@@ -45,6 +46,7 @@ std = [
 	"alloy-eips?/std",
 	"bytecode/std",
 	"database-interface/std",
+	"derive_more/std",
 	"primitives/std",
 	"state/std",
 	"serde_json/std",

--- a/crates/database/interface/src/lib.rs
+++ b/crates/database/interface/src/lib.rs
@@ -36,12 +36,15 @@ pub mod bal;
 pub mod either;
 pub mod empty_db;
 pub mod erased_error;
+/// State commit hook.
+pub mod state_hook;
 pub mod try_commit;
 
 #[cfg(feature = "asyncdb")]
 pub use async_db::{DatabaseAsync, WrapDatabaseAsync};
 pub use empty_db::{EmptyDB, EmptyDBTyped};
 pub use erased_error::ErasedError;
+pub use state_hook::{NoopHook, OnStateHook};
 pub use try_commit::{ArcUpgradeError, TryDatabaseCommit};
 
 /// Database error marker is needed to implement From conversion for Error type.

--- a/crates/database/interface/src/lib.rs
+++ b/crates/database/interface/src/lib.rs
@@ -36,7 +36,6 @@ pub mod bal;
 pub mod either;
 pub mod empty_db;
 pub mod erased_error;
-/// State commit hook.
 pub mod state_hook;
 pub mod try_commit;
 

--- a/crates/database/interface/src/state_hook.rs
+++ b/crates/database/interface/src/state_hook.rs
@@ -1,0 +1,25 @@
+use crate::state::EvmState;
+
+/// A hook that is called when state changes are committed.
+pub trait OnStateHook: Send + 'static {
+    /// Invoked with the state being committed.
+    fn on_state(&mut self, state: &EvmState);
+}
+
+impl<F> OnStateHook for F
+where
+    F: FnMut(&EvmState) + Send + 'static,
+{
+    fn on_state(&mut self, state: &EvmState) {
+        self(state)
+    }
+}
+
+/// An [`OnStateHook`] that does nothing.
+#[derive(Default, Debug, Clone)]
+#[non_exhaustive]
+pub struct NoopHook;
+
+impl OnStateHook for NoopHook {
+    fn on_state(&mut self, _state: &EvmState) {}
+}

--- a/crates/database/interface/src/state_hook.rs
+++ b/crates/database/interface/src/state_hook.rs
@@ -1,3 +1,5 @@
+//! State commit hook.
+
 use crate::state::EvmState;
 
 /// A hook that is called when state changes are committed.

--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -7,7 +7,7 @@ use super::{
 use bytecode::Bytecode;
 use database_interface::{
     bal::{BalState, EvmDatabaseError},
-    Database, DatabaseCommit, DatabaseRef, EmptyDB,
+    Database, DatabaseCommit, DatabaseRef, EmptyDB, OnStateHook,
 };
 use primitives::{hash_map, Address, AddressMap, HashMap, StorageKey, StorageValue, B256};
 use state::{
@@ -28,7 +28,7 @@ pub type StateDBBox<'a, E> = State<DBBox<'a, E>>;
 ///
 /// State clear flag is handled by the EVM journal in `finalize()` based on
 /// the spec. The database layer always applies post-EIP-161 commit semantics.
-#[derive(Debug)]
+#[derive(derive_more::Debug)]
 pub struct State<DB> {
     /// Cached state contains both changed from evm execution and cached/loaded account/storages
     /// from database
@@ -70,6 +70,9 @@ pub struct State<DB> {
     ///
     /// Can contain both the BAL for reads and BAL builder that is used to build BAL.
     pub bal_state: BalState,
+    /// Hook invoked whenever state changes are committed.
+    #[debug(skip)]
+    pub state_hook: Option<Box<dyn OnStateHook>>,
 }
 
 // Have ability to call State::builder without having to specify the type.
@@ -234,6 +237,20 @@ impl<DB: Database> State<DB> {
         self.bal_state.bal = bal;
     }
 
+    /// Sets the hook invoked whenever state changes are committed.
+    #[inline]
+    pub fn set_state_hook(&mut self, hook: Option<Box<dyn OnStateHook>>) {
+        self.state_hook = hook;
+    }
+
+    /// Sets the hook invoked whenever state changes are committed.
+    #[inline]
+    #[must_use]
+    pub fn with_state_hook(mut self, hook: Option<Box<dyn OnStateHook>>) -> Self {
+        self.set_state_hook(hook);
+        self
+    }
+
     /// Returns whether the state has a BAL configured.
     #[inline]
     pub const fn has_bal(&self) -> bool {
@@ -374,6 +391,9 @@ impl<DB: Database> Database for State<DB> {
 
 impl<DB: Database> DatabaseCommit for State<DB> {
     fn commit(&mut self, changes: AddressMap<Account>) {
+        if let Some(hook) = self.state_hook.as_mut() {
+            hook.on_state(&changes);
+        }
         self.bal_state.commit(&changes);
         let transitions = self.cache.apply_evm_state_iter(changes, |_, _| {});
         if let Some(s) = self.transition_state.as_mut() {
@@ -385,6 +405,12 @@ impl<DB: Database> DatabaseCommit for State<DB> {
     }
 
     fn commit_iter(&mut self, changes: &mut dyn Iterator<Item = (Address, Account)>) {
+        if self.state_hook.is_some() {
+            let changes = changes.collect::<AddressMap<_>>();
+            self.commit(changes);
+            return;
+        }
+
         let transitions = self
             .cache
             .apply_evm_state_iter(changes, |address, account| {

--- a/crates/database/src/states/state_builder.rs
+++ b/crates/database/src/states/state_builder.rs
@@ -168,6 +168,7 @@ impl<DB: Database> StateBuilder<DB> {
             use_preloaded_bundle,
             block_hashes: self.with_block_hashes,
             bal_state: self.bal_state,
+            state_hook: None,
         }
     }
 }

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -36,7 +36,7 @@ pub use context::{
     journal::{Journal, JournalEntry},
     Context,
 };
-pub use database_interface::{Database, DatabaseCommit, DatabaseRef};
+pub use database_interface::{Database, DatabaseCommit, DatabaseRef, NoopHook, OnStateHook};
 pub use handler::{
     ExecuteCommitEvm, ExecuteEvm, MainBuilder, MainContext, MainnetEvm, SystemCallCommitEvm,
     SystemCallEvm,


### PR DESCRIPTION
## Summary
- add StateChangeSource and OnStateHook to revm database interface
- store an optional hook and current source on State
- invoke the hook from State::commit and State::commit_iter before applying changes

## Tests
- cargo check -p revm -p revm-database-interface -p revm-database