### PR TITLE
feat(context): implement EIP-8246 (remove SELFDESTRUCT burn)

### DIFF
--- a/crates/context/interface/src/cfg.rs
+++ b/crates/context/interface/src/cfg.rs
@@ -73,14 +73,17 @@ pub trait Cfg {
     /// Returns whether EIP-7708 (ETH transfers emit logs) is disabled.
     fn is_eip7708_disabled(&self) -> bool;
 
-    /// Returns whether EIP-7708 delayed burn logging is disabled.
+    /// Returns whether the EIP-8246 delayed clearing of self-destructed accounts is disabled.
     ///
-    /// When enabled, revm tracks all self-destructed addresses and emits logs for
-    /// accounts that still have remaining balance at the end of the transaction.
-    /// This can be disabled for performance reasons as it requires storing and
-    /// iterating over all self-destructed accounts. When disabled, the logging
-    /// can be done outside of revm when applying accounts to database state.
-    fn is_eip7708_delayed_burn_disabled(&self) -> bool;
+    /// When enabled, revm tracks all self-destructed addresses and, at the end of the
+    /// transaction, clears the code, storage and nonce of any that still have a remaining
+    /// balance while preserving the balance ([EIP-8246]). This can be disabled for performance
+    /// reasons as it requires storing and iterating over all self-destructed accounts. When
+    /// disabled, this clearing can be done outside of revm when applying accounts to database
+    /// state.
+    ///
+    /// [EIP-8246]: https://eips.ethereum.org/EIPS/eip-8246
+    fn is_eip8246_delayed_clear_disabled(&self) -> bool;
 
     /// Returns the limit in bytes for the memory buffer.
     fn memory_limit(&self) -> u64;

--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -139,16 +139,17 @@ pub trait JournalTr {
     /// Sets the spec id.
     fn set_spec_id(&mut self, spec_id: SpecId);
 
-    /// Sets EIP-7708 configuration flags.
+    /// Sets EIP-7708 and EIP-8246 configuration flags.
     ///
     /// - `disabled`: Whether EIP-7708 (ETH transfers emit logs) is completely disabled.
-    /// - `delayed_burn_disabled`: Whether delayed burn logging is disabled. When enabled,
-    ///   revm tracks all self-destructed addresses and emits logs for accounts that still
-    ///   have remaining balance at the end of the transaction. This can be disabled for
-    ///   performance reasons as it requires storing and iterating over all self-destructed
-    ///   accounts. When disabled, the logging can be done outside of revm when applying
-    ///   accounts to database state.
-    fn set_eip7708_config(&mut self, disabled: bool, delayed_burn_disabled: bool);
+    /// - `eip8246_delayed_clear_disabled`: Whether the EIP-8246 delayed clearing of
+    ///   self-destructed accounts is disabled. When enabled, revm tracks all self-destructed
+    ///   addresses and, at the end of the transaction, clears the code, storage and nonce of
+    ///   any that still have a remaining balance while preserving the balance. This can be
+    ///   disabled for performance reasons as it requires storing and iterating over all
+    ///   self-destructed accounts. When disabled, this clearing can be done outside of revm
+    ///   when applying accounts to database state.
+    fn set_eip7708_config(&mut self, disabled: bool, eip8246_delayed_clear_disabled: bool);
 
     /// Touches the account.
     fn touch_account(&mut self, address: Address);

--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -158,16 +158,19 @@ pub struct CfgEnv<SPEC = SpecId> {
     ///
     /// By default, it is set to `false`.
     pub amsterdam_eip7708_disabled: bool,
-    /// Disables EIP-7708 delayed burn logging.
+    /// Disables the EIP-8246 delayed clearing of self-destructed accounts.
     ///
-    /// When enabled, revm tracks all self-destructed addresses and emits logs for
-    /// accounts that still have remaining balance at the end of the transaction.
-    /// This can be disabled for performance reasons as it requires storing and
-    /// iterating over all self-destructed accounts. When disabled, the logging
-    /// can be done outside of revm when applying accounts to database state.
+    /// When enabled, revm tracks all self-destructed addresses and, at the end of the
+    /// transaction, clears the code, storage and nonce of any that still have a remaining
+    /// balance while preserving the balance ([EIP-8246]). This can be disabled for performance
+    /// reasons as it requires storing and iterating over all self-destructed accounts. When
+    /// disabled, this clearing can be done outside of revm when applying accounts to database
+    /// state.
     ///
     /// By default, it is set to `false`.
-    pub amsterdam_eip7708_delayed_burn_disabled: bool,
+    ///
+    /// [EIP-8246]: https://eips.ethereum.org/EIPS/eip-8246
+    pub amsterdam_eip8246_delayed_clear_disabled: bool,
 }
 
 impl CfgEnv {
@@ -287,7 +290,7 @@ impl<SPEC> CfgEnv<SPEC> {
             enable_amsterdam_eip8037: self.enable_amsterdam_eip8037,
             enable_amsterdam_eip2780: self.enable_amsterdam_eip2780,
             amsterdam_eip7708_disabled: self.amsterdam_eip7708_disabled,
-            amsterdam_eip7708_delayed_burn_disabled: self.amsterdam_eip7708_delayed_burn_disabled,
+            amsterdam_eip8246_delayed_clear_disabled: self.amsterdam_eip8246_delayed_clear_disabled,
         }
     }
 
@@ -379,7 +382,7 @@ impl<SPEC: Into<SpecId> + Clone> CfgEnv<SPEC> {
             enable_amsterdam_eip8037: is_amsterdam,
             enable_amsterdam_eip2780: is_amsterdam,
             amsterdam_eip7708_disabled: false,
-            amsterdam_eip7708_delayed_burn_disabled: false,
+            amsterdam_eip8246_delayed_clear_disabled: false,
         }
     }
 
@@ -578,8 +581,8 @@ impl<SPEC: Into<SpecId> + Clone> Cfg for CfgEnv<SPEC> {
         self.amsterdam_eip7708_disabled
     }
 
-    fn is_eip7708_delayed_burn_disabled(&self) -> bool {
-        self.amsterdam_eip7708_delayed_burn_disabled
+    fn is_eip8246_delayed_clear_disabled(&self) -> bool {
+        self.amsterdam_eip8246_delayed_clear_disabled
     }
 
     fn memory_limit(&self) -> u64 {

--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -45,7 +45,7 @@ fn sync_cfg_to_journal<CFG: Cfg, JOURNAL: JournalTr>(cfg: &CFG, journal: &mut JO
     journal.set_spec_id(cfg.spec().into());
     journal.set_eip7708_config(
         cfg.is_eip7708_disabled(),
-        cfg.is_eip7708_delayed_burn_disabled(),
+        cfg.is_eip8246_delayed_clear_disabled(),
     );
 }
 

--- a/crates/context/src/journal.rs
+++ b/crates/context/src/journal.rs
@@ -203,9 +203,9 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
     }
 
     #[inline]
-    fn set_eip7708_config(&mut self, disabled: bool, delayed_burn_disabled: bool) {
+    fn set_eip7708_config(&mut self, disabled: bool, eip8246_delayed_clear_disabled: bool) {
         self.inner
-            .set_eip7708_config(disabled, delayed_burn_disabled);
+            .set_eip7708_config(disabled, eip8246_delayed_clear_disabled);
     }
 
     #[inline]

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -12,7 +12,7 @@ use context_interface::{
 use core::mem;
 use database_interface::Database;
 use primitives::{
-    eip7708::{BURN_LOG_TOPIC, ETH_TRANSFER_LOG_ADDRESS, ETH_TRANSFER_LOG_TOPIC},
+    eip7708::{ETH_TRANSFER_LOG_ADDRESS, ETH_TRANSFER_LOG_TOPIC},
     hardfork::SpecId::{self, *},
     hash_map::Entry,
     hints_util::unlikely,
@@ -42,14 +42,17 @@ pub struct JournalCfg {
     pub spec: SpecId,
     /// Whether EIP-7708 (ETH transfers emit logs) is disabled.
     pub eip7708_disabled: bool,
-    /// Whether EIP-7708 delayed burn logging is disabled.
+    /// Whether the EIP-8246 delayed clearing of self-destructed accounts is disabled.
     ///
-    /// When enabled, revm tracks all self-destructed addresses and emits logs for
-    /// accounts that still have remaining balance at the end of the transaction.
-    /// This can be disabled for performance reasons as it requires storing and
-    /// iterating over all self-destructed accounts. When disabled, the logging
-    /// can be done outside of revm when applying accounts to database state.
-    pub eip7708_delayed_burn_disabled: bool,
+    /// When enabled, revm tracks all self-destructed addresses and, at the end of the
+    /// transaction, clears the code, storage and nonce of any that still have a remaining
+    /// balance while preserving the balance (see [EIP-8246]). This can be disabled for
+    /// performance reasons as it requires storing and iterating over all self-destructed
+    /// accounts. When disabled, this clearing can be done outside of revm when applying
+    /// accounts to database state.
+    ///
+    /// [EIP-8246]: https://eips.ethereum.org/EIPS/eip-8246
+    pub eip8246_delayed_clear_disabled: bool,
 }
 /// Inner journal state that contains journal and state changes.
 ///
@@ -81,13 +84,13 @@ pub struct JournalInner<ENTRY> {
     pub warm_addresses: WarmAddresses,
     /// Addresses that were self-destructed for the first time in this transaction.
     ///
-    /// This is used by [EIP-7708] to emit logs for self-destructed accounts that still
-    /// have balance at the end of the transaction.
+    /// This is used by [EIP-8246] to clear (code, storage and nonce) self-destructed accounts
+    /// that still have balance at the end of the transaction, preserving their balance.
     ///
     /// The vec is indexed by checkpoint - on revert, entries added after the checkpoint
     /// are removed.
     ///
-    /// [EIP-7708]: https://eips.ethereum.org/EIPS/eip-7708
+    /// [EIP-8246]: https://eips.ethereum.org/EIPS/eip-8246
     pub selfdestructed_addresses: Vec<Address>,
 }
 
@@ -118,12 +121,13 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
 
     /// Returns the logs.
     ///
-    /// Before returning, this function emits EIP-7708 logs for any self-destructed
-    /// accounts that still have a non-zero balance.
+    /// Before returning, this function applies EIP-8246 to any self-destructed
+    /// accounts that still have a non-zero balance, clearing their code, storage and
+    /// nonce while preserving the balance.
     #[inline]
     pub fn take_logs(&mut self) -> Vec<Log> {
-        // EIP-7708: Emit logs for self-destructed accounts with remaining balance
-        self.eip7708_emit_burn_remaining_balance_logs();
+        // EIP-8246: clear self-destructed accounts that still hold a balance.
+        self.eip8246_clear_selfdestructed_accounts();
         mem::take(&mut self.logs)
     }
 
@@ -254,45 +258,53 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         state
     }
 
-    /// Emit EIP-7708 logs for self-destructed accounts that still have balance.
+    /// Apply [EIP-8246] to self-destructed accounts that still have a balance.
     ///
     /// This should be called before `take_logs()` at the end of transaction execution.
-    /// It checks all accounts that were self-destructed in this transaction and emits
-    /// a `Burn` log for any that still have a non-zero balance.
+    /// It iterates over all accounts that were self-destructed in this transaction and,
+    /// for any that still hold a non-zero balance, clears the rest of the account instead
+    /// of letting the balance be burned: the nonce is reset to `0`, the code and storage are
+    /// cleared, the balance is left unchanged and the self-destruct flag is removed so the
+    /// account is preserved in state as a balance-only account.
     ///
-    /// This can happen when an account receives ETH after being self-destructed
-    /// in the same transaction.
+    /// A non-zero balance can remain when an account receives ETH after being self-destructed
+    /// in the same transaction, or when a contract created in the same transaction
+    /// self-destructs to itself (see [`Self::selfdestruct`]).
     ///
-    /// Logs are emitted sorted by address in ascending order.
+    /// Accounts with a zero balance keep their self-destruct flag and are removed from state as
+    /// before (they are *empty* and deleted by [EIP-161]).
     ///
-    /// [EIP-7708](https://eips.ethereum.org/EIPS/eip-7708)
+    /// Self-destructed accounts can only reach this point if they were created in the same
+    /// transaction (EIP-6780 is always active alongside EIP-8246), so they never have storage
+    /// stored in the database and clearing the in-memory storage is sufficient.
+    ///
+    /// [EIP-8246]: https://eips.ethereum.org/EIPS/eip-8246
+    /// [EIP-161]: https://eips.ethereum.org/EIPS/eip-161
     #[inline]
-    pub fn eip7708_emit_burn_remaining_balance_logs(&mut self) {
-        if !self.cfg.spec.is_enabled_in(AMSTERDAM)
-            || self.cfg.eip7708_disabled
-            || self.cfg.eip7708_delayed_burn_disabled
-        {
+    pub fn eip8246_clear_selfdestructed_accounts(&mut self) {
+        if !self.cfg.spec.is_enabled_in(AMSTERDAM) || self.cfg.eip8246_delayed_clear_disabled {
             return;
         }
 
-        // Collect addresses with non-zero balance and sort by address
-        let mut addresses_with_balance: Vec<(Address, U256)> = self
-            .selfdestructed_addresses
-            .iter()
-            .filter_map(|address| {
-                self.state
-                    .get(address)
-                    .filter(|account| !account.info.balance.is_zero())
-                    .map(|account| (*address, account.info.balance))
-            })
-            .collect();
+        for address in &self.selfdestructed_addresses {
+            let Some(account) = self.state.get_mut(address) else {
+                continue;
+            };
 
-        // Sort by address (ascending)
-        addresses_with_balance.sort_by_key(|(addr, _)| *addr);
+            // Zero-balance accounts stay self-destructed and are removed from state (EIP-161).
+            if account.info.balance.is_zero() {
+                continue;
+            }
 
-        // Emit logs in sorted order
-        for (address, balance) in addresses_with_balance {
-            self.eip7708_burn_log(address, balance);
+            // EIP-8246: keep the balance but clear the rest of the account.
+            account.info.nonce = 0;
+            account.info.code_hash = KECCAK_EMPTY;
+            account.info.code = Some(Bytecode::default());
+            account.storage.clear();
+
+            // Remove the self-destruct flags so the account is preserved instead of destroyed.
+            account.unmark_selfdestruct();
+            account.unmark_selfdestructed_locally();
         }
     }
 
@@ -308,11 +320,15 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         self.cfg.spec = spec;
     }
 
-    /// Sets EIP-7708 configuration flags.
+    /// Sets EIP-7708 and EIP-8246 configuration flags.
     #[inline]
-    pub const fn set_eip7708_config(&mut self, disabled: bool, delayed_burn_disabled: bool) {
+    pub const fn set_eip7708_config(
+        &mut self,
+        disabled: bool,
+        eip8246_delayed_clear_disabled: bool,
+    ) {
         self.cfg.eip7708_disabled = disabled;
-        self.cfg.eip7708_delayed_burn_disabled = delayed_burn_disabled;
+        self.cfg.eip8246_delayed_clear_disabled = eip8246_delayed_clear_disabled;
     }
 
     /// Mark account as touched as only touched accounts will be added to state.
@@ -662,30 +678,41 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
 
         // EIP-6780 (Cancun hard-fork): selfdestruct only if contract is created in the same tx
         let journal_entry = if acc.is_created_locally() || !is_cancun_enabled {
-            // EIP-7708: Track first self-destruction for remaining balance log.
-            // Only track when account is actually destroyed and delayed burn is not disabled.
+            // EIP-8246: Track first self-destruction so the account can be cleared (code, storage
+            // and nonce) while preserving its balance at finalization.
+            // Only track when account is actually destroyed and delayed clearing is not disabled.
             if destroyed_status == SelfdestructionRevertStatus::GloballySelfdestroyed
-                && !self.cfg.eip7708_delayed_burn_disabled
+                && !self.cfg.eip8246_delayed_clear_disabled
             {
                 self.selfdestructed_addresses.push(address);
             }
 
             acc.mark_selfdestructed_locally();
-            acc.info.balance = U256::ZERO;
 
-            // EIP-7708: emit appropriate log for selfdestruct
-            if target != address {
-                // Transfer log for balance transferred to different address
+            // `had_balance` records the balance that left the account so it can be restored
+            // on revert.
+            let had_balance = if target != address {
+                // Balance was transferred to target above; zero out the source.
+                acc.info.balance = U256::ZERO;
+                // EIP-7708: transfer log for balance moved to a different address.
                 self.eip7708_transfer_log(address, target, balance);
+                balance
+            } else if spec.is_enabled_in(AMSTERDAM) {
+                // EIP-8246: self-destruct to self no longer burns the balance. The balance is
+                // kept and the account is cleared at finalization
+                // (see `eip8246_clear_selfdestructed_accounts`).
+                U256::ZERO
             } else {
-                // Burn log for selfdestruct to self
-                self.eip7708_burn_log(address, balance);
-            }
+                // Pre-EIP-8246: self-destruct to self burns the balance.
+                acc.info.balance = U256::ZERO;
+                balance
+            };
+
             Some(ENTRY::account_destroyed(
                 address,
                 target,
                 destroyed_status,
-                balance,
+                had_balance,
             ))
         } else if address != target {
             acc.info.balance = U256::ZERO;
@@ -1106,34 +1133,6 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         self.logs.push(Log {
             address: ETH_TRANSFER_LOG_ADDRESS,
             data: LogData::new(topics, data).expect("3 topics is valid"),
-        });
-    }
-
-    /// Creates and pushes an EIP-7708 burn log.
-    ///
-    /// This emits a LOG2 when a contract self-destructs to itself or when a
-    /// self-destructed account still has remaining balance at end of transaction.
-    /// Only emitted if EIP-7708 is enabled (Amsterdam and later) and balance is non-zero.
-    ///
-    /// [EIP-7708](https://eips.ethereum.org/EIPS/eip-7708)
-    #[inline]
-    pub fn eip7708_burn_log(&mut self, address: Address, balance: U256) {
-        // Only emit log if EIP-7708 is enabled and balance is non-zero
-        if !self.cfg.spec.is_enabled_in(AMSTERDAM) || self.cfg.eip7708_disabled || balance.is_zero()
-        {
-            return;
-        }
-
-        // Create LOG2 with Burn(address,uint256) event signature
-        // Topic[0]: Burn event signature
-        // Topic[1]: account address (zero-padded to 32 bytes)
-        // Data: amount in wei (big-endian uint256)
-        let topics = std::vec![BURN_LOG_TOPIC, B256::left_padding_from(address.as_slice()),];
-        let data = Bytes::copy_from_slice(&balance.to_be_bytes::<32>());
-
-        self.logs.push(Log {
-            address: ETH_TRANSFER_LOG_ADDRESS,
-            data: LogData::new(topics, data).expect("2 topics is valid"),
         });
     }
 }

--- a/crates/ee-tests/src/revm_tests.rs
+++ b/crates/ee-tests/src/revm_tests.rs
@@ -435,11 +435,12 @@ const SELFDESTRUCT_TO_SELF_INIT_CODE: &[u8] = &[
     opcode::SELFDESTRUCT,
 ];
 
-/// Test EIP-7708 selfdestruct-to-self log emission
-/// This test creates a contract with value that selfdestructs to itself during construction,
-/// which should emit a SelfBalanceLog since the contract is created in the same tx.
+/// Test EIP-8246 selfdestruct-to-self balance preservation.
+/// This test creates a contract with value that selfdestructs to itself during construction.
+/// Before EIP-8246 this burned the balance and emitted a `Burn` log; with EIP-8246 the balance
+/// is preserved and the account is kept with cleared code, storage and nonce.
 #[test]
-fn test_eip7708_selfdestruct_to_self() {
+fn test_eip8246_selfdestruct_to_self_preserves_balance() {
     let mut evm = Context::mainnet()
         .with_cfg(CfgEnv::new_with_spec(SpecId::AMSTERDAM))
         .modify_block_chained(|block| block.gas_limit = 100_000_000)
@@ -463,21 +464,29 @@ fn test_eip7708_selfdestruct_to_self() {
 
     assert!(result.is_success(), "Transaction should succeed");
 
-    // Find the burn log
+    // EIP-8246: self-destruct to self no longer burns the balance, so no `Burn` log is emitted.
     let logs = result.logs();
     let burn_log = logs
         .iter()
         .find(|log| log.data.topics().len() == 2 && log.data.topics()[0] == BURN_LOG_TOPIC);
-
     assert!(
-        burn_log.is_some(),
-        "Expected burn log, got logs: {:?}",
-        logs
+        burn_log.is_none(),
+        "Expected no burn log, got logs: {logs:?}"
     );
-    let log = burn_log.unwrap();
-    assert_eq!(log.address, ETH_TRANSFER_LOG_ADDRESS);
-    // The log data should contain the create value
-    assert_eq!(log.data.data.as_ref(), &create_value.to_be_bytes::<32>());
+
+    // The created account keeps its balance, while its code, storage and nonce are cleared
+    // and it is no longer marked self-destructed.
+    let created_address = result.created_address().unwrap();
+    let account = evm
+        .ctx
+        .journal_mut()
+        .state
+        .get(&created_address)
+        .expect("self-destructed account should be preserved");
+    assert_eq!(account.info.balance, create_value);
+    assert_eq!(account.info.nonce, 0);
+    assert_eq!(account.info.code_hash, KECCAK_EMPTY);
+    assert!(!account.is_selfdestructed());
 }
 
 /// Bytecode that performs a CALL with value to a specific address

--- a/examples/cheatcode_inspector/src/main.rs
+++ b/examples/cheatcode_inspector/src/main.rs
@@ -137,9 +137,9 @@ impl JournalTr for Backend {
         self.journaled_state.set_spec_id(spec_id);
     }
 
-    fn set_eip7708_config(&mut self, disabled: bool, delayed_burn_disabled: bool) {
+    fn set_eip7708_config(&mut self, disabled: bool, eip8246_delayed_clear_disabled: bool) {
         self.journaled_state
-            .set_eip7708_config(disabled, delayed_burn_disabled);
+            .set_eip7708_config(disabled, eip8246_delayed_clear_disabled);
     }
 
     fn touch_account(&mut self, address: Address) {


### PR DESCRIPTION
## Summary

Implements [EIP-8246: Remove SELFDESTRUCT Burn](https://eips.ethereum.org/EIPS/eip-8246), replacing the EIP-7708 burn-log mechanism.

Under EIP-8246, at transaction finalization a self-destructed account is no longer deleted/burned. Instead its **nonce is reset to 0, code and storage are cleared, and the balance is preserved**. If the resulting balance is `0` the account is empty and is removed by EIP-161 as before.

## Changes

- **Renamed `eip7708_emit_burn_remaining_balance_logs` → `eip8246_clear_selfdestructed_accounts`** (`JournalInner`). Instead of emitting `Burn` logs for self-destructed accounts that still hold a balance, it now clears their code/storage/nonce, keeps the balance, and removes the self-destruct flag so the account is preserved as a balance-only account. Zero-balance accounts keep the flag and are removed (EIP-161).
- **Self-destruct to self** (spec point 1): under Amsterdam the balance is no longer zeroed and no burn log is emitted; the account is cleared at finalization. Pre-Amsterdam behavior is unchanged.
- **Removed the now-dead `eip7708_burn_log` helper** and its `BURN_LOG_TOPIC` use.
- **Renamed the config flag** `eip7708_delayed_burn_disabled` → `eip8246_delayed_clear_disabled` (`CfgEnv` field `amsterdam_eip8246_delayed_clear_disabled`, `Cfg::is_eip8246_delayed_clear_disabled`, and the `JournalCfg` field), since it now gates delayed clearing rather than burn logging.

Because EIP-6780 is always active alongside EIP-8246, only same-tx-created accounts reach this path, so they never have database-resident storage and clearing the in-memory storage is sufficient.

### Gating note
The clear function gates on `AMSTERDAM && !eip8246_delayed_clear_disabled`. The old `eip7708_disabled` (transfer-log toggle) check was dropped from this path, since EIP-8246 is a state change independent of EIP-7708's logging.

## Testing

- Updated `test_eip7708_selfdestruct_to_self` → `test_eip8246_selfdestruct_to_self_preserves_balance`: asserts no burn log and that the created account keeps its balance with cleared code (`KECCAK_EMPTY`), nonce `0`, and no self-destruct flag.
- `cargo build --workspace`, `cargo clippy --workspace --all-targets`, `cargo fmt --all --check`, and `cargo nextest run` (revm-context + revm-ee-tests, 93 tests) all pass.