### PR TITLE
feat(state): accept BAL account change slices

### DIFF
--- a/crates/state/src/bal/alloy.rs
+++ b/crates/state/src/bal/alloy.rs
@@ -2,8 +2,8 @@
 
 // Re-export Alloy BAL types.
 pub use alloy_eip7928::{
-    BalanceChange as AlloyBalanceChange, BlockAccessList as AlloyBal,
-    CodeChange as AlloyCodeChange, NonceChange as AlloyNonceChange,
+    AccountChanges as AlloyAccountChanges, BalanceChange as AlloyBalanceChange,
+    BlockAccessList as AlloyBal, CodeChange as AlloyCodeChange, NonceChange as AlloyNonceChange,
     StorageChange as AlloyStorageChange,
 };
 
@@ -33,7 +33,7 @@ impl Bal {
         Ok(Self { accounts })
     }
 
-    /// Clone an EIP-7928 [`AlloyBal`] into a [`Bal`] without consuming the source.
+    /// Clone EIP-7928 [`AlloyAccountChanges`] into a [`Bal`] without consuming the source.
     ///
     /// # Errors
     ///
@@ -42,7 +42,9 @@ impl Bal {
     /// EIP-7702 bytecode, such as bytes with the EIP-7702 magic prefix but an invalid
     /// length or unsupported version.
     #[inline]
-    pub fn clone_from_alloy(alloy_bal: &AlloyBal) -> Result<Self, BytecodeDecodeError> {
+    pub fn clone_from_alloy(
+        alloy_bal: &[AlloyAccountChanges],
+    ) -> Result<Self, BytecodeDecodeError> {
         let accounts = AddressIndexMap::from_iter(
             alloy_bal
                 .iter()


### PR DESCRIPTION
## Summary

Updates `Bal::clone_from_alloy` to accept a borrowed slice of EIP-7928 account changes instead of requiring a borrowed `AlloyBal` value.

## Motivation

The borrowed conversion only needs to iterate account changes, so accepting `&[AlloyAccountChanges]` makes the API usable with any account-change slice while preserving existing `Vec`/`AlloyBal` call sites through slice coercion.

## Impact

This keeps the conversion non-consuming and broadens the accepted input type for callers that already have account changes in slice form.