### PR TITLE
fix(state): re-baseline storage original_value only across tx boundaries

### DIFF
--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -619,8 +619,12 @@ impl EvmStorageSlot {
     #[inline]
     pub const fn mark_warm_with_transaction_id(&mut self, transaction_id: TransactionId) -> bool {
         let is_cold = self.is_cold_transaction_id(transaction_id);
-        if is_cold {
-            // if slot is cold original value should be reset to present value.
+        // Re-baseline the EIP-2200 `original_value` only when the slot belongs to a *previous*
+        // transaction (transaction id mismatch). `is_cold` also covers a slot flagged cold
+        // within the same transaction (e.g. a reverted `StorageWarmed` entry, or an explicit
+        // `mark_cold`); those must keep the original value captured at the start of this
+        // transaction. The committed/original value is tx-scoped, not access-list-scoped.
+        if self.transaction_id.get() != transaction_id.get() {
             self.original_value = self.present_value;
         }
         self.transaction_id = transaction_id;


### PR DESCRIPTION
## Summary

`EvmStorageSlot::mark_warm_with_transaction_id` re-baselines the EIP-2200 `original_value` to `present_value` whenever the slot is **cold**:

```rust
let is_cold = self.is_cold_transaction_id(transaction_id);
if is_cold {
    self.original_value = self.present_value;
}
```

But `is_cold_transaction_id` is `self.transaction_id.get() != transaction_id.get() || self.is_cold` — it is `true` both on a genuine **transaction boundary** (id mismatch) *and* when the `is_cold` flag is set **within the same transaction** (a reverted `StorageWarmed` entry, or an explicit `mark_cold()`).

The EIP-2200 *original* (committed) value is **transaction-scoped** and independent of the EIP-2929 access list. Re-baselining it whenever a slot is cold conflates two orthogonal concepts. This PR keys the re-baseline on the actual transaction boundary instead:

```rust
if self.transaction_id.get() != transaction_id.get() {
    self.original_value = self.present_value;
}
```

## Why this is correct (go-ethereum / spec)

In go-ethereum the two concepts are deliberately separate:

- **EIP-2200 original** comes from `GetCommittedState` (`state_object.go`), backed by `pendingStorage` (committed by earlier txs in the block) / `originStorage` (trie value). It advances only across **transaction/block boundaries** and never consults the access list.
- **EIP-2929 warm/cold** is a separate, independently-journaled access list (`SlotInAccessList` / `accessListAddSlotChange`), reverted on call revert.

`makeGasSStoreFunc` (`operations_acl.go`) reads them independently:
```go
current, original = evm.StateDB.GetStateAndCommittedState(addr, slot) // EIP-2200 original
...
if _, slotPresent := evm.StateDB.SlotInAccessList(addr, slot); !slotPresent { // EIP-2929, separate
    cost += params.ColdSloadCostEIP2929
}
```

So `original_value` here (the EIP-2200 committed value) should mirror `GetCommittedState`: tx-scoped, decoupled from warm/cold. Keying its re-baseline on `transaction_id` does exactly that; keying it on `is_cold` does not.

## Behavioral impact

**None for standard execution.** When `is_cold` is set within the same transaction (revert-induced un-warm, or `mark_cold`), the slot's `original_value` already equals `present_value` at that point, so the old re-baseline was a no-op. Verified:

- `cargo test` across `revm-state` / `revm-context` / `revm-interpreter` / `revm-handler` / `revm` — pass.
- execution-spec-tests **state_tests** (stable + develop) and legacy GeneralStateTests (Cancun + Constantinople) — all pass.
- **blockchain_tests**: stable **39161 passed / 0 failed**, develop **57488 passed / 0 failed** (these exercise the genuine cross-transaction re-baseline that this PR keeps).

This is a robustness/precision change: it makes the re-baseline condition match its intent and prevents silent `original_value` corruption for any caller that marks a slot cold mid-transaction via the public `mark_cold` API.
