### PR TITLE
chore(database): use Option::filter in BundleAccount::take_info_revert

### DIFF
--- a/crates/database/src/states/bundle_account.rs
+++ b/crates/database/src/states/bundle_account.rs
@@ -372,6 +372,6 @@ impl BundleAccount {
             }
         };
 
-        account_revert.and_then(|acc| if acc.is_empty() { None } else { Some(acc) })
+        account_revert.filter(|acc| !acc.is_empty())
     }
 }


### PR DESCRIPTION
## Summary

Replace

```rust
account_revert.and_then(|acc| if acc.is_empty() { None } else { Some(acc) })
```

with the equivalent

```rust
account_revert.filter(|acc| !acc.is_empty())
```

in `BundleAccount::take_info_revert` (`crates/database/src/states/bundle_account.rs`).

## Motivation

`Option::filter` is the canonical form for "keep the value if a
predicate holds, otherwise turn `Some` into `None`". The `and_then` form
was flagged downstream when running `cargo clippy -- -D warnings`
against this crate from a vendored snapshot; this PR upstreams the fix
so the same change does not have to be re-applied on every sync.

## Verification

```bash
cargo fmt --check -p revm-database
cargo clippy -p revm-database --all-targets --all-features -- -D warnings
```

Both clean on the changed file.

No behaviour change — `filter` and the old `and_then` form are
semantically identical for this input.
