### PR TITLE
docs: add v112 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
 
+# v112
+date: 26.05.2026
+
+Maintenance release bundling the EIP-8037 (CPSB) gas-param work and a few utility additions. Highlights:
+* Bake EIP-8037 CPSB into gas params ([#3714](https://github.com/bluealloy/revm/pull/3714))
+* Add `OnStateHook` for `State<DB>` ([#3710](https://github.com/bluealloy/revm/pull/3710))
+* Mark `RETURN` and `REVERT` as memory-modifying ([#3703](https://github.com/bluealloy/revm/pull/3703))
+* Explain the CPSB acronym in docs ([#3716](https://github.com/bluealloy/revm/pull/3716))
+
+* `revm-primitives`: 24.0.0 -> 24.0.1 (✓ API compatible changes)
+* `revm-bytecode`: 11.0.0 -> 11.0.1 (✓ API compatible changes)
+* `revm-database-interface`: 12.1.0 -> 12.1.1 (✓ API compatible changes)
+* `revm-context-interface`: 19.0.2 -> 19.0.3 (✓ API compatible changes)
+* `revm-state`: 12.0.0 -> 12.0.1 (✓ dependency bump)
+* `revm-context`: 18.0.2 -> 18.0.3 (✓ dependency bump)
+* `revm-database`: 15.0.1 -> 15.0.2 (✓ dependency bump)
+* `revm-interpreter`: 37.0.2 -> 37.0.3 (✓ API compatible changes)
+* `revm-precompile`: 36.0.2 -> 36.0.3 (✓ dependency bump)
+* `revm-handler`: 20.0.2 -> 20.0.3 (✓ dependency bump)
+* `revm-inspector`: 21.0.2 -> 21.0.3 (✓ dependency bump)
+* `revm-statetest-types`: 19.0.2 -> 19.0.3 (✓ dependency bump)
+* `revm`: 40.0.2 -> 40.0.3 (✓ dependency bump)
+* `revme`: 17.0.2 -> 17.0.3 (✓ dependency bump)
+
 # v111
 date: 22.05.2026
 


### PR DESCRIPTION
## Summary

Adds the consolidated **v112** entry to the root `CHANGELOG.md` (above `v111`), matching the existing format — prose highlights followed by per-crate version bumps with semver annotations.

v112 (date: 26.05.2026) bundles 4 source changes plus cascade dependency bumps:

| Change | PR | Crates with source changes |
|---|---|---|
| Bake EIP-8037 CPSB into gas params | #3714 | `revm-context-interface`, `revm-interpreter` |
| Add `OnStateHook` for `State<DB>` | #3710 | `revm-database-interface` |
| Mark `RETURN`/`REVERT` memory-modifying | #3703 | `revm-bytecode` |
| Explain CPSB acronym (docs) | #3716 | `revm-primitives` |

All 14 crates were bumped at the patch level (no breaking changes); the remaining 9 are pure dependency-cascade bumps. `revm-ee-tests` (0.3.0) was not bumped, consistent with the release-prep commit (#3721).

The per-crate `CHANGELOG.md` files were already generated by release-plz in the release-prep commit, so this only adds the top-level summary entry.