### PR TITLE
feat: extend SSTORE gas-state hook for TIP-1060 storage gas tokens

### DIFF
--- a/crates/context/interface/src/cfg.rs
+++ b/crates/context/interface/src/cfg.rs
@@ -94,6 +94,15 @@ pub trait Cfg {
     /// via the reservoir model. EIP-8037 specifies concrete gas values based on
     /// `cost_per_state_byte` and adds a hash cost for deployed bytecode.
     fn is_amsterdam_eip8037_enabled(&self) -> bool;
+
+    /// Returns the TIP-1060 storage gas token account, if configured.
+    ///
+    /// When `Some`, the address points to the protocol account holding the
+    /// per-account storage-gas-token counters consumed/minted by the
+    /// `STATE_GAS_TOKEN` variant of the SSTORE instruction.
+    ///
+    /// Defaults to `None` (feature disabled).
+    fn storage_gas_token_contract(&self) -> Option<Address>;
 }
 
 /// What bytecode analysis to perform

--- a/crates/context/interface/src/host.rs
+++ b/crates/context/interface/src/host.rs
@@ -9,53 +9,6 @@ use auto_impl::auto_impl;
 use primitives::{hardfork::SpecId, Address, Bytes, Log, StorageKey, StorageValue, B256, U256};
 use state::Bytecode;
 
-/// Result of SSTORE gas-state side effects.
-///
-/// Implementations of [`GasStateTr`] return this to let opcode-level SSTORE
-/// accounting apply state-gas credits, override state-gas refill, or suppress
-/// legacy refund behavior without knowing how the gas-state backend is stored.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct GasStateOutcome {
-    /// Credit applied to the state-gas component of this SSTORE.
-    pub state_gas_credit: u64,
-    /// State-gas refill override.
-    ///
-    /// `None` uses the default EIP-8037 refill calculation.
-    /// `Some(amount)` sets a specific refill, while `Some(0)` disables it.
-    pub state_gas_refill: Option<u64>,
-    /// Whether normal SSTORE refund accounting should be skipped.
-    pub skip_sstore_refund: bool,
-}
-
-/// Type-level SSTORE gas-state policy.
-///
-/// This hook is called after the storage write has been journaled and before
-/// the subsequent state-gas/refund accounting. The default policy is a no-op.
-pub trait GasStateTr<H: Host + ?Sized> {
-    /// Called after the main SSTORE journal update and before final gas/refund accounting.
-    fn sstore_gas_state(
-        host: &mut H,
-        owner: Address,
-        vals: &SStoreResult,
-    ) -> Result<GasStateOutcome, LoadError>;
-}
-
-/// No-op SSTORE gas-state policy.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
-pub struct NoGasState;
-
-impl<H: Host + ?Sized> GasStateTr<H> for NoGasState {
-    #[inline]
-    fn sstore_gas_state(
-        _host: &mut H,
-        _owner: Address,
-        _vals: &SStoreResult,
-    ) -> Result<GasStateOutcome, LoadError> {
-        Ok(GasStateOutcome::default())
-    }
-}
-
 /// Error that can happen when loading account info.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -64,6 +17,91 @@ pub enum LoadError {
     ColdLoadSkipped,
     /// Database error.
     DBError,
