### PR TITLE
docs(handler): clarify PrecompileProvider::run return semantics

### DIFF
--- a/crates/handler/src/precompile_provider.rs
+++ b/crates/handler/src/precompile_provider.rs
@@ -17,7 +17,16 @@ pub trait PrecompileProvider<CTX: ContextTr> {
     /// Returns `true` if precompile addresses should be injected into the journal.
     fn set_spec(&mut self, spec: <CTX::Cfg as Cfg>::Spec) -> bool;
 
-    /// Run the precompile.
+    /// Runs the precompile for the given call inputs.
+    ///
+    /// Return values distinguish whether the provider handled the call:
+    /// - `Ok(Some(output))` means the call was executed by this provider.
+    /// - `Ok(None)` means this provider does not contain a precompile for the
+    ///   requested address, so the caller should continue with regular contract
+    ///   execution.
+    /// - `Err(error)` means execution failed with a provider error that should
+    ///   abort EVM execution. Non-fatal precompile failures, such as reverts,
+    ///   out-of-gas, or invalid input, should be encoded in `output` instead.
     fn run(
         &mut self,
         context: &mut CTX,


### PR DESCRIPTION
Clarifies the return semantics of `PrecompileProvider::run`.

The docs now distinguish between:

- `Ok(Some(output))` when the provider handled the precompile call
- `Ok(None)` when the provider does not contain a precompile for the requested address
- `Err(error)` for provider errors that should abort EVM execution

This also documents that non-fatal precompile failures should be represented in the returned output instead of `Err`.

Closes #2393.