### PR TITLE
feat(precompile): add num-bigint modexp backend

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           tool: cargo-codspeed
       - name: Build the benchmark target(s)
-        run: cargo codspeed build --profile profiling --workspace --exclude '*example*'
+        run: cargo codspeed build --profile profiling --workspace --exclude '*example*' --features num-bigint
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd # v4.15.1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3875,6 +3875,7 @@ dependencies = [
  "codspeed-criterion-compat",
  "gmp-mpfr-sys",
  "k256",
+ "num-bigint",
  "p256",
  "rand 0.9.2",
  "revm-context-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ ark-serialize = { version = "0.5", default-features = false }
 ark-std = { version = "0.5", default-features = false }
 aurora-engine-modexp = { version = "1.2", default-features = false }
 gmp-mpfr-sys = { version = "1.6", default-features = false }
+num-bigint = { version = "0.4.6", default-features = false }
 blst = "0.3.15"
 bn = { package = "substrate-bn", version = "0.6", default-features = false }
 c-kzg = { version = "2.1.7", default-features = false }

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -26,6 +26,7 @@ context-interface.workspace = true
 aurora-engine-modexp.workspace = true
 # gmp ffi
 gmp-mpfr-sys = { workspace = true, default-features = false, optional = true }
+num-bigint = { workspace = true, optional = true }
 
 # ecRecover
 k256 = { workspace = true, features = ["ecdsa"] }
@@ -90,6 +91,7 @@ std = [
 	"ark-bn254/std",
 	"ark-bls12-381/std",
 	"aurora-engine-modexp/std",
+	"num-bigint?/std",
 	"ark-ec/std",
 	"ark-ff/std",
 	"ark-serialize/std",
@@ -121,6 +123,9 @@ bn = ["dep:bn"]
 
 # Use GMP for accelerated modexp precompile. Dynamically links to libgmp at runtime.
 gmp = ["dep:gmp-mpfr-sys"]
+
+# Use `num-bigint` for the modexp precompile.
+num-bigint = ["dep:num-bigint"]
 
 # Use aws-lc-rs as a faster alternative to `p256` for secp256r1 signature verification.
 p256-aws-lc-rs = ["dep:aws-lc-rs"]

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -59,9 +59,13 @@ cfg_if::cfg_if! {
     }
 }
 
-// silence aurora-engine-modexp if gmp is enabled
-#[cfg(feature = "gmp")]
+// silence aurora-engine-modexp if another modexp backend is enabled
+#[cfg(any(feature = "gmp", feature = "num-bigint"))]
 use aurora_engine_modexp as _;
+
+// silence num-bigint if gmp is enabled
+#[cfg(all(feature = "gmp", feature = "num-bigint"))]
+use num_bigint as _;
 
 // silence p256 lint as aws-lc-rs will be used if both are enabled.
 #[cfg(feature = "p256-aws-lc-rs")]

--- a/crates/precompile/src/modexp.rs
+++ b/crates/precompile/src/modexp.rs
@@ -137,6 +137,21 @@ pub(crate) fn modexp(base: &[u8], exponent: &[u8], modulus: &[u8]) -> Vec<u8> {
 }
 
 #[cfg(not(feature = "gmp"))]
+#[cfg(feature = "num-bigint")]
+pub(crate) fn modexp(base: &[u8], exponent: &[u8], modulus: &[u8]) -> Vec<u8> {
+    use num_bigint::BigUint;
+
+    let modulus = BigUint::from_bytes_be(modulus);
+    if modulus == BigUint::from(0u8) {
+        return Vec::new();
+    }
+
+    let base = BigUint::from_bytes_be(base);
+    let exponent = BigUint::from_bytes_be(exponent);
+    base.modpow(&exponent, &modulus).to_bytes_be()
+}
+
+#[cfg(not(any(feature = "gmp", feature = "num-bigint")))]
 pub(crate) fn modexp(base: &[u8], exponent: &[u8], modulus: &[u8]) -> Vec<u8> {
     aurora_engine_modexp::modexp(base, exponent, modulus)
 }

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -118,6 +118,9 @@ portable = ["precompile/portable"]
 # Use GMP for accelerated modexp precompile. Dynamically links to libgmp at runtime.
 gmp = ["precompile/gmp"]
 
+# Use `num-bigint` for the modexp precompile.
+num-bigint = ["precompile/num-bigint"]
+
 # Use aws-lc-rs as a faster alternative to `p256` for secp256r1 signature verification.
 p256-aws-lc-rs = ["precompile/p256-aws-lc-rs"]
 


### PR DESCRIPTION
## Summary
- add an optional `num-bigint` backend for MODEXP
- propagate the feature through the top-level `revm` crate
- run benchmark CI with `--features num-bigint` so CodSpeed captures this backend

## Verification
- `cargo fmt --check`
- `cargo check -p revm-precompile --features num-bigint`
- `cargo check -p revm --features num-bigint`
- `cargo metadata --no-deps --format-version 1 --features num-bigint`
- `cargo test -p revm-precompile --features num-bigint modexp`

Note: `cargo check -p revm-precompile --features gmp,num-bigint` was started to verify feature precedence, but the sandbox stalled in `gmp-mpfr-sys` native configure; the implementation keeps `gmp` precedence via cfg guards.

Prompted by: @DaniPopes