### PR TITLE
perf(precompile): skip bls msm infinity points in arkworks backend

### DIFF
--- a/crates/precompile/src/bls12_381/arkworks.rs
+++ b/crates/precompile/src/bls12_381/arkworks.rs
@@ -127,6 +127,26 @@ fn read_g1(x: &[u8; FP_LENGTH], y: &[u8; FP_LENGTH]) -> Result<G1Affine, Precomp
     Ok(point)
 }
 
+/// Reads a G1 point for use in an MSM, returning `None` for the point at infinity.
+///
+/// Infinity is the identity, lies in every subgroup, and contributes nothing to the MSM
+/// result, so it can be skipped after the on-curve validation. Non-infinity points still
+/// require a subgroup check, exactly like [`read_g1`].
+#[inline]
+fn read_g1_msm(
+    x: &[u8; FP_LENGTH],
+    y: &[u8; FP_LENGTH],
+) -> Result<Option<G1Affine>, PrecompileHalt> {
+    let point = read_g1_no_subgroup_check(x, y)?;
+    if point.is_zero() {
+        return Ok(None);
+    }
+    if !point.is_in_correct_subgroup_assuming_on_curve() {
+        return Err(PrecompileHalt::Bls12381G1NotInSubgroup);
+    }
+    Ok(Some(point))
+}
+
 /// Reads a G1 point without performing a subgroup check.
 ///
 /// Note: Skipping subgroup checks can introduce security issues.
@@ -184,6 +204,28 @@ fn read_g2(
     Ok(point)
 }
 
+/// Reads a G2 point for use in an MSM, returning `None` for the point at infinity.
+///
+/// Infinity is the identity, lies in every subgroup, and contributes nothing to the MSM
+/// result, so it can be skipped after the on-curve validation. Non-infinity points still
+/// require a subgroup check, exactly like [`read_g2`].
+#[inline]
+fn read_g2_msm(
+    a_x_0: &[u8; FP_LENGTH],
+    a_x_1: &[u8; FP_LENGTH],
+    a_y_0: &[u8; FP_LENGTH],
+    a_y_1: &[u8; FP_LENGTH],
+) -> Result<Option<G2Affine>, PrecompileHalt> {
+    let point = read_g2_no_subgroup_check(a_x_0, a_x_1, a_y_0, a_y_1)?;
+    if point.is_zero() {
+        return Ok(None);
+    }
+    if !point.is_in_correct_subgroup_assuming_on_curve() {
+        return Err(PrecompileHalt::Bls12381G2NotInSubgroup);
+    }
+    Ok(Some(point))
+}
+
 /// Reads a G2 point without performing a subgroup check.
 ///
 /// Note: Skipping subgroup checks can introduce security issues.
@@ -228,10 +270,11 @@ fn encode_g2_point(input: &G2Affine) -> [u8; G2_LENGTH] {
 }
 
 /// Extracts a scalar from a byte slice representation, decoding the input as a Big Endian
-/// unsigned integer.
+/// unsigned integer and reducing it modulo the subgroup order.
 ///
