### PR TITLE
fix(bytecode): avoid out-of-bounds pointer in analyze_legacy

### DIFF
--- a/crates/bytecode/src/legacy/analysis.rs
+++ b/crates/bytecode/src/legacy/analysis.rs
@@ -26,8 +26,10 @@ pub(crate) fn analyze_legacy(bytecode: Bytes) -> (JumpTable, Bytes) {
         } else {
             let push_offset = last_byte.wrapping_sub(opcode::PUSH1);
             if push_offset < 32 {
-                // SAFETY: Iterator access range is checked in the while loop
-                iterator = unsafe { iterator.add(push_offset as usize + 2) };
+                // A trailing PUSH can advance the iterator past the end of the
+                // bytecode allocation; `wrapping_add` keeps that offset
+                // computation defined (the `< end` guard prevents any OOB read).
+                iterator = iterator.wrapping_add(push_offset as usize + 2);
             } else {
                 // SAFETY: Iterator access range is checked in the while loop
                 iterator = unsafe { iterator.add(1) };


### PR DESCRIPTION
## What

analyze_legacy advances its cursor with raw-pointer arithmetic:

iterator = unsafe { iterator.add(push_offset as usize + 2) };

When bytecode ends mid-PUSH (e.g. a trailing PUSH32), this computes a pointer up to 33 bytes past the end of the bytecode allocation. The pointer is never dereferenced — the while iterator < end guard stops any read — but pointer::add (https://doc.rust-lang.org/std/primitive.pointer.html#method.add) requires the result to stay within (or one past) the same allocation, so forming the out-of-bounds pointer is undefined behavior in its own right.

## Fix

Use wrapping_add, which is always defined to compute and is bit-identical on real targets:

iterator = iterator.wrapping_add(push_offset as usize + 2);

The push_overflow = (iterator as usize) - (end as usize) calculation that relies on the past-end value is unchanged, and the < end guard still prevents any out-of-bounds read.

## Impact

No behavior change on current targets and no known exploit: the value is only compared and address-subtracted, never read out of bounds, and analyze_legacy's output is unaffected. This is a soundness fix — it removes UB that a future compiler (or a non-standard/zkVM backend) would be free to miscompile.

## How it was found

Surfaced by a Kani (CBMC) proof harness for analyze_legacy, which flags the pointer::add precondition violation (Miri catches it too).

## Testing

The existing analyze_legacy unit tests pass unchanged — the fix is behavior-preserving (including test_bytecode_with_max_push32).
