### PR TITLE
chore: release prep — bump all crates with unpublished changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3706,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "40.0.2"
+version = "40.0.3"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3726,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "18.0.2"
+version = "18.0.3"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "19.0.2"
+version = "19.0.3"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "15.0.1"
+version = "15.0.2"
 dependencies = [
  "alloy-eips",
  "alloy-provider",
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "12.1.0"
+version = "12.1.1"
 dependencies = [
  "auto_impl",
  "either",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "20.0.2"
+version = "20.0.3"
 dependencies = [
  "alloy-signer",
  "alloy-signer-local",
@@ -3828,7 +3828,7 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "21.0.2"
+version = "21.0.3"
 dependencies = [
  "auto_impl",
  "either",
@@ -3845,7 +3845,7 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "37.0.2"
+version = "37.0.3"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3857,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3887,7 +3887,7 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -3896,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "12.0.0"
+version = "12.0.1"
 dependencies = [
  "alloy-eip7928 0.4.0",
  "bitflags",
@@ -3909,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "revm-statetest-types"
-version = "19.0.2"
+version = "19.0.3"
 dependencies = [
  "alloy-eip7928 0.4.0",
  "k256",
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "revme"
-version = "17.0.2"
+version = "17.0.3"
 dependencies = [
  "alloy-rlp",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,19 +41,19 @@ default-members = ["crates/revm"]
 
 [workspace.dependencies]
 # revm
-revm = { path = "crates/revm", version = "40.0.2", default-features = false }
-primitives = { path = "crates/primitives", package = "revm-primitives", version = "24.0.0", default-features = false }
-bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "11.0.0", default-features = false }
-database = { path = "crates/database", package = "revm-database", version = "15.0.1", default-features = false }
-database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "12.1.0", default-features = false }
-state = { path = "crates/state", package = "revm-state", version = "12.0.0", default-features = false }
-interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "37.0.2", default-features = false }
-inspector = { path = "crates/inspector", package = "revm-inspector", version = "21.0.2", default-features = false }
-precompile = { path = "crates/precompile", package = "revm-precompile", version = "36.0.2", default-features = false }
-statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "19.0.2", default-features = false }
-context = { path = "crates/context", package = "revm-context", version = "18.0.2", default-features = false }
-context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "19.0.2", default-features = false }
-handler = { path = "crates/handler", package = "revm-handler", version = "20.0.2", default-features = false }
+revm = { path = "crates/revm", version = "40.0.3", default-features = false }
+primitives = { path = "crates/primitives", package = "revm-primitives", version = "24.0.1", default-features = false }
+bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "11.0.1", default-features = false }
+database = { path = "crates/database", package = "revm-database", version = "15.0.2", default-features = false }
+database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "12.1.1", default-features = false }
+state = { path = "crates/state", package = "revm-state", version = "12.0.1", default-features = false }
+interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "37.0.3", default-features = false }
+inspector = { path = "crates/inspector", package = "revm-inspector", version = "21.0.3", default-features = false }
+precompile = { path = "crates/precompile", package = "revm-precompile", version = "36.0.3", default-features = false }
+statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "19.0.3", default-features = false }
+context = { path = "crates/context", package = "revm-context", version = "18.0.3", default-features = false }
+context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "19.0.3", default-features = false }
+handler = { path = "crates/handler", package = "revm-handler", version = "20.0.3", default-features = false }
 ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "0.3.0", default-features = false }
 
 # alloy

