### PR TITLE
feat(amsterdam): align gas accounting & test runners to devnet-6 (v6.1.0)

### DIFF
--- a/bins/revme/src/cmd/blockchaintest/post_block.rs
+++ b/bins/revme/src/cmd/blockchaintest/post_block.rs
@@ -59,6 +59,13 @@ pub fn post_block_transition<
         system_call_eip7251_consolidation_request(evm)?;
     }
 
+    // EIP-8282: Builder execution requests system calls (builder deposit and
+    // builder exit), introduced in Amsterdam.
+    if spec.is_enabled_in(SpecId::AMSTERDAM) {
+        system_call_eip8282_builder_deposit_request(evm)?;
+        system_call_eip8282_builder_exit_request(evm)?;
+    }
+
     Ok(())
 }
 
@@ -104,5 +111,31 @@ where
     EVM: SystemCallCommitEvm<Error: core::fmt::Debug>,
 {
     evm.system_call_commit(CONSOLIDATION_REQUEST_ADDRESS, Bytes::new())?;
+    Ok(())
+}
+
+pub const BUILDER_DEPOSIT_REQUEST_ADDRESS: Address =
+    address!("0x0000884d2AA32eAa155F59A2f24eFa73D9008282");
+
+/// EIP-8282: Builder deposit requests system call (request type `0x03`).
+pub(crate) fn system_call_eip8282_builder_deposit_request<EVM>(
+    evm: &mut EVM,
+) -> Result<(), EVM::Error>
+where
+    EVM: SystemCallCommitEvm<Error: core::fmt::Debug>,
+{
+    evm.system_call_commit(BUILDER_DEPOSIT_REQUEST_ADDRESS, Bytes::new())?;
+    Ok(())
+}
+
+pub const BUILDER_EXIT_REQUEST_ADDRESS: Address =
+    address!("0x000014574A74c805590AFF9499fc7A690f008282");
+
+/// EIP-8282: Builder exit requests system call (request type `0x04`).
+pub(crate) fn system_call_eip8282_builder_exit_request<EVM>(evm: &mut EVM) -> Result<(), EVM::Error>
+where
+    EVM: SystemCallCommitEvm<Error: core::fmt::Debug>,
+{
+    evm.system_call_commit(BUILDER_EXIT_REQUEST_ADDRESS, Bytes::new())?;
     Ok(())
 }

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -317,9 +317,10 @@ pub fn execute_test_suite(
                 continue;
             }
 
-            // Skip unknown/unsupported specs (e.g. transition forks not yet
-            // mapped) instead of panicking in `to_spec_id`.
+            // Unknown/unsupported spec (e.g. a transition fork not yet mapped to a
+            // `SpecId`). Report it and skip rather than panicking in `to_spec_id`.
             if *spec_name == SpecName::Unknown {
+                eprintln!("Error: unknown spec in post state, skipping: path={path}");
                 continue;
             }
 

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -317,6 +317,12 @@ pub fn execute_test_suite(
                 continue;
             }
 
+            // Skip unknown/unsupported specs (e.g. transition forks not yet
+            // mapped) instead of panicking in `to_spec_id`.
+            if *spec_name == SpecName::Unknown {
+                continue;
+            }
+
             cfg.set_spec_and_mainnet_gas_params(spec_name.to_spec_id());
 
             // Configure max blobs per spec

--- a/crates/context/interface/src/cfg/gas.rs
+++ b/crates/context/interface/src/cfg/gas.rs
@@ -22,6 +22,15 @@ pub struct GasTracker {
     /// more state gas than the frame itself has charged (the parent previously
     /// charged the 0→x portion). The net is reconciled on frame return.
     state_gas_spent: i64,
+    /// State gas drawn from regular gas (`remaining`) because the reservoir was
+    /// empty (EIP-8037's `state_gas_from_gas_left`).
+    ///
+    /// Incremented by [`Self::record_state_cost`] whenever a state-gas charge
+    /// spills out of the reservoir into regular gas. On frame rollback (revert or
+    /// halt) the spilled portion is credited back to `remaining` in last-in-
+    /// first-out order by [`Self::rollback_state_gas`]; on success it is
+    /// propagated to the parent frame so a later parent rollback can return it.
+    state_gas_spilled: u64,
     /// Refunded gas. Used to refund the gas to the caller at the end of execution.
     refunded: i64,
 }
@@ -35,6 +44,7 @@ impl GasTracker {
             remaining,
             reservoir,
             state_gas_spent: 0,
+            state_gas_spilled: 0,
             refunded: 0,
         }
     }
@@ -93,6 +103,28 @@ impl GasTracker {
         self.state_gas_spent = val;
     }
 
