### PR TITLE
feat(gas): derive cold storage cost from gas params

### DIFF
--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -656,9 +656,11 @@ impl GasParams {
     }
 
     /// Cold storage cost.
+    ///
+    /// This includes the warm storage read cost plus the additional cold storage cost.
     #[inline]
     pub fn cold_storage_cost(&self) -> u64 {
-        self.get(GasId::cold_storage_cost())
+        self.cold_storage_additional_cost() + self.warm_storage_read_cost()
     }
 
     /// New account cost. New account cost is added to the gas cost if the account is empty.
@@ -1588,6 +1590,24 @@ mod tests {
         let mut custom = london;
         custom.override_gas([(GasId::max_refund_quotient(), 10)]);
         assert_eq!(custom.max_refund_quotient(), 10);
+    }
+
+    #[test]
+    fn test_cold_storage_cost() {
+        use crate::cfg::gas;
+
+        let istanbul = GasParams::new_spec(SpecId::ISTANBUL);
+        assert_eq!(istanbul.cold_storage_cost(), 0);
+
+        let berlin = GasParams::new_spec(SpecId::BERLIN);
+        assert_eq!(berlin.cold_storage_cost(), gas::COLD_SLOAD_COST);
+
+        let mut custom = berlin;
+        custom.override_gas([
+            (GasId::cold_storage_additional_cost(), 3000),
+            (GasId::warm_storage_read_cost(), 200),
+        ]);
+        assert_eq!(custom.cold_storage_cost(), 3200);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Make `GasParams::cold_storage_cost()` behave as a helper by deriving the cold storage cost from `cold_storage_additional_cost()` plus `warm_storage_read_cost()`.

This keeps the default Berlin value equal to `COLD_SLOAD_COST`, while also making custom gas parameter overrides compose correctly when either of the underlying values changes.

Closes #3342.

## Testing

- `cargo test -p revm-context-interface test_cold_storage_cost`
- `cargo fmt --all --check`
- `cargo test -p revm-context-interface`
- `cargo clippy -p revm-context-interface --all-targets --all-features -- -D warnings`
- `typos crates/context/interface/src/cfg/gas_params.rs`
- `git diff --check`