### PR TITLE
test(bytecode): cover all truncated pushes

### DIFF
--- a/crates/bytecode/src/legacy/analysis.rs
+++ b/crates/bytecode/src/legacy/analysis.rs
@@ -143,6 +143,19 @@ mod tests {
     }
 
     #[test]
+    fn test_truncated_pushes_are_padded_without_inbounds_pointer_advance() {
+        for push in opcode::PUSH1..=opcode::PUSH32 {
+            let bytecode = vec![push];
+            let (_, padded_bytecode) = analyze_legacy(bytecode.clone().into());
+            let push_immediate_len = (push - opcode::PUSH1 + 1) as usize;
+            assert_eq!(
+                padded_bytecode.len(),
+                bytecode.len() + push_immediate_len + 1
+            );
+        }
+    }
+
+    #[test]
     fn test_bytecode_with_invalid_opcode() {
         let bytecode = vec![0xFF, opcode::STOP]; // 0xFF is an invalid opcode
         let (jump_table, _) = analyze_legacy(bytecode.into());


### PR DESCRIPTION
Adds the same truncated-PUSH regression coverage from alloy-rs/evm2#255 to revm.

revm already has the pointer-arithmetic fix from bluealloy/revm#3752, so this keeps the follow-up scoped to the missing test coverage across PUSH1 through PUSH32.

## Testing

- `cargo test -p revm-bytecode legacy::analysis::tests::test_truncated_pushes_are_padded_without_inbounds_pointer_advance`

Prompted by: @DaniPopes