### PR TITLE
feat: Bake EIP-8037 CPSB into gas params

### DIFF
--- a/crates/context/interface/src/cfg.rs
+++ b/crates/context/interface/src/cfg.rs
@@ -94,13 +94,6 @@ pub trait Cfg {
     /// via the reservoir model. EIP-8037 specifies concrete gas values based on
     /// `cost_per_state_byte` and adds a hash cost for deployed bytecode.
     fn is_amsterdam_eip8037_enabled(&self) -> bool;
-
-    /// Returns the EIP-8037 `cost_per_state_byte` (CPSB).
-    ///
-    /// When [`Cfg::is_amsterdam_eip8037_enabled`] is `false` this returns `0`.
-    /// Otherwise, if an override is configured it is returned directly; otherwise
-    /// the fixed Glamsterdam value [`primitives::eip8037::CPSB_GLAMSTERDAM`] is returned.
-    fn cpsb(&self) -> u64;
 }
 
 /// What bytecode analysis to perform

--- a/crates/context/interface/src/cfg/gas.rs
+++ b/crates/context/interface/src/cfg/gas.rs
@@ -1,6 +1,6 @@
 //! Gas constants and functions for gas calculation.
 
-use crate::{cfg::GasParams, transaction::AccessListItemTr as _, Transaction, TransactionType};
+use crate::{cfg::GasParams, Transaction};
 use primitives::hardfork::SpecId;
 
 /// Tracker for gas during execution.
