### PR TITLE
docs: explain CPSB acronym

### DIFF
--- a/crates/primitives/src/eip8037.rs
+++ b/crates/primitives/src/eip8037.rs
@@ -32,5 +32,7 @@ pub const CODE_DEPOSIT_PER_BYTE: u64 = 1;
 /// Regular gas component of EIP-7702 `PER_EMPTY_ACCOUNT_COST` under EIP-8037.
 pub const EIP7702_PER_EMPTY_ACCOUNT_REGULAR: u64 = 7500;
 
-/// CPSB for Glamsterdam
+/// Cost per state byte (CPSB) for Glamsterdam.
+///
+/// Reference: [EIP-8037: State Creation Gas Cost Increase](https://eips.ethereum.org/EIPS/eip-8037).
 pub const CPSB_GLAMSTERDAM: u64 = 1530;


### PR DESCRIPTION
## What changed

Expanded the `CPSB_GLAMSTERDAM` rustdoc to spell out `cost per state byte` and added a direct reference to EIP-8037.

## Why

The acronym is easy to miss at the constant definition, and the EIP link gives readers the canonical context for the Glamsterdam value.

## Impact

Documentation-only change. No runtime behavior changes.