### PR TITLE
feat(database): add conditional bundle update builder

### DIFF
--- a/crates/database/src/states/state_builder.rs
+++ b/crates/database/src/states/state_builder.rs
@@ -112,6 +112,14 @@ impl<DB: Database> StateBuilder<DB> {
         }
     }
 
+    /// Conditionally makes transitions and updates bundle state.
+    pub fn with_bundle_update_if(self, enable: bool) -> Self {
+        Self {
+            with_bundle_update: enable,
+            ..self
+        }
+    }
+
     /// It will use different cache for the state.
     ///
     /// **Note**: If set, it will ignore bundle prestate.


### PR DESCRIPTION
## Summary
- add `StateBuilder::with_bundle_update_if(bool)` for conditional bundle update configuration
- cover the true and false builder paths with a focused database state test

## Impact
Callers can pass an existing boolean into the builder without branching around `with_bundle_update()`.