### PR TITLE
refactor: remove `GasStateTr`

### DIFF
--- a/crates/interpreter/src/instruction_context.rs
+++ b/crates/interpreter/src/instruction_context.rs
@@ -1,13 +1,4 @@
-use context_interface::{
-    context::{SStoreResult, StateLoad},
-    Host,
-};
-use primitives::Address;
-
-use crate::{
-    InstructionContext as Ictx, InstructionResult, Interpreter, InterpreterTypes as ITy,
-    InterpreterTypes,
-};
+use crate::{Interpreter, InterpreterTypes};
 
 /// Context passed to instruction implementations containing the host and interpreter.
 /// This struct provides access to both the host interface for external state operations
@@ -25,48 +16,5 @@ impl<H: ?Sized, IT: InterpreterTypes> std::fmt::Debug for InstructionContext<'_,
             .field("host", &"<host>")
             .field("interpreter", &"<interpreter>")
             .finish()
-    }
-}
-
-/// Result of SSTORE gas-state side effects.
-///
-/// Implementations of [`GasStateTr`] return this to let opcode-level SSTORE
-/// accounting be overridden without knowing how the gas-state backend is stored.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct GasStateOutcome {
-    /// Whether normal SSTORE refund accounting should be skipped.
-    pub skip_refund: bool,
-    /// Whether opcode-level SSTORE dynamic gas and EIP-8037 state-gas accounting should be skipped.
-    ///
-    /// When true, the gas-state policy is responsible for any replacement gas accounting.
-    pub skip_gas: bool,
-}
-
-/// Type-level SSTORE gas-state policy.
-///
-/// This hook is called after the storage write has been journaled and before
-/// the subsequent state-gas/refund accounting. The default policy is a no-op.
-pub trait GasStateTr<IT: ITy, H: Host + ?Sized> {
-    /// Called after the main SSTORE journal update and before final gas/refund accounting.
-    fn sstore_gas_state(
-        context: &mut Ictx<'_, H, IT>,
-        owner: Address,
-        state_load: &StateLoad<SStoreResult>,
-    ) -> Result<GasStateOutcome, InstructionResult>;
-}
-
-/// No-op SSTORE gas-state policy.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
-pub struct NoGasState;
-
-impl<IT: ITy, H: Host + ?Sized> GasStateTr<IT, H> for NoGasState {
-    #[inline]
-    fn sstore_gas_state(
-        _context: &mut Ictx<'_, H, IT>,
-        _owner: Address,
-        _state_load: &StateLoad<SStoreResult>,
-    ) -> Result<GasStateOutcome, InstructionResult> {
-        Ok(GasStateOutcome::default())
     }
 }

--- a/crates/interpreter/src/instructions.rs
+++ b/crates/interpreter/src/instructions.rs
@@ -29,11 +29,7 @@ pub mod utility;
 
 pub use context_interface::cfg::gas::{self, *};
 
-use crate::{
-    instruction_context::{GasStateTr, NoGasState},
-    interpreter_types::InterpreterTypes,
-    Host, InstructionContext, InstructionExecResult,
-};
+use crate::{interpreter_types::InterpreterTypes, Host, InstructionContext, InstructionExecResult};
 use primitives::hardfork::SpecId;
 
 /// EVM opcode function pointer.
@@ -81,19 +77,6 @@ pub type GasTable = [u16; 256];
 #[inline]
 pub const fn instruction_table<WIRE: InterpreterTypes, H: Host>() -> InstructionTable<WIRE, H> {
     const { instruction_table_impl::<WIRE, H>() }
-}
-
-/// Returns the default instruction table with a custom SSTORE gas-state policy.
-#[inline]
-pub const fn instruction_table_with_gas_state<GS, ITy, H>() -> InstructionTable<ITy, H>
-where
-    GS: GasStateTr<ITy, H>,
-    ITy: InterpreterTypes,
-    H: Host,
-{
-    let mut table = instruction_table_impl::<ITy, H>();
-    table[bytecode::opcode::SSTORE as usize] = Instruction::new(host::sstore::<_, _, GS>);
-    table
 }
 
 /// Returns the default gas table.
@@ -215,7 +198,7 @@ const fn instruction_table_impl<WIRE: InterpreterTypes, H: Host>() -> Instructio
     table[MSTORE as usize] = Instruction::new(memory::mstore);
     table[MSTORE8 as usize] = Instruction::new(memory::mstore8);
     table[SLOAD as usize] = Instruction::new(host::sload);
-    table[SSTORE as usize] = Instruction::new(host::sstore::<_, _, NoGasState>);
+    table[SSTORE as usize] = Instruction::new(host::sstore);
     table[JUMP as usize] = Instruction::new(control::jump);
     table[JUMPI as usize] = Instruction::new(control::jumpi);
     table[PC as usize] = Instruction::new(control::pc);

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -1,15 +1,19 @@
 use crate::{
-    instruction_context::GasStateTr,
     instructions::utility::{IntoAddress, IntoU256},
     interpreter_types::{InputsTr, InterpreterTypes as ITy, MemoryTr, RuntimeFlag, StackTr},
-    Gas, Host, InstructionContext as Ictx, InstructionExecResult as Result, InstructionResult,
+    Gas, Host, InstructionExecResult as Result, InstructionResult,
 };