+}
+
+/// Result of a TIP-1060 storage gas token counter update.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct GasTokenResult {
+    /// SStore result of the counter slot write, used to charge the extra
+    /// SSTORE-worth of gas. `None` when no write happened (a [`GasTokenOp::Consume`]
+    /// against an empty counter).
+    pub counter: Option<SStoreResult>,
+    /// Whether a token was actually consumed (a [`GasTokenOp::Consume`] that hit
+    /// a positive counter).
+    pub consumed: bool,
+}
+
+/// Derives the storage slot of an account's TIP-1060 gas token counter inside
+/// the storage gas token contract.
+///
+/// The counter is stored directly (no Solidity mapping hash): the slot is the
+/// account address left-padded into a [`StorageKey`].
+#[inline]
+pub fn storage_gas_token_slot(account: Address) -> StorageKey {
+    StorageKey::from_be_bytes(account.into_word().0)
+}
+
+/// TIP-1060 storage creation mode, encoded in bits 64..=65 of the packed state.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum StorageCreationMode {
+    /// `0`: pay the full creation cost up front and settle against the token
+    /// balance for a refund at the end of the transaction.
+    #[default]
+    RefundTokens,
+    /// `1`: always pay the full creation cost; never consume tokens.
+    PreserveTokens,
+    /// `2`: consume tokens synchronously to offset the creation cost.
+    DirectTokens,
+}
+
+impl StorageCreationMode {
+    /// Decodes the 2-bit mode field (only the low two bits are considered).
+    #[inline]
+    pub const fn from_bits(bits: u8) -> Self {
+        match bits & 0b11 {
+            0 => Self::RefundTokens,
+            1 => Self::PreserveTokens,
+            2 => Self::DirectTokens,
+            _ => Self::PreserveTokens,
+        }
+    }
+}
+
+/// Decoded TIP-1060 storage gas token packed state word.
+///
+/// Layout of the packed [`StorageValue`]:
+/// - bits `0..=63`: `gas_token_balance` (`uint64`)
+/// - bits `64..=65`: [`storage_creation_mode`](Self::storage_creation_mode)
+/// - bits `66..=255`: reserved for future hardfork-gated extensions
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct StorageGasTokenState {
+    /// Number of storage gas tokens held by the account (bits `0..=63`).
+    pub gas_token_balance: u64,
+    /// Storage creation mode (bits `64..=65`).
+    pub storage_creation_mode: StorageCreationMode,
+}
+
+impl From<StorageGasTokenState> for StorageValue {
+    fn from(state: StorageGasTokenState) -> Self {
+        StorageValue::from_limbs([
+            state.gas_token_balance,
+            state.storage_creation_mode as u64,
+            0,
+            0,
+        ])
+    }
+}
+
+impl From<StorageValue> for StorageGasTokenState {
+    fn from(value: StorageValue) -> Self {
+        // `StorageValue` (U256) limbs are little-endian: limb 0 holds bits 0..=63,
+        // limb 1 holds bits 64..=127.
+        let limbs = value.as_limbs();
+        StorageGasTokenState {
+            gas_token_balance: limbs[0],
+            storage_creation_mode: StorageCreationMode::from_bits(limbs[1] as u8),
+        }
+    }
 }
 
 /// Host trait with all methods that are needed by the Interpreter.
