### PR TITLE
perf: avoid intermediate BAL account allocation

### DIFF
--- a/crates/state/src/bal/alloy.rs
+++ b/crates/state/src/bal/alloy.rs
@@ -23,12 +23,12 @@ impl Bal {
     /// length or unsupported version.
     #[inline]
     pub fn try_from_alloy(alloy_bal: AlloyBal) -> Result<Self, BytecodeDecodeError> {
-        let accounts = AddressIndexMap::from_iter(
-            alloy_bal
-                .into_iter()
-                .map(AccountBal::try_from_alloy)
-                .collect::<Result<Vec<_>, _>>()?,
-        );
+        let mut accounts =
+            AddressIndexMap::with_capacity_and_hasher(alloy_bal.len(), Default::default());
+        for alloy_account in alloy_bal {
+            let (address, account_bal) = AccountBal::try_from_alloy(alloy_account)?;
+            accounts.insert(address, account_bal);
+        }
 
         Ok(Self { accounts })
     }
@@ -45,12 +45,12 @@ impl Bal {
     pub fn clone_from_alloy(
         alloy_bal: &[AlloyAccountChanges],
     ) -> Result<Self, BytecodeDecodeError> {
-        let accounts = AddressIndexMap::from_iter(
-            alloy_bal
-                .iter()
-                .map(AccountBal::clone_from_alloy)
-                .collect::<Result<Vec<_>, _>>()?,
-        );
+        let mut accounts =
+            AddressIndexMap::with_capacity_and_hasher(alloy_bal.len(), Default::default());
+        for alloy_account in alloy_bal {
+            let (address, account_bal) = AccountBal::clone_from_alloy(alloy_account)?;
+            accounts.insert(address, account_bal);
+        }
 
         Ok(Self { accounts })
     }


### PR DESCRIPTION
## Summary
- Build BAL account maps directly with preallocated `AddressIndexMap`s for owned and borrowed Alloy conversions.
- Remove the intermediate `Vec` that was only used to feed `IndexMap::from_iter`.

## Impact
This avoids an extra allocation during fallible BAL conversion while preserving existing duplicate-account behavior through `IndexMap::insert`.