### PR TITLE
perf: avoid reallocations and cloning during commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3776,6 +3776,7 @@ dependencies = [
  "alloy-provider",
  "alloy-transport",
  "derive_more",
+ "either",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -23,6 +23,7 @@ primitives.workspace = true
 database-interface.workspace = true
 bytecode.workspace = true
 derive_more.workspace = true
+either.workspace = true
 
 # Optional
 serde = { workspace = true, features = ["derive", "rc"], optional = true }

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -48,6 +48,7 @@ std = [
 	"bytecode/std",
 	"database-interface/std",
 	"derive_more/std",
+	"either/std",
 	"primitives/std",
 	"state/std",
 	"serde_json/std",
@@ -59,6 +60,7 @@ serde = [
 	"database-interface/serde",
 	"primitives/serde",
 	"state/serde",
+	"either/serde",
 ]
 alloydb = [
 	"std",

--- a/crates/database/interface/src/state_hook.rs
+++ b/crates/database/interface/src/state_hook.rs
@@ -5,14 +5,14 @@ use crate::state::EvmState;
 /// A hook that is called when state changes are committed.
 pub trait OnStateHook: Send + 'static {
     /// Invoked with the state being committed.
-    fn on_state(&mut self, state: &EvmState);
+    fn on_state(&mut self, state: EvmState);
 }
 
 impl<F> OnStateHook for F
 where
-    F: FnMut(&EvmState) + Send + 'static,
+    F: FnMut(EvmState) + Send + 'static,
 {
-    fn on_state(&mut self, state: &EvmState) {
+    fn on_state(&mut self, state: EvmState) {
         self(state)
     }
 }
@@ -23,5 +23,5 @@ where
 pub struct NoopHook;
 
 impl OnStateHook for NoopHook {
-    fn on_state(&mut self, _state: &EvmState) {}
+    fn on_state(&mut self, _state: EvmState) {}
 }

--- a/crates/database/src/states/cache.rs
+++ b/crates/database/src/states/cache.rs
@@ -4,7 +4,7 @@ use super::{
 use bytecode::Bytecode;
 use primitives::{hash_map, Address, AddressMap, B256Map, HashMap};
 use state::{Account, AccountInfo, EvmStorage};
-use std::vec::Vec;
+use std::{borrow::Cow, vec::Vec};
 
 /// Cache state contains both modified and original values
 ///
@@ -88,15 +88,23 @@ impl CacheState {
 
     /// Applies output of revm execution and create account transitions that are used to build BundleState.
     #[inline]
-    pub fn apply_evm_state<'a, F>(
+    pub fn apply_evm_state<F>(
         &mut self,
-        evm_state: impl IntoIterator<Item = (Address, &'a Account)>,
-        inspect: F,
-    ) -> Vec<(Address, TransitionAccount<Option<&'a EvmStorage>>)>
+        evm_state: impl IntoIterator<Item = (Address, Account)>,
+        mut inspect: F,
+    ) -> Vec<(Address, TransitionAccount<Option<Cow<'_, EvmStorage>>>)>
     where
         F: FnMut(&Address, &Account),
     {
-        self.apply_evm_state_iter(evm_state, inspect).collect()
+        self.apply_evm_state_iter(
+            evm_state
+                .into_iter()
+                .map(|(address, account)| (address, Cow::Owned(account))),
+            |address, account| {
+                inspect(address, account);
+            },
+        )
+        .collect()
     }
 
     /// Applies output of revm execution and creates an iterator of account transitions.
@@ -105,13 +113,14 @@ impl CacheState {
         &'b mut self,
         evm_state: T,
         mut inspect: F,
-    ) -> impl Iterator<Item = (Address, TransitionAccount<Option<&'a EvmStorage>>)> + use<'a, 'b, F, T>
+    ) -> impl Iterator<Item = (Address, TransitionAccount<Option<Cow<'a, EvmStorage>>>)>
+           + use<'a, 'b, F, T>
     where
-        F: FnMut(&Address, &'a Account),
-        T: IntoIterator<Item = (Address, &'a Account)>,
+        F: FnMut(&Address, &Cow<'a, Account>),
+        T: IntoIterator<Item = (Address, Cow<'a, Account>)>,
     {
         evm_state.into_iter().filter_map(move |(address, account)| {
-            inspect(&address, account);
+            inspect(&address, &account);
             self.apply_account_state(address, account)
                 .map(move |transition| (address, transition))
         })
@@ -182,8 +191,8 @@ impl CacheState {
     pub(crate) fn apply_account_state<'a>(
         &mut self,
         address: Address,
-        account: &'a Account,
-    ) -> Option<TransitionAccount<Option<&'a EvmStorage>>> {
+        account: Cow<'a, Account>,
+    ) -> Option<TransitionAccount<Option<Cow<'a, EvmStorage>>>> {
         // Not touched account are never changed.
         if !account.is_touched() {
             return None;

--- a/crates/database/src/states/cache.rs
+++ b/crates/database/src/states/cache.rs
@@ -88,11 +88,11 @@ impl CacheState {
 
     /// Applies output of revm execution and create account transitions that are used to build BundleState.
     #[inline]
-    pub fn apply_evm_state<F>(
+    pub fn apply_evm_state<'a, F>(
         &mut self,
-        evm_state: impl IntoIterator<Item = (Address, Account)>,
+        evm_state: impl IntoIterator<Item = (Address, &'a Account)>,
         inspect: F,
-    ) -> Vec<(Address, TransitionAccount<EvmStorage>)>
+    ) -> Vec<(Address, TransitionAccount<Option<&'a EvmStorage>>)>
     where
         F: FnMut(&Address, &Account),
     {
@@ -101,19 +101,19 @@ impl CacheState {
 
     /// Applies output of revm execution and creates an iterator of account transitions.
     #[inline]
-    pub(crate) fn apply_evm_state_iter<'a, F, T>(
-        &'a mut self,
+    pub(crate) fn apply_evm_state_iter<'a, 'b, F, T>(
+        &'b mut self,
         evm_state: T,
         mut inspect: F,
-    ) -> impl Iterator<Item = (Address, TransitionAccount<EvmStorage>)> + use<'a, F, T>
+    ) -> impl Iterator<Item = (Address, TransitionAccount<Option<&'a EvmStorage>>)> + use<'a, 'b, F, T>
     where
-        F: FnMut(&Address, &Account),
-        T: IntoIterator<Item = (Address, Account)>,
+        F: FnMut(&Address, &'a Account),
+        T: IntoIterator<Item = (Address, &'a Account)>,
     {
         evm_state.into_iter().filter_map(move |(address, account)| {
-            inspect(&address, &account);
+            inspect(&address, account);
             self.apply_account_state(address, account)
-                .map(|transition| (address, transition))
+                .map(move |transition| (address, transition))
         })
     }
 
@@ -179,11 +179,11 @@ impl CacheState {
     /// Applies updated account state to the cached account.
     ///
     /// Returns account transition if applicable.
-    pub(crate) fn apply_account_state(
+    pub(crate) fn apply_account_state<'a>(
         &mut self,
         address: Address,
-        account: Account,
-    ) -> Option<TransitionAccount<EvmStorage>> {
+        account: &'a Account,
+    ) -> Option<TransitionAccount<Option<&'a EvmStorage>>> {
         // Not touched account are never changed.
         if !account.is_touched() {
             return None;

--- a/crates/database/src/states/cache.rs
+++ b/crates/database/src/states/cache.rs
@@ -3,7 +3,7 @@ use super::{
 };
 use bytecode::Bytecode;
 use primitives::{hash_map, Address, AddressMap, B256Map, HashMap};
-use state::{Account, AccountInfo};
+use state::{Account, AccountInfo, EvmStorage};
 use std::vec::Vec;
 
 /// Cache state contains both modified and original values
@@ -92,7 +92,7 @@ impl CacheState {
         &mut self,
         evm_state: impl IntoIterator<Item = (Address, Account)>,
         inspect: F,
-    ) -> Vec<(Address, TransitionAccount)>
+    ) -> Vec<(Address, TransitionAccount<EvmStorage>)>
     where
         F: FnMut(&Address, &Account),
     {
@@ -105,7 +105,7 @@ impl CacheState {
         &'a mut self,
         evm_state: T,
         mut inspect: F,
-    ) -> impl Iterator<Item = (Address, TransitionAccount)> + use<'a, F, T>
+    ) -> impl Iterator<Item = (Address, TransitionAccount<EvmStorage>)> + use<'a, F, T>
     where
         F: FnMut(&Address, &Account),
         T: IntoIterator<Item = (Address, Account)>,
@@ -183,7 +183,7 @@ impl CacheState {
         &mut self,
         address: Address,
         account: Account,
-    ) -> Option<TransitionAccount> {
+    ) -> Option<TransitionAccount<EvmStorage>> {
         // Not touched account are never changed.
         if !account.is_touched() {
             return None;
@@ -217,14 +217,6 @@ impl CacheState {
         let is_created = account.is_created();
         let is_empty = account.is_empty();
 
-        // Transform evm storage to storage with previous value.
-        let changed_storage = account
-            .storage
-            .into_iter()
-            .filter(|(_, slot)| slot.is_changed())
-            .map(|(key, slot)| (key, slot.into()))
-            .collect();
-
         // Note: It can happen that created contract get selfdestructed in same block
         // that is why is_created is checked after selfdestructed
         //
@@ -234,7 +226,7 @@ impl CacheState {
         // by just setting storage inside CRATE constructor. Overlap of those contracts
         // is not possible because CREATE2 is introduced later.
         if is_created {
-            return Some(this_account.newly_created(account.info, changed_storage));
+            return Some(this_account.newly_created(account));
         }
 
         // Account is touched, but not selfdestructed or newly created.
@@ -246,7 +238,7 @@ impl CacheState {
             // Pre-EIP-161 behavior is handled by the journal in `finalize()`.
             this_account.touch_empty_eip161()
         } else {
-            Some(this_account.change(account.info, changed_storage))
+            Some(this_account.change(account))
         }
     }
 }

--- a/crates/database/src/states/cache_account.rs
+++ b/crates/database/src/states/cache_account.rs
@@ -1,9 +1,8 @@
 use super::{
-    plain_account::PlainStorage, AccountStatus, BundleAccount, PlainAccount,
-    StorageWithOriginalValues, TransitionAccount,
+    plain_account::PlainStorage, AccountStatus, BundleAccount, PlainAccount, TransitionAccount,
 };
 use primitives::{HashMap, StorageKey, StorageValue, U256};
-use state::AccountInfo;
+use state::{Account, AccountInfo, EvmStorage};
 
 /// Cache account contains plain state that gets updated
 /// at every transaction when evm output is applied to CacheState.
@@ -119,7 +118,7 @@ impl CacheAccount {
     /// Touch empty account, related to EIP-161 state clear.
     ///
     /// This account returns the Transition that is used to create the BundleState.
-    pub fn touch_empty_eip161(&mut self) -> Option<TransitionAccount> {
+    pub fn touch_empty_eip161(&mut self) -> Option<TransitionAccount<EvmStorage>> {
         let previous_status = self.status;
 
         // Set account to None.
@@ -150,7 +149,7 @@ impl CacheAccount {
     /// Consumes self and make account as destroyed.
     ///
     /// Sets account as None and set status to Destroyer or DestroyedAgain.
-    pub fn selfdestruct(&mut self) -> Option<TransitionAccount> {
+    pub fn selfdestruct(&mut self) -> Option<TransitionAccount<EvmStorage>> {
         // Account should be None after selfdestruct so we can take it.
         let previous_info = self.account.take().map(|a| a.info);
         let previous_status = self.status;
@@ -172,30 +171,27 @@ impl CacheAccount {
     }
 
     /// Newly created account.
-    pub fn newly_created(
-        &mut self,
-        new_info: AccountInfo,
-        new_storage: StorageWithOriginalValues,
-    ) -> TransitionAccount {
+    pub fn newly_created(&mut self, account: Account) -> TransitionAccount<EvmStorage> {
         let previous_status = self.status;
         let previous_info = self.account.take().map(|a| a.info);
 
-        let new_bundle_storage = new_storage
+        let new_bundle_storage = account
+            .storage
             .iter()
-            .map(|(k, s)| (*k, s.present_value))
+            .filter_map(|(k, s)| s.is_changed().then_some((*k, s.present_value)))
             .collect();
 
         self.status = self.status.on_created();
         let transition_account = TransitionAccount {
-            info: Some(new_info.clone()),
+            info: Some(account.info.clone()),
             status: self.status,
             previous_status,
             previous_info,
-            storage: new_storage,
+            storage: account.storage,
             storage_was_destroyed: false,
         };
         self.account = Some(PlainAccount {
-            info: new_info,
+            info: account.info,
             storage: new_bundle_storage,
         });
         transition_account
@@ -258,11 +254,7 @@ impl CacheAccount {
     /// Updates the account with new information and storage changes.
     ///
     /// Merges the provided storage values with the existing storage and updates the account status.
-    pub fn change(
-        &mut self,
-        new: AccountInfo,
-        storage: StorageWithOriginalValues,
-    ) -> TransitionAccount {
+    pub fn change(&mut self, account: Account) -> TransitionAccount<EvmStorage> {
         let previous_status = self.status;
         let (previous_info, mut this_storage) = if let Some(account) = self.account.take() {
             (Some(account.info), account.storage)
@@ -270,9 +262,14 @@ impl CacheAccount {
             (None, Default::default())
         };
 
-        this_storage.extend(storage.iter().map(|(k, s)| (*k, s.present_value)));
+        this_storage.extend(
+            account
+                .storage
+                .iter()
+                .filter_map(|(k, s)| s.is_changed().then_some((*k, s.present_value))),
+        );
         let changed_account = PlainAccount {
-            info: new,
+            info: account.info,
             storage: this_storage,
         };
 
@@ -288,7 +285,7 @@ impl CacheAccount {
             status: self.status,
             previous_info,
             previous_status,
-            storage,
+            storage: account.storage,
             storage_was_destroyed: false,
         }
     }

--- a/crates/database/src/states/cache_account.rs
+++ b/crates/database/src/states/cache_account.rs
@@ -3,6 +3,7 @@ use super::{
 };
 use primitives::{HashMap, StorageKey, StorageValue, U256};
 use state::{Account, AccountInfo, EvmStorage};
+use std::borrow::Cow;
 
 /// Cache account contains plain state that gets updated
 /// at every transaction when evm output is applied to CacheState.
@@ -118,7 +119,9 @@ impl CacheAccount {
     /// Touch empty account, related to EIP-161 state clear.
     ///
     /// This account returns the Transition that is used to create the BundleState.
-    pub fn touch_empty_eip161<'a>(&mut self) -> Option<TransitionAccount<Option<&'a EvmStorage>>> {
+    pub fn touch_empty_eip161<'a>(
+        &mut self,
+    ) -> Option<TransitionAccount<Option<Cow<'a, EvmStorage>>>> {
         let previous_status = self.status;
 
         // Set account to None.
@@ -149,7 +152,7 @@ impl CacheAccount {
     /// Consumes self and make account as destroyed.
     ///
     /// Sets account as None and set status to Destroyer or DestroyedAgain.
-    pub fn selfdestruct<'a>(&mut self) -> Option<TransitionAccount<Option<&'a EvmStorage>>> {
+    pub fn selfdestruct<'a>(&mut self) -> Option<TransitionAccount<Option<Cow<'a, EvmStorage>>>> {
         // Account should be None after selfdestruct so we can take it.
         let previous_info = self.account.take().map(|a| a.info);
         let previous_status = self.status;
@@ -173,8 +176,8 @@ impl CacheAccount {
     /// Newly created account.
     pub fn newly_created<'a>(
         &mut self,
-        account: &'a Account,
-    ) -> TransitionAccount<Option<&'a EvmStorage>> {
+        account: Cow<'a, Account>,
+    ) -> TransitionAccount<Option<Cow<'a, EvmStorage>>> {
         let previous_status = self.status;
         let previous_info = self.account.take().map(|a| a.info);
 
@@ -185,16 +188,20 @@ impl CacheAccount {
             .collect();
 
         self.status = self.status.on_created();
+        let (info, storage) = match account {
+            Cow::Borrowed(account) => (account.info.clone(), Cow::Borrowed(&account.storage)),
+            Cow::Owned(account) => (account.info, Cow::Owned(account.storage)),
+        };
         let transition_account = TransitionAccount {
-            info: Some(account.info.clone()),
+            info: Some(info.clone()),
             status: self.status,
             previous_status,
             previous_info,
-            storage: Some(&account.storage),
+            storage: Some(storage),
             storage_was_destroyed: false,
         };
         self.account = Some(PlainAccount {
-            info: account.info.clone(),
+            info,
             storage: new_bundle_storage,
         });
         transition_account
@@ -259,8 +266,8 @@ impl CacheAccount {
     /// Merges the provided storage values with the existing storage and updates the account status.
     pub fn change<'a>(
         &mut self,
-        account: &'a Account,
-    ) -> TransitionAccount<Option<&'a EvmStorage>> {
+        account: Cow<'a, Account>,
+    ) -> TransitionAccount<Option<Cow<'a, EvmStorage>>> {
         let previous_status = self.status;
         let (previous_info, mut this_storage) = if let Some(account) = self.account.take() {
             (Some(account.info), account.storage)
@@ -268,14 +275,18 @@ impl CacheAccount {
             (None, Default::default())
         };
 
+        let (info, storage) = match account {
+            Cow::Borrowed(account) => (account.info.clone(), Cow::Borrowed(&account.storage)),
+            Cow::Owned(account) => (account.info, Cow::Owned(account.storage)),
+        };
+
         this_storage.extend(
-            account
-                .storage
+            storage
                 .iter()
                 .filter_map(|(k, s)| s.is_changed().then_some((*k, s.present_value))),
         );
         let changed_account = PlainAccount {
-            info: account.info.clone(),
+            info,
             storage: this_storage,
         };
 
@@ -291,7 +302,7 @@ impl CacheAccount {
             status: self.status,
             previous_info,
             previous_status,
-            storage: Some(&account.storage),
+            storage: Some(storage),
             storage_was_destroyed: false,
         }
     }

--- a/crates/database/src/states/cache_account.rs
+++ b/crates/database/src/states/cache_account.rs
@@ -118,7 +118,7 @@ impl CacheAccount {
     /// Touch empty account, related to EIP-161 state clear.
     ///
     /// This account returns the Transition that is used to create the BundleState.
-    pub fn touch_empty_eip161(&mut self) -> Option<TransitionAccount<EvmStorage>> {
+    pub fn touch_empty_eip161<'a>(&mut self) -> Option<TransitionAccount<Option<&'a EvmStorage>>> {
         let previous_status = self.status;
 
         // Set account to None.
@@ -140,7 +140,7 @@ impl CacheAccount {
                 status: self.status,
                 previous_info,
                 previous_status,
-                storage: HashMap::default(),
+                storage: None,
                 storage_was_destroyed: true,
             })
         }
@@ -149,7 +149,7 @@ impl CacheAccount {
     /// Consumes self and make account as destroyed.
     ///
     /// Sets account as None and set status to Destroyer or DestroyedAgain.
-    pub fn selfdestruct(&mut self) -> Option<TransitionAccount<EvmStorage>> {
+    pub fn selfdestruct<'a>(&mut self) -> Option<TransitionAccount<Option<&'a EvmStorage>>> {
         // Account should be None after selfdestruct so we can take it.
         let previous_info = self.account.take().map(|a| a.info);
         let previous_status = self.status;
@@ -164,14 +164,17 @@ impl CacheAccount {
                 status: self.status,
                 previous_info,
                 previous_status,
-                storage: HashMap::default(),
+                storage: None,
                 storage_was_destroyed: true,
             })
         }
     }
 
     /// Newly created account.
-    pub fn newly_created(&mut self, account: Account) -> TransitionAccount<EvmStorage> {
+    pub fn newly_created<'a>(
+        &mut self,
+        account: &'a Account,
+    ) -> TransitionAccount<Option<&'a EvmStorage>> {
         let previous_status = self.status;
         let previous_info = self.account.take().map(|a| a.info);
 
@@ -187,11 +190,11 @@ impl CacheAccount {
             status: self.status,
             previous_status,
             previous_info,
-            storage: account.storage,
+            storage: Some(&account.storage),
             storage_was_destroyed: false,
         };
         self.account = Some(PlainAccount {
-            info: account.info,
+            info: account.info.clone(),
             storage: new_bundle_storage,
         });
         transition_account
@@ -254,7 +257,10 @@ impl CacheAccount {
     /// Updates the account with new information and storage changes.
     ///
     /// Merges the provided storage values with the existing storage and updates the account status.
-    pub fn change(&mut self, account: Account) -> TransitionAccount<EvmStorage> {
+    pub fn change<'a>(
+        &mut self,
+        account: &'a Account,
+    ) -> TransitionAccount<Option<&'a EvmStorage>> {
         let previous_status = self.status;
         let (previous_info, mut this_storage) = if let Some(account) = self.account.take() {
             (Some(account.info), account.storage)
@@ -269,7 +275,7 @@ impl CacheAccount {
                 .filter_map(|(k, s)| s.is_changed().then_some((*k, s.present_value))),
         );
         let changed_account = PlainAccount {
-            info: account.info,
+            info: account.info.clone(),
             storage: this_storage,
         };
 
@@ -285,7 +291,7 @@ impl CacheAccount {
             status: self.status,
             previous_info,
             previous_status,
-            storage: account.storage,
+            storage: Some(&account.storage),
             storage_was_destroyed: false,
         }
     }

--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -14,7 +14,7 @@ use state::{
     bal::{alloy::AlloyBal, Bal, BlockAccessIndex},
     Account, AccountId, AccountInfo, EvmStorage,
 };
-use std::{boxed::Box, sync::Arc};
+use std::{borrow::Cow, boxed::Box, sync::Arc};
 
 /// Database boxed with a lifetime and Send
 pub type DBBox<'a, E> = Box<dyn Database<Error = E> + Send + 'a>;
@@ -115,7 +115,7 @@ impl<DB: Database> State<DB> {
     /// Applies evm transitions to transition state.
     pub fn apply_transition<'a>(
         &mut self,
-        transitions: impl IntoIterator<Item = (Address, TransitionAccount<Option<&'a EvmStorage>>)>,
+        transitions: impl IntoIterator<Item = (Address, TransitionAccount<Option<Cow<'a, EvmStorage>>>)>,
     ) {
         // Add transition to transition state.
         if let Some(s) = self.transition_state.as_mut() {
@@ -392,18 +392,37 @@ impl<DB: Database> Database for State<DB> {
 impl<DB: Database> DatabaseCommit for State<DB> {
     fn commit(&mut self, changes: AddressMap<Account>) {
         self.bal_state.commit(&changes);
-        let transitions = self.cache.apply_evm_state_iter(
-            changes.iter().map(|(address, account)| (*address, account)),
-            |_, _| {},
-        );
-        if let Some(s) = self.transition_state.as_mut() {
-            s.add_transitions(transitions)
-        } else {
-            // Advance the iter to apply all state updates.
-            transitions.for_each(|_| {});
-        }
+
         if let Some(hook) = self.state_hook.as_mut() {
+            let transitions = self.cache.apply_evm_state_iter(
+                changes
+                    .iter()
+                    .map(|(address, account)| (*address, Cow::Borrowed(account))),
+                |_, _| {},
+            );
+
+            if let Some(s) = self.transition_state.as_mut() {
+                s.add_transitions(transitions)
+            } else {
+                // Advance the iter to apply all state updates.
+                transitions.for_each(|_| {});
+            }
+
             hook.on_state(changes);
+        } else {
+            let transitions = self.cache.apply_evm_state_iter(
+                changes
+                    .into_iter()
+                    .map(|(address, account)| (address, Cow::Owned(account))),
+                |_, _| {},
+            );
+
+            if let Some(s) = self.transition_state.as_mut() {
+                s.add_transitions(transitions)
+            } else {
+                // Advance the iter to apply all state updates.
+                transitions.for_each(|_| {});
+            }
         }
     }
 
@@ -417,14 +436,19 @@ impl<DB: Database> DatabaseCommit for State<DB> {
         if let Some(s) = self.transition_state.as_mut() {
             for (address, account) in changes {
                 self.bal_state.commit_one(address, &account);
-                if let Some(transition) = self.cache.apply_account_state(address, &account) {
+                if let Some(transition) = self
+                    .cache
+                    .apply_account_state(address, Cow::Owned(account))
+                {
                     s.add_transition(address, transition);
                 }
             }
         } else {
             for (address, account) in changes {
                 self.bal_state.commit_one(address, &account);
-                _ = self.cache.apply_account_state(address, &account);
+                _ = self
+                    .cache
+                    .apply_account_state(address, Cow::Owned(account));
             }
         }
     }
@@ -538,6 +562,14 @@ mod tests {
         AccountRevert, AccountStatus, BundleAccount, RevertToSlot,
     };
     use primitives::{keccak256, BLOCK_HASH_HISTORY, U256};
+    use state::{EvmStorageSlot, TransactionId};
+
+    fn evm_storage<const N: usize>(
+        slots: [(StorageKey, EvmStorageSlot); N],
+    ) -> Option<Cow<'static, EvmStorage>> {
+        Some(Cow::Owned(HashMap::from_iter(slots)))
+    }
+
     #[test]
     fn has_bal_helper() {
         let state = State::builder().build();
@@ -651,6 +683,7 @@ mod tests {
                     info: Some(new_account_created_info.clone()),
                     previous_status: AccountStatus::LoadedNotExisting,
                     previous_info: None,
+                    storage: None,
                     ..Default::default()
                 },
             ),
@@ -661,11 +694,12 @@ mod tests {
                     info: Some(existing_account_changed_info.clone()),
                     previous_status: AccountStatus::Loaded,
                     previous_info: Some(existing_account_initial_info.clone()),
-                    storage: HashMap::from_iter([(
+                    storage: evm_storage([(
                         slot1,
-                        StorageSlot::new_changed(
+                        EvmStorageSlot::new_changed(
                             *existing_account_initial_storage.get(&slot1).unwrap(),
                             StorageValue::from(1000),
+                            TransactionId::ZERO,
                         ),
                     )]),
                     storage_was_destroyed: false,
@@ -694,9 +728,13 @@ mod tests {
                     info: Some(new_account_changed_info2.clone()),
                     previous_status: AccountStatus::InMemoryChange,
                     previous_info: Some(new_account_changed_info),
-                    storage: HashMap::from_iter([(
+                    storage: evm_storage([(
                         slot1,
-                        StorageSlot::new_changed(StorageValue::ZERO, StorageValue::from(1)),
+                        EvmStorageSlot::new_changed(
+                            StorageValue::ZERO,
+                            StorageValue::from(1),
+                            TransactionId::ZERO,
+                        ),
                     )]),
                     storage_was_destroyed: false,
                 },
@@ -708,25 +746,31 @@ mod tests {
                     info: Some(existing_account_changed_info.clone()),
                     previous_status: AccountStatus::InMemoryChange,
                     previous_info: Some(existing_account_changed_info.clone()),
-                    storage: HashMap::from_iter([
+                    storage: evm_storage([
                         (
                             slot1,
-                            StorageSlot::new_changed(
+                            EvmStorageSlot::new_changed(
                                 StorageValue::from(100),
                                 StorageValue::from(1_000),
+                                TransactionId::ZERO,
                             ),
                         ),
                         (
                             slot2,
-                            StorageSlot::new_changed(
+                            EvmStorageSlot::new_changed(
                                 *existing_account_initial_storage.get(&slot2).unwrap(),
                                 StorageValue::from(2_000),
+                                TransactionId::ZERO,
                             ),
                         ),
                         // Create new slot
                         (
                             slot3,
-                            StorageSlot::new_changed(StorageValue::ZERO, StorageValue::from(3_000)),
+                            EvmStorageSlot::new_changed(
+                                StorageValue::ZERO,
+                                StorageValue::from(3_000),
+                                TransactionId::ZERO,
+                            ),
                         ),
                     ]),
                     storage_was_destroyed: false,
@@ -894,14 +938,22 @@ mod tests {
                     info: Some(existing_account_with_storage_info.clone()),
                     previous_status: AccountStatus::Loaded,
                     previous_info: Some(existing_account_with_storage_info.clone()),
-                    storage: HashMap::from_iter([
+                    storage: evm_storage([
                         (
                             slot1,
-                            StorageSlot::new_changed(StorageValue::from(1), StorageValue::from(10)),
+                            EvmStorageSlot::new_changed(
+                                StorageValue::from(1),
+                                StorageValue::from(10),
+                                TransactionId::ZERO,
+                            ),
                         ),
                         (
                             slot2,
-                            StorageSlot::new_changed(StorageValue::ZERO, StorageValue::from(20)),
+                            EvmStorageSlot::new_changed(
+                                StorageValue::ZERO,
+                                StorageValue::from(20),
+                                TransactionId::ZERO,
+                            ),
                         ),
                     ]),
                     storage_was_destroyed: false,
@@ -938,14 +990,22 @@ mod tests {
                     info: Some(existing_account_with_storage_info.clone()),
                     previous_status: AccountStatus::Changed,
                     previous_info: Some(existing_account_with_storage_info.clone()),
-                    storage: HashMap::from_iter([
+                    storage: evm_storage([
                         (
                             slot1,
-                            StorageSlot::new_changed(StorageValue::from(10), StorageValue::from(1)),
+                            EvmStorageSlot::new_changed(
+                                StorageValue::from(10),
+                                StorageValue::from(1),
+                                TransactionId::ZERO,
+                            ),
                         ),
                         (
                             slot2,
-                            StorageSlot::new_changed(StorageValue::from(20), StorageValue::ZERO),
+                            EvmStorageSlot::new_changed(
+                                StorageValue::from(20),
+                                StorageValue::ZERO,
+                                TransactionId::ZERO,
+                            ),
                         ),
                     ]),
                     storage_was_destroyed: false,
@@ -985,7 +1045,7 @@ mod tests {
                 info: None,
                 previous_status: AccountStatus::Loaded,
                 previous_info: Some(existing_account_info.clone()),
-                storage: HashMap::default(),
+                storage: Some(Cow::Owned(HashMap::default())),
                 storage_was_destroyed: true,
             },
         )]));
@@ -998,9 +1058,13 @@ mod tests {
                 info: Some(existing_account_info.clone()),
                 previous_status: AccountStatus::Destroyed,
                 previous_info: None,
-                storage: HashMap::from_iter([(
+                storage: evm_storage([(
                     slot1,
-                    StorageSlot::new_changed(StorageValue::ZERO, StorageValue::from(1)),
+                    EvmStorageSlot::new_changed(
+                        StorageValue::ZERO,
+                        StorageValue::from(1),
+                        TransactionId::ZERO,
+                    ),
                 )]),
                 storage_was_destroyed: false,
             },
@@ -1015,7 +1079,7 @@ mod tests {
                 previous_status: AccountStatus::DestroyedChanged,
                 previous_info: Some(existing_account_info.clone()),
                 // storage change should be ignored
-                storage: HashMap::default(),
+                storage: Some(Cow::Owned(HashMap::default())),
                 storage_was_destroyed: true,
             },
         )]));
@@ -1028,9 +1092,13 @@ mod tests {
                 info: Some(existing_account_info.clone()),
                 previous_status: AccountStatus::DestroyedAgain,
                 previous_info: None,
-                storage: HashMap::from_iter([(
+                storage: evm_storage([(
                     slot2,
-                    StorageSlot::new_changed(StorageValue::ZERO, StorageValue::from(2)),
+                    EvmStorageSlot::new_changed(
+                        StorageValue::ZERO,
+                        StorageValue::from(2),
+                        TransactionId::ZERO,
+                    ),
                 )]),
                 storage_was_destroyed: false,
             },

--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -12,7 +12,7 @@ use database_interface::{
 use primitives::{hash_map, Address, AddressMap, HashMap, StorageKey, StorageValue, B256};
 use state::{
     bal::{alloy::AlloyBal, Bal, BlockAccessIndex},
-    Account, AccountId, AccountInfo,
+    Account, AccountId, AccountInfo, EvmStorage,
 };
 use std::{boxed::Box, sync::Arc};
 
@@ -115,7 +115,7 @@ impl<DB: Database> State<DB> {
     /// Applies evm transitions to transition state.
     pub fn apply_transition(
         &mut self,
-        transitions: impl IntoIterator<Item = (Address, TransitionAccount)>,
+        transitions: impl IntoIterator<Item = (Address, TransitionAccount<EvmStorage>)>,
     ) {
         // Add transition to transition state.
         if let Some(s) = self.transition_state.as_mut() {

--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -113,9 +113,9 @@ impl<DB: Database> State<DB> {
     }
 
     /// Applies evm transitions to transition state.
-    pub fn apply_transition(
+    pub fn apply_transition<'a>(
         &mut self,
-        transitions: impl IntoIterator<Item = (Address, TransitionAccount<EvmStorage>)>,
+        transitions: impl IntoIterator<Item = (Address, TransitionAccount<Option<&'a EvmStorage>>)>,
     ) {
         // Add transition to transition state.
         if let Some(s) = self.transition_state.as_mut() {
@@ -391,16 +391,19 @@ impl<DB: Database> Database for State<DB> {
 
 impl<DB: Database> DatabaseCommit for State<DB> {
     fn commit(&mut self, changes: AddressMap<Account>) {
-        if let Some(hook) = self.state_hook.as_mut() {
-            hook.on_state(&changes);
-        }
         self.bal_state.commit(&changes);
-        let transitions = self.cache.apply_evm_state_iter(changes, |_, _| {});
+        let transitions = self.cache.apply_evm_state_iter(
+            changes.iter().map(|(address, account)| (*address, account)),
+            |_, _| {},
+        );
         if let Some(s) = self.transition_state.as_mut() {
             s.add_transitions(transitions)
         } else {
             // Advance the iter to apply all state updates.
             transitions.for_each(|_| {});
+        }
+        if let Some(hook) = self.state_hook.as_mut() {
+            hook.on_state(changes);
         }
     }
 
@@ -411,16 +414,18 @@ impl<DB: Database> DatabaseCommit for State<DB> {
             return;
         }
 
-        let transitions = self
-            .cache
-            .apply_evm_state_iter(changes, |address, account| {
-                self.bal_state.commit_one(*address, account);
-            });
         if let Some(s) = self.transition_state.as_mut() {
-            s.add_transitions(transitions)
+            for (address, account) in changes {
+                self.bal_state.commit_one(address, &account);
+                if let Some(transition) = self.cache.apply_account_state(address, &account) {
+                    s.add_transition(address, transition);
+                }
+            }
         } else {
-            // Advance the iter to apply all state updates.
-            transitions.for_each(|_| {});
+            for (address, account) in changes {
+                self.bal_state.commit_one(address, &account);
+                _ = self.cache.apply_account_state(address, &account);
+            }
         }
     }
 }

--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -436,9 +436,8 @@ impl<DB: Database> DatabaseCommit for State<DB> {
         if let Some(s) = self.transition_state.as_mut() {
             for (address, account) in changes {
                 self.bal_state.commit_one(address, &account);
-                if let Some(transition) = self
-                    .cache
-                    .apply_account_state(address, Cow::Owned(account))
+                if let Some(transition) =
+                    self.cache.apply_account_state(address, Cow::Owned(account))
                 {
                     s.add_transition(address, transition);
                 }
@@ -446,9 +445,7 @@ impl<DB: Database> DatabaseCommit for State<DB> {
         } else {
             for (address, account) in changes {
                 self.bal_state.commit_one(address, &account);
-                _ = self
-                    .cache
-                    .apply_account_state(address, Cow::Owned(account));
+                _ = self.cache.apply_account_state(address, Cow::Owned(account));
             }
         }
     }

--- a/crates/database/src/states/transition_account.rs
+++ b/crates/database/src/states/transition_account.rs
@@ -1,7 +1,7 @@
 use super::{AccountRevert, AccountStatus, BundleAccount, StorageWithOriginalValues};
 use bytecode::Bytecode;
 use primitives::{hash_map, B256, U256};
-use state::AccountInfo;
+use state::{AccountInfo, EvmStorage};
 
 /// Account Created when EVM state is merged to cache state.
 /// And it is sent to Block state.
@@ -9,7 +9,7 @@ use state::AccountInfo;
 /// It is used when block state gets merged to bundle state to
 /// create needed Reverts.
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
-pub struct TransitionAccount {
+pub struct TransitionAccount<S = StorageWithOriginalValues> {
     /// Account information, if account exists.
     pub info: Option<AccountInfo>,
     /// Current account status.
@@ -21,7 +21,7 @@ pub struct TransitionAccount {
     /// Mostly needed when previous status Loaded/LoadedEmpty.
     pub previous_status: AccountStatus,
     /// Storage contains both old and new account
-    pub storage: StorageWithOriginalValues,
+    pub storage: S,
     /// If there is transition that clears the storage we should mark it here and
     /// delete all storages in BundleState. This flag is needed if we have transition
     /// between Destroyed states from DestroyedChanged-> DestroyedAgain-> DestroyedChanged
@@ -74,7 +74,7 @@ impl TransitionAccount {
 
     /// Update new values of transition. Don't override old values.
     /// Both account info and old storages need to be left intact.
-    pub fn update(&mut self, other: Self) {
+    pub fn update(&mut self, other: TransitionAccount<EvmStorage>) {
         self.info = other.info;
         self.status = other.status;
 
@@ -84,14 +84,21 @@ impl TransitionAccount {
             other.status,
             AccountStatus::Destroyed | AccountStatus::DestroyedAgain
         ) {
-            self.storage = other.storage;
+            self.storage = other
+                .storage
+                .into_iter()
+                .filter_map(|(k, v)| v.is_changed().then_some((k, v.into())))
+                .collect();
             self.storage_was_destroyed = true;
         } else {
             // Update changed values to this transition.
             for (key, slot) in other.storage.into_iter() {
+                if !slot.is_changed() {
+                    continue;
+                }
                 match self.storage.entry(key) {
                     hash_map::Entry::Vacant(entry) => {
-                        entry.insert(slot);
+                        entry.insert(slot.into());
                     }
                     hash_map::Entry::Occupied(mut entry) => {
                         let value = entry.get_mut();
@@ -131,6 +138,31 @@ impl TransitionAccount {
             original_info: self.previous_info.clone(),
             storage: StorageWithOriginalValues::default(),
             status: self.previous_status,
+        }
+    }
+}
+
+impl<S> TransitionAccount<S> {
+    /// Map the storage of the transition account.
+    pub fn map_storage<F, N>(self, f: F) -> TransitionAccount<N>
+    where
+        F: FnOnce(S) -> N,
+    {
+        let Self {
+            info,
+            status,
+            previous_info,
+            previous_status,
+            storage,
+            storage_was_destroyed,
+        } = self;
+        TransitionAccount {
+            info,
+            status,
+            previous_info,
+            previous_status,
+            storage: f(storage),
+            storage_was_destroyed,
         }
     }
 }

--- a/crates/database/src/states/transition_account.rs
+++ b/crates/database/src/states/transition_account.rs
@@ -1,4 +1,4 @@
-use super::{AccountRevert, AccountStatus, BundleAccount, StorageWithOriginalValues};
+use super::{AccountRevert, AccountStatus, BundleAccount, StorageSlot, StorageWithOriginalValues};
 use bytecode::Bytecode;
 use primitives::{hash_map, B256, U256};
 use state::{AccountInfo, EvmStorage};
@@ -74,7 +74,7 @@ impl TransitionAccount {
 
     /// Update new values of transition. Don't override old values.
     /// Both account info and old storages need to be left intact.
-    pub fn update(&mut self, other: TransitionAccount<EvmStorage>) {
+    pub fn update(&mut self, other: TransitionAccount<Option<&EvmStorage>>) {
         self.info = other.info;
         self.status = other.status;
 
@@ -87,27 +87,36 @@ impl TransitionAccount {
             self.storage = other
                 .storage
                 .into_iter()
-                .filter_map(|(k, v)| v.is_changed().then_some((k, v.into())))
+                .flat_map(|storage| storage.iter())
+                .filter_map(|(key, slot)| {
+                    slot.is_changed().then_some((
+                        *key,
+                        StorageSlot::new_changed(slot.original_value, slot.present_value),
+                    ))
+                })
                 .collect();
             self.storage_was_destroyed = true;
         } else {
             // Update changed values to this transition.
-            for (key, slot) in other.storage.into_iter() {
-                if !slot.is_changed() {
-                    continue;
-                }
-                match self.storage.entry(key) {
-                    hash_map::Entry::Vacant(entry) => {
-                        entry.insert(slot.into());
+            if let Some(storage) = other.storage {
+                for (key, slot) in storage {
+                    if !slot.is_changed() {
+                        continue;
                     }
-                    hash_map::Entry::Occupied(mut entry) => {
-                        let value = entry.get_mut();
-                        // If new value is same as original value. Remove storage entry.
-                        if value.original_value() == slot.present_value() {
-                            entry.remove();
-                        } else {
-                            // If value is different, update transition present value;
-                            value.present_value = slot.present_value;
+                    let slot = StorageSlot::new_changed(slot.original_value, slot.present_value);
+                    match self.storage.entry(*key) {
+                        hash_map::Entry::Vacant(entry) => {
+                            entry.insert(slot);
+                        }
+                        hash_map::Entry::Occupied(mut entry) => {
+                            let value = entry.get_mut();
+                            // If new value is same as original value. Remove storage entry.
+                            if value.original_value() == slot.present_value() {
+                                entry.remove();
+                            } else {
+                                // If value is different, update transition present value;
+                                value.present_value = slot.present_value;
+                            }
                         }
                     }
                 }

--- a/crates/database/src/states/transition_account.rs
+++ b/crates/database/src/states/transition_account.rs
@@ -1,5 +1,8 @@
+use std::borrow::Cow;
+
 use super::{AccountRevert, AccountStatus, BundleAccount, StorageSlot, StorageWithOriginalValues};
 use bytecode::Bytecode;
+use either::Either;
 use primitives::{hash_map, B256, U256};
 use state::{AccountInfo, EvmStorage};
 
@@ -74,9 +77,22 @@ impl TransitionAccount {
 
     /// Update new values of transition. Don't override old values.
     /// Both account info and old storages need to be left intact.
-    pub fn update(&mut self, other: TransitionAccount<Option<&EvmStorage>>) {
+    pub fn update(&mut self, other: TransitionAccount<Option<Cow<'_, EvmStorage>>>) {
         self.info = other.info;
         self.status = other.status;
+
+        let storage = other.storage.into_iter().flat_map(|storage| match storage {
+            Cow::Borrowed(storage) => Either::Left(
+                storage
+                    .iter()
+                    .map(|(k, v)| (Cow::Borrowed(k), Cow::Borrowed(v))),
+            ),
+            Cow::Owned(storage) => Either::Right(
+                storage
+                    .into_iter()
+                    .map(|(k, v)| (Cow::Owned(k), Cow::Owned(v))),
+            ),
+        });
 
         // If transition is from some to destroyed drop the storage.
         // This need to be done here as it is one increment of the state.
@@ -84,10 +100,7 @@ impl TransitionAccount {
             other.status,
             AccountStatus::Destroyed | AccountStatus::DestroyedAgain
         ) {
-            self.storage = other
-                .storage
-                .into_iter()
-                .flat_map(|storage| storage.iter())
+            self.storage = storage
                 .filter_map(|(key, slot)| {
                     slot.is_changed().then_some((
                         *key,
@@ -98,25 +111,23 @@ impl TransitionAccount {
             self.storage_was_destroyed = true;
         } else {
             // Update changed values to this transition.
-            if let Some(storage) = other.storage {
-                for (key, slot) in storage {
-                    if !slot.is_changed() {
-                        continue;
+            for (key, slot) in storage {
+                if !slot.is_changed() {
+                    continue;
+                }
+                let slot = StorageSlot::new_changed(slot.original_value, slot.present_value);
+                match self.storage.entry(*key) {
+                    hash_map::Entry::Vacant(entry) => {
+                        entry.insert(slot);
                     }
-                    let slot = StorageSlot::new_changed(slot.original_value, slot.present_value);
-                    match self.storage.entry(*key) {
-                        hash_map::Entry::Vacant(entry) => {
-                            entry.insert(slot);
-                        }
-                        hash_map::Entry::Occupied(mut entry) => {
-                            let value = entry.get_mut();
-                            // If new value is same as original value. Remove storage entry.
-                            if value.original_value() == slot.present_value() {
-                                entry.remove();
-                            } else {
-                                // If value is different, update transition present value;
-                                value.present_value = slot.present_value;
-                            }
+                    hash_map::Entry::Occupied(mut entry) => {
+                        let value = entry.get_mut();
+                        // If new value is same as original value. Remove storage entry.
+                        if value.original_value() == slot.present_value() {
+                            entry.remove();
+                        } else {
+                            // If value is different, update transition present value;
+                            value.present_value = slot.present_value;
                         }
                     }
                 }

--- a/crates/database/src/states/transition_state.rs
+++ b/crates/database/src/states/transition_state.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use super::{StorageSlot, TransitionAccount};
 use primitives::{hash_map::Entry, Address, AddressMap, HashMap};
 use state::EvmStorage;
@@ -36,7 +38,7 @@ impl TransitionState {
     /// [`update`][TransitionAccount::update].
     pub fn add_transitions<'a>(
         &mut self,
-        transitions: impl IntoIterator<Item = (Address, TransitionAccount<Option<&'a EvmStorage>>)>,
+        transitions: impl IntoIterator<Item = (Address, TransitionAccount<Option<Cow<'a, EvmStorage>>>)>,
     ) {
         let transitions = transitions.into_iter();
         if let Some(upper) = transitions.size_hint().1 {
@@ -51,22 +53,28 @@ impl TransitionState {
     pub fn add_transition(
         &mut self,
         address: Address,
-        account: TransitionAccount<Option<&EvmStorage>>,
+        account: TransitionAccount<Option<Cow<'_, EvmStorage>>>,
     ) {
         match self.transitions.entry(address) {
             Entry::Occupied(entry) => entry.into_mut().update(account),
             Entry::Vacant(entry) => {
                 _ = entry.insert(account.map_storage(|storage| {
                     storage
-                        .into_iter()
-                        .flat_map(|storage| storage.iter())
-                        .filter_map(|(key, slot)| {
-                            slot.is_changed().then_some((
-                                *key,
-                                StorageSlot::new_changed(slot.original_value, slot.present_value),
-                            ))
+                        .map(|storage| {
+                            storage
+                                .iter()
+                                .filter_map(|(key, slot)| {
+                                    slot.is_changed().then_some((
+                                        *key,
+                                        StorageSlot::new_changed(
+                                            slot.original_value,
+                                            slot.present_value,
+                                        ),
+                                    ))
+                                })
+                                .collect()
                         })
-                        .collect()
+                        .unwrap_or_default()
                 }))
             }
         }

--- a/crates/database/src/states/transition_state.rs
+++ b/crates/database/src/states/transition_state.rs
@@ -1,5 +1,6 @@
 use super::TransitionAccount;
 use primitives::{hash_map::Entry, Address, AddressMap, HashMap};
+use state::{EvmStorage};
 
 /// State of accounts in transition between transaction executions.
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
@@ -35,7 +36,7 @@ impl TransitionState {
     /// [`update`][TransitionAccount::update].
     pub fn add_transitions(
         &mut self,
-        transitions: impl IntoIterator<Item = (Address, TransitionAccount)>,
+        transitions: impl IntoIterator<Item = (Address, TransitionAccount<EvmStorage>)>,
     ) {
         let transitions = transitions.into_iter();
         if let Some(upper) = transitions.size_hint().1 {
@@ -44,7 +45,15 @@ impl TransitionState {
         for (address, account) in transitions {
             match self.transitions.entry(address) {
                 Entry::Occupied(entry) => entry.into_mut().update(account),
-                Entry::Vacant(entry) => _ = entry.insert(account),
+                Entry::Vacant(entry) => {
+                    _ = entry.insert(account.map_storage(|storage| {
+                        // The storage piped from EVM might contain both changed and unchanged slots.
+                        storage
+                            .into_iter()
+                            .filter_map(|(k, v)| v.is_changed().then_some((k, v.into())))
+                            .collect()
+                    }))
+                }
             }
         }
     }

--- a/crates/database/src/states/transition_state.rs
+++ b/crates/database/src/states/transition_state.rs
@@ -1,6 +1,6 @@
-use super::TransitionAccount;
+use super::{StorageSlot, TransitionAccount};
 use primitives::{hash_map::Entry, Address, AddressMap, HashMap};
-use state::{EvmStorage};
+use state::EvmStorage;
 
 /// State of accounts in transition between transaction executions.
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
@@ -34,26 +34,40 @@ impl TransitionState {
     ///
     /// This will insert new [`TransitionAccount`]s, or update existing ones via
     /// [`update`][TransitionAccount::update].
-    pub fn add_transitions(
+    pub fn add_transitions<'a>(
         &mut self,
-        transitions: impl IntoIterator<Item = (Address, TransitionAccount<EvmStorage>)>,
+        transitions: impl IntoIterator<Item = (Address, TransitionAccount<Option<&'a EvmStorage>>)>,
     ) {
         let transitions = transitions.into_iter();
         if let Some(upper) = transitions.size_hint().1 {
             self.transitions.reserve(upper);
         }
         for (address, account) in transitions {
-            match self.transitions.entry(address) {
-                Entry::Occupied(entry) => entry.into_mut().update(account),
-                Entry::Vacant(entry) => {
-                    _ = entry.insert(account.map_storage(|storage| {
-                        // The storage piped from EVM might contain both changed and unchanged slots.
-                        storage
-                            .into_iter()
-                            .filter_map(|(k, v)| v.is_changed().then_some((k, v.into())))
-                            .collect()
-                    }))
-                }
+            self.add_transition(address, account);
+        }
+    }
+
+    /// Add one transition to the transition state.
+    pub fn add_transition(
+        &mut self,
+        address: Address,
+        account: TransitionAccount<Option<&EvmStorage>>,
+    ) {
+        match self.transitions.entry(address) {
+            Entry::Occupied(entry) => entry.into_mut().update(account),
+            Entry::Vacant(entry) => {
+                _ = entry.insert(account.map_storage(|storage| {
+                    storage
+                        .into_iter()
+                        .flat_map(|storage| storage.iter())
+                        .filter_map(|(key, slot)| {
+                            slot.is_changed().then_some((
+                                *key,
+                                StorageSlot::new_changed(slot.original_value, slot.present_value),
+                            ))
+                        })
+                        .collect()
+                }))
             }
         }
     }


### PR DESCRIPTION
Right now when state hook is configured on `State<DB>`, it ends up cloning the entire state being commited before sending to it. This is done because the `apply_account_state` takes an owned account which is only useful to avoid a clone of `AccountInfo` (storage hashmap allocation is not reused)

This PR changes `apply_account_state` to take a `Cow<'_, Account>` and avoid cloning when state hook is configured