--- a/bins/revme/CHANGELOG.md
+++ b/bins/revme/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [17.0.3](https://github.com/bluealloy/revm/compare/revme-v17.0.2...revme-v17.0.3) - 2026-05-26
+
+### Other
+
+- updated the following local packages: revm
+
 ## [17.0.2](https://github.com/bluealloy/revm/compare/revme-v17.0.1...revme-v17.0.2) - 2026-05-22
 
 ### Other

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revme"
 description = "Rust Ethereum Virtual Machine Executable"
-version = "17.0.2"
+version = "17.0.3"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/bytecode/CHANGELOG.md
+++ b/crates/bytecode/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.0.1](https://github.com/bluealloy/revm/compare/revm-bytecode-v11.0.0...revm-bytecode-v11.0.1) - 2026-05-26
+
+### Other
+
+- mark RETURN and REVERT as memory-modifying ([#3703](https://github.com/bluealloy/revm/pull/3703))
+
 ## [11.0.0](https://github.com/bluealloy/revm/compare/revm-bytecode-v10.0.0...revm-bytecode-v11.0.0) - 2026-05-19
 
 ### Fixed

--- a/crates/bytecode/Cargo.toml
+++ b/crates/bytecode/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-bytecode"
 description = "EVM Bytecodes"
-version = "11.0.0"
+version = "11.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/context/CHANGELOG.md
+++ b/crates/context/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [18.0.3](https://github.com/bluealloy/revm/compare/revm-context-v18.0.2...revm-context-v18.0.3) - 2026-05-26
+
+### Added
+
+- Bake EIP-8037 CPSB into gas params ([#3714](https://github.com/bluealloy/revm/pull/3714))
+
 ## [18.0.2](https://github.com/bluealloy/revm/compare/revm-context-v18.0.1...revm-context-v18.0.2) - 2026-05-22
 
 ### Other

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-context"
 description = "Revm context crates"
-version = "18.0.2"
+version = "18.0.3"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/context/interface/CHANGELOG.md
+++ b/crates/context/interface/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [19.0.3](https://github.com/bluealloy/revm/compare/revm-context-interface-v19.0.2...revm-context-interface-v19.0.3) - 2026-05-26
+
+### Added
+
+- Bake EIP-8037 CPSB into gas params ([#3714](https://github.com/bluealloy/revm/pull/3714))
+
 ## [19.0.2](https://github.com/bluealloy/revm/compare/revm-context-interface-v19.0.1...revm-context-interface-v19.0.2) - 2026-05-22
 
 ### Other

--- a/crates/context/interface/Cargo.toml
+++ b/crates/context/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-context-interface"
 description = "Revm context interface crates"
-version = "19.0.2"
+version = "19.0.3"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/database/CHANGELOG.md
+++ b/crates/database/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.2](https://github.com/bluealloy/revm/compare/revm-database-v15.0.1...revm-database-v15.0.2) - 2026-05-26
+
+### Added
+
+- add `OnStateHook` for `State<DB>` ([#3710](https://github.com/bluealloy/revm/pull/3710))
+
 ## [15.0.1](https://github.com/bluealloy/revm/compare/revm-database-v15.0.0...revm-database-v15.0.1) - 2026-05-22
 
 ### Other

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-database"
 description = "Revm Database implementations"
-version = "15.0.1"
+version = "15.0.2"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/database/interface/CHANGELOG.md
+++ b/crates/database/interface/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [12.1.1](https://github.com/bluealloy/revm/compare/revm-database-interface-v12.1.0...revm-database-interface-v12.1.1) - 2026-05-26
+
+### Added
+
+- add `OnStateHook` for `State<DB>` ([#3710](https://github.com/bluealloy/revm/pull/3710))
+
 ## [12.1.0](https://github.com/bluealloy/revm/compare/revm-database-interface-v12.0.0...revm-database-interface-v12.1.0) - 2026-05-22
 
 ### Added

--- a/crates/database/interface/Cargo.toml
+++ b/crates/database/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-database-interface"
 description = "Revm Database interface"
-version = "12.1.0"
+version = "12.1.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/handler/CHANGELOG.md
+++ b/crates/handler/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [20.0.3](https://github.com/bluealloy/revm/compare/revm-handler-v20.0.2...revm-handler-v20.0.3) - 2026-05-26
+
+### Added
+
+- Bake EIP-8037 CPSB into gas params ([#3714](https://github.com/bluealloy/revm/pull/3714))
+
 ## [20.0.2](https://github.com/bluealloy/revm/compare/revm-handler-v20.0.1...revm-handler-v20.0.2) - 2026-05-22
 
 ### Other

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-handler"
 description = "Revm handler crates"
-version = "20.0.2"
+version = "20.0.3"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/inspector/CHANGELOG.md
+++ b/crates/inspector/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [21.0.3](https://github.com/bluealloy/revm/compare/revm-inspector-v21.0.2...revm-inspector-v21.0.3) - 2026-05-26
+
+### Added
+
+- Bake EIP-8037 CPSB into gas params ([#3714](https://github.com/bluealloy/revm/pull/3714))
+
 ## [21.0.2](https://github.com/bluealloy/revm/compare/revm-inspector-v21.0.1...revm-inspector-v21.0.2) - 2026-05-22
 
 ### Other

--- a/crates/inspector/Cargo.toml
+++ b/crates/inspector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-inspector"
 description = "Revm inspector interface"
-version = "21.0.2"
+version = "21.0.3"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [37.0.3](https://github.com/bluealloy/revm/compare/revm-interpreter-v37.0.2...revm-interpreter-v37.0.3) - 2026-05-26
+
+### Added
+
+- Bake EIP-8037 CPSB into gas params ([#3714](https://github.com/bluealloy/revm/pull/3714))
+
 ## [37.0.2](https://github.com/bluealloy/revm/compare/revm-interpreter-v37.0.1...revm-interpreter-v37.0.2) - 2026-05-22
 
 ### Other

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-interpreter"
 description = "Revm Interpreter that executes bytecode."
-version = "37.0.2"
+version = "37.0.3"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/precompile/CHANGELOG.md
+++ b/crates/precompile/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [36.0.3](https://github.com/bluealloy/revm/compare/revm-precompile-v36.0.2...revm-precompile-v36.0.3) - 2026-05-26
+
+### Other
+
+- updated the following local packages: revm-primitives, revm-context-interface
+
 ## [36.0.2](https://github.com/bluealloy/revm/compare/revm-precompile-v36.0.1...revm-precompile-v36.0.2) - 2026-05-22
 
 ### Other

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-precompile"
 description = "Revm Precompiles - Ethereum compatible precompiled contracts"
-version = "36.0.2"
+version = "36.0.3"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/primitives/CHANGELOG.md
+++ b/crates/primitives/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [24.0.1](https://github.com/bluealloy/revm/compare/revm-primitives-v24.0.0...revm-primitives-v24.0.1) - 2026-05-26
+
+### Other
+
+- explain CPSB acronym ([#3716](https://github.com/bluealloy/revm/pull/3716))
+
 ## [24.0.0](https://github.com/bluealloy/revm/compare/revm-primitives-v23.0.0...revm-primitives-v24.0.0) - 2026-05-19
 
 ### Added

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-primitives"
 description = "Revm primitives types"
-version = "24.0.0"
+version = "24.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/revm/CHANGELOG.md
+++ b/crates/revm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [40.0.3](https://github.com/bluealloy/revm/compare/revm-v40.0.2...revm-v40.0.3) - 2026-05-26
+
+### Other
+
+- updated the following local packages: revm-database, revm-context, revm-handler, revm-inspector, revm-statetest-types
+
 ## [40.0.2](https://github.com/bluealloy/revm/compare/revm-v40.0.1...revm-v40.0.2) - 2026-05-22
 
 ### Other

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm"
 description = "Revm - Rust Ethereum Virtual Machine"
-version = "40.0.2"
+version = "40.0.3"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/state/CHANGELOG.md
+++ b/crates/state/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [12.0.1](https://github.com/bluealloy/revm/compare/revm-state-v12.0.0...revm-state-v12.0.1) - 2026-05-26
+
+### Other
+
+- updated the following local packages: revm-primitives, revm-bytecode
+
 ## [12.0.0](https://github.com/bluealloy/revm/compare/revm-state-v11.0.1...revm-state-v12.0.0) - 2026-05-19
 
 ### Added

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-state"
 description = "Revm state types"
-version = "12.0.0"
+version = "12.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/statetest-types/CHANGELOG.md
+++ b/crates/statetest-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [19.0.3](https://github.com/bluealloy/revm/compare/revm-statetest-types-v19.0.2...revm-statetest-types-v19.0.3) - 2026-05-26
+
+### Other
+
+- updated the following local packages: revm-database, revm-context
+
 ## [19.0.2](https://github.com/bluealloy/revm/compare/revm-statetest-types-v19.0.1...revm-statetest-types-v19.0.2) - 2026-05-22
 
 ### Other

--- a/crates/statetest-types/Cargo.toml
+++ b/crates/statetest-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-statetest-types"
 description = "Statetest types for revme"
-version = "19.0.2"
+version = "19.0.3"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
## Summary

Completes the release version bumps. The prior release-plz run only bumped **7 crates** (`revm-database` + its dependents), but several crates had **unpublished source changes** still sitting on their already-published crates.io versions. Verified by comparing local `HEAD` source directly against the published `.crate` files (e.g. `revm-context-interface` differed from published 19.0.2 by 211 lines — the `initial_tx_gas_for_tx` method was missing).

## Crates added to the bump list (7)

| Crate | Bump | Reason |
|-------|------|--------|
| `revm-context-interface` | 19.0.2 → 19.0.3 | #3714 (CPSB) |
| `revm-interpreter` | 37.0.2 → 37.0.3 | #3714 (CPSB) |
| `revm-bytecode` | 11.0.0 → 11.0.1 | #3703 (RETURN/REVERT memory-modifying) |
| `revm-database-interface` | 12.1.0 → 12.1.1 | #3710 (`OnStateHook`) |
| `revm-precompile` | 36.0.2 → 36.0.3 | cascade (primitives, context-interface) |
| `revm-primitives` | 24.0.0 → 24.0.1 | #3716 (docs comment) |
| `revm-state` | 12.0.0 → 12.0.1 | cascade (primitives, bytecode) |

Already bumped by release-plz: `revm-database` 15.0.2, `revm-context` 18.0.3, `revm-handler` 20.0.3, `revm-inspector` 21.0.3, `revm-statetest-types` 19.0.3, `revm` 40.0.3, `revme` 17.0.3.

## Why release-plz missed them

The repo uses **global** `v###` tags, but release-plz's default baseline is **per-crate** `<pkg>-v<version>` tags (which don't exist). With no per-crate baseline, its only reliable change signal was `cargo-semver-checks`, which flagged `revm-database` but not the others. Detection was done here by direct crates.io content comparison instead.

## Verification

- All 14 crates bumped (patch); root `workspace.dependencies` refs + `Cargo.lock` synced.
- `cargo check --workspace` passes.

> Note: the cascade "updated the following local packages" lists in `revm`/`revme`/`statetest-types` were generated by release-plz before the extra crates were added and may not enumerate every newly-bumped dep. Versions/lock are correct.