### PR TITLE
fix(eip-8037): exclude floor and refund from block_regular_gas_used

### DIFF
--- a/crates/context/interface/src/result.rs
+++ b/crates/context/interface/src/result.rs
@@ -63,7 +63,9 @@ impl<R, S> ExecResultAndState<R, S> {
 /// ## Derived values
 ///
 /// - [`tx_gas_used()`](ResultGas::tx_gas_used) = `max(total_gas_spent − refunded, floor_gas)` (the value that goes into receipts)
-/// - [`block_regular_gas_used()`](ResultGas::block_regular_gas_used) = `max(total_gas_spent − state_gas_spent, floor_gas)`
+/// - [`block_regular_gas_used()`](ResultGas::block_regular_gas_used) — EIP-8037 + EIP-7778:
+///   - floor-dominant (`floor_gas ≥ total_gas_spent − refunded`): `tx_gas_used − state_gas_spent`
+///   - refund-dominant: `total_gas_spent − state_gas_spent` (pre-refund; refunds are excluded from block accounting per EIP-7778)
 /// - [`block_state_gas_used()`](ResultGas::block_state_gas_used) = `state_gas_spent`
 /// - [`spent_sub_refunded()`](ResultGas::spent_sub_refunded) = `total_gas_spent − refunded` (before floor gas check)
 /// - [`final_refunded()`](ResultGas::final_refunded) = `refunded` when floor gas is inactive, `0` when floor gas kicks in
@@ -267,13 +269,24 @@ impl ResultGas {
         max(tx_gas_refunded, self.floor_gas())
     }
 
-    /// Returns the regular gas used by the block.
+    /// Returns the regular gas used by the block per EIP-8037 + EIP-7778.
+    ///
+    /// Refunds are excluded from block accounting (EIP-7778). The floor only
+    /// participates when it dominates the post-refund total:
+    ///
+    /// - Floor-dominant (`floor_gas >= total_gas_spent - refunded`):
+    ///   `tx_gas_used - state_gas_spent` (where `tx_gas_used = floor_gas`).
+    /// - Refund-dominant: `total_gas_spent - state_gas_spent` (pre-refund).
     #[inline]
     pub const fn block_regular_gas_used(&self) -> u64 {
-        let execution_gas_spent = self
-            .total_gas_spent()
-            .saturating_sub(self.state_gas_spent_final());
-        max(execution_gas_spent, self.floor_gas())
+        let state_gas = self.state_gas_spent_final();
+        if self.floor_gas() >= self.spent_sub_refunded() {
+            // Floor-dominant: tx_gas_used == floor_gas.
+            self.tx_gas_used().saturating_sub(state_gas)
+        } else {
+            // Refund-dominant: refunds excluded from block accounting.
+            self.total_gas_spent().saturating_sub(state_gas)
+        }
     }
 
     /// Returns the state gas used by the block.
@@ -1383,5 +1396,63 @@ mod tests {
             .with_floor_gas(40000);
         assert_eq!(gas.tx_gas_used(), 40000);
         assert_eq!(gas.final_refunded(), 10000);
+    }
+
+    #[test]
+    fn test_block_regular_gas_used_eip7778_branching() {
+        // Refund-dominant (floor < spent - refunded): pre-refund total minus state.
+        // spent=100k, refunded=10k, floor=20k → after_refund=90k > floor=20k.
+        // block_regular = total - state = 100k - 30k = 70k.
+        let gas = ResultGas::default()
+            .with_total_gas_spent(100_000)
+            .with_refunded(10_000)
+            .with_floor_gas(20_000)
+            .with_state_gas_spent(30_000);
+        assert_eq!(gas.tx_gas_used(), 90_000);
+        assert_eq!(gas.block_regular_gas_used(), 70_000);
+        assert_eq!(gas.block_state_gas_used(), 30_000);
+
+        // Floor-dominant (floor >= spent - refunded): tx_gas_used (=floor) minus state.
+        // spent=100k, refunded=90k, floor=50k → after_refund=10k <= floor=50k.
+        // tx_gas_used = 50k; block_regular = 50k - 30k = 20k.
+        let gas = ResultGas::default()
+            .with_total_gas_spent(100_000)
+            .with_refunded(90_000)
+            .with_floor_gas(50_000)
+            .with_state_gas_spent(30_000);
+        assert_eq!(gas.tx_gas_used(), 50_000);
+        assert_eq!(gas.block_regular_gas_used(), 20_000);
+
+        // No floor, no refund: block_regular = total - state.
+        let gas = ResultGas::default()
+            .with_total_gas_spent(100_000)
+            .with_state_gas_spent(30_000);
+        assert_eq!(gas.block_regular_gas_used(), 70_000);
+
+        // No state gas: block_regular tracks tx_gas_used in floor case,
+        // total in refund case.
+        let gas = ResultGas::default()
+            .with_total_gas_spent(50_000)
+            .with_refunded(10_000);
+        assert_eq!(gas.block_regular_gas_used(), 50_000);
+
+        // Refunds excluded from block accounting (EIP-7778):
+        // even with a non-floor refund, block_regular uses pre-refund total.
+        let gas = ResultGas::default()
+            .with_total_gas_spent(50_000)
+            .with_refunded(10_000)
+            .with_floor_gas(30_000);
+        // after_refund=40k > floor=30k → refund-dominant.
+        assert_eq!(gas.tx_gas_used(), 40_000);
+        assert_eq!(gas.block_regular_gas_used(), 50_000);
+
+        // Floor-dominant edge: state_gas exceeds floor → saturates to 0.
+        let gas = ResultGas::default()
+            .with_total_gas_spent(100_000)
+            .with_refunded(90_000)
+            .with_floor_gas(30_000)
+            .with_state_gas_spent(40_000);
+        assert_eq!(gas.tx_gas_used(), 30_000);
+        assert_eq!(gas.block_regular_gas_used(), 0);
     }
 }