@@ -115,6 +153,13 @@ pub trait Host {
 
     /// Returns whether state gas (EIP-8037) is enabled.
     fn is_amsterdam_eip8037_enabled(&self) -> bool;
+
+    /// Returns the TIP-1060 storage gas token account, calls
+    /// `ContextTr::cfg().storage_gas_token_contract()`.
+    ///
+    /// When `Some`, SSTORE operations that create (0→x) or clear (x→0) storage
+    /// mint/consume a per-account counter held in this account.
+    fn storage_gas_token_contract(&self) -> Option<Address>;
 
     /* Database */
 
@@ -288,6 +333,10 @@ impl Host for DummyHost {
 
     fn is_amsterdam_eip8037_enabled(&self) -> bool {
         false
+    }
+
+    fn storage_gas_token_contract(&self) -> Option<Address> {
+        None
     }
 
     fn difficulty(&self) -> U256 {

--- a/crates/context/interface/src/lib.rs
+++ b/crates/context/interface/src/lib.rs
@@ -23,7 +23,7 @@ pub use cfg::{Cfg, CreateScheme, TransactTo};
 pub use context::{ContextError, ContextSetters, ContextTr};
 pub use database_interface::{erased_error::ErasedError, DBErrorMarker, Database};
 pub use either;
-pub use host::{DummyHost, GasStateOutcome, GasStateTr, Host, NoGasState};
+pub use host::{DummyHost, Host};
 pub use journaled_state::JournalTr;
 pub use local::{FrameStack, FrameToken, LocalContextTr, OutFrame};
 pub use transaction::{Transaction, TransactionType};

--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -2,7 +2,7 @@
 pub use context_interface::Cfg;
 
 use context_interface::cfg::GasParams;
-use primitives::{eip170, eip3860, eip7825, eip7954, hardfork::SpecId};
+use primitives::{eip170, eip3860, eip7825, eip7954, hardfork::SpecId, Address};
 
 /// EVM configuration
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -153,6 +153,15 @@ pub struct CfgEnv<SPEC = SpecId> {
     ///
     /// By default, it is set to `false`.
     pub amsterdam_eip7708_delayed_burn_disabled: bool,
+    /// TIP-1060 storage gas token account.
+    ///
+    /// When `Some`, the address points to the protocol account that holds the
+    /// per-account storage-gas-token counters. SSTORE operations that create
+    /// (0→x) or clear (x→0) storage mint/consume tokens against this account.
+    /// Only consulted by the `STATE_GAS_TOKEN` variant of the SSTORE instruction.
+    ///
+    /// By default, it is set to `None` (feature disabled).
+    pub storage_gas_token_contract: Option<Address>,
 }
 
 impl CfgEnv {
@@ -269,6 +278,7 @@ impl<SPEC> CfgEnv<SPEC> {
             enable_amsterdam_eip8037: self.enable_amsterdam_eip8037,
             amsterdam_eip7708_disabled: self.amsterdam_eip7708_disabled,
             amsterdam_eip7708_delayed_burn_disabled: self.amsterdam_eip7708_delayed_burn_disabled,
+            storage_gas_token_contract: self.storage_gas_token_contract,
         }
     }
 
@@ -314,6 +324,12 @@ impl<SPEC> CfgEnv<SPEC> {
         self.enable_amsterdam_eip8037 = enable;
         self
     }
+
+    /// Sets the TIP-1060 storage gas token account.
+    pub const fn with_storage_gas_token_contract(mut self, address: Option<Address>) -> Self {
+        self.storage_gas_token_contract = address;
+        self
+    }
 }
 
 impl<SPEC: Into<SpecId> + Clone> CfgEnv<SPEC> {
@@ -352,6 +368,7 @@ impl<SPEC: Into<SpecId> + Clone> CfgEnv<SPEC> {
             enable_amsterdam_eip8037: is_amsterdam,
             amsterdam_eip7708_disabled: false,
             amsterdam_eip7708_delayed_burn_disabled: false,
+            storage_gas_token_contract: None,
         }
     }
 
@@ -570,6 +587,10 @@ impl<SPEC: Into<SpecId> + Clone> Cfg for CfgEnv<SPEC> {
 
     fn is_amsterdam_eip8037_enabled(&self) -> bool {
         self.enable_amsterdam_eip8037
+    }
+
+    fn storage_gas_token_contract(&self) -> Option<Address> {
+        self.storage_gas_token_contract
     }
 }
 

--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -467,6 +467,10 @@ impl<
         self.cfg().is_amsterdam_eip8037_enabled()
     }
 
+    fn storage_gas_token_contract(&self) -> Option<Address> {
+        self.cfg().storage_gas_token_contract()
+    }
+
     fn block_number(&self) -> U256 {
         self.block().number()
     }

--- a/crates/interpreter/src/instruction_context.rs
+++ b/crates/interpreter/src/instruction_context.rs
@@ -1,4 +1,10 @@
-use crate::{Interpreter, InterpreterTypes};
+use context_interface::{context::SStoreResult, Host};
+use primitives::Address;
+
+use crate::{
+    InstructionContext as Ictx, InstructionResult, Interpreter, InterpreterTypes as ITy,
+    InterpreterTypes,
+};
 
 /// Context passed to instruction implementations containing the host and interpreter.
 /// This struct provides access to both the host interface for external state operations
@@ -16,5 +22,49 @@ impl<H: ?Sized, IT: InterpreterTypes> std::fmt::Debug for InstructionContext<'_,
             .field("host", &"<host>")
             .field("interpreter", &"<interpreter>")
             .finish()
+    }
+}
+
+/// Result of SSTORE gas-state side effects.
+///
+/// Implementations of [`GasStateTr`] return this to let opcode-level SSTORE
+/// accounting apply state-gas credits, override state-gas refill, or suppress
+/// legacy refund behavior without knowing how the gas-state backend is stored.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GasStateOutcome {
+    /// Whether normal SSTORE refund accounting should be skipped.
+    pub skip_refund: bool,
+    /// Whether state-gas accounting should be performed.
+    pub skip_state_gas: bool,
+    /// Whether regular gas accounting should be performed.
+    pub skip_regular_gas: bool,
+}
+
+/// Type-level SSTORE gas-state policy.
+///
+/// This hook is called after the storage write has been journaled and before
+/// the subsequent state-gas/refund accounting. The default policy is a no-op.
+pub trait GasStateTr<IT: ITy, H: Host + ?Sized> {
+    /// Called after the main SSTORE journal update and before final gas/refund accounting.
+    fn sstore_gas_state(
+        context: &mut Ictx<'_, H, IT>,
+        owner: Address,
+        vals: &SStoreResult,
+    ) -> Result<GasStateOutcome, InstructionResult>;
+}
+
+/// No-op SSTORE gas-state policy.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct NoGasState;
+
+impl<IT: ITy, H: Host + ?Sized> GasStateTr<IT, H> for NoGasState {
+    #[inline]
+    fn sstore_gas_state(
+        _context: &mut Ictx<'_, H, IT>,
+        _owner: Address,
+        _vals: &SStoreResult,
+    ) -> Result<GasStateOutcome, InstructionResult> {
+        Ok(GasStateOutcome::default())
     }
 }