+    /// Returns the state gas drawn from regular gas (`remaining`) because the
+    /// reservoir was empty (EIP-8037's `state_gas_from_gas_left`).
+    #[inline]
+    pub const fn state_gas_spilled(&self) -> u64 {
+        self.state_gas_spilled
+    }
+
+    /// Sets the spilled state gas.
+    #[inline]
+    pub const fn set_state_gas_spilled(&mut self, val: u64) {
+        self.state_gas_spilled = val;
+    }
+
+    /// Adds `delta` to the spilled state gas, saturating.
+    ///
+    /// Used to merge a successful child frame's spilled state gas into this
+    /// (parent) frame so a later parent rollback can return it.
+    #[inline]
+    pub const fn add_state_gas_spilled(&mut self, delta: u64) {
+        self.state_gas_spilled = self.state_gas_spilled.saturating_add(delta);
+    }
+
     /// Returns the refunded gas.
     #[inline]
     pub const fn refunded(&self) -> i64 {
@@ -139,9 +171,34 @@ impl GasTracker {
         let success = self.record_regular_cost(spill);
         if success {
             self.state_gas_spent = self.state_gas_spent.saturating_add(cost as i64);
+            self.state_gas_spilled = self.state_gas_spilled.saturating_add(spill);
             self.reservoir = 0;
         }
         success
+    }
+
+    /// Rolls back this frame's state-gas charges on revert or exceptional halt
+    /// (EIP-8037).
+    ///
+    /// The state gas charged within the frame is refilled in last-in-first-out
+    /// order: the spilled portion is credited back to `remaining` (the pool
+    /// charged last) and the rest restores the reservoir to its frame-start
+    /// value. Concretely, `remaining` gains `state_gas_spilled` and the reservoir
+    /// becomes `reservoir + state_gas_spent - state_gas_spilled`, which is exactly
+    /// the reservoir the frame inherited. Both state-gas counters are then reset.
+    ///
+    /// On revert the resulting `remaining` (including the refilled spill) is
+    /// returned to the parent; on halt the caller additionally zeroes `remaining`
+    /// so the spilled gas is consumed while the reservoir is left untouched.
+    #[inline]
+    pub const fn rollback_state_gas(&mut self) {
+        self.reservoir = self
+            .reservoir
+            .saturating_add_signed(self.state_gas_spent)
+            .saturating_sub(self.state_gas_spilled);
+        self.remaining = self.remaining.saturating_add(self.state_gas_spilled);
+        self.state_gas_spent = 0;
+        self.state_gas_spilled = 0;
     }
 
     /// Refills the reservoir with state gas that is returned by 0→x→0 storage
@@ -152,12 +209,25 @@ impl GasTracker {
     /// transition is directly restored to the reservoir rather than routed
     /// through the capped refund counter.
     ///
-    /// `state_gas_spent` is decremented by the same amount and may become
-    /// negative if the matching 0→x charge was made by a parent frame. The
-    /// parent's total is reconciled on frame return.
+    /// `state_gas_spent` is decremented by the full `amount` and may become
+    /// negative if the matching 0→x charge was made by a parent frame (so this
+    /// frame's `state_gas_spilled` is zero and the whole refill lands in the
+    /// reservoir); the parent's total is reconciled on frame return.
+    ///
+    /// Because charges deduct from the reservoir first and from regular gas
+    /// (`remaining`) last, the refill credits the pool charged last first:
+    /// `remaining` is credited up to `state_gas_spilled` and any remainder tops
+    /// up the reservoir.
     #[inline]
     pub const fn refill_reservoir(&mut self, amount: u64) {
-        self.reservoir = self.reservoir.saturating_add(amount);
+        let to_remaining = if amount < self.state_gas_spilled {
+            amount
+        } else {
+            self.state_gas_spilled
+        };
+        self.remaining = self.remaining.saturating_add(to_remaining);
+        self.state_gas_spilled -= to_remaining;
+        self.reservoir = self.reservoir.saturating_add(amount - to_remaining);
         self.state_gas_spent = self.state_gas_spent.saturating_sub(amount as i64);
     }
 

--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -373,17 +373,17 @@ impl GasParams {
                 gas::ACCESS_LIST_STORAGE_KEY + 32 * 64;
             table[GasId::tx_access_list_floor_byte_multiplier().as_usize()] = 4;
 
-            // EIP-8038: State-access gas cost update. All TBD parameters are
-            // set to `previous_value + 1` per the user-supplied rule.
-            //   WARM_ACCESS                  100 -> 101
-            //   COLD_ACCOUNT_ACCESS        2,600 -> 2,601
-            //   ACCOUNT_WRITE              6,700 -> 6,701
-            //   COLD_STORAGE_ACCESS        2,100 -> 2,101
-            //   STORAGE_WRITE              2,800 -> 2,801
-            //   STORAGE_CLEAR_REFUND       4,800 -> 4,801
-            //   CREATE_ACCESS              7,000 -> 7,001
-            //   ACCESS_LIST_ADDRESS_COST   2,400 -> 2,401
-            //   ACCESS_LIST_STORAGE_KEY_COST 1,900 -> 1,901
+            // EIP-8038: State-access gas cost update (ethereum/EIPs#11802;
+            // preliminary draft values). Constants live in `primitives::eip8038`.
+            //   WARM_ACCESS                    100 ->    100  (unchanged)
+            //   COLD_ACCOUNT_ACCESS          2,600 ->  3,000
+            //   ACCOUNT_WRITE                6,700 ->  8,000
+            //   COLD_STORAGE_ACCESS          2,100 ->  3,000
+            //   STORAGE_WRITE                2,800 -> 10,000
+            //   STORAGE_CLEAR_REFUND         4,800 -> 12,480
+            //   CREATE_ACCESS                7,000 -> 11,000  (ACCOUNT_WRITE + COLD_STORAGE_ACCESS)
+            //   ACCESS_LIST_ADDRESS_COST     2,400 ->  3,000  (COLD_ACCOUNT_ACCESS)
+            //   ACCESS_LIST_STORAGE_KEY_COST 1,900 ->  3,000  (COLD_STORAGE_ACCESS)
             //
             // Account access table values.
             table[GasId::warm_storage_read_cost().as_usize()] = eip8038::WARM_ACCESS;
@@ -418,8 +418,8 @@ impl GasParams {
             table[GasId::create().as_usize()] = eip8038::CREATE_ACCESS;
             table[GasId::tx_create_cost().as_usize()] = eip8038::CREATE_ACCESS;
 
-            // Access-list per-item costs: bump the base by +1 each, keeping the
-            // EIP-7981 64 gas/byte data charge on top.
+            // Access-list per-item costs: EIP-8038 base (COLD_*_ACCESS, 3,000 each),
+            // keeping the EIP-7981 64 gas/byte data charge on top.
             table[GasId::tx_access_list_address_cost().as_usize()] =
                 eip8038::ACCESS_LIST_ADDRESS_COST + 20 * 64;
             table[GasId::tx_access_list_storage_key_cost().as_usize()] =
@@ -1840,15 +1840,15 @@ mod tests {
     fn test_eip7981_access_list_cost_amsterdam() {
         // EIP-7981 folds a 64 gas/byte data charge into the per-item access-list cost
         // and adds 4 floor tokens per access-list byte on top of the EIP-7976 floor.
-        // EIP-8038 bumps the per-item base by +1 (ACCESS_LIST_ADDRESS_COST 2400 ->
-        // 2401, ACCESS_LIST_STORAGE_KEY_COST 1900 -> 1901).
+        // EIP-8038 sets the per-item base to COLD_ACCOUNT_ACCESS / COLD_STORAGE_ACCESS
+        // (both 3,000).
         let params = GasParams::new_spec(SpecId::AMSTERDAM);
 
         // Per-item intrinsic cost: base + bytes * 64
-        assert_eq!(params.tx_access_list_address_cost(), 2401 + 20 * 64);
-        assert_eq!(params.tx_access_list_storage_key_cost(), 1901 + 32 * 64);
-        assert_eq!(params.tx_access_list_cost(1, 0), 2401 + 20 * 64);
-        assert_eq!(params.tx_access_list_cost(0, 1), 1901 + 32 * 64);
+        assert_eq!(params.tx_access_list_address_cost(), 3000 + 20 * 64);
+        assert_eq!(params.tx_access_list_storage_key_cost(), 3000 + 32 * 64);
+        assert_eq!(params.tx_access_list_cost(1, 0), 3000 + 20 * 64);
+        assert_eq!(params.tx_access_list_cost(0, 1), 3000 + 32 * 64);
 
         // Floor multiplier activates at AMSTERDAM.
         assert_eq!(params.tx_access_list_floor_byte_multiplier(), 4);

--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -344,15 +344,21 @@ impl GasParams {
             // to the reservoir via `GasParams::sstore_state_gas_refill`.
             table[GasId::sstore_set_refund().as_usize()] = 2800;
 
-            // EIP-7702 under EIP-8037: only the regular-gas slots live here.
+            // EIP-7702 under EIP-8037/8038: only the regular-gas slots live here.
             // The state-gas portions are sourced from `new_account_state_gas`
             // (per-account) and `tx_eip7702_state_gas_bytecode` (per-bytecode);
-            // helpers in `GasParams` combine the pre-scaled values.
-            //   regular per-auth cost: 7500 (state bytes added pessimistically in `initial_tx_gas`)
-            //   regular refund:        0   (per-auth refund is entirely state gas)
+            // helpers in `GasParams` combine the pre-scaled values. The per-auth
+            // ACCOUNT_WRITE is charged pessimistically in the regular per-auth cost
+            // and refunded (`tx_eip7702_auth_refund`) for existing or rejected
+            // authorizations whose target account is not newly created.
+            //   regular per-auth cost: 15816 (incl. ACCOUNT_WRITE)
+            //   regular refund:        8000  (ACCOUNT_WRITE, per existing/rejected auth)
             table[GasId::tx_eip7702_per_empty_account_cost().as_usize()] =
-                eip8037::EIP7702_PER_EMPTY_ACCOUNT_REGULAR;
-            table[GasId::tx_eip7702_auth_refund().as_usize()] = 0;
+                eip8038::EIP7702_PER_EMPTY_ACCOUNT_REGULAR;
+            table[GasId::tx_eip7702_auth_refund().as_usize()] = eip8038::ACCOUNT_WRITE;
+
+            // EIP-2780: the floor base drops from 21,000 to TX_BASE (12,000).
+            table[GasId::tx_floor_cost_base_gas().as_usize()] = eip2780::TX_BASE_COST;
 
             // EIP-7976: Increase calldata floor cost from 10/40 to 64/64 gas per byte
             // (zero/nonzero). The per-token constant bumps from 10 to 16, and
@@ -391,14 +397,21 @@ impl GasParams {
                 eip8038::COLD_ACCOUNT_ACCESS_ADDITIONAL;
             table[GasId::cold_storage_additional_cost().as_usize()] =
                 eip8038::COLD_STORAGE_ACCESS_ADDITIONAL;
-            table[GasId::cold_storage_cost().as_usize()] = eip8038::COLD_STORAGE_ACCESS;
+            // EIP-8038 folds the warm base into the cold cost: a cold SSTORE pays
+            // COLD_STORAGE_ACCESS (3000) total, not warm(100)+cold. Since
+            // `sstore_static` (warm, 100) is always charged in `sstore_dynamic_gas`,
+            // the cold add-on here is the premium above warm (2900), unlike pre-8038
+            // forks which add the full `COLD_SLOAD_COST` on top of the warm base.
+            table[GasId::cold_storage_cost().as_usize()] = eip8038::COLD_STORAGE_ACCESS_ADDITIONAL;
             // CALL_VALUE = ACCOUNT_WRITE + CALL_STIPEND.
+            // CALL_VALUE = ACCOUNT_WRITE + CALL_STIPEND. A value-bearing CALL already
+            // pays the ACCOUNT_WRITE surcharge via `transfer_value_cost`, so creating
+            // the target charges no extra regular gas — only the NEW_ACCOUNT state gas
+            // (hence `new_account_cost` is zero). SELFDESTRUCT has no such bundled
+            // charge, so it still pays a separate ACCOUNT_WRITE when sending balance to
+            // an empty account (execution-specs `selfdestruct`).
             table[GasId::transfer_value_cost().as_usize()] = eip8038::CALL_VALUE;
-            // ACCOUNT_WRITE surcharge for first-time writes to an account: CALL
-            // to empty account, SELFDESTRUCT sending balance to empty account.
-            // Under EIP-8037 these were zeroed out (cost moved to state gas);
-            // EIP-8038 reintroduces a regular-gas surcharge.
-            table[GasId::new_account_cost().as_usize()] = eip8038::ACCOUNT_WRITE;
+            table[GasId::new_account_cost().as_usize()] = 0;
             table[GasId::new_account_cost_for_selfdestruct().as_usize()] = eip8038::ACCOUNT_WRITE;
 
             // SSTORE table values.
@@ -1134,28 +1147,28 @@ impl GasParams {
     /// regular-gas charges. Excludes calldata, access list, authorizations,
     /// and initcode/state-gas pieces which are added by the caller.
     ///
-    /// The self-transfer and precompile zero-charge edge cases from the
-    /// current EIP-2780 draft are not implemented — a future revision is
-    /// expected to drop those carve-outs, so self-transfers and precompile
-    /// transfers pay the same `to`/`value` charges as any other recipient.
+    /// Per execution-specs, a self-transfer (`tx.to == sender`) pays neither
+    /// the `to`- nor `value`-based charge — only the base. Precompile
+    /// recipients are charged the same as any other account (the precompile
+    /// carve-out from the draft is not implemented).
     fn eip2780_base_to_value_gas(&self, is_create: bool, info: &Eip2780TxInfo) -> u64 {
-        // tx.to charge
-        let to_cost = if is_create {
-            self.tx_create_access_cost()
-        } else {
-            eip8038::COLD_ACCOUNT_ACCESS
-        };
+        let mut gas = eip2780::TX_BASE_COST;
 
-        // tx.value charge
-        let value_cost = if info.value.is_zero() {
-            0
-        } else if is_create {
-            self.tx_transfer_log_cost()
-        } else {
-            self.tx_transfer_log_cost() + self.tx_account_write_cost()
-        };
+        if is_create {
+            // tx.to charge: contract-creation access cost.
+            gas += self.tx_create_access_cost();
+            if !info.value.is_zero() {
+                gas += self.tx_transfer_log_cost();
+            }
+        } else if !info.is_self_transfer {
+            // tx.to charge: cold account access of the recipient.
+            gas += eip8038::COLD_ACCOUNT_ACCESS;
+            if !info.value.is_zero() {
+                gas += self.tx_transfer_log_cost() + eip2780::TX_VALUE_COST;
+            }
+        }
 
-        eip2780::TX_BASE_COST + to_cost + value_cost
+        gas
     }
 
     /// Calculates the initial transaction gas directly from a [`Transaction`],
@@ -1197,15 +1210,17 @@ impl GasParams {
 
 /// EIP-2780 inputs to [`GasParams::initial_tx_gas`].
 ///
-/// Only carries the transferred value — the decomposed intrinsic model only
-/// branches on `is_create` (already passed to `initial_tx_gas`) and whether
-/// `tx.value` is zero. The self-transfer and precompile carve-outs in the
-/// current draft are intentionally not implemented; see
+/// Carries the transferred value and whether the transaction is a
+/// self-transfer (`tx.to == sender`). The decomposed intrinsic model branches
+/// on `is_create` (already passed to `initial_tx_gas`), whether `tx.value` is
+/// zero, and the self-transfer carve-out; see
 /// [`GasParams::eip2780_base_to_value_gas`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Eip2780TxInfo {
     /// Transferred value.
     pub value: U256,
+    /// Whether `tx.to == sender` (a `Call` to the sender's own address).
+    pub is_self_transfer: bool,
 }
 
 #[inline]

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -300,7 +300,15 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
             account.info.nonce = 0;
             account.info.code_hash = KECCAK_EMPTY;
             account.info.code = Some(Bytecode::default());
-            account.storage.clear();
+            // Wipe storage to zero in place rather than dropping the entries: the
+            // slots were accessed during the (now self-destructed) execution and
+            // EIP-7928 records those accesses in the block access list. Keeping the
+            // entries (present_value = 0) preserves the access — read-only slots
+            // stay read-only and written slots become writes-to-zero — while the
+            // committed state is still an empty (balance-only) account.
+            for slot in account.storage.values_mut() {
+                slot.present_value = StorageValue::ZERO;
+            }
 
             // Remove the self-destruct flags so the account is preserved instead of destroyed.
             account.unmark_selfdestruct();

--- a/crates/ee-tests/src/eip2780.rs
+++ b/crates/ee-tests/src/eip2780.rs
@@ -4,10 +4,10 @@
 //! value-based) and the top-level execution charges (state gas for empty
 //! recipient with value, extra cold access for EIP-7702-delegated recipients).
 //!
-//! The self-transfer and precompile zero-charge edge cases in the current
-//! EIP-2780 draft are intentionally not implemented (a future revision is
-//! expected to drop them), so the tests below treat self-transfers and
-//! precompile transfers as regular recipients.
+//! Self-transfers (`tx.to == sender`) are special-cased per execution-specs:
+//! they pay only `TX_BASE_COST` with no `to`- or `value`-based charge. The
+//! precompile zero-charge edge case from the draft is not implemented, so
+//! precompile transfers are charged as regular recipients.
 
 use revm::{
     context::TxEnv,
@@ -77,11 +77,8 @@ fn regular_spent(gas: &revm::context_interface::result::ResultGas) -> u64 {
 fn test_eip2780_self_transfer() {
     let mut evm = evm();
     let gas = run(&mut evm, TxKind::Call(BENCH_CALLER), U256::ZERO);
-    // Self-transfer is not special-cased: pays TX_BASE_COST + COLD_ACCOUNT_ACCESS.
-    assert_eq!(
-        gas.total_gas_spent(),
-        eip2780::TX_BASE_COST + eip8038::COLD_ACCOUNT_ACCESS
-    );
+    // Self-transfer pays only TX_BASE_COST (no `to`- or `value`-based charge).
+    assert_eq!(gas.total_gas_spent(), eip2780::TX_BASE_COST);
     assert_eq!(gas.state_gas_spent_final(), 0);
 }
 
@@ -104,12 +101,13 @@ fn test_eip2780_call_empty_with_value() {
     let mut evm = evm();
     let to = address!("0x00000000000000000000000000000000000000ab");
     let gas = run(&mut evm, TxKind::Call(to), U256::from(1u64));
-    // Intrinsic regular: TX_BASE_COST + COLD_ACCOUNT_ACCESS + ACCOUNT_WRITE + TRANSFER_LOG_COST = 23_356.
-    // Top-level state gas: STATE_BYTES_PER_NEW_ACCOUNT × CPSB = 183_600.
+    // Intrinsic regular: TX_BASE_COST + COLD_ACCOUNT_ACCESS + TRANSFER_LOG_COST + TX_VALUE_COST = 21_000.
+    // The ACCOUNT_WRITE for creating the empty recipient is not charged as regular
+    // gas (only the NEW_ACCOUNT state gas is). Top-level state gas: 183_600.
     let expected_regular = eip2780::TX_BASE_COST
         + eip8038::COLD_ACCOUNT_ACCESS
-        + eip8038::ACCOUNT_WRITE
-        + eip2780::TRANSFER_LOG_COST;
+        + eip2780::TRANSFER_LOG_COST
+        + eip2780::TX_VALUE_COST;
     assert_eq!(regular_spent(&gas), expected_regular);
     assert_eq!(gas.state_gas_spent_final(), STATE_BYTES_PER_NEW_ACCOUNT);
 }

--- a/crates/ee-tests/src/eip8037.rs
+++ b/crates/ee-tests/src/eip8037.rs
@@ -1458,11 +1458,13 @@ fn test_eip8037_spend_all_preserves_reservoir() {
         }
         _ => panic!("Expected Halt variant"),
     }
-    // On halt, state gas is refunded via reservoir, so tx_gas_used is reduced.
+    // On halt the SSTORE state gas had spilled into regular gas (the reservoir
+    // starts empty), so it is consumed like any other regular gas — tx_gas_used
+    // is the full gas limit, matching the non-state-gas baseline.
     assert_eq!(
         result.tx_gas_used(),
-        gas_limit - STATE_GAS_SSTORE_SET,
-        "Halt refunds state gas via reservoir"
+        gas_limit,
+        "Halt consumes spilled state gas (not refunded)"
     );
     // state_gas_spent_final is zeroed on halt (state changes rolled back).
     assert_eq!(result.gas().state_gas_spent_final(), 0);

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_block_gas_limit_enforced_with_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_block_gas_limit_enforced_with_state_gas.snap
@@ -6,7 +6,7 @@ expression: "&result_fits"
   "Success": {
     "reason": "Stop",
     "gas": {
-      "gas_spent": 226009,
+      "gas_spent": 234106,
       "state_gas_spent": 200000,
       "gas_refunded": 0,
       "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_block_gas_limit_enforced_with_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_block_gas_limit_enforced_with_state_gas.snap
@@ -6,10 +6,10 @@ expression: "&result_fits"
   "Success": {
     "reason": "Stop",
     "gas": {
-      "gas_spent": 234106,
+      "gas_spent": 234006,
       "state_gas_spent": 200000,
       "gas_refunded": 0,
-      "floor_gas": 21000
+      "floor_gas": 12000
     },
     "logs": [],
     "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_propagates.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_propagates.snap
@@ -7,10 +7,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 45625,
+        "gas_spent": 45525,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -22,10 +22,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 581631,
+        "gas_spent": 581531,
         "state_gas_spent": 536000,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_propagates.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_propagates.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 33530,
+        "gas_spent": 45625,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 569536,
+        "gas_spent": 581631,
         "state_gas_spent": 536000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_reverts.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_reverts.snap
@@ -7,10 +7,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 45847,
+        "gas_spent": 45747,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -22,10 +22,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 385853,
+        "gas_spent": 385753,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_reverts.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_reverts.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 33752,
+        "gas_spent": 45847,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 373758,
+        "gas_spent": 385853,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_existing_account.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_existing_account.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 27824,
+        "gas_spent": 29122,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -32,7 +32,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 27824,
+        "gas_spent": 29122,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_existing_account.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_existing_account.snap
@@ -10,7 +10,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 29122,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [
         {
@@ -35,7 +35,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 29122,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [
         {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 37025,
+        "gas_spent": 40022,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -32,7 +32,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 287025,
+        "gas_spent": 290022,
         "state_gas_spent": 250000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account.snap
@@ -7,10 +7,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 40022,
+        "gas_spent": 32022,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [
         {
@@ -32,10 +32,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 290022,
+        "gas_spent": 282022,
         "state_gas_spent": 250000,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [
         {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account_no_value.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account_no_value.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 23623,
+        "gas_spent": 24022,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 23623,
+        "gas_spent": 24022,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account_no_value.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account_no_value.snap
@@ -10,7 +10,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 24022,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -25,7 +25,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 24022,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create2_with_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create2_with_code.snap
@@ -10,7 +10,7 @@ expression: "&(baseline_result, result, create_result)"
         "gas_spent": 32079,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -25,7 +25,7 @@ expression: "&(baseline_result, result, create_result)"
         "gas_spent": 372085,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -40,7 +40,7 @@ expression: "&(baseline_result, result, create_result)"
         "gas_spent": 372076,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create2_with_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create2_with_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 28080,
+        "gas_spent": 32079,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 368086,
+        "gas_spent": 372085,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -37,7 +37,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 368077,
+        "gas_spent": 372076,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_child_propagates.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_child_propagates.snap
@@ -7,10 +7,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 45221,
+        "gas_spent": 45121,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -22,10 +22,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 576227,
+        "gas_spent": 576127,
         "state_gas_spent": 531000,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_child_propagates.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_child_propagates.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 33125,
+        "gas_spent": 45221,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 564131,
+        "gas_spent": 576227,
         "state_gas_spent": 531000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_code_deposit_state_gas_oog.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_code_deposit_state_gas_oog.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, baseline_tight_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 28080,
+        "gas_spent": 32079,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, baseline_tight_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 28080,
+        "gas_spent": 32079,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -39,7 +39,7 @@ expression: "&(baseline_result, baseline_tight_result, result)"
         "OutOfGas": "Basic"
       },
       "gas": {
-        "gas_spent": 28081,
+        "gas_spent": 32080,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_code_deposit_state_gas_oog.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_code_deposit_state_gas_oog.snap
@@ -10,7 +10,7 @@ expression: "&(baseline_result, baseline_tight_result, result)"
         "gas_spent": 32079,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -25,7 +25,7 @@ expression: "&(baseline_result, baseline_tight_result, result)"
         "gas_spent": 32079,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -42,7 +42,7 @@ expression: "&(baseline_result, baseline_tight_result, result)"
         "gas_spent": 32080,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": []
     }

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_empty_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_empty_code.snap
@@ -10,7 +10,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 32067,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -25,7 +25,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 362067,
         "state_gas_spent": 330000,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_empty_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_empty_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 28068,
+        "gas_spent": 32067,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 358068,
+        "gas_spent": 362067,
         "state_gas_spent": 330000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_large_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_large_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 28089,
+        "gas_spent": 32088,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 558131,
+        "gas_spent": 562130,
         "state_gas_spent": 530000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_large_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_large_code.snap
@@ -10,7 +10,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 32088,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -25,7 +25,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 562130,
         "state_gas_spent": 530000,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 28071,
+        "gas_spent": 32070,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 368077,
+        "gas_spent": 372076,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_code.snap
@@ -10,7 +10,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 32070,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -25,7 +25,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 372076,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_sstore.snap
@@ -7,10 +7,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 45221,
+        "gas_spent": 45121,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -22,10 +22,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 576227,
+        "gas_spent": 576127,
         "state_gas_spent": 531000,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_sstore.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 33125,
+        "gas_spent": 45221,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 564131,
+        "gas_spent": 576227,
         "state_gas_spent": 531000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_gas_opcode_excludes_reservoir.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_gas_opcode_excludes_reservoir.snap
@@ -10,7 +10,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 21017,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -25,7 +25,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 21017,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_nested_call_create_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_nested_call_create_sstore.snap
@@ -7,10 +7,10 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 45625,
+        "gas_spent": 45525,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -22,10 +22,10 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 581631,
+        "gas_spent": 581531,
         "state_gas_spent": 536000,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -40,7 +40,7 @@ expression: "&(baseline_result, result, create_result)"
         "gas_spent": 368076,
         "state_gas_spent": 336000,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_nested_call_create_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_nested_call_create_sstore.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 33530,
+        "gas_spent": 45625,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 569536,
+        "gas_spent": 581631,
         "state_gas_spent": 536000,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -37,7 +37,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 364077,
+        "gas_spent": 368076,
         "state_gas_spent": 336000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_parent_sstore_after_child_revert.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_parent_sstore_after_child_revert.snap
@@ -7,10 +7,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 58953,
+        "gas_spent": 58753,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -22,10 +22,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 598959,
+        "gas_spent": 598759,
         "state_gas_spent": 540000,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_parent_sstore_after_child_revert.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_parent_sstore_after_child_revert.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 38761,
+        "gas_spent": 58953,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 578767,
+        "gas_spent": 598959,
         "state_gas_spent": 540000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_precompile_no_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_precompile_no_state_gas.snap
@@ -10,7 +10,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 21137,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -25,7 +25,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 21137,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_precompile_no_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_precompile_no_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 21138,
+        "gas_spent": 21137,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 21138,
+        "gas_spent": 21137,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_causes_oog.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_causes_oog.snap
@@ -7,10 +7,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 34106,
+        "gas_spent": 34006,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -27,7 +27,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 30000,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": []
     }

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_causes_oog.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_causes_oog.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26009,
+        "gas_spent": 34106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_sufficient.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_sufficient.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26009,
+        "gas_spent": 34106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226009,
+        "gas_spent": 234106,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_sufficient.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_sufficient.snap
@@ -7,10 +7,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 34106,
+        "gas_spent": 34006,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -22,10 +22,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 234106,
+        "gas_spent": 234006,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_state_gas_less.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_state_gas_less.snap
@@ -7,10 +7,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 34106,
+        "gas_spent": 34006,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -27,7 +27,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 25000,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": []
     }

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_state_gas_less.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_state_gas_less.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26009,
+        "gas_spent": 34106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_state_gas_more.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_state_gas_more.snap
@@ -11,7 +11,7 @@ expression: "&result"
       "gas_spent": 30000,
       "state_gas_spent": 0,
       "gas_refunded": 0,
-      "floor_gas": 21000
+      "floor_gas": 12000
     },
     "logs": []
   }

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_vs_revert_difference.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_vs_revert_difference.snap
@@ -12,7 +12,7 @@ expression: "&(result_halt, result_revert)"
         "gas_spent": 25000,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": []
     }
@@ -20,10 +20,10 @@ expression: "&(result_halt, result_revert)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 34112,
+        "gas_spent": 34012,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": "0x"

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_vs_revert_difference.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_vs_revert_difference.snap
@@ -20,7 +20,7 @@ expression: "&(result_halt, result_revert)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 26015,
+        "gas_spent": 34112,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_less.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_less.snap
@@ -6,7 +6,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 26015,
+        "gas_spent": 34112,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -18,7 +18,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 26015,
+        "gas_spent": 34112,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_less.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_less.snap
@@ -6,10 +6,10 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 34112,
+        "gas_spent": 34012,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": "0x"
@@ -18,10 +18,10 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 34112,
+        "gas_spent": 34012,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": "0x"

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_more.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_more.snap
@@ -6,10 +6,10 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 47218,
+        "gas_spent": 47018,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": "0x"
@@ -18,10 +18,10 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 47218,
+        "gas_spent": 47018,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": "0x"

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_more.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_more.snap
@@ -6,7 +6,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 31024,
+        "gas_spent": 47218,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -18,7 +18,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 31024,
+        "gas_spent": 47218,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reverted_create_child.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reverted_create_child.snap
@@ -7,10 +7,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 45218,
+        "gas_spent": 45118,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -22,10 +22,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 45218,
+        "gas_spent": 45118,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reverted_create_child.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reverted_create_child.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 33122,
+        "gas_spent": 45218,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 33122,
+        "gas_spent": 45218,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_selfdestruct_existing_account.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_selfdestruct_existing_account.snap
@@ -10,7 +10,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 26003,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [
         {
@@ -35,7 +35,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 26003,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [
         {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_selfdestruct_new_account.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_selfdestruct_new_account.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "SelfDestruct",
       "gas": {
-        "gas_spent": 35305,
+        "gas_spent": 37003,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -32,7 +32,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "SelfDestruct",
       "gas": {
-        "gas_spent": 285305,
+        "gas_spent": 287003,
         "state_gas_spent": 250000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_selfdestruct_new_account.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_selfdestruct_new_account.snap
@@ -10,7 +10,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 37003,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [
         {
@@ -35,7 +35,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 287003,
         "state_gas_spent": 250000,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [
         {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_spend_all_preserves_reservoir.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_spend_all_preserves_reservoir.snap
@@ -10,7 +10,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 500000,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": []
     }
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 300000,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": []
     }

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_spend_all_preserves_reservoir.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_spend_all_preserves_reservoir.snap
@@ -19,7 +19,7 @@ expression: "&(baseline_result, result)"
     "Halt": {
       "reason": "InvalidFEOpcode",
       "gas": {
-        "gas_spent": 300000,
+        "gas_spent": 500000,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_multiple_new_slots.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_multiple_new_slots.snap
@@ -7,10 +7,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 60318,
+        "gas_spent": 60018,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -22,10 +22,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 660318,
+        "gas_spent": 660018,
         "state_gas_spent": 600000,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_multiple_new_slots.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_multiple_new_slots.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 36027,
+        "gas_spent": 60318,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 636027,
+        "gas_spent": 660318,
         "state_gas_spent": 600000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_new_slot.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_new_slot.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26009,
+        "gas_spent": 34106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226009,
+        "gas_spent": 234106,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_new_slot.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_new_slot.snap
@@ -7,10 +7,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 34106,
+        "gas_spent": 34006,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -22,10 +22,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 234106,
+        "gas_spent": 234006,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_overwrite_no_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_overwrite_no_state_gas.snap
@@ -7,10 +7,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 34212,
+        "gas_spent": 34112,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -22,10 +22,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 234212,
+        "gas_spent": 234112,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_overwrite_no_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_overwrite_no_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26116,
+        "gas_spent": 34212,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226116,
+        "gas_spent": 234212,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_set_then_clear_refund.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_set_then_clear_refund.snap
@@ -7,9 +7,9 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26116,
+        "gas_spent": 34212,
         "state_gas_spent": 0,
-        "gas_refunded": 2801,
+        "gas_refunded": 6842,
         "floor_gas": 21000
       },
       "logs": [],
@@ -22,9 +22,9 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26116,
+        "gas_spent": 34212,
         "state_gas_spent": 0,
-        "gas_refunded": 2801,
+        "gas_refunded": 6842,
         "floor_gas": 21000
       },
       "logs": [],

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_set_then_clear_refund.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_set_then_clear_refund.snap
@@ -7,10 +7,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 34212,
+        "gas_spent": 34112,
         "state_gas_spent": 0,
-        "gas_refunded": 6842,
-        "floor_gas": 21000
+        "gas_refunded": 6822,
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -22,10 +22,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 34212,
+        "gas_spent": 34112,
         "state_gas_spent": 0,
-        "gas_refunded": 6842,
-        "floor_gas": 21000
+        "gas_refunded": 6822,
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_zero_to_zero_no_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_zero_to_zero_no_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 23208,
+        "gas_spent": 24106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 23208,
+        "gas_spent": 24106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_zero_to_zero_no_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_zero_to_zero_no_state_gas.snap
@@ -7,10 +7,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 24106,
+        "gas_spent": 24006,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -22,10 +22,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 24106,
+        "gas_spent": 24006,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_does_not_reduce_regular_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_does_not_reduce_regular_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26009,
+        "gas_spent": 34106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226009,
+        "gas_spent": 234106,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_does_not_reduce_regular_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_does_not_reduce_regular_gas.snap
@@ -7,10 +7,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 34106,
+        "gas_spent": 34006,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -22,10 +22,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 234106,
+        "gas_spent": 234006,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_oog_remaining.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_oog_remaining.snap
@@ -7,10 +7,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 34106,
+        "gas_spent": 34006,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -27,7 +27,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 50000,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": []
     }

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_oog_remaining.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_oog_remaining.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26009,
+        "gas_spent": 34106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_spent_final_in_result.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_spent_final_in_result.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26009,
+        "gas_spent": 34106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226009,
+        "gas_spent": 234106,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_spent_final_in_result.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_spent_final_in_result.snap
@@ -7,10 +7,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 34106,
+        "gas_spent": 34006,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -22,10 +22,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 234106,
+        "gas_spent": 234006,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_collision.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_collision.snap
@@ -10,7 +10,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 16777216,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21384
+        "floor_gas": 12384
       },
       "logs": []
     }
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 16447226,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21384
+        "floor_gas": 12384
       },
       "logs": []
     }

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_halts.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_halts.snap
@@ -19,7 +19,7 @@ expression: "&(baseline_result, result)"
     "Halt": {
       "reason": "InvalidFEOpcode",
       "gas": {
-        "gas_spent": 999470000,
+        "gas_spent": 999670000,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12384

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_halts.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_halts.snap
@@ -10,7 +10,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 1000000000,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21384
+        "floor_gas": 12384
       },
       "logs": []
     }
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 999470000,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21384
+        "floor_gas": 12384
       },
       "logs": []
     }

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_selfdestruct_after_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_selfdestruct_after_sstore.snap
@@ -7,10 +7,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Return",
       "gas": {
-        "gas_spent": 50531,
+        "gas_spent": 50431,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 22728
+        "floor_gas": 13728
       },
       "logs": [],
       "output": {
@@ -25,10 +25,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Return",
       "gas": {
-        "gas_spent": 580531,
+        "gas_spent": 580431,
         "state_gas_spent": 530000,
         "gas_refunded": 0,
-        "floor_gas": 22728
+        "floor_gas": 13728
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_selfdestruct_after_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_selfdestruct_after_sstore.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ee-tests/src/eip8037.rs
-assertion_line: 2199
 expression: "&(baseline_result, result)"
 ---
 [
@@ -8,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Return",
       "gas": {
-        "gas_spent": 38435,
+        "gas_spent": 50531,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 22728
@@ -26,7 +25,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Return",
       "gas": {
-        "gas_spent": 568435,
+        "gas_spent": 580531,
         "state_gas_spent": 530000,
         "gas_refunded": 0,
         "floor_gas": 22728

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_limit_cap_not_enforced_with_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_limit_cap_not_enforced_with_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 26009,
+        "gas_spent": 34106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 21000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 226009,
+        "gas_spent": 234106,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 21000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_limit_cap_not_enforced_with_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_limit_cap_not_enforced_with_state_gas.snap
@@ -7,10 +7,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 34106,
+        "gas_spent": 34006,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {
@@ -22,10 +22,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 234106,
+        "gas_spent": 234006,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
-        "floor_gas": 21000
+        "floor_gas": 12000
       },
       "logs": [],
       "output": {

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -556,6 +556,18 @@ impl EthFrame<EthInterpreter> {
                 // unused regular gas, adopts the reservoir, and propagates state
                 // gas / refunds on success).
                 handle_reservoir_remaining_gas(ins_result, &mut interpreter.gas, &mut out_gas);
+
+                // EIP-8037: the CALL charged `new_account_state_gas` upfront on the
+                // parent's tracker (for a value transfer to an empty recipient).
+                // When the call does not result in account creation (revert, halt,
+                // or an early failure such as insufficient balance), refund that
+                // upfront charge to the parent's reservoir — the child rollback in
+                // `handle_reservoir_remaining_gas` cannot, since the charge lives on
+                // the parent, not the child.
+                if !ins_result.is_ok() && outcome.charged_new_account_state_gas {
+                    let charge = ctx.cfg().gas_params().new_account_state_gas();
+                    interpreter.gas.refill_reservoir(charge);
+                }
             }
             FrameResult::Create(outcome) => {
                 let instruction_result = *outcome.instruction_result();

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -166,10 +166,12 @@ impl EthFrame<EthInterpreter> {
             && ctx.cfg().is_amsterdam_eip2780_enabled()
             && !precompiles.contains(&inputs.target_address)
         {
-            // Load the (already-cached) recipient account.
+            // Load the recipient account *with code* so the EIP-7702 delegation
+            // designator can be read (`load_account` alone does not populate
+            // `info.code`).
             let acc_info = ctx
                 .journal_mut()
-                .load_account(inputs.target_address)
+                .load_account_with_code(inputs.target_address)
                 .ok()
                 .map(|a| a.info.clone());
 
@@ -282,7 +284,8 @@ impl EthFrame<EthInterpreter> {
         }
 
         // Create interpreter and executes call and push new CallStackFrame.
-        this.get(EthFrame::invalid).clear(
+        let frame = this.get(EthFrame::invalid);
+        frame.clear(
             FrameData::Call(CallFrame {
                 return_memory_range: inputs.return_memory_offset.clone(),
             }),
@@ -297,6 +300,13 @@ impl EthFrame<EthInterpreter> {
             reservoir_remaining_gas,
             checkpoint,
         );
+        // `clear` rebuilds the interpreter's gas from `gas_limit`/reservoir, which
+        // discards any EIP-2780 depth-0 charges (delegate cold access, empty-
+        // recipient state gas) applied to `gas` above. Carry them over: `gas` was
+        // built with the same limit and reservoir, so this preserves the charges'
+        // effect on `remaining`, `reservoir`, and the state-gas counters while
+        // leaving memory gas (unused so far) at its fresh state.
+        frame.interpreter.gas = gas;
         Ok(ItemOrResult::Item(this.consume()))
     }
 

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -512,7 +512,7 @@ impl EthFrame<EthInterpreter> {
         // Insert result to the top frame.
         match result {
             FrameResult::Call(outcome) => {
-                let out_gas = outcome.gas();
+                let mut out_gas = outcome.gas();
                 let ins_result = *outcome.instruction_result();
                 let returned_len = outcome.result.output.len();
 
@@ -535,20 +535,17 @@ impl EthFrame<EthInterpreter> {
                 // Safe to push without stack limit check
                 let _ = interpreter.stack.push(item);
 
-                // Return unspend gas.
+                // Copy returned data into the parent's memory on success or revert.
                 if ins_result.is_ok_or_revert() {
-                    interpreter.gas.erase_cost(out_gas.remaining());
                     interpreter
                         .memory
                         .set(mem_start, &interpreter.return_data.buffer()[..target_len]);
                 }
 
-                // handle reservoir remaining gas
-                handle_reservoir_remaining_gas(ins_result, &mut interpreter.gas, &out_gas);
-
-                if ins_result.is_ok() {
-                    interpreter.gas.record_refund(out_gas.refunded());
-                }
+                // Settle the child's gas and merge it into the parent (returns
+                // unused regular gas, adopts the reservoir, and propagates state
+                // gas / refunds on success).
+                handle_reservoir_remaining_gas(ins_result, &mut interpreter.gas, &mut out_gas);
             }
             FrameResult::Create(outcome) => {
                 let instruction_result = *outcome.instruction_result();
@@ -570,14 +567,13 @@ impl EthFrame<EthInterpreter> {
                     "Fatal external error in insert_eofcreate_outcome"
                 );
 
+                let mut create_gas = *outcome.gas();
                 let this_gas = &mut interpreter.gas;
-                // Refund unused gas for success and revert cases.
-                if instruction_result.is_ok_or_revert() {
-                    this_gas.erase_cost(outcome.gas().remaining());
-                }
 
-                // handle reservoir remaining gas
-                handle_reservoir_remaining_gas(instruction_result, this_gas, outcome.gas());
+                // Settle the child's gas and merge it into the parent (returns
+                // unused regular gas, adopts the reservoir, and propagates state
+                // gas / refunds on success).
+                handle_reservoir_remaining_gas(instruction_result, this_gas, &mut create_gas);
 
                 // EIP-8037: The CREATE opcode charged `create_state_gas` upfront on
                 // this frame's tracker. When the child fails to deploy a contract
@@ -595,7 +591,6 @@ impl EthFrame<EthInterpreter> {
                 }
 
                 let stack_item = if instruction_result.is_ok() {
-                    this_gas.record_refund(outcome.gas().refunded());
                     outcome.address.unwrap_or_default().into_word().into()
                 } else {
                     U256::ZERO
@@ -610,47 +605,62 @@ impl EthFrame<EthInterpreter> {
     }
 }
 
-/// Handles the remaining gas of the parent frame.
+/// Settles a returning child frame's gas and merges it into the parent
+/// (EIP-8037 reservoir model).
+///
+/// First the child *settles its own gas*: a failing frame (revert or halt) rolls
+/// its state-gas charges back in last-in-first-out order
+/// ([`Gas::rollback_state_gas`]) — crediting the spilled portion back to its
+/// `remaining` and restoring the reservoir to the value it inherited — and drops
+/// its execution refund counter; an exceptional halt additionally consumes the
+/// child's regular gas.
+///
+/// Then the parent *merges* the settled child:
+/// - unused regular gas (`remaining`, including any spill returned on revert)
+///   flows back to the parent on success or revert; a halt consumes it.
+/// - the reservoir, a shared state-gas pool the child inherited at call time, is
+///   always adopted from the child (restored to the inherited value on
+///   revert/halt).
+/// - net state gas, its spilled portion, and the refund counter persist only on
+///   success; on revert/halt the child's state changes roll back and contribute
+///   nothing.
 #[inline]
 pub const fn handle_reservoir_remaining_gas(
     instruction_result: InstructionResult,
     parent_gas: &mut Gas,
-    child_gas: &Gas,
+    child_gas: &mut Gas,
 ) {
+    // Settle the child's own gas for its stop reason.
+    if !instruction_result.is_ok() {
+        child_gas.rollback_state_gas();
+        child_gas.set_refunded(0);
+    }
+    let is_halt = !instruction_result.is_ok_or_revert();
+    if is_halt {
+        // Exceptional halt consumes the child's regular gas (including the spill
+        // just credited back by `rollback_state_gas`); the reservoir is left
+        // restored to the inherited value for the parent.
+        child_gas.spend_all();
+    }
+
+    // Merge the settled child into the parent.
+    if instruction_result.is_ok_or_revert() {
+        parent_gas.erase_cost(child_gas.remaining());
+    }
+    parent_gas.set_reservoir(child_gas.reservoir());
     if instruction_result.is_ok() {
-        // On success: parent takes the child's final reservoir.
-        parent_gas.set_reservoir(child_gas.reservoir());
-        // Accumulate child's state gas into parent's total.
-        // Parent may have already charged state gas (e.g., new_account + create) before
-        // creating the child frame. Child starts with state_gas_spent=0, so we must add
-        // rather than overwrite to preserve the parent's prior charges.
-        //
-        // `child.state_gas_spent()` can be negative (EIP-8037 issue #2) when the
-        // child did more 0→x→0 restorations than 0→x creations; the negative
+        // Parent may have already charged state gas (e.g. new_account + create)
+        // before creating the child frame, so add rather than overwrite. The
+        // child's `state_gas_spent` can be negative (EIP-8037 issue #2) when it
+        // did more 0→x→0 restorations than 0→x creations; the negative
         // contribution is the parent's matching charge flowing back out.
         parent_gas.set_state_gas_spent(
             parent_gas
                 .state_gas_spent()
                 .saturating_add(child_gas.state_gas_spent()),
         );
-    } else {
-        // On revert/halt: the child's state changes are rolled back, so any
-        // 0→x→0 refills the child (or its descendants) credited to the
-        // reservoir must unwind too — the underlying clears no longer exist.
-        //
-        // Invariant when no reservoir→remaining spill happened in the child:
-        //     pre_call_reservoir = child.reservoir + child.state_gas_spent
-        // because every reservoir-funded `record_state_cost(c)` increments
-        // state_gas_spent by `c` while decrementing reservoir by `c`, and every
-        // `refill_reservoir(r)` does the opposite. Adding the (possibly negative)
-        // state_gas_spent back to the final reservoir recovers the pre-call value
-        // — discarding the negative branch (the old `.max(0)`) would leak
-        // grandchild refill credits up through a reverting parent.
-        parent_gas.set_reservoir(
-            child_gas
-                .reservoir()
-                .saturating_add_signed(child_gas.state_gas_spent()),
-        );
+        parent_gas.add_state_gas_spilled(child_gas.state_gas_spilled());
+        parent_gas.record_refund(child_gas.refunded());
     }
 }
 

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -339,6 +339,7 @@ impl EthFrame<EthInterpreter> {
                     output: Bytes::new(),
                 },
                 address: None,
+                target_was_alive: false,
             })))
         };
 
@@ -372,7 +373,13 @@ impl EthFrame<EthInterpreter> {
         drop(caller_info); // Drop caller info to avoid borrow checker issues.
 
         // warm load account.
-        journal.load_account(created_address)?;
+        // EIP-8037: capture whether the target leaf is already alive (existing,
+        // non-empty) before creation, so a successful create at a pre-existing
+        // balance-only account refunds the upfront `create_state_gas`.
+        let target_was_alive = {
+            let acc = journal.load_account(created_address)?;
+            !acc.info.is_empty()
+        };
 
         // Create account, transfer funds and make the journal checkpoint.
         let checkpoint = match context.journal_mut().create_account_checkpoint(
@@ -400,7 +407,10 @@ impl EthFrame<EthInterpreter> {
         let gas_limit = inputs.gas_limit();
 
         this.get(EthFrame::invalid).clear(
-            FrameData::Create(CreateFrame { created_address }),
+            FrameData::Create(CreateFrame {
+                created_address,
+                target_was_alive,
+            }),
             FrameInput::Create(inputs),
             depth,
             memory,
@@ -500,10 +510,10 @@ impl EthFrame<EthInterpreter> {
                     frame.created_address,
                 );
 
-                ItemOrResult::Result(FrameResult::Create(CreateOutcome::new(
-                    interpreter_result,
-                    Some(frame.created_address),
-                )))
+                let mut create_outcome =
+                    CreateOutcome::new(interpreter_result, Some(frame.created_address));
+                create_outcome.target_was_alive = frame.target_was_alive;
+                ItemOrResult::Result(FrameResult::Create(create_outcome))
             }
         };
 
@@ -598,16 +608,19 @@ impl EthFrame<EthInterpreter> {
                 handle_reservoir_remaining_gas(instruction_result, this_gas, &mut create_gas);
 
                 // EIP-8037: The CREATE opcode charged `create_state_gas` upfront on
-                // this frame's tracker. When the child fails to deploy a contract
-                // (revert, halt, or early-fail paths that return `address == None`
-                // such as nonce overflow, depth, OutOfFunds), refund the upfront
-                // charge to the reservoir and undo it on `state_gas_spent` via
-                // `refill_reservoir` (matching 0→x→0 storage restoration). The
-                // nonce-overflow path reports `InstructionResult::Return` (ok)
-                // with `address == None`, so gate on address rather than the result.
+                // this frame's tracker. Refund it via `refill_reservoir` (matching
+                // 0→x→0 storage restoration) when no new account leaf ends up
+                // created: either the child failed to deploy (revert, halt, or
+                // early-fail paths that return `address == None` such as nonce
+                // overflow, depth, OutOfFunds — the nonce-overflow path reports
+                // `InstructionResult::Return` (ok) with `address == None`, so gate
+                // on address rather than the result), or it succeeded at a
+                // pre-existing alive (balance-only) target.
                 let create_failed = outcome.address.is_none() || !instruction_result.is_ok();
 
-                if create_failed && ctx.cfg().is_amsterdam_eip8037_enabled() {
+                if (create_failed || outcome.target_was_alive)
+                    && ctx.cfg().is_amsterdam_eip8037_enabled()
+                {
                     let state_gas_charged = ctx.cfg().gas_params().create_state_gas();
                     this_gas.refill_reservoir(state_gas_charged);
                 }

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -162,10 +162,7 @@ impl EthFrame<EthInterpreter> {
         // EIP-2780 top-level execution charges. Applied before any state changes
         // so the recipient's pre-call state determines the charge.
         let mut early_halt: Option<InstructionResult> = None;
-        if depth == 0
-            && ctx.cfg().is_amsterdam_eip2780_enabled()
-            && !precompiles.contains(&inputs.target_address)
-        {
+        if depth == 0 && ctx.cfg().is_amsterdam_eip2780_enabled() {
             // Load the recipient account *with code* so the EIP-7702 delegation
             // designator can be read (`load_account` alone does not populate
             // `info.code`).
@@ -253,7 +250,20 @@ impl EthFrame<EthInterpreter> {
         let is_static = inputs.is_static;
         let gas_limit = inputs.gas_limit;
 
-        if let Some(result) = precompiles.run(ctx, &inputs).map_err(ERROR::from_string)? {
+        if let Some(mut result) = precompiles.run(ctx, &inputs).map_err(ERROR::from_string)? {
+            // EIP-2780 depth-0 `new_account_state_gas` was charged to the local
+            // `gas` above, but the precompile path returns its own result gas, so
+            // re-apply that charge here (drawing from the reservoir). Only at depth
+            // 0: a precompile reached by a CALL opcode (depth > 0) already had the
+            // charge applied on the parent's tracker. Precompiles are never EIP-7702
+            // delegated, so only the state-gas portion applies.
+            if depth == 0 && charged_new_account_state_gas && result.result.is_ok() {
+                let charge = ctx.cfg().gas_params().new_account_state_gas();
+                if !result.gas.record_state_cost(charge) {
+                    result.gas.spend_all();
+                    result.result = InstructionResult::OutOfGas;
+                }
+            }
             let mut logs = Vec::new();
             if result.result.is_ok() {
                 // Preserve the reservoir on the result gas so it can be reimbursed.

--- a/crates/handler/src/frame_data.rs
+++ b/crates/handler/src/frame_data.rs
@@ -17,6 +17,10 @@ pub struct CallFrame {
 pub struct CreateFrame {
     /// Create frame has a created address.
     pub created_address: Address,
+    /// EIP-8037: whether the created address was already alive (existing,
+    /// non-empty) before this CREATE. When true, no new account leaf is created,
+    /// so the upfront `create_state_gas` is refunded on a successful create.
+    pub target_was_alive: bool,
 }
 
 /// Frame Data
@@ -124,7 +128,10 @@ impl FrameResult {
 impl FrameData {
     /// Creates a new create frame data.
     pub const fn new_create(created_address: Address) -> Self {
-        Self::Create(CreateFrame { created_address })
+        Self::Create(CreateFrame {
+            created_address,
+            target_was_alive: false,
+        })
     }
 
     /// Creates a new call frame data.

--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -292,8 +292,14 @@ pub trait Handler {
         let ctx = evm.ctx_ref();
         let is_amsterdam_eip2780_enabled = ctx.cfg().is_amsterdam_eip2780_enabled();
         let tx = ctx.tx();
-        let eip2780 =
-            is_amsterdam_eip2780_enabled.then(|| gas_params::Eip2780TxInfo { value: tx.value() });
+        let eip2780 = is_amsterdam_eip2780_enabled.then(|| {
+            // Self-transfer: a `Call` whose recipient is the sender itself.
+            let is_self_transfer = tx.kind().to() == Some(&tx.caller());
+            gas_params::Eip2780TxInfo {
+                value: tx.value(),
+                is_self_transfer,
+            }
+        });
         let gas = validation::validate_initial_tx_gas_with_gas_params(
             tx,
             ctx.cfg().spec().into(),

--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -390,6 +390,20 @@ pub trait Handler {
             matches!(frame_result, FrameResult::Create(_)) && !instruction_result.is_ok();
 
         let gas = frame_result.gas_mut();
+
+        // Settle the top frame's own gas (mirrors `handle_reservoir_remaining_gas`'s
+        // child settle). A failing frame rolls its state-gas charges back in LIFO
+        // order — crediting the spilled portion back to `remaining` and restoring
+        // the reservoir to its pre-tx value — and drops the refund counter; an
+        // exceptional halt additionally consumes the regular gas.
+        if !instruction_result.is_ok() {
+            gas.rollback_state_gas();
+            gas.set_refunded(0);
+        }
+        if !instruction_result.is_ok_or_revert() {
+            gas.spend_all();
+        }
+
         let remaining = gas.remaining();
         let refunded = gas.refunded();
         let reservoir = gas.reservoir();
@@ -399,35 +413,14 @@ pub trait Handler {
         *gas = Gas::new_spent_with_reservoir(evm.ctx().tx().gas_limit(), reservoir);
 
         if instruction_result.is_ok_or_revert() {
-            // Return unused regular gas. Reservoir is handled separately via state_gas_spent.
+            // Return unused regular gas (including any spill credited back by the
+            // rollback above on revert). The reservoir was restored separately.
             gas.erase_cost(remaining);
         }
 
         if instruction_result.is_ok() {
             gas.record_refund(refunded);
-        }
-
-        // return zero state gas on halt/revert.
-        if instruction_result.is_ok() {
             gas.set_state_gas_spent(state_gas_spent);
-        } else {
-            gas.set_state_gas_spent(0);
-        }
-
-        // state gas
-        if !instruction_result.is_ok() {
-            // State changes rolled back (revert or halt). Apply the same
-            // invariant used by `handle_reservoir_remaining_gas` to recover
-            // the pre-call reservoir value: signed `reservoir + state_gas_spent`.
-            //
-            // record_state_cost increments state_gas_spent and decrements
-            // reservoir by the same amount; refill_reservoir does the inverse.
-            // Their sum is conserved, so adding the (possibly negative)
-            // state_gas_spent back to the final reservoir recovers the
-            // pre-call (here: pre-tx) value. The negative branch unwinds any
-            // 0→x→0 refill inflation propagated up from descendants — the
-            // grandchild-leak fix at the frame level applied to the top frame.
-            gas.set_reservoir(reservoir.saturating_add_signed(state_gas_spent));
         }
 
         // EIP-8037: for a failed top-level CREATE (or one that self-destructs

--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -383,11 +383,15 @@ pub trait Handler {
     ) -> Result<(), Self::Error> {
         let instruction_result = frame_result.interpreter_result().result;
 
-        // Detect a failed top-level CREATE so the intrinsic `create_state_gas`
-        // charged at tx entry can be unwound below. Mirrors the `create_failed`
-        // condition used in `EthFrame::return_result` for nested creates.
-        let create_failed =
-            matches!(frame_result, FrameResult::Create(_)) && !instruction_result.is_ok();
+        // Detect a top-level CREATE that creates no new account leaf — either it
+        // failed, or it succeeded at a pre-existing alive (balance-only) target —
+        // so the intrinsic `create_state_gas` charged at tx entry can be unwound
+        // below. Mirrors the condition used in `EthFrame::return_result` for
+        // nested creates.
+        let create_refunds_state_gas = match &frame_result {
+            FrameResult::Create(outcome) => !instruction_result.is_ok() || outcome.target_was_alive,
+            _ => false,
+        };
 
         let gas = frame_result.gas_mut();
 
@@ -431,7 +435,7 @@ pub trait Handler {
         // `initial_gas_and_reservoir` rather than via `record_state_cost`, so
         // it would otherwise stay consumed when the deployment is rolled back
         // or erased.
-        if create_failed && evm.ctx().cfg().is_amsterdam_eip8037_enabled() {
+        if create_refunds_state_gas && evm.ctx().cfg().is_amsterdam_eip8037_enabled() {
             let ctx = evm.ctx();
             let state_gas_charged = ctx.cfg().gas_params().create_state_gas();
             gas.refill_reservoir(state_gas_charged);

--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -302,16 +302,44 @@ pub fn apply_auth_list<
             reject!();
         }
 
-        // 7. Add `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST` gas to the global refund counter if `authority` exists in the trie.
-        if !(authority_acc_info.is_empty()
+        // Refund-relevant facts for this accepted authorization (mirrors
+        // execution-specs `set_delegation` / evm2 `apply_one_auth`).
+        //   existed             — the authority account already existed in state.
+        //   delegated_now       — its current code is a delegation (non-empty code
+        //                          is necessarily EIP-7702 here, having passed the
+        //                          validity check above).
+        //   delegated_before_tx — its code at the start of the transaction was a
+        //                          delegation (may differ from `delegated_now` when
+        //                          an earlier authorization in this tx cleared it).
+        //   clearing            — this authorization clears the delegation.
+        let existed = !(authority_acc_info.is_empty()
             && authority_acc
                 .account()
-                .is_loaded_as_not_existing_not_touched())
-        {
+                .is_loaded_as_not_existing_not_touched());
+        let delegated_now = !authority_acc_info.is_code_hash_empty_or_zero();
+        let delegated_before_tx = authority_acc
+            .account()
+            .original_info()
+            .code
+            .as_ref()
+            .is_some_and(Bytecode::is_eip7702);
+        let clearing = authorization.address().is_zero();
+
+        // Existing authority: the worst-case `ACCOUNT_WRITE` regular gas and the
+        // per-account `NEW_ACCOUNT` state gas were not needed.
+        if existed {
             refunded_accounts += 1;
         }
 
-        if !authority_acc_info.is_code_hash_empty_or_zero() || authorization.address().is_zero() {
+        // Bytecode (`AUTH_BASE`) state-gas refunds.
+        if clearing {
+            refunded_bytecodes += 1;
+            // Clearing a delegation freshly installed earlier in this transaction
+            // refills the bytecode state gas a second time.
+            if delegated_now && !delegated_before_tx {
+                refunded_bytecodes += 1;
+            }
+        } else if delegated_now || delegated_before_tx {
             refunded_bytecodes += 1;
         }
 

--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -210,7 +210,7 @@ pub fn apply_eip7702_auth_list<
         return Ok(0);
     }
     let (number_of_refunded_accounts, number_of_refunded_bytecodes) =
-        apply_auth_list::<_, ERROR>(chain_id, tx.authorization_list(), journal)?;
+        apply_auth_list::<_, ERROR>(chain_id, tx.authorization_list(), journal, is_eip8037)?;
 
     let params = context.cfg().gas_params();
 
@@ -248,25 +248,40 @@ pub fn apply_auth_list<
     chain_id: u64,
     auth_list: impl Iterator<Item = impl AuthorizationTr>,
     journal: &mut JOURNAL,
+    is_eip8037: bool,
 ) -> Result<(u64, u64), ERROR> {
     let mut refunded_accounts = 0;
     let mut refunded_bytecodes = 0;
+    // EIP-8037: a rejected authorization had its full pessimistic intrinsic cost
+    // charged (regular ACCOUNT_WRITE plus per-account NEW_ACCOUNT and per-bytecode
+    // AUTH_BASE state gas), none of which is needed, so all of it is refunded.
+    // Counting both refund slots credits the regular ACCOUNT_WRITE and both
+    // state-gas portions. Before EIP-8037 rejected authorizations refund nothing.
+    macro_rules! reject {
+        () => {{
+            if is_eip8037 {
+                refunded_accounts += 1;
+                refunded_bytecodes += 1;
+            }
+            continue;
+        }};
+    }
     for authorization in auth_list {
         // 1. Verify the chain id is either 0 or the chain's current ID.
         let auth_chain_id = authorization.chain_id();
         if !auth_chain_id.is_zero() && auth_chain_id != U256::from(chain_id) {
-            continue;
+            reject!();
         }
 
         // 2. Verify the `nonce` is less than `2**64 - 1`.
         if authorization.nonce() == u64::MAX {
-            continue;
+            reject!();
         }
 
         // recover authority and authorized addresses.
         // 3. `authority = ecrecover(keccak(MAGIC || rlp([chain_id, address, nonce])), y_parity, r, s]`
         let Some(authority) = authorization.authority() else {
-            continue;
+            reject!();
         };
 
         // warm authority account and check nonce.
@@ -278,13 +293,13 @@ pub fn apply_auth_list<
         if let Some(bytecode) = &authority_acc_info.code {
             // if it is not empty and it is not eip7702
             if !bytecode.is_empty() && !bytecode.is_eip7702() {
-                continue;
+                reject!();
             }
         }
 
         // 6. Verify the nonce of `authority` is equal to `nonce`. In case `authority` does not exist in the trie, verify that `nonce` is equal to `0`.
         if authorization.nonce() != authority_acc_info.nonce {
-            continue;
+            reject!();
         }
 
         // 7. Add `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST` gas to the global refund counter if `authority` exists in the trie.

--- a/crates/interpreter/src/gas.rs
+++ b/crates/interpreter/src/gas.rs
@@ -98,6 +98,12 @@ impl Gas {
         self.tracker.refunded()
     }
 
+    /// Sets the refunded gas counter (used to drop a failing frame's refunds).
+    #[inline]
+    pub const fn set_refunded(&mut self, val: i64) {
+        self.tracker.set_refunded(val);
+    }
+
     /// Returns the total amount of gas spent.
     #[inline]
     #[deprecated(
@@ -166,6 +172,34 @@ impl Gas {
     #[inline]
     pub const fn set_state_gas_spent(&mut self, val: i64) {
         self.tracker.set_state_gas_spent(val);
+    }
+
+    /// Returns the state gas drawn from regular gas because the reservoir was
+    /// empty (EIP-8037). See [`GasTracker::state_gas_spilled`].
+    #[inline]
+    pub const fn state_gas_spilled(&self) -> u64 {
+        self.tracker.state_gas_spilled()
+    }
+
+    /// Sets the spilled state gas (used when propagating from a child frame).
+    #[inline]
+    pub const fn set_state_gas_spilled(&mut self, val: u64) {
+        self.tracker.set_state_gas_spilled(val);
+    }
+
+    /// Adds `delta` to the spilled state gas (used when merging a successful
+    /// child frame).
+    #[inline]
+    pub const fn add_state_gas_spilled(&mut self, delta: u64) {
+        self.tracker.add_state_gas_spilled(delta);
+    }
+
+    /// Rolls back this frame's state-gas charges on revert or exceptional halt.
+    ///
+    /// See [`GasTracker::rollback_state_gas`].
+    #[inline]
+    pub const fn rollback_state_gas(&mut self) {
+        self.tracker.rollback_state_gas();
     }
 
     /// Refills the reservoir with state gas returned by 0→x→0 storage restoration.

--- a/crates/interpreter/src/instructions.rs
+++ b/crates/interpreter/src/instructions.rs
@@ -126,20 +126,13 @@ pub const fn gas_table_spec(spec: SpecId) -> GasTable {
     }
 
     if spec.is_enabled_in(AMSTERDAM) {
-        // EIP-8038: bump every warm/cold access base from 100 to 101.
-        // SLOAD / *CALL / BALANCE / EXTCODEHASH: a single WARM_ACCESS.
+        // EIP-8038 §"EXT* family update": EXTCODESIZE and EXTCODECOPY perform two
+        // database reads (load the account object, then read its code), so their
+        // per-access base is charged an extra WARM_ACCESS on top of the normal
+        // account access. WARM_ACCESS itself is unchanged by EIP-8038 (100), so
+        // every other access opcode keeps its Berlin warm base; only these two
+        // change. The dynamic cold premium is still added by `load_account`.
         let warm = primitives::eip8038::WARM_ACCESS as u16;
-        table[SLOAD as usize] = warm;
-        table[BALANCE as usize] = warm;
-        table[EXTCODEHASH as usize] = warm;
-        table[CALL as usize] = warm;
-        table[CALLCODE as usize] = warm;
-        table[DELEGATECALL as usize] = warm;
-        table[STATICCALL as usize] = warm;
-        // EIP-8038 §"EXT* family update": EXTCODESIZE and EXTCODECOPY do two
-        // database reads, so the per-call access cost is `WARM_ACCESS` above
-        // the regular access cost. Bake the extra WARM_ACCESS into the static
-        // base; the dynamic cold premium is still added by `load_account`.
         table[EXTCODESIZE as usize] = warm + warm;
         table[EXTCODECOPY as usize] = warm + warm;
     }
@@ -517,5 +510,25 @@ mod tests {
                 "Opcode 0x{i:X?} is not handled",
             );
         }
+    }
+
+    #[test]
+    fn amsterdam_eip8038_ext_family_second_read() {
+        use super::gas_table_spec;
+        use primitives::hardfork::SpecId;
+
+        let warm = primitives::eip8038::WARM_ACCESS as u16;
+        let table = gas_table_spec(SpecId::AMSTERDAM);
+        // EIP-8038 §"EXT* family update": EXTCODESIZE / EXTCODECOPY make a second
+        // database read, charged an extra WARM_ACCESS on the static base.
+        assert_eq!(table[EXTCODESIZE as usize], warm + warm);
+        assert_eq!(table[EXTCODECOPY as usize], warm + warm);
+        // Other account-access opcodes keep a single WARM_ACCESS base.
+        assert_eq!(table[EXTCODEHASH as usize], warm);
+        assert_eq!(table[BALANCE as usize], warm);
+        assert_eq!(table[SLOAD as usize], warm);
+        // The surcharge is Amsterdam-only: pre-Amsterdam EXTCODESIZE == EXTCODEHASH.
+        let prague = gas_table_spec(SpecId::PRAGUE);
+        assert_eq!(prague[EXTCODESIZE as usize], prague[EXTCODEHASH as usize]);
     }
 }

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -233,11 +233,14 @@ where
     );
 
     let state_load = if spec_id.is_enabled_in(BERLIN) {
-        let skip_cold = context.interpreter.gas.remaining()
-            < context.host.gas_params().cold_storage_additional_cost();
+        // Note: the slot is always cold-loaded (warmed), even when there is not
+        // enough gas to pay the cold cost. Skipping the load would avoid a DB
+        // read on a certain out-of-gas, but EIP-7928 (block access lists) records
+        // the slot access regardless of the subsequent OOG, so the warming must
+        // happen. The OOG outcome is unchanged: the cold charge below still fails.
         context
             .host
-            .sstore_skip_cold_load(target, index, value, skip_cold)?
+            .sstore_skip_cold_load(target, index, value, false)?
     } else {
         context
             .host

--- a/crates/interpreter/src/interpreter_action/create_outcome.rs
+++ b/crates/interpreter/src/interpreter_action/create_outcome.rs
@@ -13,6 +13,11 @@ pub struct CreateOutcome {
     pub result: InterpreterResult,
     /// An optional address associated with the create operation
     pub address: Option<Address>,
+    /// EIP-8037: whether the created address was already alive (existing,
+    /// non-empty) before this CREATE. When the create succeeds at such an
+    /// address no new account leaf is created, so the upfront `create_state_gas`
+    /// is refunded to the parent's reservoir.
+    pub target_was_alive: bool,
 }
 
 impl CreateOutcome {
@@ -27,7 +32,11 @@ impl CreateOutcome {
     ///
     /// A new [`CreateOutcome`] instance.
     pub const fn new(result: InterpreterResult, address: Option<Address>) -> Self {
-        Self { result, address }
+        Self {
+            result,
+            address,
+            target_was_alive: false,
+        }
     }
 
     /// Constructs a new [`CreateOutcome`] for an out-of-gas error.

--- a/crates/primitives/src/eip2780.rs
+++ b/crates/primitives/src/eip2780.rs
@@ -1,17 +1,12 @@
 //! EIP-2780: Reduce intrinsic transaction gas
 //!
 //! Replaces the legacy `21,000` intrinsic base with a decomposed model that
-//! prices ECDSA recovery, sender access + write, and additional `to`/`value`
-//! charges separately. Composes with EIP-8037 (state gas) and reuses the
-//! placeholder values from [`crate::eip8038`] for `ACCOUNT_WRITE`,
-//! `CREATE_ACCESS`, and `COLD_ACCOUNT_ACCESS`.
+//! prices a reduced sender base plus additional `to`- and `value`-based
+//! charges. Composes with EIP-8037 (state gas) and EIP-8038 (state-access
+//! costs) starting at the Amsterdam hardfork.
 
-/// Reduced intrinsic base cost charged to `tx.sender`.
-///
-/// Per the EIP, `TX_BASE_COST = GAS_PRECOMPILE_ECRECOVER + COLD_ACCOUNT_ACCESS + ACCOUNT_WRITE`.
-/// Kept at the literal `12_300` from the EIP-2780 reference table; the `+1`
-/// placeholder values in [`crate::eip8038`] would compute `12_302` instead.
-pub const TX_BASE_COST: u64 = 12_300;
+/// Reduced intrinsic base cost charged to `tx.sender` (execution-specs `TX_BASE`).
+pub const TX_BASE_COST: u64 = 12_000;
 
 /// Regular gas cost of the EIP-7708 transfer log emitted for every nonzero-value
 /// transfer to a different account.
@@ -19,3 +14,8 @@ pub const TX_BASE_COST: u64 = 12_300;
 /// `TRANSFER_LOG_COST = GAS_LOG + 3 * GAS_LOG_TOPIC + 32 * GAS_LOG_DATA_PER_BYTE`
 /// = `375 + 1_125 + 256 = 1_756`.
 pub const TRANSFER_LOG_COST: u64 = 1_756;
+
+/// Additional intrinsic regular-gas charge for a value-bearing (non-create,
+/// non-self) transaction (execution-specs `TX_VALUE_COST`), on top of
+/// [`TRANSFER_LOG_COST`].
+pub const TX_VALUE_COST: u64 = 4_244;

--- a/crates/primitives/src/eip8038.rs
+++ b/crates/primitives/src/eip8038.rs
@@ -54,17 +54,31 @@ pub const COLD_STORAGE_ACCESS_ADDITIONAL: u64 = COLD_STORAGE_ACCESS - WARM_ACCES
 /// CALL value transfer cost: `ACCOUNT_WRITE + CALL_STIPEND` per the EIP.
 pub const CALL_VALUE: u64 = ACCOUNT_WRITE + 2_300;
 
+/// Calldata bytes charged for one EIP-7702 authorization tuple (execution-specs
+/// `AUTH_TUPLE_BYTES`): chain id, authority address, nonce, signature parity, and
+/// the two signature scalars. Charged at the calldata floor rate.
+pub const EIP7702_AUTH_TUPLE_BYTES: u64 = 101;
+
+/// ecRecover precompile base cost, charged once per EIP-7702 authorization to
+/// recover the authority.
+pub const EIP7702_ECRECOVER_COST: u64 = 3_000;
+
+/// Calldata floor rate per token under EIP-7976 (Amsterdam).
+pub const TX_DATA_TOKEN_FLOOR: u64 = 16;
+
 /// Regular-gas portion of EIP-7702 `PER_EMPTY_ACCOUNT_COST` under EIP-8038.
 ///
-/// Built on the EIP-8037 regular base
-/// ([`crate::eip8037::EIP7702_PER_EMPTY_ACCOUNT_REGULAR`]) by applying only the
-/// EIP-8038 deltas of the primitives in the per-auth breakdown: `ACCOUNT_WRITE`
-/// (6,700→8,000) and `COLD_ACCOUNT_ACCESS` (2,600→3,000). The two `WARM_ACCESS`
-/// occurrences and the `PRECOMPILE_ECRECOVER` (EIP-7904) / calldata terms are
-/// unchanged by EIP-8038, so they contribute no delta. Evaluates to 9,200.
-pub const EIP7702_PER_EMPTY_ACCOUNT_REGULAR: u64 = crate::eip8037::EIP7702_PER_EMPTY_ACCOUNT_REGULAR
-    + (ACCOUNT_WRITE - 6_700)
-    + (COLD_ACCOUNT_ACCESS - 2_600);
+/// Per execution-specs, the regular per-auth charge is
+/// `ACCOUNT_WRITE + REGULAR_PER_AUTH_BASE_COST`, where
+/// `REGULAR_PER_AUTH_BASE_COST = AUTH_TUPLE_BYTES * TX_DATA_TOKEN_FLOOR
+/// + PRECOMPILE_ECRECOVER + COLD_ACCOUNT_ACCESS + 2 * WARM_ACCESS`.
+/// Evaluates to `8,000 + (101*16 + 3,000 + 3,000 + 200) = 8,000 + 7,816 = 15,816`.
+/// (The per-auth state gas — `NEW_ACCOUNT + AUTH_BASE` — is charged separately.)
+pub const EIP7702_PER_EMPTY_ACCOUNT_REGULAR: u64 = ACCOUNT_WRITE
+    + (EIP7702_AUTH_TUPLE_BYTES * TX_DATA_TOKEN_FLOOR
+        + EIP7702_ECRECOVER_COST
+        + COLD_ACCOUNT_ACCESS
+        + 2 * WARM_ACCESS);
 
 #[cfg(test)]
 mod tests {
@@ -83,7 +97,7 @@ mod tests {
         assert_eq!(ACCESS_LIST_ADDRESS_COST, 3_000);
         assert_eq!(ACCESS_LIST_STORAGE_KEY_COST, 3_000);
         assert_eq!(CALL_VALUE, 10_300);
-        assert_eq!(EIP7702_PER_EMPTY_ACCOUNT_REGULAR, 9_200);
+        assert_eq!(EIP7702_PER_EMPTY_ACCOUNT_REGULAR, 15_816);
     }
 
     /// Spec-defined relationships between the parameters (kept as derivations so a

--- a/crates/primitives/src/eip8038.rs
+++ b/crates/primitives/src/eip8038.rs
@@ -1,46 +1,49 @@
 //! EIP-8038: State-Access Gas Cost Update
 //!
 //! Increases the gas cost of state-access operations to reflect Ethereum's
-//! larger state. All "TBD" values in the draft spec are filled in here as
-//! `previous_value + 1`.
+//! larger state. The values below are the parameters proposed in
+//! [ethereum/EIPs#11802](https://github.com/ethereum/EIPs/pull/11802) (still a
+//! draft — treat as preliminary), superseding the earlier `previous_value + 1`
+//! placeholders.
 //!
 //! Active alongside EIP-7904 and EIP-8037 starting at the Amsterdam hardfork.
 
 /// Cold touch of an account (was 2,600 pre-EIP-8038).
-pub const COLD_ACCOUNT_ACCESS: u64 = 2_601;
+pub const COLD_ACCOUNT_ACCESS: u64 = 3_000;
 
 /// Surcharge for writing to an account that changes one account leaf value for
 /// the first time (was 6,700 pre-EIP-8038).
-pub const ACCOUNT_WRITE: u64 = 6_701;
+pub const ACCOUNT_WRITE: u64 = 8_000;
 
 /// Cold touch of a storage slot (was 2,100 pre-EIP-8038).
-pub const COLD_STORAGE_ACCESS: u64 = 2_101;
+pub const COLD_STORAGE_ACCESS: u64 = 3_000;
 
 /// Surcharge for writing to a storage slot that changes its value for the
 /// first time (was 2,800 pre-EIP-8038).
-pub const STORAGE_WRITE: u64 = 2_801;
+pub const STORAGE_WRITE: u64 = 10_000;
 
-/// Touch of an already-warm account or storage slot (was 100 pre-EIP-8038).
-pub const WARM_ACCESS: u64 = 101;
+/// Touch of an already-warm account or storage slot. Unchanged by EIP-8038.
+pub const WARM_ACCESS: u64 = 100;
 
 /// Refund for clearing a storage slot (was 4,800 pre-EIP-8038).
-pub const STORAGE_CLEAR_REFUND: u64 = 4_801;
+///
+/// Derived per the spec as `(STORAGE_WRITE + COLD_STORAGE_ACCESS) * 4800 / 5000`.
+pub const STORAGE_CLEAR_REFUND: u64 = (STORAGE_WRITE + COLD_STORAGE_ACCESS) * 4_800 / 5_000;
 
 /// State access cost for contract deployment (was 7,000 pre-EIP-8038).
 ///
-/// Note: the spec also defines `CREATE_ACCESS = ACCOUNT_WRITE + COLD_STORAGE_ACCESS`,
-/// which does not exactly match the legacy decomposition. Per the user-supplied
-/// rule we keep this slot at the literal `previous + 1` value rather than the
-/// derived sum.
-pub const CREATE_ACCESS: u64 = 7_001;
+/// Per the spec, `CREATE_ACCESS = ACCOUNT_WRITE + COLD_STORAGE_ACCESS`. This does
+/// not match the legacy decomposition (`GAS_CREATE - GAS_NEW_ACCOUNT = 7,000`); the
+/// EIP keeps that discrepancy rather than reconciling it.
+pub const CREATE_ACCESS: u64 = ACCOUNT_WRITE + COLD_STORAGE_ACCESS;
 
 /// Gas charged per storage key included in a transaction's access list
-/// (was 1,900 pre-EIP-8038).
-pub const ACCESS_LIST_STORAGE_KEY_COST: u64 = 1_901;
+/// (was 1,900 pre-EIP-8038). Derived per the spec as `COLD_STORAGE_ACCESS`.
+pub const ACCESS_LIST_STORAGE_KEY_COST: u64 = COLD_STORAGE_ACCESS;
 
 /// Gas charged per address included in a transaction's access list
-/// (was 2,400 pre-EIP-8038).
-pub const ACCESS_LIST_ADDRESS_COST: u64 = 2_401;
+/// (was 2,400 pre-EIP-8038). Derived per the spec as `COLD_ACCOUNT_ACCESS`.
+pub const ACCESS_LIST_ADDRESS_COST: u64 = COLD_ACCOUNT_ACCESS;
 
 /// Cold premium on top of `WARM_ACCESS` for account access.
 pub const COLD_ACCOUNT_ACCESS_ADDITIONAL: u64 = COLD_ACCOUNT_ACCESS - WARM_ACCESS;
@@ -53,8 +56,55 @@ pub const CALL_VALUE: u64 = ACCOUNT_WRITE + 2_300;
 
 /// Regular-gas portion of EIP-7702 `PER_EMPTY_ACCOUNT_COST` under EIP-8038.
 ///
-/// Equal to the pre-EIP-8038 value (`crate::eip8037::EIP7702_PER_EMPTY_ACCOUNT_REGULAR`)
-/// plus the delta from the modified primitives that appear in the per-auth
-/// breakdown (`ACCOUNT_WRITE` +1, `COLD_ACCOUNT_ACCESS` +1, two `WARM_ACCESS`
-/// occurrences +1 each — total +4).
-pub const EIP7702_PER_EMPTY_ACCOUNT_REGULAR: u64 = 7_504;
+/// Built on the EIP-8037 regular base
+/// ([`crate::eip8037::EIP7702_PER_EMPTY_ACCOUNT_REGULAR`]) by applying only the
+/// EIP-8038 deltas of the primitives in the per-auth breakdown: `ACCOUNT_WRITE`
+/// (6,700→8,000) and `COLD_ACCOUNT_ACCESS` (2,600→3,000). The two `WARM_ACCESS`
+/// occurrences and the `PRECOMPILE_ECRECOVER` (EIP-7904) / calldata terms are
+/// unchanged by EIP-8038, so they contribute no delta. Evaluates to 9,200.
+pub const EIP7702_PER_EMPTY_ACCOUNT_REGULAR: u64 = crate::eip8037::EIP7702_PER_EMPTY_ACCOUNT_REGULAR
+    + (ACCOUNT_WRITE - 6_700)
+    + (COLD_ACCOUNT_ACCESS - 2_600);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Values must match the parameters table in ethereum/EIPs#11802.
+    #[test]
+    fn constants_match_spec() {
+        assert_eq!(WARM_ACCESS, 100); // unchanged by EIP-8038
+        assert_eq!(COLD_ACCOUNT_ACCESS, 3_000);
+        assert_eq!(ACCOUNT_WRITE, 8_000);
+        assert_eq!(COLD_STORAGE_ACCESS, 3_000);
+        assert_eq!(STORAGE_WRITE, 10_000);
+        assert_eq!(STORAGE_CLEAR_REFUND, 12_480);
+        assert_eq!(CREATE_ACCESS, 11_000);
+        assert_eq!(ACCESS_LIST_ADDRESS_COST, 3_000);
+        assert_eq!(ACCESS_LIST_STORAGE_KEY_COST, 3_000);
+        assert_eq!(CALL_VALUE, 10_300);
+        assert_eq!(EIP7702_PER_EMPTY_ACCOUNT_REGULAR, 9_200);
+    }
+
+    /// Spec-defined relationships between the parameters (kept as derivations so a
+    /// renumber of one base value propagates correctly).
+    #[test]
+    fn derived_relations() {
+        assert_eq!(CREATE_ACCESS, ACCOUNT_WRITE + COLD_STORAGE_ACCESS);
+        assert_eq!(CALL_VALUE, ACCOUNT_WRITE + 2_300);
+        assert_eq!(ACCESS_LIST_ADDRESS_COST, COLD_ACCOUNT_ACCESS);
+        assert_eq!(ACCESS_LIST_STORAGE_KEY_COST, COLD_STORAGE_ACCESS);
+        assert_eq!(
+            STORAGE_CLEAR_REFUND,
+            (STORAGE_WRITE + COLD_STORAGE_ACCESS) * 4_800 / 5_000
+        );
+        assert_eq!(
+            COLD_ACCOUNT_ACCESS_ADDITIONAL,
+            COLD_ACCOUNT_ACCESS - WARM_ACCESS
+        );
+        assert_eq!(
+            COLD_STORAGE_ACCESS_ADDITIONAL,
+            COLD_STORAGE_ACCESS - WARM_ACCESS
+        );
+    }
+}

--- a/crates/statetest-types/src/blockchain.rs
+++ b/crates/statetest-types/src/blockchain.rs
@@ -262,8 +262,10 @@ pub enum ForkSpec {
     /// Homestead to Tangerine
     HomesteadToEIP150At5,
     /// Tangerine
+    #[serde(alias = "TangerineWhistle")]
     EIP150,
     /// Spurious Dragon
+    #[serde(alias = "SpuriousDragon")]
     EIP158,
     /// Spurious Dragon to Byzantium
     EIP158ToByzantiumAt5,

--- a/crates/statetest-types/src/spec.rs
+++ b/crates/statetest-types/src/spec.rs
@@ -15,8 +15,10 @@ pub enum SpecName {
     /// Transition from Homestead to EIP-150 at block 5
     HomesteadToEIP150At5,
     /// EIP-150 hardfork (Tangerine Whistle, October 2016)
+    #[serde(alias = "TangerineWhistle")]
     EIP150,
     /// EIP-158/EIP-161 hardfork (Spurious Dragon, November 2016)
+    #[serde(alias = "SpuriousDragon")]
     EIP158, // EIP-161: State trie clearing
     /// Transition from EIP-158 to Byzantium at block 5
     EIP158ToByzantiumAt5,


### PR DESCRIPTION
## Summary

Aligns Amsterdam (glamsterdam) gas accounting and the test runners to **devnet-6 / EELS v6.1.0**, using [`evm2`](https://github.com/bluealloy/evm2) (which passes the v6.1.0 fixtures) as the reference. Base branch: `glam-devnet-6`.

With these changes the full **glam-v610** fixture suite passes:
- **state tests:** all pass (all forks)
- **blockchain tests:** all pass (71158, 0 failed)
- `cargo nextest run --workspace`: 354 passed, no regressions

## Gas-parameter alignment

### EIP-8038 — finalized state-access parameters
- Cherry-picks #3771 to replace the `previous_value + 1` placeholders with the ethereum/EIPs#11802 values (`COLD_*_ACCESS` 3000, `ACCOUNT_WRITE` 8000, `STORAGE_WRITE` 10000, `STORAGE_CLEAR_REFUND` 12480, `CREATE_ACCESS` 11000, …).
- A cold SSTORE folds the warm base into the cold cost: `cold_storage_cost` uses the *additional* (2900) since `sstore_static` (warm 100) is charged separately — fixing a 100-gas overcharge on nearly every SSTORE.
- `new_account_cost` = 0 (a value CALL already pays `ACCOUNT_WRITE` via `CALL_VALUE`); `SELFDESTRUCT` keeps its separate `ACCOUNT_WRITE`.

### EIP-2780 — reduced intrinsic gas
- `TX_BASE` 12300 → **12000**; add `TX_VALUE_COST` (4244) for value-bearing calls (replacing the incorrect `ACCOUNT_WRITE`); implement the **self-transfer carve-out** (base only); floor base → 12000.
- Apply the depth-0 charges (delegate `COLD_ACCOUNT_ACCESS`, empty-recipient `new_account_state_gas`) to the **executing frame** — they were applied to a throwaway `Gas` and discarded when the recipient ran code.
- Charge `new_account_state_gas` for value transfers to **empty precompiles** (no precompile carve-out, matching evm2), re-applied to the precompile's result gas and gated on `depth == 0` to avoid double-charging CALL-opcode precompiles.

### EIP-7702 — per-auth gas
- Per-auth regular gas = **15816** (`ACCOUNT_WRITE` + auth-tuple calldata + ecrecover + cold account + 2×warm); refund `ACCOUNT_WRITE` (8000) per existing/rejected auth.
- Refund rejected authorizations under EIP-8037 (regular + state).
- Mirror execution-specs' `AUTH_BASE` state-gas refund: refund when the authority was delegated at the start of the tx (`delegated_before_tx`), and twice when clearing a delegation freshly installed earlier in the same tx.

## EIP-8037 reservoir model

### Spilled state gas
revm's `GasTracker` did not distinguish state gas drawn from the reservoir from state gas that spilled into regular gas when the reservoir was empty. On an exceptional **halt** the spilled portion was wrongly credited back (and refunded via `gas_used = spent − reservoir`) instead of consumed, breaking every revert/halt/OOG test that charged state gas. Mirrors evm2's `GasTracker`: adds a `state_gas_spilled` counter, credits it back to `remaining` (LIFO) on rollback, and propagates it to the parent on success; `handle_reservoir_remaining_gas` and `last_frame_result` now settle a failing frame and `spend_all` on halt.

### create_state_gas / new_account_state_gas refunds
- Refund the upfront `new_account_state_gas` when a value-transferring CALL to an empty recipient does not create the account (revert/halt/insufficient balance).
- Refund `create_state_gas` when a CREATE/CREATE2 targets an **already-alive** (balance-only) account (execution-specs `created_target_alive`), threaded through `CreateFrame`/`CreateOutcome` and applied to both nested and top-level CREATEs.

## EIP-7928 — block access lists (blockchain tests)

- Add the **EIP-8282 builder execution-request system calls** (builder deposit `0x..884d` type `0x03`, builder exit `0x..14574a` type `0x04`) to the post-block transition (Amsterdam), so they are warmed and appear in the BAL.
- Record the SSTORE slot access in the BAL even when the cold load OOGs (the slot is still warmed; the OOG outcome is unchanged). The skip is retained for CALL, where EIP-7928 defers EIP-7702 delegation warming.
- Preserve self-destructed slot accesses under EIP-8246: when a self-destructed account's balance is preserved, wipe its storage values in place (`present_value = 0`) instead of dropping the entries, so the accesses survive into the BAL.

## Test-runner (`revme`) fixes

- Map the modern fork names `TangerineWhistle → EIP150` and `SpuriousDragon → EIP158` (serde aliases on both `SpecName` and `ForkSpec`) so those fixtures decode.
- Print an error (instead of silently skipping or panicking) for an unknown post-state spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
