### PR TITLE
ci(bench): allow dispatch benchmarks with cargo features

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+    inputs:
+      cargo_features:
+        description: "Optional Cargo features for cargo codspeed build, e.g. revm-precompile/gmp"
+        required: false
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
@@ -28,7 +33,14 @@ jobs:
         with:
           tool: cargo-codspeed
       - name: Build the benchmark target(s)
-        run: cargo codspeed build --profile profiling --workspace --exclude '*example*'
+        env:
+          CARGO_FEATURES: ${{ inputs.cargo_features }}
+        run: |
+          if [ -n "$CARGO_FEATURES" ]; then
+            cargo codspeed build --profile profiling --workspace --exclude '*example*' --features "$CARGO_FEATURES"
+          else
+            cargo codspeed build --profile profiling --workspace --exclude '*example*'
+          fi
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd # v4.15.1
         with:


### PR DESCRIPTION
Adds an optional `cargo_features` input to the existing `workflow_dispatch` trigger for the CodSpeed benchmark workflow.

Manual runs can now pass package-qualified Cargo feature strings such as `revm-precompile/gmp` to the CodSpeed build step. When the input is empty, the workflow executes the same `cargo codspeed build --profile profiling --workspace --exclude '*example*'` command as before. The `cargo codspeed run --workspace` invocation is unchanged, so automatic `pull_request` and `push` behavior remains unchanged.

Validation: `git diff --check`. `actionlint` is not installed in this environment.