--- a/crates/interpreter/src/instructions.rs
+++ b/crates/interpreter/src/instructions.rs
@@ -29,8 +29,11 @@ pub mod utility;
 
 pub use context_interface::cfg::gas::{self, *};
 
-use crate::{interpreter_types::InterpreterTypes, Host, InstructionContext, InstructionExecResult};
-use context_interface::host::{GasStateTr, NoGasState};
+use crate::{
+    instruction_context::{GasStateTr, NoGasState},
+    interpreter_types::InterpreterTypes,
+    Host, InstructionContext, InstructionExecResult,
+};
 use primitives::hardfork::SpecId;
 
 /// EVM opcode function pointer.
@@ -82,14 +85,14 @@ pub const fn instruction_table<WIRE: InterpreterTypes, H: Host>() -> Instruction
 
 /// Returns the default instruction table with a custom SSTORE gas-state policy.
 #[inline]
-pub const fn instruction_table_with_gas_state<GS, WIRE, H>() -> InstructionTable<WIRE, H>
+pub const fn instruction_table_with_gas_state<GS, ITy, H>() -> InstructionTable<ITy, H>
 where
-    GS: GasStateTr<H>,
-    WIRE: InterpreterTypes,
+    GS: GasStateTr<ITy, H>,
+    ITy: InterpreterTypes,
     H: Host,
 {
-    let mut table = instruction_table_impl::<WIRE, H>();
-    table[bytecode::opcode::SSTORE as usize] = Instruction::new(host::sstore::<GS, _, _>);
+    let mut table = instruction_table_impl::<ITy, H>();
+    table[bytecode::opcode::SSTORE as usize] = Instruction::new(host::sstore::<_, _, GS>);
     table
 }
 
