### PR TITLE
feat(eip8038): finalize gas parameters per ethereum/EIPs#11802

### DIFF
--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -371,17 +371,17 @@ impl GasParams {
                 gas::ACCESS_LIST_STORAGE_KEY + 32 * 64;
             table[GasId::tx_access_list_floor_byte_multiplier().as_usize()] = 4;
 
-            // EIP-8038: State-access gas cost update. All TBD parameters are
-            // set to `previous_value + 1` per the user-supplied rule.
-            //   WARM_ACCESS                  100 -> 101
-            //   COLD_ACCOUNT_ACCESS        2,600 -> 2,601
-            //   ACCOUNT_WRITE              6,700 -> 6,701
-            //   COLD_STORAGE_ACCESS        2,100 -> 2,101
-            //   STORAGE_WRITE              2,800 -> 2,801
-            //   STORAGE_CLEAR_REFUND       4,800 -> 4,801
-            //   CREATE_ACCESS              7,000 -> 7,001
-            //   ACCESS_LIST_ADDRESS_COST   2,400 -> 2,401
-            //   ACCESS_LIST_STORAGE_KEY_COST 1,900 -> 1,901
+            // EIP-8038: State-access gas cost update (ethereum/EIPs#11802;
+            // preliminary draft values). Constants live in `primitives::eip8038`.
+            //   WARM_ACCESS                    100 ->    100  (unchanged)
+            //   COLD_ACCOUNT_ACCESS          2,600 ->  3,000
+            //   ACCOUNT_WRITE                6,700 ->  8,000
+            //   COLD_STORAGE_ACCESS          2,100 ->  3,000
+            //   STORAGE_WRITE                2,800 -> 10,000
+            //   STORAGE_CLEAR_REFUND         4,800 -> 12,480
+            //   CREATE_ACCESS                7,000 -> 11,000  (ACCOUNT_WRITE + COLD_STORAGE_ACCESS)
+            //   ACCESS_LIST_ADDRESS_COST     2,400 ->  3,000  (COLD_ACCOUNT_ACCESS)
+            //   ACCESS_LIST_STORAGE_KEY_COST 1,900 ->  3,000  (COLD_STORAGE_ACCESS)
             //
             // Account access table values.
             table[GasId::warm_storage_read_cost().as_usize()] = eip8038::WARM_ACCESS;
@@ -416,8 +416,8 @@ impl GasParams {
             table[GasId::create().as_usize()] = eip8038::CREATE_ACCESS;
             table[GasId::tx_create_cost().as_usize()] = eip8038::CREATE_ACCESS;
 
-            // Access-list per-item costs: bump the base by +1 each, keeping the
-            // EIP-7981 64 gas/byte data charge on top.
+            // Access-list per-item costs: EIP-8038 base (COLD_*_ACCESS, 3,000 each),
+            // keeping the EIP-7981 64 gas/byte data charge on top.
             table[GasId::tx_access_list_address_cost().as_usize()] =
                 eip8038::ACCESS_LIST_ADDRESS_COST + 20 * 64;
             table[GasId::tx_access_list_storage_key_cost().as_usize()] =
@@ -1804,15 +1804,15 @@ mod tests {
     fn test_eip7981_access_list_cost_amsterdam() {
         // EIP-7981 folds a 64 gas/byte data charge into the per-item access-list cost
         // and adds 4 floor tokens per access-list byte on top of the EIP-7976 floor.
-        // EIP-8038 bumps the per-item base by +1 (ACCESS_LIST_ADDRESS_COST 2400 ->
-        // 2401, ACCESS_LIST_STORAGE_KEY_COST 1900 -> 1901).
+        // EIP-8038 sets the per-item base to COLD_ACCOUNT_ACCESS / COLD_STORAGE_ACCESS
+        // (both 3,000).
         let params = GasParams::new_spec(SpecId::AMSTERDAM);
 
         // Per-item intrinsic cost: base + bytes * 64
-        assert_eq!(params.tx_access_list_address_cost(), 2401 + 20 * 64);
-        assert_eq!(params.tx_access_list_storage_key_cost(), 1901 + 32 * 64);
-        assert_eq!(params.tx_access_list_cost(1, 0), 2401 + 20 * 64);
-        assert_eq!(params.tx_access_list_cost(0, 1), 1901 + 32 * 64);
+        assert_eq!(params.tx_access_list_address_cost(), 3000 + 20 * 64);
+        assert_eq!(params.tx_access_list_storage_key_cost(), 3000 + 32 * 64);
+        assert_eq!(params.tx_access_list_cost(1, 0), 3000 + 20 * 64);
+        assert_eq!(params.tx_access_list_cost(0, 1), 3000 + 32 * 64);
 
         // Floor multiplier activates at AMSTERDAM.
         assert_eq!(params.tx_access_list_floor_byte_multiplier(), 4);

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_block_gas_limit_enforced_with_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_block_gas_limit_enforced_with_state_gas.snap
@@ -6,7 +6,7 @@ expression: "&result_fits"
   "Success": {
     "reason": "Stop",
     "gas": {
-      "gas_spent": 226009,
+      "gas_spent": 234106,
       "state_gas_spent": 200000,
       "gas_refunded": 0,
       "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_propagates.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_propagates.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 33530,
+        "gas_spent": 45625,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 569536,
+        "gas_spent": 581631,
         "state_gas_spent": 536000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_reverts.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_reverts.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 33752,
+        "gas_spent": 45847,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 373758,
+        "gas_spent": 385853,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_existing_account.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_existing_account.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 27824,
+        "gas_spent": 29122,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -32,7 +32,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 27824,
+        "gas_spent": 29122,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 37025,
+        "gas_spent": 40022,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -32,7 +32,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 287025,
+        "gas_spent": 290022,
         "state_gas_spent": 250000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account_no_value.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account_no_value.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 23623,
+        "gas_spent": 24022,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 23623,
+        "gas_spent": 24022,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create2_with_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create2_with_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 28080,
+        "gas_spent": 32079,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 368086,
+        "gas_spent": 372085,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -37,7 +37,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 368077,
+        "gas_spent": 372076,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_child_propagates.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_child_propagates.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 33125,
+        "gas_spent": 45221,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 564131,
+        "gas_spent": 576227,
         "state_gas_spent": 531000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_code_deposit_state_gas_oog.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_code_deposit_state_gas_oog.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, baseline_tight_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 28080,
+        "gas_spent": 32079,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, baseline_tight_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 28080,
+        "gas_spent": 32079,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -39,7 +39,7 @@ expression: "&(baseline_result, baseline_tight_result, result)"
         "OutOfGas": "Basic"
       },
       "gas": {
-        "gas_spent": 28081,
+        "gas_spent": 32080,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_empty_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_empty_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 28068,
+        "gas_spent": 32067,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 358068,
+        "gas_spent": 362067,
         "state_gas_spent": 330000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_large_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_large_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 28089,
+        "gas_spent": 32088,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 558131,
+        "gas_spent": 562130,
         "state_gas_spent": 530000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 28071,
+        "gas_spent": 32070,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 368077,
+        "gas_spent": 372076,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_sstore.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 33125,
+        "gas_spent": 45221,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 564131,
+        "gas_spent": 576227,
         "state_gas_spent": 531000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_nested_call_create_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_nested_call_create_sstore.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 33530,
+        "gas_spent": 45625,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 569536,
+        "gas_spent": 581631,
         "state_gas_spent": 536000,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -37,7 +37,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 364077,
+        "gas_spent": 368076,
         "state_gas_spent": 336000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_parent_sstore_after_child_revert.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_parent_sstore_after_child_revert.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 38761,
+        "gas_spent": 58953,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 578767,
+        "gas_spent": 598959,
         "state_gas_spent": 540000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_precompile_no_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_precompile_no_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 21138,
+        "gas_spent": 21137,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 21138,
+        "gas_spent": 21137,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_causes_oog.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_causes_oog.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26009,
+        "gas_spent": 34106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_sufficient.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_sufficient.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26009,
+        "gas_spent": 34106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226009,
+        "gas_spent": 234106,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_state_gas_less.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_state_gas_less.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26009,
+        "gas_spent": 34106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_vs_revert_difference.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_vs_revert_difference.snap
@@ -20,7 +20,7 @@ expression: "&(result_halt, result_revert)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 26015,
+        "gas_spent": 34112,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_less.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_less.snap
@@ -6,7 +6,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 26015,
+        "gas_spent": 34112,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -18,7 +18,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 26015,
+        "gas_spent": 34112,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_more.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_more.snap
@@ -6,7 +6,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 31024,
+        "gas_spent": 47218,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -18,7 +18,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 31024,
+        "gas_spent": 47218,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reverted_create_child.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reverted_create_child.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 33122,
+        "gas_spent": 45218,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 33122,
+        "gas_spent": 45218,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_selfdestruct_new_account.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_selfdestruct_new_account.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "SelfDestruct",
       "gas": {
-        "gas_spent": 35305,
+        "gas_spent": 37003,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -32,7 +32,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "SelfDestruct",
       "gas": {
-        "gas_spent": 285305,
+        "gas_spent": 287003,
         "state_gas_spent": 250000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_multiple_new_slots.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_multiple_new_slots.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 36027,
+        "gas_spent": 60318,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 636027,
+        "gas_spent": 660318,
         "state_gas_spent": 600000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_new_slot.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_new_slot.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26009,
+        "gas_spent": 34106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226009,
+        "gas_spent": 234106,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_overwrite_no_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_overwrite_no_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26116,
+        "gas_spent": 34212,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226116,
+        "gas_spent": 234212,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_set_then_clear_refund.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_set_then_clear_refund.snap
@@ -7,9 +7,9 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26116,
+        "gas_spent": 34212,
         "state_gas_spent": 0,
-        "gas_refunded": 2801,
+        "gas_refunded": 6842,
         "floor_gas": 21000
       },
       "logs": [],
@@ -22,9 +22,9 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26116,
+        "gas_spent": 34212,
         "state_gas_spent": 0,
-        "gas_refunded": 2801,
+        "gas_refunded": 6842,
         "floor_gas": 21000
       },
       "logs": [],

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_zero_to_zero_no_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_zero_to_zero_no_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 23208,
+        "gas_spent": 24106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 23208,
+        "gas_spent": 24106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_does_not_reduce_regular_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_does_not_reduce_regular_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26009,
+        "gas_spent": 34106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226009,
+        "gas_spent": 234106,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_oog_remaining.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_oog_remaining.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26009,
+        "gas_spent": 34106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_spent_final_in_result.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_spent_final_in_result.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26009,
+        "gas_spent": 34106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226009,
+        "gas_spent": 234106,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_selfdestruct_after_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_selfdestruct_after_sstore.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ee-tests/src/eip8037.rs
-assertion_line: 2199
 expression: "&(baseline_result, result)"
 ---
 [
@@ -8,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Return",
       "gas": {
-        "gas_spent": 38435,
+        "gas_spent": 50531,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 22728
@@ -26,7 +25,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Return",
       "gas": {
-        "gas_spent": 568435,
+        "gas_spent": 580531,
         "state_gas_spent": 530000,
         "gas_refunded": 0,
         "floor_gas": 22728

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_limit_cap_not_enforced_with_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_limit_cap_not_enforced_with_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26009,
+        "gas_spent": 34106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226009,
+        "gas_spent": 234106,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/interpreter/src/instructions.rs
+++ b/crates/interpreter/src/instructions.rs
@@ -126,20 +126,13 @@ pub const fn gas_table_spec(spec: SpecId) -> GasTable {
     }
 
     if spec.is_enabled_in(AMSTERDAM) {
-        // EIP-8038: bump every warm/cold access base from 100 to 101.
-        // SLOAD / *CALL / BALANCE / EXTCODEHASH: a single WARM_ACCESS.
+        // EIP-8038 §"EXT* family update": EXTCODESIZE and EXTCODECOPY perform two
+        // database reads (load the account object, then read its code), so their
+        // per-access base is charged an extra WARM_ACCESS on top of the normal
+        // account access. WARM_ACCESS itself is unchanged by EIP-8038 (100), so
+        // every other access opcode keeps its Berlin warm base; only these two
+        // change. The dynamic cold premium is still added by `load_account`.
         let warm = primitives::eip8038::WARM_ACCESS as u16;
-        table[SLOAD as usize] = warm;
-        table[BALANCE as usize] = warm;
-        table[EXTCODEHASH as usize] = warm;
-        table[CALL as usize] = warm;
-        table[CALLCODE as usize] = warm;
-        table[DELEGATECALL as usize] = warm;
-        table[STATICCALL as usize] = warm;
-        // EIP-8038 §"EXT* family update": EXTCODESIZE and EXTCODECOPY do two
-        // database reads, so the per-call access cost is `WARM_ACCESS` above
-        // the regular access cost. Bake the extra WARM_ACCESS into the static
-        // base; the dynamic cold premium is still added by `load_account`.
         table[EXTCODESIZE as usize] = warm + warm;
         table[EXTCODECOPY as usize] = warm + warm;
     }
@@ -517,5 +510,25 @@ mod tests {
                 "Opcode 0x{i:X?} is not handled",
             );
         }
+    }
+
+    #[test]
+    fn amsterdam_eip8038_ext_family_second_read() {
+        use super::gas_table_spec;
+        use primitives::hardfork::SpecId;
+
+        let warm = primitives::eip8038::WARM_ACCESS as u16;
+        let table = gas_table_spec(SpecId::AMSTERDAM);
+        // EIP-8038 §"EXT* family update": EXTCODESIZE / EXTCODECOPY make a second
+        // database read, charged an extra WARM_ACCESS on the static base.
+        assert_eq!(table[EXTCODESIZE as usize], warm + warm);
+        assert_eq!(table[EXTCODECOPY as usize], warm + warm);
+        // Other account-access opcodes keep a single WARM_ACCESS base.
+        assert_eq!(table[EXTCODEHASH as usize], warm);
+        assert_eq!(table[BALANCE as usize], warm);
+        assert_eq!(table[SLOAD as usize], warm);
+        // The surcharge is Amsterdam-only: pre-Amsterdam EXTCODESIZE == EXTCODEHASH.
+        let prague = gas_table_spec(SpecId::PRAGUE);
+        assert_eq!(prague[EXTCODESIZE as usize], prague[EXTCODEHASH as usize]);
     }
 }

--- a/crates/primitives/src/eip8038.rs
+++ b/crates/primitives/src/eip8038.rs
@@ -1,46 +1,49 @@
 //! EIP-8038: State-Access Gas Cost Update
 //!
 //! Increases the gas cost of state-access operations to reflect Ethereum's
-//! larger state. All "TBD" values in the draft spec are filled in here as
-//! `previous_value + 1`.
+//! larger state. The values below are the parameters proposed in
+//! [ethereum/EIPs#11802](https://github.com/ethereum/EIPs/pull/11802) (still a
+//! draft — treat as preliminary), superseding the earlier `previous_value + 1`
+//! placeholders.
 //!
 //! Active alongside EIP-7904 and EIP-8037 starting at the Amsterdam hardfork.
 
 /// Cold touch of an account (was 2,600 pre-EIP-8038).
-pub const COLD_ACCOUNT_ACCESS: u64 = 2_601;
+pub const COLD_ACCOUNT_ACCESS: u64 = 3_000;
 
 /// Surcharge for writing to an account that changes one account leaf value for
 /// the first time (was 6,700 pre-EIP-8038).
-pub const ACCOUNT_WRITE: u64 = 6_701;
+pub const ACCOUNT_WRITE: u64 = 8_000;
 
 /// Cold touch of a storage slot (was 2,100 pre-EIP-8038).
-pub const COLD_STORAGE_ACCESS: u64 = 2_101;
+pub const COLD_STORAGE_ACCESS: u64 = 3_000;
 
 /// Surcharge for writing to a storage slot that changes its value for the
 /// first time (was 2,800 pre-EIP-8038).
-pub const STORAGE_WRITE: u64 = 2_801;
+pub const STORAGE_WRITE: u64 = 10_000;
 
-/// Touch of an already-warm account or storage slot (was 100 pre-EIP-8038).
-pub const WARM_ACCESS: u64 = 101;
+/// Touch of an already-warm account or storage slot. Unchanged by EIP-8038.
+pub const WARM_ACCESS: u64 = 100;
 
 /// Refund for clearing a storage slot (was 4,800 pre-EIP-8038).
-pub const STORAGE_CLEAR_REFUND: u64 = 4_801;
+///
+/// Derived per the spec as `(STORAGE_WRITE + COLD_STORAGE_ACCESS) * 4800 / 5000`.
+pub const STORAGE_CLEAR_REFUND: u64 = (STORAGE_WRITE + COLD_STORAGE_ACCESS) * 4_800 / 5_000;
 
 /// State access cost for contract deployment (was 7,000 pre-EIP-8038).
 ///
-/// Note: the spec also defines `CREATE_ACCESS = ACCOUNT_WRITE + COLD_STORAGE_ACCESS`,
-/// which does not exactly match the legacy decomposition. Per the user-supplied
-/// rule we keep this slot at the literal `previous + 1` value rather than the
-/// derived sum.
-pub const CREATE_ACCESS: u64 = 7_001;
+/// Per the spec, `CREATE_ACCESS = ACCOUNT_WRITE + COLD_STORAGE_ACCESS`. This does
+/// not match the legacy decomposition (`GAS_CREATE - GAS_NEW_ACCOUNT = 7,000`); the
+/// EIP keeps that discrepancy rather than reconciling it.
+pub const CREATE_ACCESS: u64 = ACCOUNT_WRITE + COLD_STORAGE_ACCESS;
 
 /// Gas charged per storage key included in a transaction's access list
-/// (was 1,900 pre-EIP-8038).
-pub const ACCESS_LIST_STORAGE_KEY_COST: u64 = 1_901;
+/// (was 1,900 pre-EIP-8038). Derived per the spec as `COLD_STORAGE_ACCESS`.
+pub const ACCESS_LIST_STORAGE_KEY_COST: u64 = COLD_STORAGE_ACCESS;
 
 /// Gas charged per address included in a transaction's access list
-/// (was 2,400 pre-EIP-8038).
-pub const ACCESS_LIST_ADDRESS_COST: u64 = 2_401;
+/// (was 2,400 pre-EIP-8038). Derived per the spec as `COLD_ACCOUNT_ACCESS`.
+pub const ACCESS_LIST_ADDRESS_COST: u64 = COLD_ACCOUNT_ACCESS;
 
 /// Cold premium on top of `WARM_ACCESS` for account access.
 pub const COLD_ACCOUNT_ACCESS_ADDITIONAL: u64 = COLD_ACCOUNT_ACCESS - WARM_ACCESS;
@@ -53,8 +56,55 @@ pub const CALL_VALUE: u64 = ACCOUNT_WRITE + 2_300;
 
 /// Regular-gas portion of EIP-7702 `PER_EMPTY_ACCOUNT_COST` under EIP-8038.
 ///
-/// Equal to the pre-EIP-8038 value (`crate::eip8037::EIP7702_PER_EMPTY_ACCOUNT_REGULAR`)
-/// plus the delta from the modified primitives that appear in the per-auth
-/// breakdown (`ACCOUNT_WRITE` +1, `COLD_ACCOUNT_ACCESS` +1, two `WARM_ACCESS`
-/// occurrences +1 each — total +4).
-pub const EIP7702_PER_EMPTY_ACCOUNT_REGULAR: u64 = 7_504;
+/// Built on the EIP-8037 regular base
+/// ([`crate::eip8037::EIP7702_PER_EMPTY_ACCOUNT_REGULAR`]) by applying only the
+/// EIP-8038 deltas of the primitives in the per-auth breakdown: `ACCOUNT_WRITE`
+/// (6,700→8,000) and `COLD_ACCOUNT_ACCESS` (2,600→3,000). The two `WARM_ACCESS`
+/// occurrences and the `PRECOMPILE_ECRECOVER` (EIP-7904) / calldata terms are
+/// unchanged by EIP-8038, so they contribute no delta. Evaluates to 9,200.
+pub const EIP7702_PER_EMPTY_ACCOUNT_REGULAR: u64 = crate::eip8037::EIP7702_PER_EMPTY_ACCOUNT_REGULAR
+    + (ACCOUNT_WRITE - 6_700)
+    + (COLD_ACCOUNT_ACCESS - 2_600);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Values must match the parameters table in ethereum/EIPs#11802.
+    #[test]
+    fn constants_match_spec() {
+        assert_eq!(WARM_ACCESS, 100); // unchanged by EIP-8038
+        assert_eq!(COLD_ACCOUNT_ACCESS, 3_000);
+        assert_eq!(ACCOUNT_WRITE, 8_000);
+        assert_eq!(COLD_STORAGE_ACCESS, 3_000);
+        assert_eq!(STORAGE_WRITE, 10_000);
+        assert_eq!(STORAGE_CLEAR_REFUND, 12_480);
+        assert_eq!(CREATE_ACCESS, 11_000);
+        assert_eq!(ACCESS_LIST_ADDRESS_COST, 3_000);
+        assert_eq!(ACCESS_LIST_STORAGE_KEY_COST, 3_000);
+        assert_eq!(CALL_VALUE, 10_300);
+        assert_eq!(EIP7702_PER_EMPTY_ACCOUNT_REGULAR, 9_200);
+    }
+
+    /// Spec-defined relationships between the parameters (kept as derivations so a
+    /// renumber of one base value propagates correctly).
+    #[test]
+    fn derived_relations() {
+        assert_eq!(CREATE_ACCESS, ACCOUNT_WRITE + COLD_STORAGE_ACCESS);
+        assert_eq!(CALL_VALUE, ACCOUNT_WRITE + 2_300);
+        assert_eq!(ACCESS_LIST_ADDRESS_COST, COLD_ACCOUNT_ACCESS);
+        assert_eq!(ACCESS_LIST_STORAGE_KEY_COST, COLD_STORAGE_ACCESS);
+        assert_eq!(
+            STORAGE_CLEAR_REFUND,
+            (STORAGE_WRITE + COLD_STORAGE_ACCESS) * 4_800 / 5_000
+        );
+        assert_eq!(
+            COLD_ACCOUNT_ACCESS_ADDITIONAL,
+            COLD_ACCOUNT_ACCESS - WARM_ACCESS
+        );
+        assert_eq!(
+            COLD_STORAGE_ACCESS_ADDITIONAL,
+            COLD_STORAGE_ACCESS - WARM_ACCESS
+        );
+    }
+}


### PR DESCRIPTION
Fills in the EIP-8038 (state-access gas cost update) parameters that #3697
introduced as `previous_value + 1` placeholders, setting them to the values
proposed in [ethereum/EIPs#11802](https://github.com/ethereum/EIPs/pull/11802):

| Parameter | Placeholder | This PR |
| --- | --- | --- |
| `COLD_ACCOUNT_ACCESS` | 2,601 | 3,000 |
| `COLD_STORAGE_ACCESS` | 2,101 | 3,000 |
| `ACCOUNT_WRITE` | 6,701 | 8,000 |
| `STORAGE_WRITE` | 2,801 | 10,000 |
| `STORAGE_CLEAR_REFUND` | 4,801 | 12,480 |
| `CREATE_ACCESS` | 7,001 | 11,000 |
| `ACCESS_LIST_ADDRESS_COST` | 2,401 | 3,000 |
| `ACCESS_LIST_STORAGE_KEY_COST` | 1,901 | 3,000 |

- `WARM_ACCESS` is restored to 100; #3697 bumped it to 101 but the spec leaves it unchanged.
- `CREATE_ACCESS`, the access-list costs and `CALL_VALUE` now use the spec's derivations (`ACCOUNT_WRITE + COLD_STORAGE_ACCESS`, `COLD_*_ACCESS`, `ACCOUNT_WRITE + CALL_STIPEND`).
- `EIP7702_PER_EMPTY_ACCOUNT_REGULAR` is recomputed from the EIP-8037 base plus the EIP-8038 deltas (`ACCOUNT_WRITE`, `COLD_ACCOUNT_ACCESS`); the ecRecover and calldata terms are unchanged by EIP-8038.
- Adds constant and gas-table conformance tests, and regenerates the `eip8037` ee-test snapshots (state gas unchanged; regular gas reflects the new params).

`ethereum/EIPs#11802` is still an open draft, so these values are preliminary. Targets `glam-devnet-5` (where EIP-8038 lives) per #3698.
