### PR TITLE
fix(interpreter): use IntoAddress in pop_address to avoid const-eval panic

### DIFF
--- a/crates/interpreter/src/interpreter/stack.rs
+++ b/crates/interpreter/src/interpreter/stack.rs
@@ -503,34 +503,6 @@ mod tests {
     }
 
     #[test]
-    fn pop_address_truncates_to_low_20_bytes() {
-        use primitives::Address;
-
-        // A full 32-byte word whose high 12 bytes are set and must be discarded,
-        // and whose low 20 bytes are the address. This mirrors how the EVM reads an
-        // address from a stack word (e.g. BALANCE/EXTCODESIZE/EXTCODECOPY targets).
-        let word = U256::from_be_bytes::<32>([
-            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x11, 0x22,
-            0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00,
-            0x12, 0x34, 0x56, 0x78,
-        ]);
-        let expected = Address::from([
-            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee,
-            0xff, 0x00, 0x12, 0x34, 0x56, 0x78,
-        ]);
-
-        run(|stack| {
-            assert!(stack.push(word));
-            assert_eq!(stack.pop_address(), Some(expected));
-        });
-
-        // Empty stack returns None rather than panicking.
-        run(|stack| {
-            assert_eq!(stack.pop_address(), None);
-        });
-    }
-
-    #[test]
     fn stack_clone() {
         // Test cloning an empty stack
         let empty_stack = Stack::new();

--- a/crates/interpreter/src/interpreter/stack.rs
+++ b/crates/interpreter/src/interpreter/stack.rs
@@ -503,6 +503,34 @@ mod tests {
     }
 
     #[test]
+    fn pop_address_truncates_to_low_20_bytes() {
+        use primitives::Address;
+
+        // A full 32-byte word whose high 12 bytes are set and must be discarded,
+        // and whose low 20 bytes are the address. This mirrors how the EVM reads an
+        // address from a stack word (e.g. BALANCE/EXTCODESIZE/EXTCODECOPY targets).
+        let word = U256::from_be_bytes::<32>([
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x11, 0x22,
+            0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00,
+            0x12, 0x34, 0x56, 0x78,
+        ]);
+        let expected = Address::from([
+            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee,
+            0xff, 0x00, 0x12, 0x34, 0x56, 0x78,
+        ]);
+
+        run(|stack| {
+            assert!(stack.push(word));
+            assert_eq!(stack.pop_address(), Some(expected));
+        });
+
+        // Empty stack returns None rather than panicking.
+        run(|stack| {
+            assert_eq!(stack.pop_address(), None);
+        });
+    }
+
+    #[test]
     fn stack_clone() {
         // Test cloning an empty stack
         let empty_stack = Stack::new();

--- a/crates/interpreter/src/interpreter_types.rs
+++ b/crates/interpreter/src/interpreter_types.rs
@@ -1,4 +1,4 @@
-use crate::{CallInput, InstructionResult, InterpreterAction};
+use crate::{instructions::utility::IntoAddress, CallInput, InstructionResult, InterpreterAction};
 use core::{
     cell::Ref,
     ops::{Deref, Range},
@@ -222,7 +222,7 @@ pub trait StackTr {
     /// Internally call [`StackTr::pop`] and converts [`U256`] into [`Address`].
     #[must_use]
     fn pop_address(&mut self) -> Option<Address> {
-        self.pop().map(|value| Address::from(value.to_be_bytes()))
+        self.pop().map(|value| value.into_address())
     }
 
     /// Exchanges two values on the stack.


### PR DESCRIPTION
## Summary

`StackTr::pop_address` converts the popped stack word with
`Address::from(value.to_be_bytes())`. Because `Address: From<[u8; 20]>`, type
inference forces ruint's const-generic `Uint::<256, 4>::to_be_bytes::<20>()`,
whose `const { Self::assert_bytes(BYTES) }` requires `BYTES == Self::BYTES`
(32 for `U256`).

That const block is unreachable for valid inputs, so the code compiles whenever
the compiler dead-code-eliminates it — but the Rust Reference only guarantees such
a block *may or may not* be evaluated. Build profiles that do evaluate it
(cargo-fuzz coverage instrumentation, release codegen) hit
`error[E0080]: evaluation panicked: BYTES must be equal to Self::BYTES`,
breaking downstream builds. Fixes #3728.

## Fix

Reuse the crate's existing canonical converter, `IntoAddress for U256`
(`crates/interpreter/src/instructions/utility.rs`), via `value.into_address()`.
It does `Address::from_word(B256::from(value.to_be_bytes()))`, whose
`to_be_bytes()` infers the correct `[u8; 32]` size — identical EVM word→address
truncation (keep the low 20 bytes) with no fragile const-generic instantiation.
This also removes the inlined conversion in favour of the shared helper. The same
problematic idiom is present on `main`, so this is not release-specific.

## Testing

Added `pop_address_truncates_to_low_20_bytes` (truncates a full 32-byte word to its
low 20 bytes; returns `None` on an empty stack). Verified on rustc 1.96:

- `cargo test -p revm-interpreter --all-features` → 45 passed
- `cargo clippy -p revm-interpreter --all-targets --all-features` → clean
- `cargo fmt --all --check` → clean
- `cargo build -p revm-interpreter --release` and `--no-default-features` → both build
  (these are the profiles that previously hit the `E0080`)

Closes #3728