### PR TITLE
feat: wrap TransientStorage as AddressMap<StorageKeyMap<U256>>

### DIFF
--- a/crates/context/interface/src/journaled_state/entry.rs
+++ b/crates/context/interface/src/journaled_state/entry.rs
@@ -419,13 +419,12 @@ impl JournalEntryTr for JournalEntry {
                 let Some(transient_storage) = transient_storage else {
                     return;
                 };
-                let tkey = (address, key);
                 if had_value.is_zero() {
                     // if previous value is zero, remove it
-                    transient_storage.remove(&tkey);
+                    transient_storage.remove_value(address, key);
                 } else {
                     // if not zero, reinsert old value to transient storage.
-                    transient_storage.insert(tkey, had_value);
+                    transient_storage.insert_value(address, key, had_value);
                 }
             }
             JournalEntry::CodeChange { address } => {

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -1029,10 +1029,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
     /// EIP-1153: Transient storage opcodes
     #[inline]
     pub fn tload(&mut self, address: Address, key: StorageKey) -> StorageValue {
-        self.transient_storage
-            .get(&(address, key))
-            .copied()
-            .unwrap_or_default()
+        self.transient_storage.get_value(address, key)
     }
 
     /// Store transient storage tied to the account.
@@ -1047,12 +1044,12 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
             // if new values is zero, remove entry from transient storage.
             // if previous values was some insert it inside journal.
             // If it is none nothing should be inserted.
-            self.transient_storage.remove(&(address, key))
+            self.transient_storage.remove_value(address, key)
         } else {
             // insert values
             let previous_value = self
                 .transient_storage
-                .insert((address, key), new)
+                .insert_value(address, key, new)
                 .unwrap_or_default();
 
             // check if previous value is same

--- a/crates/state/src/types.rs
+++ b/crates/state/src/types.rs
@@ -1,11 +1,88 @@
 use super::{Account, EvmStorageSlot};
-use primitives::{Address, AddressMap, HashMap, StorageKey, StorageKeyMap, StorageValue};
+use core::ops::{Deref, DerefMut};
+use primitives::{Address, AddressMap, StorageKey, StorageKeyMap, StorageValue};
 
 /// EVM State is a mapping from addresses to accounts.
 pub type EvmState = AddressMap<Account>;
 
-/// Structure used for EIP-1153 transient storage
-pub type TransientStorage = HashMap<(Address, StorageKey), StorageValue>;
-
 /// An account's Storage is a mapping from 256-bit integer keys to [EvmStorageSlot]s.
 pub type EvmStorage = StorageKeyMap<EvmStorageSlot>;
+
+/// Structure used for EIP-1153 transient storage.
+///
+/// Maps each account [`Address`] to its transient storage slots, a mapping from
+/// storage [`StorageKey`]s to [`StorageValue`]s. Transient storage is discarded
+/// after every transaction.
+///
+/// See [EIP-1153](https://eips.ethereum.org/EIPS/eip-1153).
+///
+/// This is a thin wrapper around an [`AddressMap`] of [`StorageKeyMap`]s. It
+/// implements [`Deref`]/[`DerefMut`] to the inner map so all map operations are
+/// available, and provides [`get_value`](Self::get_value),
+/// [`insert_value`](Self::insert_value) and [`remove_value`](Self::remove_value)
+/// helpers for accessing individual slots without manually traversing the two
+/// levels of maps.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct TransientStorage(pub AddressMap<StorageKeyMap<StorageValue>>);
+
+impl Deref for TransientStorage {
+    type Target = AddressMap<StorageKeyMap<StorageValue>>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for TransientStorage {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl TransientStorage {
+    /// Returns the transient storage value for the given account `address` and
+    /// storage `key`.
+    ///
+    /// Returns [`StorageValue::ZERO`](primitives::StorageValue) (the default) if
+    /// the slot was never set.
+    #[inline]
+    pub fn get_value(&self, address: Address, key: StorageKey) -> StorageValue {
+        self.0
+            .get(&address)
+            .and_then(|slots| slots.get(&key))
+            .copied()
+            .unwrap_or_default()
+    }
+
+    /// Inserts a transient storage `value` for the given account `address` and
+    /// storage `key`, creating the account's slot map if it does not exist yet.
+    ///
+    /// Returns the previous value if the slot was already set.
+    #[inline]
+    pub fn insert_value(
+        &mut self,
+        address: Address,
+        key: StorageKey,
+        value: StorageValue,
+    ) -> Option<StorageValue> {
+        self.0.entry(address).or_default().insert(key, value)
+    }
+
+    /// Removes the transient storage slot for the given account `address` and
+    /// storage `key`.
+    ///
+    /// Returns the removed value if the slot was set. If the account has no
+    /// remaining slots after removal, its (now empty) slot map is removed as well.
+    #[inline]
+    pub fn remove_value(&mut self, address: Address, key: StorageKey) -> Option<StorageValue> {
+        let slots = self.0.get_mut(&address)?;
+        let removed = slots.remove(&key);
+        if slots.is_empty() {
+            self.0.remove(&address);
+        }
+        removed
+    }
+}

--- a/crates/state/src/types.rs
+++ b/crates/state/src/types.rs
@@ -74,15 +74,9 @@ impl TransientStorage {
     /// Removes the transient storage slot for the given account `address` and
     /// storage `key`.
     ///
-    /// Returns the removed value if the slot was set. If the account has no
-    /// remaining slots after removal, its (now empty) slot map is removed as well.
+    /// Returns the removed value if the slot was set.
     #[inline]
     pub fn remove_value(&mut self, address: Address, key: StorageKey) -> Option<StorageValue> {
-        let slots = self.0.get_mut(&address)?;
-        let removed = slots.remove(&key);
-        if slots.is_empty() {
-            self.0.remove(&address);
-        }
-        removed
+        self.0.get_mut(&address)?.remove(&key)
     }
 }


### PR DESCRIPTION
## Summary

Changes `TransientStorage` from a flat tuple-keyed map type alias into a newtype wrapper over a nested map, with `Deref`/`DerefMut` and slot-access helpers.

Before:
```rust
pub type TransientStorage = HashMap<(Address, StorageKey), StorageValue>;
```

After:
```rust
pub struct TransientStorage(pub AddressMap<StorageKeyMap<StorageValue>>);
```

## Changes

- **`crates/state/src/types.rs`**
  - `TransientStorage` is now a newtype over `AddressMap<StorageKeyMap<StorageValue>>`.
  - Implements `Deref`/`DerefMut` to the inner map, so all map operations (`clear`, `iter`, etc.) keep working.
  - Adds helpers for two-level slot access:
    - `get_value(address, key) -> StorageValue` — value or `0` default.
    - `insert_value(address, key, value) -> Option<StorageValue>` — inserts (creating the account map via `entry().or_default()`), returns previous value.
    - `remove_value(address, key) -> Option<StorageValue>` — removes the slot and cleans up the account's now-empty map.
  - Derives `Debug, Clone, Default, PartialEq, Eq` + serde (needed because `JournalInner` derives serde).
- **`crates/context/src/journal/inner.rs`** — `tload`/`tstore` use the new helpers; journal recording semantics unchanged.
- **`crates/context/interface/src/journaled_state/entry.rs`** — `TransientStorageChange` revert path uses the helpers.

## Notes

The serde representation changes (nested map vs. the old tuple-keyed flat map). Since transient storage is cleared after every transaction, this is not a persisted/wire format.

## Testing

- `cargo build --workspace`
- `cargo nextest run -p revm-state -p revm-context`
- `cargo clippy -p revm-state -p revm-context -p revm-context-interface --all-targets`
- `cargo fmt --all`