@@ -212,7 +215,7 @@ const fn instruction_table_impl<WIRE: InterpreterTypes, H: Host>() -> Instructio
     table[MSTORE as usize] = Instruction::new(memory::mstore);
     table[MSTORE8 as usize] = Instruction::new(memory::mstore8);
     table[SLOAD as usize] = Instruction::new(host::sload);
-    table[SSTORE as usize] = Instruction::new(host::sstore::<NoGasState, _, _>);
+    table[SSTORE as usize] = Instruction::new(host::sstore::<_, _, NoGasState>);
     table[JUMP as usize] = Instruction::new(control::jump);
     table[JUMPI as usize] = Instruction::new(control::jumpi);
     table[PC as usize] = Instruction::new(control::pc);

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -199,7 +199,6 @@ where
     let spec_id = context.interpreter.runtime_flag.spec_id();
 
     let is_eip8037 = context.host.is_amsterdam_eip8037_enabled();
-    let cold_storage_additional_cost = context.host.gas_params().cold_storage_additional_cost();
 
     // EIP-2200: Structured Definitions for Net Gas Metering
     // If gasleft is less than or equal to gas stipend, fail the current call frame with 'out of gas' exception.
@@ -215,7 +214,8 @@ where
     );
 
     let state_load = if spec_id.is_enabled_in(BERLIN) {
-        let skip_cold = context.interpreter.gas.remaining() < cold_storage_additional_cost;
+        let skip_cold = context.interpreter.gas.remaining()
+            < context.host.gas_params().cold_storage_additional_cost();
         context
             .host
             .sstore_skip_cold_load(target, index, value, skip_cold)?

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -1,19 +1,15 @@
 use crate::{
+    instruction_context::GasStateTr,
     instructions::utility::{IntoAddress, IntoU256},
     interpreter_types::{InputsTr, InterpreterTypes as ITy, MemoryTr, RuntimeFlag, StackTr},
-    Gas, Host, InstructionExecResult as Result, InstructionResult,
+    Gas, Host, InstructionContext as Ictx, InstructionExecResult as Result, InstructionResult,
 };
-use context_interface::{
-    host::{GasStateTr, LoadError},
-    journaled_state::AccountInfoLoad,
-};
+use context_interface::{host::LoadError, journaled_state::AccountInfoLoad};
 use core::cmp::min;
 use primitives::{
     hardfork::SpecId::{self, *},
     Bytes, Log, LogData, B256, BLOCK_HASH_HISTORY, U256,
 };
-
-use crate::InstructionContext as Ictx;
 
 /// Loads an account, handling cold load gas accounting.
 ///
@@ -190,17 +186,20 @@ pub fn sload<IT: ITy, H: Host + ?Sized>(context: Ictx<'_, H, IT>) -> Result {
 /// Implements the SSTORE instruction.
 ///
 /// Stores a word to storage.
-pub fn sstore<GS, IT, H>(context: Ictx<'_, H, IT>) -> Result
+pub fn sstore<IT, H, GS>(mut context: Ictx<'_, H, IT>) -> Result
 where
-    GS: GasStateTr<H>,
     IT: ITy,
     H: Host + ?Sized,
+    GS: GasStateTr<IT, H>,
 {
     require_non_staticcall!(context.interpreter);
     popn!([index, value], context.interpreter);
 
     let target = context.interpreter.input.target_address();
     let spec_id = context.interpreter.runtime_flag.spec_id();
+
+    let is_eip8037 = context.host.is_amsterdam_eip8037_enabled();
+    let cold_storage_additional_cost = context.host.gas_params().cold_storage_additional_cost();
 
     // EIP-2200: Structured Definitions for Net Gas Metering
     // If gasleft is less than or equal to gas stipend, fail the current call frame with 'out of gas' exception.
@@ -216,8 +215,7 @@ where
     );
 
     let state_load = if spec_id.is_enabled_in(BERLIN) {
-        let additional_cold_cost = context.host.gas_params().cold_storage_additional_cost();
-        let skip_cold = context.interpreter.gas.remaining() < additional_cold_cost;
+        let skip_cold = context.interpreter.gas.remaining() < cold_storage_additional_cost;
         context
             .host
             .sstore_skip_cold_load(target, index, value, skip_cold)?
@@ -228,46 +226,42 @@ where
             .ok_or(InstructionResult::FatalExternalError)?
     };
 
-    let gas_state_outcome = GS::sstore_gas_state(context.host, target, &state_load.data)?;
+    let outcome = GS::sstore_gas_state(&mut context, target, &state_load.data)?;
 
     let is_istanbul = spec_id.is_enabled_in(ISTANBUL);
 
-    // dynamic gas
-    gas!(
-        context.interpreter,
-        context.host.gas_params().sstore_dynamic_gas(
-            is_istanbul,
-            &state_load.data,
-            state_load.is_cold
-        )
-    );
+    if !outcome.skip_regular_gas {
+        // dynamic gas
+        gas!(
+            context.interpreter,
+            context.host.gas_params().sstore_dynamic_gas(
+                is_istanbul,
+                &state_load.data,
+                state_load.is_cold
+            )
+        );
+    }
 
-    // state gas for new slot creation (EIP-8037)
-    if context.host.is_amsterdam_eip8037_enabled() {
-        let state_gas = context
-            .host
-            .gas_params()
-            .sstore_state_gas(&state_load.data)
-            .saturating_sub(gas_state_outcome.state_gas_credit);
-        state_gas!(context.interpreter, state_gas);
-
+    if !outcome.skip_state_gas && is_eip8037 {
+        state_gas!(
+            context.interpreter,
+            context.host.gas_params().sstore_state_gas(&state_load.data)
+        );
         // EIP-8037 issue #2: 0→x→0 storage restoration refills the reservoir
         // directly rather than routing the state gas through the capped refund
         // counter. The regular-gas portion of the restoration still flows
         // through `sstore_refund` below.
-        let refill = gas_state_outcome.state_gas_refill.unwrap_or_else(|| {
-            context
-                .host
-                .gas_params()
-                .sstore_state_gas_refill(&state_load.data)
-        });
+        let refill = context
+            .host
+            .gas_params()
+            .sstore_state_gas_refill(&state_load.data);
         if refill > 0 {
             context.interpreter.gas.refill_reservoir(refill);
         }
     }
 
     // refund
-    if !gas_state_outcome.skip_sstore_refund {
+    if !outcome.skip_refund {
         context.interpreter.gas.record_refund(
             context
                 .host
@@ -275,6 +269,7 @@ where
                 .sstore_refund(is_istanbul, &state_load.data),
         );
     }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Extends the SSTORE gas-state policy hook (added in #3731) to support **TIP-1060 storage gas tokens**.

- Add `storage_gas_token_contract` to the `Cfg` trait, `CfgEnv`, and the `Host` trait (defaults to `None`, feature disabled). When set, it points to the protocol account holding the per-account storage-gas-token counters consumed/minted by the `STATE_GAS_TOKEN` SSTORE variant.
- Add `LoadError`, `GasTokenResult`, `StorageCreationMode`, `StorageGasTokenState`, and `storage_gas_token_slot` to the host interface for decoding/encoding the packed gas-token state word (balance in bits `0..=63`, creation mode in bits `64..=65`).
- Move `GasStateTr`, `NoGasState`, and `GasStateOutcome` into the interpreter's `instruction_context`, reworking the trait to take an `InstructionContext` (and `InterpreterTypes`) so policies can drive full opcode-level gas accounting. `GasStateOutcome` now exposes `skip_refund` / `skip_state_gas` / `skip_regular_gas` toggles.
- Update the `sstore` instruction to honor the new outcome flags and thread the gas-state policy through the instruction-table generics.

## Testing

- `cargo check -p revm-interpreter -p revm-context -p revm-context-interface`