### PR TITLE
perf(precompile): reduce bounds checks in precompile parsing

### DIFF
--- a/crates/precompile/src/bls12_381/g1_msm.rs
+++ b/crates/precompile/src/bls12_381/g1_msm.rs
@@ -33,16 +33,15 @@ pub fn g1_msm(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
         return Err(PrecompileHalt::Bls12381G1MsmInputLength);
     }
 
-    let k = input_len / G1_MSM_INPUT_LENGTH;
+    let input_chunks = input.chunks_exact(G1_MSM_INPUT_LENGTH);
+    let k = input_chunks.len();
     let required_gas = msm_required_gas(k, &DISCOUNT_TABLE_G1_MSM, G1_MSM_BASE_GAS_FEE);
     if required_gas > gas_limit {
         return Err(PrecompileHalt::OutOfGas);
     }
 
-    let mut valid_pairs_iter = (0..k).map(|i| {
-        let start = i * G1_MSM_INPUT_LENGTH;
-        let padded_g1 = &input[start..start + PADDED_G1_LENGTH];
-        let scalar_bytes = &input[start + PADDED_G1_LENGTH..start + G1_MSM_INPUT_LENGTH];
+    let mut valid_pairs_iter = input_chunks.map(|pair| {
+        let (padded_g1, scalar_bytes) = pair.split_at(PADDED_G1_LENGTH);
 
         // Remove padding from G1 point - this validates padding format
         let [x, y] = remove_g1_padding(padded_g1)?;

--- a/crates/precompile/src/bls12_381/g2_msm.rs
+++ b/crates/precompile/src/bls12_381/g2_msm.rs
@@ -30,16 +30,15 @@ pub fn g2_msm(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
         return Err(PrecompileHalt::Bls12381G2MsmInputLength);
     }
 
-    let k = input_len / G2_MSM_INPUT_LENGTH;
+    let input_chunks = input.chunks_exact(G2_MSM_INPUT_LENGTH);
+    let k = input_chunks.len();
     let required_gas = msm_required_gas(k, &DISCOUNT_TABLE_G2_MSM, G2_MSM_BASE_GAS_FEE);
     if required_gas > gas_limit {
         return Err(PrecompileHalt::OutOfGas);
     }
 
-    let mut valid_pairs_iter = (0..k).map(|i| {
-        let start = i * G2_MSM_INPUT_LENGTH;
-        let padded_g2 = &input[start..start + PADDED_G2_LENGTH];
-        let scalar_bytes = &input[start + PADDED_G2_LENGTH..start + G2_MSM_INPUT_LENGTH];
+    let mut valid_pairs_iter = input_chunks.map(|pair| {
+        let (padded_g2, scalar_bytes) = pair.split_at(PADDED_G2_LENGTH);
 
         // Remove padding from G2 point - this validates padding format
         let [x_0, x_1, y_0, y_1] = remove_g2_padding(padded_g2)?;

--- a/crates/precompile/src/bls12_381/pairing.rs
+++ b/crates/precompile/src/bls12_381/pairing.rs
@@ -5,8 +5,8 @@ use super::{
 };
 use crate::{
     bls12_381_const::{
-        PADDED_G1_LENGTH, PADDED_G2_LENGTH, PAIRING_ADDRESS, PAIRING_INPUT_LENGTH,
-        PAIRING_MULTIPLIER_BASE, PAIRING_OFFSET_BASE,
+        PADDED_G1_LENGTH, PAIRING_ADDRESS, PAIRING_INPUT_LENGTH, PAIRING_MULTIPLIER_BASE,
+        PAIRING_OFFSET_BASE,
     },
     crypto, eth_precompile_fn, EthPrecompileOutput, EthPrecompileResult, Precompile,
     PrecompileHalt, PrecompileId,
@@ -49,11 +49,8 @@ pub fn pairing(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
 
     // Collect pairs of points for the pairing check
     let mut pairs: Vec<PairingPair> = Vec::with_capacity(k);
-    for i in 0..k {
-        let encoded_g1_element =
-            &input[i * PAIRING_INPUT_LENGTH..i * PAIRING_INPUT_LENGTH + PADDED_G1_LENGTH];
-        let encoded_g2_element = &input[i * PAIRING_INPUT_LENGTH + PADDED_G1_LENGTH
-            ..i * PAIRING_INPUT_LENGTH + PADDED_G1_LENGTH + PADDED_G2_LENGTH];
+    for pair in input.chunks_exact(PAIRING_INPUT_LENGTH) {
+        let (encoded_g1_element, encoded_g2_element) = pair.split_at(PADDED_G1_LENGTH);
 
         let [a_x, a_y] = remove_g1_padding(encoded_g1_element)?;
         let [b_x_0, b_x_1, b_y_0, b_y_1] = remove_g2_padding(encoded_g2_element)?;

--- a/crates/precompile/src/bn254.rs
+++ b/crates/precompile/src/bn254.rs
@@ -196,17 +196,8 @@ pub fn run_pair(
 
     let mut points = Vec::with_capacity(elements);
 
-    for idx in 0..elements {
-        // Offset to the start of the pairing element at index `idx` in the byte slice
-        let start = idx * PAIR_ELEMENT_LEN;
-        let g1_start = start;
-        // Offset to the start of the G2 element in the pairing element
-        // This is where G1 ends.
-        let g2_start = start + G1_LEN;
-
-        // Get G1 and G2 points from the input
-        let encoded_g1_element = &input[g1_start..g2_start];
-        let encoded_g2_element = &input[g2_start..g2_start + G2_LEN];
+    for pair in input.chunks_exact(PAIR_ELEMENT_LEN) {
+        let (encoded_g1_element, encoded_g2_element) = pair.split_at(G1_LEN);
         points.push((encoded_g1_element, encoded_g2_element));
     }
 

--- a/crates/precompile/src/bn254/arkworks.rs
+++ b/crates/precompile/src/bn254/arkworks.rs
@@ -1,5 +1,5 @@
 //! BN128 precompile using Arkworks BLS12-381 implementation.
-use super::{FQ2_LEN, FQ_LEN, G1_LEN, SCALAR_LEN};
+use super::{FQ2_LEN, FQ_LEN, G1_LEN, G2_LEN, SCALAR_LEN};
 use crate::PrecompileHalt;
 use std::vec::Vec;
 
@@ -18,9 +18,7 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 ///
 /// Panics if the input is not at least 32 bytes long.
 #[inline]
-fn read_fq(input_be: &[u8]) -> Result<Fq, PrecompileHalt> {
-    assert_eq!(input_be.len(), FQ_LEN, "input must be {FQ_LEN} bytes");
-
+fn read_fq(input_be: &[u8; FQ_LEN]) -> Result<Fq, PrecompileHalt> {
     let mut input_le = [0u8; FQ_LEN];
     input_le.copy_from_slice(input_be);
 
@@ -42,8 +40,12 @@ fn read_fq(input_be: &[u8]) -> Result<Fq, PrecompileHalt> {
 /// Panics if the input is not at least 64 bytes long.
 #[inline]
 fn read_fq2(input: &[u8]) -> Result<Fq2, PrecompileHalt> {
-    let y = read_fq(&input[..FQ_LEN])?;
-    let x = read_fq(&input[FQ_LEN..2 * FQ_LEN])?;
+    let input: &[u8; FQ2_LEN] = input[..FQ2_LEN]
+        .try_into()
+        .expect("input must be at least FQ2_LEN bytes");
+    let (y, x) = input.split_at(FQ_LEN);
+    let y = read_fq(y.try_into().expect("split must yield FQ_LEN bytes"))?;
+    let x = read_fq(x.try_into().expect("split must yield FQ_LEN bytes"))?;
 
     Ok(Fq2::new(x, y))
 }
@@ -108,8 +110,12 @@ fn new_g2_point(x: Fq2, y: Fq2) -> Result<G2Affine, PrecompileHalt> {
 /// Panics if the input is not at least 64 bytes long.
 #[inline]
 pub(super) fn read_g1_point(input: &[u8]) -> Result<G1Affine, PrecompileHalt> {
-    let px = read_fq(&input[0..FQ_LEN])?;
-    let py = read_fq(&input[FQ_LEN..2 * FQ_LEN])?;
+    let input: &[u8; G1_LEN] = input[..G1_LEN]
+        .try_into()
+        .expect("input must be at least G1_LEN bytes");
+    let (px, py) = input.split_at(FQ_LEN);
+    let px = read_fq(px.try_into().expect("split must yield FQ_LEN bytes"))?;
+    let py = read_fq(py.try_into().expect("split must yield FQ_LEN bytes"))?;
     new_g1_point(px, py)
 }
 
@@ -156,8 +162,12 @@ pub(super) fn encode_g1_point(point: G1Affine) -> [u8; G1_LEN] {
 /// Panics if the input is not at least 128 bytes long.
 #[inline]
 pub(super) fn read_g2_point(input: &[u8]) -> Result<G2Affine, PrecompileHalt> {
-    let ba = read_fq2(&input[0..FQ2_LEN])?;
-    let bb = read_fq2(&input[FQ2_LEN..2 * FQ2_LEN])?;
+    let input: &[u8; G2_LEN] = input[..G2_LEN]
+        .try_into()
+        .expect("input must be at least G2_LEN bytes");
+    let (ba, bb) = input.split_at(FQ2_LEN);
+    let ba = read_fq2(ba)?;
+    let bb = read_fq2(bb)?;
     new_g2_point(ba, bb)
 }
 
@@ -170,12 +180,7 @@ pub(super) fn read_g2_point(input: &[u8]) -> Result<G2Affine, PrecompileHalt> {
 /// If `input.len()` is not equal to [`SCALAR_LEN`].
 #[inline]
 pub(super) fn read_scalar(input: &[u8]) -> Fr {
-    assert_eq!(
-        input.len(),
-        SCALAR_LEN,
-        "unexpected scalar length. got {}, expected {SCALAR_LEN}",
-        input.len()
-    );
+    let input: &[u8; SCALAR_LEN] = input.try_into().expect("input must be SCALAR_LEN bytes");
     Fr::from_be_bytes_mod_order(input)
 }
 


### PR DESCRIPTION
## Summary

This PR applies a small set of assembly-checked precompile parsing optimizations. The current stack is limited to exact chunk/split handling for BLS/BN254 pair-like inputs and fixed-size byte readers in the BN254 arkworks backend.

The earlier BLS G2 padding read rewrite was removed after review; `remove_g2_padding` now keeps the previous loop implementation.

## Commits

- `perf(precompile): chunk BLS pairing inputs`
  - Replaces manual `i * PAIRING_INPUT_LENGTH` range construction with `chunks_exact(PAIRING_INPUT_LENGTH)` plus `split_at`.
  - Keeps the existing input-length validation while giving LLVM a clearer fixed-width chunk shape and removing redundant slice-index failure paths in the pairing parser.

- `perf(precompile): chunk BLS MSM inputs`
  - Updates BLS12-381 G1/G2 MSM parsing to iterate over exact input chunks and split each chunk into point/scalar components.
  - Avoids recomputing byte offsets for each pair and removes the MSM iterator closure slice-index failure paths.

- `perf(precompile): chunk BN254 pair inputs`
  - Replaces manual BN254 pair element offset arithmetic with `chunks_exact(PAIR_ELEMENT_LEN)` and `split_at(G1_LEN)`.
  - Keeps the existing multiple-of-length validation and removes redundant pair parsing bounds paths.

- `perf(precompile): type BN254 reader slices`
  - Changes BN254 Fq reads to accept fixed-size array references after the surrounding point/scalar readers establish the relevant length.
  - Reduces repeated length proof work in the arkworks reader path while preserving field-membership errors as `PrecompileHalt`.
  - Uses `expect` for documented precondition panics so the panic reason mirrors the function contracts.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p revm-precompile --lib`
- `cargo clippy -p revm-precompile --all-targets --all-features`
- `typos crates/precompile/src`
