### PR TITLE
chore(deny): allow proc-macro-error2 advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -6,6 +6,8 @@ ignore = [
     "RUSTSEC-2024-0436",
     # https://rustsec.org/advisories/RUSTSEC-2026-0097 rand 0.9.2 unsound (no fix available yet)
     "RUSTSEC-2026-0097",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0173 proc-macro-error2 is unmaintained
+    "RUSTSEC-2026-0173",
 ]
 
 [bans]


### PR DESCRIPTION
## Summary

Adds `RUSTSEC-2026-0173` to the cargo-deny advisory ignore list for `proc-macro-error2`.

## Motivation

The deny job currently fails because `proc-macro-error2 v2.0.1` is reported as unmaintained. It is pulled in transitively through Alloy macro dependencies, and the advisory reports that no safe upgrade is available.

## Impact

This unblocks the advisory check while keeping the existing cargo-deny policy intact for bans, licenses, and sources.