--- a/crates/context/interface/src/result.rs
+++ b/crates/context/interface/src/result.rs
@@ -63,9 +63,8 @@ impl<R, S> ExecResultAndState<R, S> {
 /// ## Derived values
 ///
 /// - [`tx_gas_used()`](ResultGas::tx_gas_used) = `max(total_gas_spent − refunded, floor_gas)` (the value that goes into receipts)
-/// - [`block_regular_gas_used()`](ResultGas::block_regular_gas_used) — EIP-8037 + EIP-7778:
-///   - floor-dominant (`floor_gas ≥ total_gas_spent − refunded`): `tx_gas_used − state_gas_spent`
-///   - refund-dominant: `total_gas_spent − state_gas_spent` (pre-refund; refunds are excluded from block accounting per EIP-7778)
+/// - [`block_regular_gas_used()`](ResultGas::block_regular_gas_used) = `total_gas_spent − state_gas_spent`
+///   (EIP-8037 + EIP-7778: pre-refund; refund and floor only affect `tx_gas_used`, not block-level regular gas)
 /// - [`block_state_gas_used()`](ResultGas::block_state_gas_used) = `state_gas_spent`
 /// - [`spent_sub_refunded()`](ResultGas::spent_sub_refunded) = `total_gas_spent − refunded` (before floor gas check)
 /// - [`final_refunded()`](ResultGas::final_refunded) = `refunded` when floor gas is inactive, `0` when floor gas kicks in
@@ -271,22 +270,13 @@ impl ResultGas {
 
     /// Returns the regular gas used by the block per EIP-8037 + EIP-7778.
     ///
-    /// Refunds are excluded from block accounting (EIP-7778). The floor only
-    /// participates when it dominates the post-refund total:
-    ///
-    /// - Floor-dominant (`floor_gas >= total_gas_spent - refunded`):
-    ///   `tx_gas_used - state_gas_spent` (where `tx_gas_used = floor_gas`).
-    /// - Refund-dominant: `total_gas_spent - state_gas_spent` (pre-refund).
+    /// `total_gas_spent - state_gas_spent` (pre-refund). Refund and floor are
+    /// applied to the combined pre-refund total and only affect `tx_gas_used`
+    /// (the receipt value), not the block-level regular component.
     #[inline]
     pub const fn block_regular_gas_used(&self) -> u64 {
-        let state_gas = self.state_gas_spent_final();
-        if self.floor_gas() >= self.spent_sub_refunded() {
-            // Floor-dominant: tx_gas_used == floor_gas.
-            self.tx_gas_used().saturating_sub(state_gas)
-        } else {
-            // Refund-dominant: refunds excluded from block accounting.
-            self.total_gas_spent().saturating_sub(state_gas)
-        }
+        self.total_gas_spent()
+            .saturating_sub(self.state_gas_spent_final())
     }
 
     /// Returns the state gas used by the block.
@@ -1399,60 +1389,42 @@ mod tests {
     }
 
     #[test]
-    fn test_block_regular_gas_used_eip7778_branching() {
-        // Refund-dominant (floor < spent - refunded): pre-refund total minus state.
-        // spent=100k, refunded=10k, floor=20k → after_refund=90k > floor=20k.
-        // block_regular = total - state = 100k - 30k = 70k.
+    fn test_block_regular_gas_used_no_floor_no_refund() {
+        // block_regular_gas_used = total_gas_spent - state_gas_spent.
+        // Refund and floor only affect tx_gas_used, never block_regular.
+
+        // No state, no refund, no floor.
+        let gas = ResultGas::default().with_total_gas_spent(100_000);
+        assert_eq!(gas.block_regular_gas_used(), 100_000);
+
+        // With state gas.
         let gas = ResultGas::default()
             .with_total_gas_spent(100_000)
-            .with_refunded(10_000)
-            .with_floor_gas(20_000)
             .with_state_gas_spent(30_000);
-        assert_eq!(gas.tx_gas_used(), 90_000);
         assert_eq!(gas.block_regular_gas_used(), 70_000);
         assert_eq!(gas.block_state_gas_used(), 30_000);
 
-        // Floor-dominant (floor >= spent - refunded): tx_gas_used (=floor) minus state.
-        // spent=100k, refunded=90k, floor=50k → after_refund=10k <= floor=50k.
-        // tx_gas_used = 50k; block_regular = 50k - 30k = 20k.
+        // Refund present: tx_gas_used drops, block_regular does not.
+        let gas = ResultGas::default()
+            .with_total_gas_spent(100_000)
+            .with_refunded(10_000)
+            .with_state_gas_spent(30_000);
+        assert_eq!(gas.tx_gas_used(), 90_000);
+        assert_eq!(gas.block_regular_gas_used(), 70_000);
+
+        // Floor active: tx_gas_used floors up, block_regular does not.
         let gas = ResultGas::default()
             .with_total_gas_spent(100_000)
             .with_refunded(90_000)
             .with_floor_gas(50_000)
             .with_state_gas_spent(30_000);
         assert_eq!(gas.tx_gas_used(), 50_000);
-        assert_eq!(gas.block_regular_gas_used(), 20_000);
-
-        // No floor, no refund: block_regular = total - state.
-        let gas = ResultGas::default()
-            .with_total_gas_spent(100_000)
-            .with_state_gas_spent(30_000);
         assert_eq!(gas.block_regular_gas_used(), 70_000);
 
-        // No state gas: block_regular tracks tx_gas_used in floor case,
-        // total in refund case.
+        // State gas exceeds total → saturates to 0.
         let gas = ResultGas::default()
-            .with_total_gas_spent(50_000)
-            .with_refunded(10_000);
-        assert_eq!(gas.block_regular_gas_used(), 50_000);
-
-        // Refunds excluded from block accounting (EIP-7778):
-        // even with a non-floor refund, block_regular uses pre-refund total.
-        let gas = ResultGas::default()
-            .with_total_gas_spent(50_000)
-            .with_refunded(10_000)
-            .with_floor_gas(30_000);
-        // after_refund=40k > floor=30k → refund-dominant.
-        assert_eq!(gas.tx_gas_used(), 40_000);
-        assert_eq!(gas.block_regular_gas_used(), 50_000);
-
-        // Floor-dominant edge: state_gas exceeds floor → saturates to 0.
-        let gas = ResultGas::default()
-            .with_total_gas_spent(100_000)
-            .with_refunded(90_000)
-            .with_floor_gas(30_000)
-            .with_state_gas_spent(40_000);
-        assert_eq!(gas.tx_gas_used(), 30_000);
+            .with_total_gas_spent(20_000)
+            .with_state_gas_spent(30_000);
         assert_eq!(gas.block_regular_gas_used(), 0);
     }
 }


### PR DESCRIPTION
## Summary

Updates `block_regular_gas_used` to the pre-refund regular component of execution per EIP-8037 + EIP-7778:

```
block_regular_gas_used = total_gas_spent - state_gas_spent
```

Refund and floor are scalar adjustments on the combined `state + regular` total — they only affect the receipt's `tx_gas_used`, not the block-level split.

**Before:** `max(total_gas_spent - state_gas_spent, floor_gas)` — floor was applied as a `max(...)` against the regular component, which incorrectly attributed floor charge to regular block gas.

## Test plan
- [x] `cargo nextest run --workspace` — 348/348 pass
- [x] `cargo nextest run -p revm-ee-tests` — 60/60 EIP-8037 tests pass
- [x] `cargo clippy -p revm-context-interface --all-targets` — clean
- [x] `cargo fmt --all --check` — clean
- [x] New unit test `test_block_regular_gas_used_no_floor_no_refund` confirms refund and floor never affect block_regular_gas_used, only tx_gas_used