@@ -492,31 +492,7 @@ pub fn calculate_initial_tx_gas(
 /// - Intrinsic gas
 /// - Number of tokens in calldata
 pub fn calculate_initial_tx_gas_for_tx(tx: impl Transaction, spec: SpecId) -> InitialAndFloorGas {
-    let mut accounts = 0;
-    let mut storages = 0;
-    // legacy is only tx type that does not have access list.
-    if tx.tx_type() != TransactionType::Legacy {
-        (accounts, storages) = tx
-            .access_list()
-            .map(|al| {
-                al.fold((0, 0), |(mut num_accounts, mut num_storage_slots), item| {
-                    num_accounts += 1;
-                    num_storage_slots += item.storage_slots().count();
-
-                    (num_accounts, num_storage_slots)
-                })
-            })
-            .unwrap_or_default();
-    }
-
-    calculate_initial_tx_gas(
-        spec,
-        tx.input(),
-        tx.kind().is_create(),
-        accounts as u64,
-        storages as u64,
-        tx.authorization_list_len() as u64,
-    )
+    GasParams::new_spec(spec).initial_tx_gas_for_tx(tx)
 }
 
 /// Retrieve the total number of tokens in calldata.

--- a/crates/context/interface/src/cfg/gas.rs
+++ b/crates/context/interface/src/cfg/gas.rs
@@ -474,7 +474,6 @@ pub fn calculate_initial_tx_gas(
     access_list_accounts: u64,
     access_list_storages: u64,
     authorization_list_num: u64,
-    cpsb: u64,
 ) -> InitialAndFloorGas {
     GasParams::new_spec(spec_id).initial_tx_gas(
         input,
@@ -482,7 +481,6 @@ pub fn calculate_initial_tx_gas(
         access_list_accounts,
         access_list_storages,
         authorization_list_num,
-        cpsb,
     )
 }
 
@@ -493,11 +491,7 @@ pub fn calculate_initial_tx_gas(
 ///
 /// - Intrinsic gas
 /// - Number of tokens in calldata
-pub fn calculate_initial_tx_gas_for_tx(
-    tx: impl Transaction,
-    spec: SpecId,
-    cpsb: u64,
-) -> InitialAndFloorGas {
+pub fn calculate_initial_tx_gas_for_tx(tx: impl Transaction, spec: SpecId) -> InitialAndFloorGas {
     let mut accounts = 0;
     let mut storages = 0;
     // legacy is only tx type that does not have access list.
@@ -522,7 +516,6 @@ pub fn calculate_initial_tx_gas_for_tx(
         accounts as u64,
         storages as u64,
         tx.authorization_list_len() as u64,
-        cpsb,
     )
 }
 

--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -310,9 +310,8 @@ impl GasParams {
         }
 
         // EIP-8037: State creation gas cost increase.
-        // State-gas entries store *byte counts* here; the helper methods multiply
-        // by the current `cost_per_state_byte` (CPSB), which is derived from the
-        // block gas limit at charge time via `Cfg::cpsb`.
+        // State-gas entries store final gas values, with Glamsterdam CPSB applied
+        // once when building the gas table.
         if spec.is_enabled_in(SpecId::AMSTERDAM) {
             // Regular gas changes
             table[GasId::create().as_usize()] = 9000;
@@ -324,22 +323,27 @@ impl GasParams {
             // sstore_set_without_load_cost = 2900 - WARM_STORAGE_READ_COST(100) = 2800
             table[GasId::sstore_set_without_load_cost().as_usize()] = 2800;
 
-            // State gas byte counts (multiplied by CPSB at charge time).
-            table[GasId::sstore_set_state_gas().as_usize()] = eip8037::SSTORE_SET_BYTES;
-            table[GasId::new_account_state_gas().as_usize()] = eip8037::NEW_ACCOUNT_BYTES;
-            table[GasId::code_deposit_state_gas().as_usize()] = eip8037::CODE_DEPOSIT_PER_BYTE;
-            table[GasId::create_state_gas().as_usize()] = eip8037::NEW_ACCOUNT_BYTES;
-            table[GasId::tx_eip7702_state_gas_bytecode().as_usize()] = eip8037::AUTH_BASE_BYTES;
+            // State gas values with Glamsterdam CPSB baked in.
+            table[GasId::sstore_set_state_gas().as_usize()] =
+                eip8037::SSTORE_SET_BYTES * eip8037::CPSB_GLAMSTERDAM;
+            table[GasId::new_account_state_gas().as_usize()] =
+                eip8037::NEW_ACCOUNT_BYTES * eip8037::CPSB_GLAMSTERDAM;
+            table[GasId::code_deposit_state_gas().as_usize()] =
+                eip8037::CODE_DEPOSIT_PER_BYTE * eip8037::CPSB_GLAMSTERDAM;
+            table[GasId::create_state_gas().as_usize()] =
+                eip8037::NEW_ACCOUNT_BYTES * eip8037::CPSB_GLAMSTERDAM;
+            table[GasId::tx_eip7702_state_gas_bytecode().as_usize()] =
+                eip8037::AUTH_BASE_BYTES * eip8037::CPSB_GLAMSTERDAM;
 
             // SSTORE refund for 0→X→0 restoration: regular gas only.
-            // The state-gas portion (SSTORE_SET_BYTES × CPSB) is restored directly
+            // The state-gas portion is restored directly
             // to the reservoir via `GasParams::sstore_state_gas_refill`.
             table[GasId::sstore_set_refund().as_usize()] = 2800;
 
             // EIP-7702 under EIP-8037: only the regular-gas slots live here.
             // The state-gas portions are sourced from `new_account_state_gas`
             // (per-account) and `tx_eip7702_state_gas_bytecode` (per-bytecode);
-            // helpers in `GasParams` combine them with the current CPSB.
+            // helpers in `GasParams` combine the pre-scaled values.
             //   regular per-auth cost: 7500 (state bytes added pessimistically in `initial_tx_gas`)
             //   regular refund:        0   (per-auth refund is entirely state gas)
             table[GasId::tx_eip7702_per_empty_account_cost().as_usize()] =
@@ -691,12 +695,12 @@ impl GasParams {
 
     /// State gas for SSTORE: charges for new slot creation (zero → non-zero).
     #[inline]
-    pub fn sstore_state_gas(&self, vals: &SStoreResult, cpsb: u64) -> u64 {
+    pub fn sstore_state_gas(&self, vals: &SStoreResult) -> u64 {
         if vals.new_values_changes_present()
             && vals.is_original_eq_present()
             && vals.is_original_zero()
         {
-            self.get(GasId::sstore_set_state_gas()).saturating_mul(cpsb)
+            self.get(GasId::sstore_set_state_gas())
         } else {
             0
         }
@@ -709,11 +713,10 @@ impl GasParams {
     /// transition is returned directly to the reservoir (not via the capped
     /// refund counter). Returns 0 in any other case.
     ///
-    /// `cpsb` is the current `cost_per_state_byte` (see [`super::Cfg::cpsb`]).
     #[inline]
-    pub fn sstore_state_gas_refill(&self, vals: &SStoreResult, cpsb: u64) -> u64 {
+    pub fn sstore_state_gas_refill(&self, vals: &SStoreResult) -> u64 {
         if !vals.is_new_eq_present() && vals.is_original_eq_new() && vals.is_original_zero() {
-            self.get(GasId::sstore_set_state_gas()).saturating_mul(cpsb)
+            self.get(GasId::sstore_set_state_gas())
         } else {
             0
         }
@@ -721,34 +724,32 @@ impl GasParams {
 
     /// State gas for new account creation.
     #[inline]
-    pub fn new_account_state_gas(&self, cpsb: u64) -> u64 {
+    pub fn new_account_state_gas(&self) -> u64 {
         self.get(GasId::new_account_state_gas())
-            .saturating_mul(cpsb)
     }
 
     /// State gas for code deposit of `len` bytes.
     #[inline]
-    pub fn code_deposit_state_gas(&self, len: usize, cpsb: u64) -> u64 {
+    pub fn code_deposit_state_gas(&self, len: usize) -> u64 {
         self.get(GasId::code_deposit_state_gas())
             .saturating_mul(len as u64)
-            .saturating_mul(cpsb)
     }
 
     /// State gas for contract metadata creation.
     #[inline]
-    pub fn create_state_gas(&self, cpsb: u64) -> u64 {
-        self.get(GasId::create_state_gas()).saturating_mul(cpsb)
+    pub fn create_state_gas(&self) -> u64 {
+        self.get(GasId::create_state_gas())
     }
 
     /// Used in [GasParams::initial_tx_gas] to calculate the eip7702 per-auth cost.
     ///
-    /// Under EIP-8037 this combines a regular portion with a state-bytes portion
-    /// (new-account + bytecode) multiplied by `cpsb`. Pre-EIP-8037 the state-bytes
-    /// portion is zero so this returns the legacy `PER_EMPTY_ACCOUNT_COST`.
+    /// Under EIP-8037 this combines a regular portion with a state-gas portion.
+    /// Pre-EIP-8037 the state-gas portion is zero so this returns the legacy
+    /// `PER_EMPTY_ACCOUNT_COST`.
     #[inline]
-    pub fn tx_eip7702_per_empty_account_cost(&self, cpsb: u64) -> u64 {
+    pub fn tx_eip7702_per_empty_account_cost(&self) -> u64 {
         let regular = self.get(GasId::tx_eip7702_per_empty_account_cost());
-        let state = self.tx_eip7702_state_gas(cpsb);
+        let state = self.tx_eip7702_state_gas();
         regular.saturating_add(state)
     }
 
@@ -756,48 +757,39 @@ impl GasParams {
     ///
     /// Pre-Amsterdam this is a fixed regular-gas refund (`PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST`).
     /// Under EIP-8037 the refund is fully state gas, equal to the per-account
-    /// state-gas portion (`NEW_ACCOUNT_BYTES * cpsb`).
+    /// state-gas portion.
     #[inline]
-    pub fn tx_eip7702_auth_refund(&self, cpsb: u64) -> u64 {
+    pub fn tx_eip7702_auth_refund(&self) -> u64 {
         let regular = self.get(GasId::tx_eip7702_auth_refund());
-        let state = self.new_account_state_gas(cpsb);
+        let state = self.new_account_state_gas();
         regular.saturating_add(state)
     }
 
     /// EIP-8037: State gas per EIP-7702 authorization (pessimistic).
     ///
-    /// Sums the new-account and bytecode state-bytes portions and multiplies by
-    /// `cpsb`. Used for `initial_state_gas` tracking. Zero before AMSTERDAM.
+    /// Sums the new-account and bytecode state-gas portions. Used for
+    /// `initial_state_gas` tracking. Zero before AMSTERDAM.
     #[inline]
-    pub fn tx_eip7702_state_gas(&self, cpsb: u64) -> u64 {
+    pub fn tx_eip7702_state_gas(&self) -> u64 {
         let new_account = self.get(GasId::new_account_state_gas());
         let bytecode = self.get(GasId::tx_eip7702_state_gas_bytecode());
-        new_account.saturating_add(bytecode).saturating_mul(cpsb)
+        new_account.saturating_add(bytecode)
     }
 
     /// EIP-7702 total state-gas refund for a transaction.
     ///
-    /// Combines the per-account refund (`NEW_ACCOUNT_BYTES * cpsb` per refunded
-    /// account, when the authorization targets an account that already exists)
-    /// with the per-bytecode refund (`AUTH_BASE_BYTES * cpsb` per refunded
-    /// bytecode, when the delegation target is already deployed). Returns zero
-    /// before AMSTERDAM.
+    /// Combines the per-account refund for an existing authorization account
+    /// with the per-bytecode refund for an already deployed delegation target.
+    /// Returns zero before AMSTERDAM.
     #[inline]
-    pub fn tx_eip7702_state_refund(
-        &self,
-        refunded_accounts: u64,
-        refunded_bytecodes: u64,
-        cpsb: u64,
-    ) -> u64 {
+    pub fn tx_eip7702_state_refund(&self, refunded_accounts: u64, refunded_bytecodes: u64) -> u64 {
         let per_account = self
             .get(GasId::new_account_state_gas())
             .saturating_mul(refunded_accounts);
         let per_bytecode = self
             .get(GasId::tx_eip7702_state_gas_bytecode())
             .saturating_mul(refunded_bytecodes);
-        per_account
-            .saturating_add(per_bytecode)
-            .saturating_mul(cpsb)
+        per_account.saturating_add(per_bytecode)
     }
 
     /// EIP-7702 per-auth refund: regular-gas portion only.
@@ -970,7 +962,6 @@ impl GasParams {
         access_list_accounts: u64,
         access_list_storages: u64,
         authorization_list_num: u64,
-        cpsb: u64,
     ) -> InitialAndFloorGas {
         // Initdate stipend
         let tokens_in_calldata =
@@ -979,8 +970,8 @@ impl GasParams {
         // EIP-7702: Compute auth list costs.
         // Under EIP-8037, tx_eip7702_per_empty_account_cost bundles regular + state gas.
         // We split them: regular goes in initial_regular_gas, state goes in initial_state_gas.
-        let auth_total_cost = authorization_list_num * self.tx_eip7702_per_empty_account_cost(cpsb);
-        let auth_state_gas = authorization_list_num * self.tx_eip7702_state_gas(cpsb);
+        let auth_total_cost = authorization_list_num * self.tx_eip7702_per_empty_account_cost();
+        let auth_state_gas = authorization_list_num * self.tx_eip7702_state_gas();
 
         let auth_regular_cost = auth_total_cost - auth_state_gas;
 
@@ -1005,7 +996,7 @@ impl GasParams {
 
             // EIP-8037: State gas for CREATE transactions.
             // create_state_gas covers both account creation and contract metadata.
-            initial_state_gas += self.create_state_gas(cpsb);
+            initial_state_gas += self.create_state_gas();
         }
 
         // Calculate gas floor. Introduced by EIP-7623, updated by EIP-7976, and
@@ -1427,7 +1418,7 @@ impl GasId {
     }
 
     /// EIP-8037: State bytes for the bytecode (delegation) portion of an EIP-7702 authorization.
-    /// Equals `eip8037::AUTH_BASE_BYTES`. Multiplied by CPSB at charge time.
+    /// Equals `eip8037::AUTH_BASE_BYTES * eip8037::CPSB_GLAMSTERDAM`.
     /// Zero before AMSTERDAM.
     pub const fn tx_eip7702_state_gas_bytecode() -> GasId {
         Self::new(44)
@@ -1573,11 +1564,9 @@ mod tests {
     fn test_initial_state_gas_for_create() {
         // Use AMSTERDAM spec since EIP-8037 state gas is only enabled starting from Amsterdam.
         let gas_params = GasParams::new_spec(SpecId::AMSTERDAM);
-        let cpsb = eip8037::CPSB_GLAMSTERDAM;
-
         // Test CREATE transaction (is_create = true)
-        let create_gas = gas_params.initial_tx_gas(b"", true, 0, 0, 0, cpsb);
-        let expected_state_gas = gas_params.create_state_gas(cpsb);
+        let create_gas = gas_params.initial_tx_gas(b"", true, 0, 0, 0);
+        let expected_state_gas = gas_params.create_state_gas();
 
         assert_eq!(create_gas.initial_state_gas_final(), expected_state_gas);
         assert_eq!(
@@ -1594,7 +1583,7 @@ mod tests {
         );
 
         // Test CALL transaction (is_create = false)
-        let call_gas = gas_params.initial_tx_gas(b"", false, 0, 0, 0, cpsb);
+        let call_gas = gas_params.initial_tx_gas(b"", false, 0, 0, 0);
         assert_eq!(call_gas.initial_state_gas_final(), 0);
         // initial_gas should be unchanged for calls
         assert_eq!(call_gas.initial_total_gas(), gas_params.tx_base_stipend());

--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -1027,7 +1027,10 @@ impl GasParams {
                 .access_list()
                 .map(|al| {
                     al.fold((0, 0), |(num_accounts, num_storage_slots), item| {
-                        (num_accounts + 1, num_storage_slots + item.storage_slots().count() as u64)
+                        (
+                            num_accounts + 1,
+                            num_storage_slots + item.storage_slots().count() as u64,
+                        )
                     })
                 })
                 .unwrap_or_default();

--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -1607,7 +1607,7 @@ mod tests {
         assert_eq!(params.tx_floor_tokens_in_access_list(2, 3), (40 + 96) * 4);
 
         // Floor gas includes both calldata (empty here) and access-list contribution.
-        let gas = params.initial_tx_gas(b"", false, 2, 3, 0, 0);
+        let gas = params.initial_tx_gas(b"", false, 2, 3, 0);
         let expected_al_floor = (40 + 96) * 4 * params.tx_floor_cost_per_token();
         assert_eq!(
             gas.floor_gas(),
@@ -1618,7 +1618,7 @@ mod tests {
         let prague = GasParams::new_spec(SpecId::PRAGUE);
         assert_eq!(prague.tx_access_list_floor_byte_multiplier(), 0);
         assert_eq!(prague.tx_floor_tokens_in_access_list(2, 3), 0);
-        let prague_gas = prague.initial_tx_gas(b"", false, 2, 3, 0, 0);
+        let prague_gas = prague.initial_tx_gas(b"", false, 2, 3, 0);
         assert_eq!(prague_gas.floor_gas(), prague.tx_floor_cost_base_gas());
     }
 }

--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -3,6 +3,8 @@
 use crate::{
     cfg::gas::{self, get_tokens_in_calldata, InitialAndFloorGas},
     context::SStoreResult,
+    transaction::AccessListItemTr as _,
+    Transaction, TransactionType,
 };
 use core::hash::{Hash, Hasher};
 use primitives::{
@@ -1010,6 +1012,34 @@ impl GasParams {
             .with_initial_regular_gas(initial_regular_gas)
             .with_initial_state_gas(initial_state_gas)
             .with_floor_gas(floor_gas)
+    }
+
+    /// Calculates the initial transaction gas directly from a [`Transaction`],
+    /// deriving the access list counts from the transaction itself.
+    ///
+    /// See [`GasParams::initial_tx_gas`] for details on the returned gas.
+    pub fn initial_tx_gas_for_tx(&self, tx: impl Transaction) -> InitialAndFloorGas {
+        let mut accounts = 0;
+        let mut storages = 0;
+        // Legacy is the only tx type that does not have an access list.
+        if tx.tx_type() != TransactionType::Legacy {
+            (accounts, storages) = tx
+                .access_list()
+                .map(|al| {
+                    al.fold((0, 0), |(num_accounts, num_storage_slots), item| {
+                        (num_accounts + 1, num_storage_slots + item.storage_slots().count() as u64)
+                    })
+                })
+                .unwrap_or_default();
+        }
+
+        self.initial_tx_gas(
+            tx.input(),
+            tx.kind().is_create(),
+            accounts,
+            storages,
+            tx.authorization_list_len() as u64,
+        )
     }
 }
 

--- a/crates/context/interface/src/host.rs
+++ b/crates/context/interface/src/host.rs
@@ -69,13 +69,6 @@ pub trait Host {
     /// Returns whether state gas (EIP-8037) is enabled.
     fn is_amsterdam_eip8037_enabled(&self) -> bool;
 
-    /// Returns the EIP-8037 `cost_per_state_byte` for the current transaction.
-    ///
-    /// Reads the cached value set on the local context at transaction start
-    /// (via `cfg.cpsb()`, honoring `cpsb_override`). Returns
-    /// `0` when EIP-8037 is not enabled.
-    fn cpsb(&self) -> u64;
-
     /* Database */
 
     /// Block hash, calls `ContextTr::journal_mut().db().block_hash(number)`
@@ -248,10 +241,6 @@ impl Host for DummyHost {
 
     fn is_amsterdam_eip8037_enabled(&self) -> bool {
         false
-    }
-
-    fn cpsb(&self) -> u64 {
-        0
     }
 
     fn difficulty(&self) -> U256 {

--- a/crates/context/interface/src/local.rs
+++ b/crates/context/interface/src/local.rs
@@ -234,20 +234,6 @@ pub trait LocalContextTr {
     ///
     /// Returns `Some(String)` if a precompile error message was recorded.
     fn take_precompile_error_context(&mut self) -> Option<String>;
-
-    /// EIP-8037 `cost_per_state_byte` cached for the current transaction.
-    ///
-    /// Populated by [`LocalContextTr::set_cpsb`] at transaction start so that
-    /// the hot-path `Host::cpsb` is a single field read instead of recomputing
-    /// `cfg.cpsb()`.
-    fn cpsb(&self) -> u64;
-
-    /// Caches the EIP-8037 `cost_per_state_byte` for the current transaction.
-    ///
-    /// Called at the start of every execution entry point (regular transaction,
-    /// system call, and their inspector variants). The value must be derived via
-    /// `cfg.cpsb()` so that `cpsb_override` is honored.
-    fn set_cpsb(&mut self, cpsb: u64);
 }
 
 #[cfg(test)]

--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -2,7 +2,7 @@
 pub use context_interface::Cfg;
 
 use context_interface::cfg::GasParams;
-use primitives::{eip170, eip3860, eip7825, eip7954, eip8037, hardfork::SpecId};
+use primitives::{eip170, eip3860, eip7825, eip7954, hardfork::SpecId};
 
 /// EVM configuration
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -67,12 +67,6 @@ pub struct CfgEnv<SPEC = SpecId> {
     /// Introduced in Osaka in [EIP-7825: Transaction Gas Limit Cap](https://eips.ethereum.org/EIPS/eip-7825)
     /// with initials cap of 30M.
     pub tx_gas_limit_cap: Option<u64>,
-    /// Overrides the EIP-8037 `cost_per_state_byte` (CPSB).
-    ///
-    /// If `None`, CPSB defaults to [`primitives::eip8037::CPSB_GLAMSTERDAM`]
-    /// when EIP-8037 is enabled. If `Some`, the provided value is used
-    /// verbatim (useful for tests and replay).
-    pub cpsb_override: Option<u64>,
     /// A hard memory limit in bytes beyond which
     /// [OutOfGasError::Memory][context_interface::result::OutOfGasError::Memory] cannot be resized.
     ///
@@ -251,7 +245,6 @@ impl<SPEC> CfgEnv<SPEC> {
             spec,
             disable_nonce_check: self.disable_nonce_check,
             tx_gas_limit_cap: self.tx_gas_limit_cap,
-            cpsb_override: self.cpsb_override,
             max_blobs_per_tx: self.max_blobs_per_tx,
             blob_base_fee_update_fraction: self.blob_base_fee_update_fraction,
             gas_params,
@@ -336,7 +329,6 @@ impl<SPEC: Into<SpecId> + Clone> CfgEnv<SPEC> {
             disable_nonce_check: false,
             max_blobs_per_tx: None,
             tx_gas_limit_cap: None,
-            cpsb_override: None,
             blob_base_fee_update_fraction: None,
             gas_params,
             #[cfg(feature = "memory_limit")]
@@ -578,14 +570,6 @@ impl<SPEC: Into<SpecId> + Clone> Cfg for CfgEnv<SPEC> {
 
     fn is_amsterdam_eip8037_enabled(&self) -> bool {
         self.enable_amsterdam_eip8037
-    }
-
-    #[inline]
-    fn cpsb(&self) -> u64 {
-        if !self.enable_amsterdam_eip8037 {
-            return 0;
-        }
-        self.cpsb_override.unwrap_or(eip8037::CPSB_GLAMSTERDAM)
     }
 }
 

--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -467,11 +467,6 @@ impl<
         self.cfg().is_amsterdam_eip8037_enabled()
     }
 
-    #[inline]
-    fn cpsb(&self) -> u64 {
-        self.local().cpsb()
-    }
-
     fn block_number(&self) -> U256 {
         self.block().number()
     }

--- a/crates/context/src/local.rs
+++ b/crates/context/src/local.rs
@@ -10,11 +10,6 @@ pub struct LocalContext {
     pub shared_memory_buffer: Rc<RefCell<Vec<u8>>>,
     /// Optional precompile error message to bubble up.
     pub precompile_error_message: Option<String>,
-    /// EIP-8037 `cost_per_state_byte` cached for the current transaction.
-    ///
-    /// Populated at transaction start from `cfg.cpsb(block.gas_limit())`
-    /// (honoring `cpsb_override`). Read by the hot-path `Host::cpsb`.
-    pub cpsb: u64,
 }
 
 impl Default for LocalContext {
@@ -22,7 +17,6 @@ impl Default for LocalContext {
         Self {
             shared_memory_buffer: Rc::new(RefCell::new(Vec::with_capacity(1024 * 4))),
             precompile_error_message: None,
-            cpsb: 0,
         }
     }
 }
@@ -32,7 +26,6 @@ impl LocalContextTr for LocalContext {
         // Sets len to 0 but it will not shrink to drop the capacity.
         unsafe { self.shared_memory_buffer.borrow_mut().set_len(0) };
         self.precompile_error_message = None;
-        self.cpsb = 0;
     }
 
     fn shared_memory_buffer(&self) -> &Rc<RefCell<Vec<u8>>> {
@@ -45,14 +38,6 @@ impl LocalContextTr for LocalContext {
 
     fn take_precompile_error_context(&mut self) -> Option<String> {
         self.precompile_error_message.take()
-    }
-
-    fn cpsb(&self) -> u64 {
-        self.cpsb
-    }
-
-    fn set_cpsb(&mut self, cpsb: u64) {
-        self.cpsb = cpsb;
     }
 }
 

--- a/crates/ee-tests/src/eip8037.rs
+++ b/crates/ee-tests/src/eip8037.rs
@@ -2193,7 +2193,7 @@ fn test_eip8037_tx_create_initcode_selfdestruct_after_sstore() {
     assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
     assert_eq!(
         result.gas().state_gas_spent_final(),
-        STATE_GAS_SSTORE_SET + revm::primitives::eip8037::NEW_ACCOUNT_BYTES
+        STATE_GAS_SSTORE_SET + STATE_GAS_CREATE
     );
 
     crate::assert_sorted_json_snapshot!(&(baseline_result, result));

--- a/crates/ee-tests/src/eip8037.rs
+++ b/crates/ee-tests/src/eip8037.rs
@@ -29,15 +29,11 @@ const fn hash_cost(len: usize) -> u64 {
 type MainEvm = MainnetEvm<MainnetContext<BenchmarkDB>>;
 
 /// Builds an EVM with state gas enabled and custom gas params.
-///
-/// Sets `cpsb_override = Some(1)` so the overridden gas-table values are
-/// interpreted as final gas amounts (the CPSB multiplier becomes a no-op).
 fn state_gas_evm(bytecode: Bytecode, cap: u64) -> MainEvm {
     Context::mainnet()
         .modify_cfg_chained(|cfg| {
             cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
             cfg.tx_gas_limit_cap = Some(cap);
-            cfg.cpsb_override = Some(1);
             cfg.gas_params.override_gas([
                 (GasId::sstore_set_state_gas(), STATE_GAS_SSTORE_SET),
                 (GasId::new_account_state_gas(), STATE_GAS_NEW_ACCOUNT),
@@ -1048,7 +1044,6 @@ fn test_eip8037_block_gas_limit_enforced_with_state_gas() {
         .modify_cfg_chained(|cfg| {
             cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
             cfg.tx_gas_limit_cap = Some(u64::MAX);
-            cfg.cpsb_override = Some(1);
             cfg.gas_params.override_gas([
                 (GasId::sstore_set_state_gas(), STATE_GAS_SSTORE_SET),
                 (GasId::new_account_state_gas(), STATE_GAS_NEW_ACCOUNT),
@@ -2272,12 +2267,11 @@ fn test_eip8037_tx_create_collision() {
         .build_mainnet();
     let baseline_result = baseline.transact_one(build_tx(TX_GAS_LIMIT_CAP)).unwrap();
 
-    // State-gas variant: EIP-8037 enabled with cpsb_override = 1 so the
-    // gas-table overrides are interpreted as final amounts.
+    // State-gas variant: EIP-8037 enabled with gas-table overrides interpreted
+    // as final amounts.
     let mut evm = Context::mainnet()
         .modify_cfg_chained(|cfg| {
             cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
-            cfg.cpsb_override = Some(1);
             cfg.gas_params.override_gas([
                 (GasId::sstore_set_state_gas(), STATE_GAS_SSTORE_SET),
                 (GasId::new_account_state_gas(), STATE_GAS_NEW_ACCOUNT),
@@ -2310,8 +2304,8 @@ fn test_eip8037_tx_create_collision() {
     assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
     assert_eq!(result.gas().state_gas_spent_final(), 0);
 
-    // Halt consumes the regular gas budget in full. With cpsb_override = 1 the
-    // intrinsic create_state_gas equals STATE_GAS_CREATE, and the state-gas
+    // Halt consumes the regular gas budget in full. The intrinsic
+    // create_state_gas equals STATE_GAS_CREATE, and the state-gas
     // variant's total gas spent is exactly that much less than the baseline,
     // because the create_failed branch refills the reservoir with it.
     //

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_selfdestruct_after_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_selfdestruct_after_sstore.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ee-tests/src/eip8037.rs
+assertion_line: 2199
 expression: "&(baseline_result, result)"
 ---
 [
@@ -25,8 +26,8 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Return",
       "gas": {
-        "gas_spent": 240551,
-        "state_gas_spent": 200120,
+        "gas_spent": 570431,
+        "state_gas_spent": 530000,
         "gas_refunded": 0,
         "floor_gas": 22728
       },

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -2,7 +2,7 @@ use crate::{
     evm::FrameTr, item_or_result::FrameInitOrResult, precompile_provider::PrecompileProvider,
     CallFrame, CreateFrame, FrameData, FrameResult, ItemOrResult,
 };
-use context::{result::FromStringError, LocalContextTr};
+use context::result::FromStringError;
 use context_interface::{
     context::{take_error, ContextError},
     journaled_state::{account::JournaledAccountTr, JournalCheckpoint, JournalTr},
@@ -541,8 +541,7 @@ impl EthFrame<EthInterpreter> {
                 let create_failed = outcome.address.is_none() || !instruction_result.is_ok();
 
                 if create_failed && ctx.cfg().is_amsterdam_eip8037_enabled() {
-                    let state_gas_charged =
-                        ctx.cfg().gas_params().create_state_gas(ctx.local().cpsb());
+                    let state_gas_charged = ctx.cfg().gas_params().create_state_gas();
                     this_gas.refill_reservoir(state_gas_charged);
                 }
 
@@ -619,13 +618,12 @@ pub fn return_create<CTX: ContextTr>(
     interpreter_result: &mut InterpreterResult,
     address: Address,
 ) {
-    let (_, _, cfg, journal, _, local) = context.all_mut();
+    let (_, _, cfg, journal, _, _) = context.all_mut();
 
     let max_code_size = cfg.max_code_size();
     let is_eip3541_disabled = cfg.is_eip3541_disabled();
     let spec_id = cfg.spec().into();
     let is_amsterdam_eip8037 = cfg.is_amsterdam_eip8037_enabled();
-    let cpsb = local.cpsb();
     let gas_params = cfg.gas_params();
 
     // If return is not ok revert and return.
@@ -691,8 +689,7 @@ pub fn return_create<CTX: ContextTr>(
         //
         // Note: This should be last operation before checkpoint commit as spending state before this messes
         // with refilling of state gas.
-        let state_gas_for_code =
-            gas_params.code_deposit_state_gas(interpreter_result.output.len(), cpsb);
+        let state_gas_for_code = gas_params.code_deposit_state_gas(interpreter_result.output.len());
         if state_gas_for_code > 0 && !interpreter_result.gas.record_state_cost(state_gas_for_code) {
             journal.checkpoint_revert(checkpoint);
             interpreter_result.result = InstructionResult::OutOfGas;

--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -41,17 +41,6 @@ impl<
 {
 }
 
-/// Caches the EIP-8037 `cost_per_state_byte` on the local context for the
-/// current transaction, honoring `cfg.cpsb_override`.
-///
-/// Called at the start of every top-level execution entry point so that
-/// `Host::cpsb` becomes a single field read instead of a recomputation.
-#[inline]
-pub fn cache_cpsb_on_local<CTX: ContextTr>(ctx: &mut CTX) {
-    let cpsb = ctx.cfg().cpsb();
-    ctx.local_mut().set_cpsb(cpsb);
-}
-
 /// The main implementation of Ethereum Mainnet transaction execution.
 ///
 /// The [`Handler::run`] method serves as the entry point for execution and provides
@@ -109,9 +98,6 @@ pub trait Handler {
         &mut self,
         evm: &mut Self::Evm,
     ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
-        // Cache EIP-8037 cost_per_state_byte on the local context so the hot-path
-        // Host::cpsb is a single field read. Honors cfg.cpsb_override.
-        cache_cpsb_on_local(evm.ctx_mut());
         // Run inner handler and catch all errors to handle cleanup.
         match self.run_without_catch_error(evm) {
             Ok(output) => Ok(output),
@@ -138,10 +124,6 @@ pub trait Handler {
         &mut self,
         evm: &mut Self::Evm,
     ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
-        // Cache EIP-8037 cost_per_state_byte on the local context. System calls
-        // skip validation/pre-execution but still execute interpreter code that
-        // reads Host::cpsb, so this must be populated here too.
-        cache_cpsb_on_local(evm.ctx_mut());
         // dummy values that are not used.
         let init_and_floor_gas = InitialAndFloorGas::new(0, 0);
         // call execution and than output.
@@ -313,7 +295,6 @@ pub trait Handler {
             ctx.cfg().is_eip7623_disabled(),
             ctx.cfg().is_amsterdam_eip8037_enabled(),
             ctx.cfg().tx_gas_limit_cap(),
-            ctx.cfg().cpsb(),
         )?;
 
         Ok(gas)
@@ -446,7 +427,7 @@ pub trait Handler {
         // or erased.
         if create_failed && evm.ctx().cfg().is_amsterdam_eip8037_enabled() {
             let ctx = evm.ctx();
-            let state_gas_charged = ctx.cfg().gas_params().create_state_gas(ctx.local().cpsb());
+            let state_gas_charged = ctx.cfg().gas_params().create_state_gas();
             gas.refill_reservoir(state_gas_charged);
         }
 

--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -289,7 +289,7 @@ pub trait Handler {
         evm: &mut Self::Evm,
     ) -> Result<InitialAndFloorGas, Self::Error> {
         let ctx = evm.ctx_ref();
-        let gas = validation::validate_initial_tx_gas(
+        let gas = validation::validate_initial_tx_gas_with_gas_params(
             ctx.tx(),
             ctx.cfg().spec().into(),
             ctx.cfg().gas_params(),

--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -292,6 +292,7 @@ pub trait Handler {
         let gas = validation::validate_initial_tx_gas(
             ctx.tx(),
             ctx.cfg().spec().into(),
+            ctx.cfg().gas_params(),
             ctx.cfg().is_eip7623_disabled(),
             ctx.cfg().is_amsterdam_eip8037_enabled(),
             ctx.cfg().tx_gas_limit_cap(),

--- a/crates/handler/src/lib.rs
+++ b/crates/handler/src/lib.rs
@@ -45,7 +45,7 @@ pub use api::{ExecuteCommitEvm, ExecuteEvm};
 pub use evm::{EvmTr, FrameTr};
 pub use frame::{handle_reservoir_remaining_gas, return_create, ContextTrDbError, EthFrame};
 pub use frame_data::{CallFrame, CreateFrame, FrameData, FrameResult};
-pub use handler::{cache_cpsb_on_local, EvmTrError, Handler};
+pub use handler::{EvmTrError, Handler};
 pub use item_or_result::{FrameInitOrResult, ItemOrResult};
 pub use mainnet_builder::{MainBuilder, MainContext, MainnetContext, MainnetEvm};
 pub use mainnet_handler::MainnetHandler;

--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -202,7 +202,6 @@ pub fn apply_eip7702_auth_list<
     init_and_floor_gas: &mut InitialAndFloorGas,
 ) -> Result<u64, ERROR> {
     let chain_id = context.cfg().chain_id();
-    let cpsb = context.cfg().cpsb();
     let is_eip8037 = context.cfg().is_amsterdam_eip8037_enabled();
     let (tx, journal) = context.tx_journal_mut();
 
@@ -221,11 +220,8 @@ pub fn apply_eip7702_auth_list<
     // from the reservoir). The regular portion is returned and routed through
     // the standard refund counter, subject to the 1/5 cap.
     if is_eip8037 {
-        init_and_floor_gas.state_refund += params.tx_eip7702_state_refund(
-            number_of_refunded_accounts,
-            number_of_refunded_bytecodes,
-            cpsb,
-        );
+        init_and_floor_gas.state_refund += params
+            .tx_eip7702_state_refund(number_of_refunded_accounts, number_of_refunded_bytecodes);
     }
 
     let regular_gas_refund = params

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -1,7 +1,7 @@
 use context_interface::{
     cfg::GasParams,
     result::{InvalidHeader, InvalidTransaction},
-    transaction::{AccessListItemTr, Transaction, TransactionType},
+    transaction::{Transaction, TransactionType},
     Block, Cfg, ContextTr,
 };
 use core::cmp;
@@ -245,30 +245,7 @@ pub fn validate_initial_tx_gas(
     is_amsterdam_eip8037_enabled: bool,
     tx_gas_limit_cap: u64,
 ) -> Result<InitialAndFloorGas, InvalidTransaction> {
-    let mut accounts = 0;
-    let mut storages = 0;
-    // legacy is only tx type that does not have access list.
-    if tx.tx_type() != TransactionType::Legacy {
-        (accounts, storages) = tx
-            .access_list()
-            .map(|al| {
-                al.fold((0, 0), |(mut num_accounts, mut num_storage_slots), item| {
-                    num_accounts += 1;
-                    num_storage_slots += item.storage_slots().count();
-
-                    (num_accounts, num_storage_slots)
-                })
-            })
-            .unwrap_or_default();
-    }
-
-    let mut gas = gas_params.initial_tx_gas(
-        tx.input(),
-        tx.kind().is_create(),
-        accounts as u64,
-        storages as u64,
-        tx.authorization_list_len() as u64,
-    );
+    let mut gas = gas_params.initial_tx_gas_for_tx(&tx);
 
     if is_eip7623_disabled {
         gas.set_floor_gas(0);

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -1,10 +1,11 @@
 use context_interface::{
+    cfg::GasParams,
     result::{InvalidHeader, InvalidTransaction},
-    transaction::{Transaction, TransactionType},
+    transaction::{AccessListItemTr, Transaction, TransactionType},
     Block, Cfg, ContextTr,
 };
 use core::cmp;
-use interpreter::{instructions::calculate_initial_tx_gas_for_tx, InitialAndFloorGas};
+use interpreter::InitialAndFloorGas;
 use primitives::{eip4844, hardfork::SpecId, B256};
 
 /// Validates the execution environment including block and transaction parameters.
@@ -239,14 +240,42 @@ pub fn validate_tx_env<CTX: ContextTr>(
 pub fn validate_initial_tx_gas(
     tx: impl Transaction,
     spec: SpecId,
+    gas_params: &GasParams,
     is_eip7623_disabled: bool,
     is_amsterdam_eip8037_enabled: bool,
     tx_gas_limit_cap: u64,
 ) -> Result<InitialAndFloorGas, InvalidTransaction> {
-    let mut gas = calculate_initial_tx_gas_for_tx(&tx, spec);
+    let mut accounts = 0;
+    let mut storages = 0;
+    // legacy is only tx type that does not have access list.
+    if tx.tx_type() != TransactionType::Legacy {
+        (accounts, storages) = tx
+            .access_list()
+            .map(|al| {
+                al.fold((0, 0), |(mut num_accounts, mut num_storage_slots), item| {
+                    num_accounts += 1;
+                    num_storage_slots += item.storage_slots().count();
+
+                    (num_accounts, num_storage_slots)
+                })
+            })
+            .unwrap_or_default();
+    }
+
+    let mut gas = gas_params.initial_tx_gas(
+        tx.input(),
+        tx.kind().is_create(),
+        accounts as u64,
+        storages as u64,
+        tx.authorization_list_len() as u64,
+    );
 
     if is_eip7623_disabled {
         gas.set_floor_gas(0);
+    }
+
+    if !is_amsterdam_eip8037_enabled {
+        gas.set_initial_state_gas(0);
     }
 
     // Additional check to see if limit is big enough to cover initial gas.

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -236,8 +236,29 @@ pub fn validate_tx_env<CTX: ContextTr>(
     Ok(())
 }
 
-/// Validate initial transaction gas.
+/// Validate initial transaction gas using the default [`GasParams`] for the given [`SpecId`].
+///
+/// For custom gas parameters (e.g. configured on the context), use
+/// [`validate_initial_tx_gas_with_gas_params`].
 pub fn validate_initial_tx_gas(
+    tx: impl Transaction,
+    spec: SpecId,
+    is_eip7623_disabled: bool,
+    is_amsterdam_eip8037_enabled: bool,
+    tx_gas_limit_cap: u64,
+) -> Result<InitialAndFloorGas, InvalidTransaction> {
+    validate_initial_tx_gas_with_gas_params(
+        tx,
+        spec,
+        &GasParams::new_spec(spec),
+        is_eip7623_disabled,
+        is_amsterdam_eip8037_enabled,
+        tx_gas_limit_cap,
+    )
+}
+
+/// Validate initial transaction gas using the provided [`GasParams`].
+pub fn validate_initial_tx_gas_with_gas_params(
     tx: impl Transaction,
     spec: SpecId,
     gas_params: &GasParams,

--- a/crates/handler/src/validation.rs
+++ b/crates/handler/src/validation.rs
@@ -242,9 +242,8 @@ pub fn validate_initial_tx_gas(
     is_eip7623_disabled: bool,
     is_amsterdam_eip8037_enabled: bool,
     tx_gas_limit_cap: u64,
-    cpsb: u64,
 ) -> Result<InitialAndFloorGas, InvalidTransaction> {
-    let mut gas = calculate_initial_tx_gas_for_tx(&tx, spec, cpsb);
+    let mut gas = calculate_initial_tx_gas_for_tx(&tx, spec);
 
     if is_eip7623_disabled {
         gas.set_floor_gas(0);

--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -1,8 +1,7 @@
 use crate::{Inspector, InspectorEvmTr, JournalExt};
 use context::{result::ExecutionResult, Cfg, ContextTr, JournalEntry, JournalTr, Transaction};
 use handler::{
-    cache_cpsb_on_local, evm::FrameTr, post_execution::build_result_gas, EvmTr, FrameResult,
-    Handler, ItemOrResult,
+    evm::FrameTr, post_execution::build_result_gas, EvmTr, FrameResult, Handler, ItemOrResult,
 };
 use interpreter::{
     instructions::{GasTable, InstructionTable},
@@ -46,9 +45,6 @@ where
         &mut self,
         evm: &mut Self::Evm,
     ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
-        // Cache EIP-8037 cost_per_state_byte on the local context so the hot-path
-        // Host::cpsb is a single field read. Honors cfg.cpsb_override.
-        cache_cpsb_on_local(evm.ctx_mut());
         match self.inspect_run_without_catch_error(evm) {
             Ok(output) => Ok(output),
             Err(e) => self.catch_error(evm, e),
@@ -152,10 +148,6 @@ where
         &mut self,
         evm: &mut Self::Evm,
     ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
-        // Cache EIP-8037 cost_per_state_byte on the local context. Inspector
-        // system calls skip validation/pre-execution but still execute
-        // interpreter code that reads Host::cpsb.
-        cache_cpsb_on_local(evm.ctx_mut());
         // dummy values that are not used.
         let init_and_floor_gas = InitialAndFloorGas::new(0, 0);
         // call execution with inspection and then output.

--- a/crates/interpreter/src/instructions/contract.rs
+++ b/crates/interpreter/src/instructions/contract.rs
@@ -92,10 +92,7 @@ pub fn create<const IS_CREATE2: bool, IT: ITy, H: Host + ?Sized>(
     if context.host.is_amsterdam_eip8037_enabled() {
         state_gas!(
             context.interpreter,
-            context
-                .host
-                .gas_params()
-                .create_state_gas(context.host.cpsb())
+            context.host.gas_params().create_state_gas()
         );
     }
 

--- a/crates/interpreter/src/instructions/contract/call_helpers.rs
+++ b/crates/interpreter/src/instructions/contract/call_helpers.rs
@@ -171,7 +171,7 @@ pub fn load_account_delegated<H: Host + ?Sized>(
             .gas_params()
             .new_account_cost(is_spurious_dragon, transfers_value);
         if host.is_amsterdam_eip8037_enabled() && transfers_value {
-            state_gas_cost += host.gas_params().new_account_state_gas(host.cpsb());
+            state_gas_cost += host.gas_params().new_account_state_gas();
         }
         return Ok((cost, state_gas_cost, bytecode, code_hash));
     }

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -234,13 +234,9 @@ pub fn sstore<IT: ITy, H: Host + ?Sized>(context: Ictx<'_, H, IT>) -> Result {
 
     // state gas for new slot creation (EIP-8037)
     if context.host.is_amsterdam_eip8037_enabled() {
-        let cpsb = context.host.cpsb();
         state_gas!(
             context.interpreter,
-            context
-                .host
-                .gas_params()
-                .sstore_state_gas(&state_load.data, cpsb)
+            context.host.gas_params().sstore_state_gas(&state_load.data)
         );
 
         // EIP-8037 issue #2: 0→x→0 storage restoration refills the reservoir
@@ -250,7 +246,7 @@ pub fn sstore<IT: ITy, H: Host + ?Sized>(context: Ictx<'_, H, IT>) -> Result {
         let refill = context
             .host
             .gas_params()
-            .sstore_state_gas_refill(&state_load.data, cpsb);
+            .sstore_state_gas_refill(&state_load.data);
         if refill > 0 {
             context.interpreter.gas.refill_reservoir(refill);
         }
@@ -364,10 +360,7 @@ pub fn selfdestruct<IT: ITy, H: Host + ?Sized>(context: Ictx<'_, H, IT>) -> Resu
     if context.host.is_amsterdam_eip8037_enabled() && should_charge_topup {
         state_gas!(
             context.interpreter,
-            context
-                .host
-                .gas_params()
-                .new_account_state_gas(context.host.cpsb())
+            context.host.gas_params().new_account_state_gas()
         );
     }
 

--- a/crates/interpreter/src/interpreter_action/call_inputs.rs
+++ b/crates/interpreter/src/interpreter_action/call_inputs.rs
@@ -351,12 +351,6 @@ mod tests {
         fn take_precompile_error_context(&mut self) -> Option<String> {
             None
         }
-
-        fn cpsb(&self) -> u64 {
-            0
-        }
-
-        fn set_cpsb(&mut self, _cpsb: u64) {}
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- bake Glamsterdam CPSB into Amsterdam GasParams entries in new_spec_inner
- remove cpsb_override/cached local cpsb/Host::cpsb plumbing
- simplify state gas helper APIs so callers use pre-scaled gas values

## Tests
- cargo check -p revm-context-interface -p revm-context -p revm-interpreter -p revm-handler -p revm-inspector -p revm-ee-tests