-/// Note: We do not check that the scalar is a canonical Fr element, because the EIP specifies:
-/// * The corresponding integer is not required to be less than or equal than main subgroup order.
+/// EIP-2537 does not require the corresponding integer to be less than the main subgroup order.
+/// Because every MSM input point is subgroup-checked (order `r`), reducing the scalar modulo `r`
+/// yields an identical result while letting callers cheaply skip scalars that reduce to zero.
 #[inline]
 fn read_scalar(input: &[u8]) -> Result<Fr, PrecompileHalt> {
     if input.len() != SCALAR_LENGTH {
@@ -431,8 +474,10 @@ pub(crate) fn p1_msm_bytes(
     for pair_result in point_scalar_pairs {
         let ((x, y), scalar_bytes) = pair_result?;
 
-        // NB: MSM requires subgroup check
-        let point = read_g1(&x, &y)?;
+        // Skip points at infinity after validating they are on-curve and in the subgroup.
+        let Some(point) = read_g1_msm(&x, &y)? else {
+            continue;
+        };
 
         let scalar = read_scalar(&scalar_bytes)?;
 
@@ -470,8 +515,10 @@ pub(crate) fn p2_msm_bytes(
     for pair_result in point_scalar_pairs {
         let ((x_0, x_1, y_0, y_1), scalar_bytes) = pair_result?;
 
-        // NB: MSM requires subgroup check
-        let point = read_g2(&x_0, &x_1, &y_0, &y_1)?;
+        // Skip points at infinity after validating they are on-curve and in the subgroup.
+        let Some(point) = read_g2_msm(&x_0, &x_1, &y_0, &y_1)? else {
+            continue;
+        };
 
         let scalar = read_scalar(&scalar_bytes)?;
 
@@ -494,4 +541,21 @@ pub(crate) fn p2_msm_bytes(
 
     // Encode result
     Ok(encode_g2_point(&result))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_g1_msm_skips_infinity() {
+        let zero = [0u8; FP_LENGTH];
+        assert!(read_g1_msm(&zero, &zero).unwrap().is_none());
+    }
+
+    #[test]
+    fn read_g2_msm_skips_infinity() {
+        let zero = [0u8; FP_LENGTH];
+        assert!(read_g2_msm(&zero, &zero, &zero, &zero).unwrap().is_none());
+    }
 }

--- a/crates/precompile/src/bls12_381/arkworks.rs
+++ b/crates/precompile/src/bls12_381/arkworks.rs
@@ -127,24 +127,30 @@ fn read_g1(x: &[u8; FP_LENGTH], y: &[u8; FP_LENGTH]) -> Result<G1Affine, Precomp
     Ok(point)
 }
 
-/// Reads a G1 point for use in an MSM, returning `None` for the point at infinity.
+/// A non-infinity G1 point proven to lie in the order-`r` subgroup.
 ///
-/// Infinity is the identity, lies in every subgroup, and contributes nothing to the MSM
-/// result, so it can be skipped after the on-curve validation. Non-infinity points still
-/// require a subgroup check, exactly like [`read_g1`].
-#[inline]
-fn read_g1_msm(
-    x: &[u8; FP_LENGTH],
-    y: &[u8; FP_LENGTH],
-) -> Result<Option<G1Affine>, PrecompileHalt> {
-    let point = read_g1_no_subgroup_check(x, y)?;
-    if point.is_zero() {
-        return Ok(None);
+/// MSM scalars are reduced modulo `r`, so keeping this proof in the type prevents an unchecked
+/// point reader from being wired into the MSM path accidentally.
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+struct SubgroupCheckedG1(G1Affine);
+
+impl SubgroupCheckedG1 {
+    /// Reads a G1 MSM operand, returning `None` for the point at infinity.
+    ///
+    /// Infinity is the identity and contributes nothing to the MSM result, so it can be skipped
+    /// after the on-curve validation. Every returned point has passed the subgroup check.
+    #[inline]
+    fn read_msm(x: &[u8; FP_LENGTH], y: &[u8; FP_LENGTH]) -> Result<Option<Self>, PrecompileHalt> {
+        let point = read_g1_no_subgroup_check(x, y)?;
+        if point.is_zero() {
+            return Ok(None);
+        }
+        if !point.is_in_correct_subgroup_assuming_on_curve() {
+            return Err(PrecompileHalt::Bls12381G1NotInSubgroup);
+        }
+        Ok(Some(Self(point)))
     }
-    if !point.is_in_correct_subgroup_assuming_on_curve() {
-        return Err(PrecompileHalt::Bls12381G1NotInSubgroup);
-    }
-    Ok(Some(point))
 }
 
 /// Reads a G1 point without performing a subgroup check.
@@ -204,26 +210,35 @@ fn read_g2(
     Ok(point)
 }
 
-/// Reads a G2 point for use in an MSM, returning `None` for the point at infinity.
+/// A non-infinity G2 point proven to lie in the order-`r` subgroup.
 ///
-/// Infinity is the identity, lies in every subgroup, and contributes nothing to the MSM
-/// result, so it can be skipped after the on-curve validation. Non-infinity points still
-/// require a subgroup check, exactly like [`read_g2`].
-#[inline]
-fn read_g2_msm(
-    a_x_0: &[u8; FP_LENGTH],
-    a_x_1: &[u8; FP_LENGTH],
-    a_y_0: &[u8; FP_LENGTH],
-    a_y_1: &[u8; FP_LENGTH],
-) -> Result<Option<G2Affine>, PrecompileHalt> {
-    let point = read_g2_no_subgroup_check(a_x_0, a_x_1, a_y_0, a_y_1)?;
-    if point.is_zero() {
-        return Ok(None);
+/// MSM scalars are reduced modulo `r`, so keeping this proof in the type prevents an unchecked
+/// point reader from being wired into the MSM path accidentally.
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+struct SubgroupCheckedG2(G2Affine);
+
+impl SubgroupCheckedG2 {
+    /// Reads a G2 MSM operand, returning `None` for the point at infinity.
+    ///
+    /// Infinity is the identity and contributes nothing to the MSM result, so it can be skipped
+    /// after the on-curve validation. Every returned point has passed the subgroup check.
+    #[inline]
+    fn read_msm(
+        a_x_0: &[u8; FP_LENGTH],
+        a_x_1: &[u8; FP_LENGTH],
+        a_y_0: &[u8; FP_LENGTH],
+        a_y_1: &[u8; FP_LENGTH],
+    ) -> Result<Option<Self>, PrecompileHalt> {
+        let point = read_g2_no_subgroup_check(a_x_0, a_x_1, a_y_0, a_y_1)?;
+        if point.is_zero() {
+            return Ok(None);
+        }
+        if !point.is_in_correct_subgroup_assuming_on_curve() {
+            return Err(PrecompileHalt::Bls12381G2NotInSubgroup);
+        }
+        Ok(Some(Self(point)))
     }
-    if !point.is_in_correct_subgroup_assuming_on_curve() {
-        return Err(PrecompileHalt::Bls12381G2NotInSubgroup);
-    }
-    Ok(Some(point))
 }
 
 /// Reads a G2 point without performing a subgroup check.
@@ -274,7 +289,9 @@ fn encode_g2_point(input: &G2Affine) -> [u8; G2_LENGTH] {
 ///
 /// EIP-2537 does not require the corresponding integer to be less than the main subgroup order.
 /// Because every MSM input point is subgroup-checked (order `r`), reducing the scalar modulo `r`
-/// yields an identical result while letting callers cheaply skip scalars that reduce to zero.
+/// yields an identical result while letting callers cheaply skip scalars that reduce to zero. The
+/// MSM APIs accept only [`SubgroupCheckedG1`] or [`SubgroupCheckedG2`] operands so this invariant
+/// is enforced by the type system.
 #[inline]
 fn read_scalar(input: &[u8]) -> Result<Fr, PrecompileHalt> {
     if input.len() != SCALAR_LENGTH {
@@ -302,11 +319,12 @@ fn p2_add_affine(p1: &G2Affine, p2: &G2Affine) -> G2Affine {
 
 /// Performs multi-scalar multiplication (MSM) for G1 points
 ///
-/// Takes a vector of G1 points and corresponding scalars, and returns their weighted sum
+/// Takes a vector of subgroup-checked G1 points and corresponding scalars, and returns their
+/// weighted sum.
 ///
 /// Note: This method assumes that `g1_points` does not contain any points at infinity.
 #[inline]
-fn p1_msm(g1_points: Vec<G1Affine>, scalars: Vec<Fr>) -> G1Affine {
+fn p1_msm(g1_points: Vec<SubgroupCheckedG1>, scalars: Vec<Fr>) -> G1Affine {
     assert_eq!(
         g1_points.len(),
         scalars.len(),
@@ -319,8 +337,11 @@ fn p1_msm(g1_points: Vec<G1Affine>, scalars: Vec<Fr>) -> G1Affine {
 
     if g1_points.len() == 1 {
         let big_int = scalars[0].into_bigint();
-        return g1_points[0].mul_bigint(big_int).into_affine();
+        return g1_points[0].0.mul_bigint(big_int).into_affine();
     }
+
+    // Unwrap the subgroup proof only at the arkworks MSM boundary.
+    let g1_points: Vec<G1Affine> = g1_points.into_iter().map(|point| point.0).collect();
 
     // Perform multi-scalar multiplication
     G1Projective::msm(&g1_points, &scalars)
@@ -330,11 +351,12 @@ fn p1_msm(g1_points: Vec<G1Affine>, scalars: Vec<Fr>) -> G1Affine {
 
 /// Performs multi-scalar multiplication (MSM) for G2 points
 ///
-/// Takes a vector of G2 points and corresponding scalars, and returns their weighted sum
+/// Takes a vector of subgroup-checked G2 points and corresponding scalars, and returns their
+/// weighted sum.
 ///
 /// Note: This method assumes that `g2_points` does not contain any points at infinity.
 #[inline]
-fn p2_msm(g2_points: Vec<G2Affine>, scalars: Vec<Fr>) -> G2Affine {
+fn p2_msm(g2_points: Vec<SubgroupCheckedG2>, scalars: Vec<Fr>) -> G2Affine {
     assert_eq!(
         g2_points.len(),
         scalars.len(),
@@ -347,8 +369,11 @@ fn p2_msm(g2_points: Vec<G2Affine>, scalars: Vec<Fr>) -> G2Affine {
 
     if g2_points.len() == 1 {
         let big_int = scalars[0].into_bigint();
-        return g2_points[0].mul_bigint(big_int).into_affine();
+        return g2_points[0].0.mul_bigint(big_int).into_affine();
     }
+
+    // Unwrap the subgroup proof only at the arkworks MSM boundary.
+    let g2_points: Vec<G2Affine> = g2_points.into_iter().map(|point| point.0).collect();
 
     // Perform multi-scalar multiplication
     G2Projective::msm(&g2_points, &scalars)
@@ -475,7 +500,7 @@ pub(crate) fn p1_msm_bytes(
         let ((x, y), scalar_bytes) = pair_result?;
 
         // Skip points at infinity after validating they are on-curve and in the subgroup.
-        let Some(point) = read_g1_msm(&x, &y)? else {
+        let Some(point) = SubgroupCheckedG1::read_msm(&x, &y)? else {
             continue;
         };
 
@@ -516,7 +541,7 @@ pub(crate) fn p2_msm_bytes(
         let ((x_0, x_1, y_0, y_1), scalar_bytes) = pair_result?;
 
         // Skip points at infinity after validating they are on-curve and in the subgroup.
-        let Some(point) = read_g2_msm(&x_0, &x_1, &y_0, &y_1)? else {
+        let Some(point) = SubgroupCheckedG2::read_msm(&x_0, &x_1, &y_0, &y_1)? else {
             continue;
         };
 
@@ -550,12 +575,14 @@ mod tests {
     #[test]
     fn read_g1_msm_skips_infinity() {
         let zero = [0u8; FP_LENGTH];
-        assert!(read_g1_msm(&zero, &zero).unwrap().is_none());
+        assert!(SubgroupCheckedG1::read_msm(&zero, &zero).unwrap().is_none());
     }
 
     #[test]
     fn read_g2_msm_skips_infinity() {
         let zero = [0u8; FP_LENGTH];
-        assert!(read_g2_msm(&zero, &zero, &zero, &zero).unwrap().is_none());
+        assert!(SubgroupCheckedG2::read_msm(&zero, &zero, &zero, &zero)
+            .unwrap()
+            .is_none());
     }
 }

--- a/crates/precompile/src/bls12_381/blst.rs
+++ b/crates/precompile/src/bls12_381/blst.rs
@@ -639,9 +639,9 @@ fn read_fp(input: &[u8; FP_LENGTH]) -> Result<blst_fp, PrecompileHalt> {
 /// * A scalar for the multiplication operation is encoded as 32 bytes by performing BigEndian
 ///   encoding of the corresponding (unsigned) integer.
 ///
-/// We do not check that the scalar is a canonical Fr element, because the EIP specifies:
-/// * The corresponding integer is not required to be less than or equal than main subgroup order
-///   `q`.
+/// EIP-2537 does not require the corresponding integer to be less than the main subgroup order
+/// `r`. Because every MSM input point is subgroup-checked (order `r`), reducing the scalar modulo
+/// `r` yields an identical result while letting callers cheaply skip scalars that reduce to zero.
 fn read_scalar(input: &[u8]) -> Result<blst_scalar, PrecompileHalt> {
     if input.len() != SCALAR_LENGTH {
         return Err(PrecompileHalt::Bls12381ScalarInputLength);

--- a/crates/precompile/src/bls12_381/g1_msm.rs
+++ b/crates/precompile/src/bls12_381/g1_msm.rs
@@ -96,4 +96,42 @@ mod test {
         assert_eq!(output.gas_used, G1_MSM_BASE_GAS_FEE);
         assert_eq!(output.bytes, Bytes::from(vec![0; PADDED_G1_LENGTH]));
     }
+
+    fn g1_generator_point() -> [u8; PADDED_G1_LENGTH] {
+        let mut point = [0u8; PADDED_G1_LENGTH];
+        point[16..64].copy_from_slice(&hex!(
+            "17f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb"
+        ));
+        point[80..128].copy_from_slice(&hex!(
+            "08b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e1"
+        ));
+        point
+    }
+
+    fn scalar32(value: u8) -> [u8; SCALAR_LENGTH] {
+        let mut scalar = [0u8; SCALAR_LENGTH];
+        scalar[SCALAR_LENGTH - 1] = value;
+        scalar
+    }
+
+    /// An infinity point paired with a non-zero scalar must be skipped, leaving the result
+    /// identical to omitting it entirely.
+    #[test]
+    fn bls_g1msm_skips_infinity_points() {
+        let generator = g1_generator_point();
+
+        let mut single = Vec::with_capacity(G1_MSM_INPUT_LENGTH);
+        single.extend_from_slice(&generator);
+        single.extend_from_slice(&scalar32(2));
+        let expected = g1_msm(&single, 1_000_000).unwrap();
+
+        let mut mixed = Vec::with_capacity(2 * G1_MSM_INPUT_LENGTH);
+        mixed.extend_from_slice(&generator);
+        mixed.extend_from_slice(&scalar32(2));
+        mixed.extend_from_slice(&[0u8; PADDED_G1_LENGTH]);
+        mixed.extend_from_slice(&scalar32(5));
+        let got = g1_msm(&mixed, 1_000_000).unwrap();
+
+        assert_eq!(got.bytes, expected.bytes);
+    }
 }

--- a/crates/precompile/src/bls12_381/g2_msm.rs
+++ b/crates/precompile/src/bls12_381/g2_msm.rs
@@ -93,4 +93,48 @@ mod test {
         assert_eq!(output.gas_used, G2_MSM_BASE_GAS_FEE);
         assert_eq!(output.bytes, Bytes::from(vec![0; PADDED_G2_LENGTH]));
     }
+
+    fn g2_generator_point() -> [u8; PADDED_G2_LENGTH] {
+        let mut point = [0u8; PADDED_G2_LENGTH];
+        point[16..64].copy_from_slice(&hex!(
+            "024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"
+        ));
+        point[80..128].copy_from_slice(&hex!(
+            "13e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e"
+        ));
+        point[144..192].copy_from_slice(&hex!(
+            "0ce5d527727d6e118cc9cdc6da2e351aadfd9baa8cbdd3a76d429a695160d12c923ac9cc3baca289e193548608b82801"
+        ));
+        point[208..256].copy_from_slice(&hex!(
+            "0606c4a02ea734cc32acd2b02bc28b99cb3e287e85a763af267492ab572e99ab3f370d275cec1da1aaa9075ff05f79be"
+        ));
+        point
+    }
+
+    fn scalar32(value: u8) -> [u8; SCALAR_LENGTH] {
+        let mut scalar = [0u8; SCALAR_LENGTH];
+        scalar[SCALAR_LENGTH - 1] = value;
+        scalar
+    }
+
+    /// An infinity point paired with a non-zero scalar must be skipped, leaving the result
+    /// identical to omitting it entirely.
+    #[test]
+    fn bls_g2msm_skips_infinity_points() {
+        let generator = g2_generator_point();
+
+        let mut single = Vec::with_capacity(G2_MSM_INPUT_LENGTH);
+        single.extend_from_slice(&generator);
+        single.extend_from_slice(&scalar32(2));
+        let expected = g2_msm(&single, 1_000_000).unwrap();
+
+        let mut mixed = Vec::with_capacity(2 * G2_MSM_INPUT_LENGTH);
+        mixed.extend_from_slice(&generator);
+        mixed.extend_from_slice(&scalar32(2));
+        mixed.extend_from_slice(&[0u8; PADDED_G2_LENGTH]);
+        mixed.extend_from_slice(&scalar32(5));
+        let got = g2_msm(&mixed, 1_000_000).unwrap();
+
+        assert_eq!(got.bytes, expected.bytes);
+    }
 }


### PR DESCRIPTION
Builds on #3766. That PR adds BLS12-381 MSM benches and teaches the **blst** backend to skip points at infinity and zero-reduced scalars in G1/G2 MSM. The **arkworks** fallback only got the zero-scalar skip — it still pushed infinity points into the MSM.

This PR brings the arkworks backend to parity:

- Add `read_g1_msm` / `read_g2_msm` in `arkworks.rs` mirroring the blst helpers: validate on-curve, return `None` for the point at infinity (skip it), then subgroup-check the non-infinity points. Wire them into `p1_msm_bytes` / `p2_msm_bytes`. Output is unchanged — an infinity point contributes nothing to the MSM — but it no longer enters the MSM (and skips the subgroup check, matching blst).
- Resolve the now-contradictory `read_scalar` doc comment in `blst.rs`: it reduces modulo the subgroup order `r` via `blst_scalar_from_be_bytes`, so the leftover "we do not reduce" note was wrong. Clarify the arkworks equivalent too. Reducing modulo `r` is sound because every MSM input point is subgroup-checked (order `r`), so `scalar · P == (scalar mod r) · P`.

### Tests
- arkworks unit tests mirroring blst's `read_g{1,2}_msm_skips_infinity`.
- Backend-agnostic integration tests `bls_g{1,2}msm_skips_infinity_points`, asserting an infinity point paired with a non-zero scalar yields the same result as omitting it.

Verified locally:
- `cargo test -p revm-precompile bls12_381` (blst, default) — 13 passed
- `cargo test -p revm-precompile --no-default-features --features std bls12_381` (arkworks) — 11 passed
- `cargo clippy -p revm-precompile` and `--no-default-features --features std` — clean

Targeting `dan/bls12-381-precompile-benches` so the diff is only these changes on top of #3766.