-use context_interface::{host::LoadError, journaled_state::AccountInfoLoad};
+use context_interface::{
+    context::{SStoreResult, StateLoad},
+    host::LoadError,
+    journaled_state::AccountInfoLoad,
+};
 use core::cmp::min;
 use primitives::{
     hardfork::SpecId::{self, *},
-    Bytes, Log, LogData, B256, BLOCK_HASH_HISTORY, U256,
+    Address, Bytes, Log, LogData, B256, BLOCK_HASH_HISTORY, U256,
 };
+use crate::InstructionContext as Ictx;
 
 /// Loads an account, handling cold load gas accounting.
 ///
@@ -186,19 +190,34 @@ pub fn sload<IT: ITy, H: Host + ?Sized>(context: Ictx<'_, H, IT>) -> Result {
 /// Implements the SSTORE instruction.
 ///
 /// Stores a word to storage.
-pub fn sstore<IT, H, GS>(mut context: Ictx<'_, H, IT>) -> Result
+pub fn sstore<IT: ITy, H: Host + ?Sized>(context: Ictx<'_, H, IT>) -> Result {
+    sstore_with_gas_accounting(context, sstore_default_gas_accounting)
+}
+
+/// Implements SSTORE, delegating dynamic gas and refund accounting to `gas_accounting`.
+///
+/// This helper performs the common SSTORE instruction flow: static-call checks,
+/// stack pops, stipend/static-gas charging, and the journaled storage write.
+/// Custom instruction sets can override the SSTORE opcode and call this helper
+/// with their own gas accounting closure.
+pub fn sstore_with_gas_accounting<'a, IT, H, F>(
+    mut context: Ictx<'a, H, IT>,
+    gas_accounting: F,
+) -> Result
 where
     IT: ITy,
     H: Host + ?Sized,
-    GS: GasStateTr<IT, H>,
+    F: for<'ctx, 'load> FnOnce(
+        &'ctx mut Ictx<'a, H, IT>,
+        Address,
+        &'load StateLoad<SStoreResult>,
+    ) -> Result,
 {
     require_non_staticcall!(context.interpreter);
     popn!([index, value], context.interpreter);
 
     let target = context.interpreter.input.target_address();
     let spec_id = context.interpreter.runtime_flag.spec_id();
-
-    let is_eip8037 = context.host.is_amsterdam_eip8037_enabled();
 
     // EIP-2200: Structured Definitions for Net Gas Metering
     // If gasleft is less than or equal to gas stipend, fail the current call frame with 'out of gas' exception.
@@ -226,27 +245,39 @@ where
             .ok_or(InstructionResult::FatalExternalError)?
     };
 
-    let outcome = GS::sstore_gas_state(&mut context, target, &state_load)?;
+    gas_accounting(&mut context, target, &state_load)
+}
 
+/// Default dynamic gas and refund accounting for SSTORE.
+pub fn sstore_default_gas_accounting<IT, H>(
+    context: &mut Ictx<'_, H, IT>,
+    _target: Address,
+    state_load: &StateLoad<SStoreResult>,
+) -> Result
+where
+    IT: ITy,
+    H: Host + ?Sized,
+{
+    let spec_id = context.interpreter.runtime_flag.spec_id();
     let is_istanbul = spec_id.is_enabled_in(ISTANBUL);
 
-    if !outcome.skip_gas {
-        // dynamic gas
-        gas!(
-            context.interpreter,
-            context.host.gas_params().sstore_dynamic_gas(
-                is_istanbul,
-                &state_load.data,
-                state_load.is_cold
-            )
-        );
-    }
+    // dynamic gas
+    gas!(
+        context.interpreter,
+        context.host.gas_params().sstore_dynamic_gas(
+            is_istanbul,
+            &state_load.data,
+            state_load.is_cold
+        )
+    );
 
-    if !outcome.skip_gas && is_eip8037 {
+    // state gas for new slot creation (EIP-8037)
+    if context.host.is_amsterdam_eip8037_enabled() {
         state_gas!(
             context.interpreter,
             context.host.gas_params().sstore_state_gas(&state_load.data)
         );
+
         // EIP-8037 issue #2: 0→x→0 storage restoration refills the reservoir
         // directly rather than routing the state gas through the capped refund
         // counter. The regular-gas portion of the restoration still flows
@@ -261,15 +292,12 @@ where
     }
 
     // refund
-    if !outcome.skip_refund {
-        context.interpreter.gas.record_refund(
-            context
-                .host
-                .gas_params()
-                .sstore_refund(is_istanbul, &state_load.data),
-        );
-    }
-
+    context.interpreter.gas.record_refund(
+        context
+            .host
+            .gas_params()
+            .sstore_refund(is_istanbul, &state_load.data),
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Removes `GasStateTr` in favor of exposing `sstore_with_gas_accounting` allowing to customize gas accounting for the instruction directly