### PR TITLE
feat: `Account::is_changed`

### DIFF
--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -203,9 +203,10 @@ impl Account {
     /// Returns true if account info was changed.
     #[inline]
     pub fn is_changed(&self) -> bool {
-        self.original_info
-            .as_deref()
-            .map_or(!self.info.is_default(), |original| self.info != *original)
+        self.original_info.as_deref().map_or_else(
+            || !self.info.is_default(),
+            |original| self.info != *original,
+        )
     }
 
     /// Marks the account as newly created.

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -200,6 +200,14 @@ impl Account {
         self.status.contains(AccountStatus::Touched)
     }
 
+    /// Returns true if account info was changed.
+    #[inline]
+    pub fn is_changed(&self) -> bool {
+        self.original_info
+            .as_deref()
+            .map_or(!self.info.is_default(), |original| self.info != *original)
+    }
+
     /// Marks the account as newly created.
     #[inline]
     pub fn mark_created(&mut self) {


### PR DESCRIPTION
Adds `is_changed` helper that allows to know if account's info has changed vs original one without cloning the original info