### PR TITLE
perf(precompile): use malachite for std modexp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,6 +1170,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2899,6 +2905,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "malachite"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bba00455c89cf785ef73a0dfc941ab3c21211963c86130c0bd48d7994b942707"
+dependencies = [
+ "malachite-base",
+ "malachite-nz",
+]
+
+[[package]]
+name = "malachite-base"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f44099731f17094b07825c88ccb5fbd1bfa1f82fafff7daa33e8b8652db16e"
+dependencies = [
+ "hashbrown 0.16.1",
+ "itertools 0.14.0",
+ "libm",
+ "ryu",
+]
+
+[[package]]
+name = "malachite-nz"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a137660cdba20f136c8a223125f08088adb4e0b72fbb8466f08c43e31cc0427d"
+dependencies = [
+ "itertools 0.14.0",
+ "libm",
+ "malachite-base",
+ "wide",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3875,6 +3915,7 @@ dependencies = [
  "codspeed-criterion-compat",
  "gmp-mpfr-sys",
  "k256",
+ "malachite",
  "p256",
  "rand 0.9.2",
  "revm-context-interface",
@@ -4194,6 +4235,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -5269,6 +5319,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wide"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ ark-ff = { version = "0.5", default-features = false }
 ark-serialize = { version = "0.5", default-features = false }
 ark-std = { version = "0.5", default-features = false }
 aurora-engine-modexp = { version = "1.2", default-features = false }
+malachite = { version = "0.9.2", default-features = false, features = ["naturals_and_integers"] }
 gmp-mpfr-sys = { version = "1.6", default-features = false }
 blst = "0.3.15"
 bn = { package = "substrate-bn", version = "0.6", default-features = false }

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -24,6 +24,7 @@ context-interface.workspace = true
 
 # modexp precompiles
 aurora-engine-modexp.workspace = true
+malachite = { workspace = true, optional = true }
 # gmp ffi
 gmp-mpfr-sys = { workspace = true, default-features = false, optional = true }
 
@@ -89,12 +90,12 @@ std = [
 	"secp256k1?/std",
 	"ark-bn254/std",
 	"ark-bls12-381/std",
-	"aurora-engine-modexp/std",
 	"ark-ec/std",
 	"ark-ff/std",
 	"ark-serialize/std",
 	"ark-std/std",
 	"p256/std",
+	"dep:malachite",
 ]
 hashbrown = ["primitives/hashbrown"]
 asm-keccak = ["primitives/asm-keccak"]

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -59,9 +59,13 @@ cfg_if::cfg_if! {
     }
 }
 
-// silence aurora-engine-modexp if gmp is enabled
-#[cfg(feature = "gmp")]
+// silence aurora-engine-modexp when std uses malachite or gmp takes precedence.
+#[cfg(any(feature = "gmp", feature = "std"))]
 use aurora_engine_modexp as _;
+
+// silence malachite if gmp is enabled, because gmp takes precedence for MODEXP.
+#[cfg(all(feature = "gmp", feature = "std"))]
+use malachite as _;
 
 // silence p256 lint as aws-lc-rs will be used if both are enabled.
 #[cfg(feature = "p256-aws-lc-rs")]

--- a/crates/precompile/src/modexp.rs
+++ b/crates/precompile/src/modexp.rs
@@ -136,7 +136,30 @@ pub(crate) fn modexp(base: &[u8], exponent: &[u8], modulus: &[u8]) -> Vec<u8> {
     result.to_be_bytes()
 }
 
-#[cfg(not(feature = "gmp"))]
+#[cfg(all(not(feature = "gmp"), feature = "std"))]
+pub(crate) fn modexp(base: &[u8], exponent: &[u8], modulus: &[u8]) -> Vec<u8> {
+    use malachite::{
+        base::num::{arithmetic::traits::ModPow, conversion::traits::PowerOf2Digits},
+        Natural,
+    };
+
+    if modulus.iter().all(|&byte| byte == 0) {
+        return Vec::new();
+    }
+
+    let base = Natural::from_power_of_2_digits_desc(8, base.iter().copied())
+        .expect("u8 digits are always valid base-256 digits");
+    let exponent = Natural::from_power_of_2_digits_desc(8, exponent.iter().copied())
+        .expect("u8 digits are always valid base-256 digits");
+    let modulus = Natural::from_power_of_2_digits_desc(8, modulus.iter().copied())
+        .expect("u8 digits are always valid base-256 digits");
+
+    (base % &modulus)
+        .mod_pow(exponent, &modulus)
+        .to_power_of_2_digits_desc(8)
+}
+
+#[cfg(all(not(feature = "gmp"), not(feature = "std")))]
 pub(crate) fn modexp(base: &[u8], exponent: &[u8], modulus: &[u8]) -> Vec<u8> {
     aurora_engine_modexp::modexp(base, exponent, modulus)
 }


### PR DESCRIPTION
Switches the default std MODEXP backend from `aurora-engine-modexp` to `malachite::Natural` with `ModPow::mod_pow`. The `gmp` feature still takes precedence when explicitly enabled, and no-std builds continue to use the existing Aurora implementation.

The Malachite path imports base, exponent, and modulus as big-endian base-256 digits, handles zero modulus the same way as the previous backend, and reduces the base before calling `mod_pow` because Malachite requires the base to already be reduced modulo the modulus. The new dependency is wired only through `revm-precompile/std` with `default-features = false` and `naturals_and_integers` enabled.

Validated with:
- `cargo check -p revm-precompile`
- `cargo check -p revm-precompile --no-default-features`
- `cargo test -p revm-precompile modexp`
- `cargo test -p revm-precompile modexp --no-default-features`
- `cargo check -p revm-precompile --features gmp`
- `cargo test -p revm-precompile modexp --features gmp`
- `cargo check -p revm-precompile --all-features`
- `cargo bench -p revm-precompile --bench bench modexp --no-run`
- `cargo fmt --all --check`
- `git diff --check`