### PR TITLE
feat(amsterdam): EIP-2780 runtime gas phase (ethereum/EIPs#11844)

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,4 +1,16 @@
 
+# Unreleased
+
+### EIP-2780 runtime gas phase (ethereum/EIPs#11844)
+
+Gated on `CfgEnv::enable_amsterdam_eip2780`; older forks and 2780-disabled configs are unchanged.
+
+* Intrinsic gas no longer includes the create-transaction `create_state_gas` (charged at runtime, only when the deployment target does not exist) nor the pessimistic EIP-7702 per-auth charge — each authorization now costs `REGULAR_PER_AUTH_BASE_COST` (7,816, new `eip8038::EIP7702_PER_AUTH_BASE_REGULAR`) intrinsically, with the state-dependent remainder charged per authority at runtime and no refunds.
+* New struct field (breaks literal construction): `InitialAndFloorGas.runtime_oog` — set when the transaction passes the intrinsic check but cannot afford the runtime charges; the handler includes it as an out-of-gas halt consuming all gas, reverting applied delegations.
+* Additive: `InitialAndFloorGas::checked_initial_gas_and_reservoir`, `GasParams::tx_eip7702_state_gas_bytecode`, `pre_execution::apply_eip2780_runtime_gas`, `pre_execution::apply_auth_list_eip2780`.
+* `pre_execution::apply_eip7702_auth_list` runs the runtime gas phase (and returns no refund) when EIP-2780 is enabled.
+* The delegated-recipient delegation-target access is now warm/cold aware (`WARM_ACCESS` if pre-warmed) and charged in the runtime phase instead of a flat `COLD_ACCOUNT_ACCESS` at frame entry.
+
 # v113 tag (all crates v41.0.0)
 
 All crates are now versioned in lockstep, starting at **41.0.0** — hence the version jump (e.g. `revm-bytecode` 11.0.1 → 41.0.0).

--- a/bins/revme/src/cmd/blockchaintest/post_block.rs
+++ b/bins/revme/src/cmd/blockchaintest/post_block.rs
@@ -115,7 +115,7 @@ where
 }
 
 pub const BUILDER_DEPOSIT_REQUEST_ADDRESS: Address =
-    address!("0x0000884d2AA32eAa155F59A2f24eFa73D9008282");
+    address!("0x0000BFF46984E3725691FA540A8C7589300D8282");
 
 /// EIP-8282: Builder deposit requests system call (request type `0x03`).
 pub(crate) fn system_call_eip8282_builder_deposit_request<EVM>(
@@ -129,7 +129,7 @@ where
 }
 
 pub const BUILDER_EXIT_REQUEST_ADDRESS: Address =
-    address!("0x000014574A74c805590AFF9499fc7A690f008282");
+    address!("0x000064D678505AD48F8CCB093BC65613800E8282");
 
 /// EIP-8282: Builder exit requests system call (request type `0x04`).
 pub(crate) fn system_call_eip8282_builder_exit_request<EVM>(evm: &mut EVM) -> Result<(), EVM::Error>

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -347,7 +347,9 @@ pub fn execute_test_suite(
                         return Err(TestError {
                             name,
                             path,
-                            kind: TestErrorKind::UnknownPrivateKey(unit.transaction.secret_key),
+                            kind: TestErrorKind::UnknownPrivateKey(
+                                unit.transaction.secret_key.unwrap_or_default(),
+                            ),
                         });
                     }
                 };

--- a/crates/context/interface/src/cfg/gas.rs
+++ b/crates/context/interface/src/cfg/gas.rs
@@ -363,15 +363,11 @@ pub struct InitialAndFloorGas {
     /// Under EIP-8037, this is the part constrained by `TX_MAX_GAS_LIMIT`;
     /// state gas uses its own reservoir and is not subject to that cap.
     pub initial_regular_gas: u64,
-    /// State gas component of the initial intrinsic gas.
-    /// Under EIP-8037, this includes:
-    /// - EIP-7702 auth list state gas (per-auth account creation + metadata costs)
-    /// - For CREATE transactions: `create_state_gas` (account creation + contract metadata)
-    /// - For CALL transactions: 0 (state gas is unpredictable at validation time)
+    /// State gas charged before the first frame is entered.
+    ///
+    /// Zero at the intrinsic phase; the EIP-2780 runtime gas phase adds the
+    /// state-dependent charges metered while applying EIP-7702 authorizations.
     pub initial_state_gas: u64,
-    /// EIP-7702 refund for existing authorities.
-    /// This is the refund given when an authorization is applied to an already existing account.
-    pub state_refund: u64,
     /// If transaction is a Call and Prague is enabled
     /// floor_gas is at least amount of gas that is going to be spent.
     pub floor_gas: u64,
@@ -408,7 +404,6 @@ impl InitialAndFloorGas {
         Self {
             initial_regular_gas,
             initial_state_gas: 0,
-            state_refund: 0,
             floor_gas,
             runtime_oog: false,
             first_frame_state_gas: 0,
@@ -425,7 +420,6 @@ impl InitialAndFloorGas {
         Self {
             initial_regular_gas,
             initial_state_gas,
-            state_refund: 0,
             floor_gas,
             runtime_oog: false,
             first_frame_state_gas: 0,
@@ -443,11 +437,10 @@ impl InitialAndFloorGas {
         self.initial_regular_gas
     }
 
-    /// State gas component of the initial intrinsic gas.
-    /// This is the state gas component of the initial intrinsic gas minus the EIP-7702 refund.
+    /// State gas charged before the first frame is entered.
     #[inline]
     pub const fn initial_state_gas_final(&self) -> u64 {
-        self.initial_state_gas - self.state_refund
+        self.initial_state_gas
     }
 
     /// EIP-7623 floor gas.
@@ -513,8 +506,7 @@ impl InitialAndFloorGas {
     ///   reservoir = execution_gas - regular_gas_budget
     ///
     /// Initial state gas is then deducted from the reservoir (spilling into the
-    /// regular budget when the reservoir is insufficient), and the EIP-7702
-    /// refund for existing authorities is added back to the reservoir.
+    /// regular budget when the reservoir is insufficient).
     ///
     /// On mainnet (state gas disabled), reservoir = 0 and gas_limit is unchanged.
     ///
@@ -546,11 +538,6 @@ impl InitialAndFloorGas {
             regular_gas_limit -= self.initial_state_gas - reservoir;
             reservoir = 0;
         }
-
-        // EIP-7702 state gas refund for existing authorities goes directly to
-        // the reservoir. In the Python spec, set_delegation adds this refund to
-        // state_gas_reservoir so it stays as state gas (not regular gas).
-        reservoir += self.state_refund;
 
         (regular_gas_limit, reservoir)
     }
@@ -592,11 +579,6 @@ impl InitialAndFloorGas {
                 regular_gas_limit.checked_sub(self.initial_state_gas - reservoir)?;
             reservoir = 0;
         }
-
-        // EIP-7702 state gas refund for existing authorities goes directly to
-        // the reservoir. In the Python spec, set_delegation adds this refund to
-        // state_gas_reservoir so it stays as state gas (not regular gas).
-        reservoir += self.state_refund;
 
         Some((regular_gas_limit, reservoir))
     }

--- a/crates/context/interface/src/cfg/gas.rs
+++ b/crates/context/interface/src/cfg/gas.rs
@@ -375,6 +375,17 @@ pub struct InitialAndFloorGas {
     /// If transaction is a Call and Prague is enabled
     /// floor_gas is at least amount of gas that is going to be spent.
     pub floor_gas: u64,
+    /// EIP-2780: the transaction passed the intrinsic validity check but its gas
+    /// cannot cover the state-dependent runtime charges applied in the
+    /// pre-execution phase (EIP-7702 authority charges, recipient
+    /// delegation-target access, new-account state gas).
+    ///
+    /// The transaction stays valid and included: execution is skipped, all gas
+    /// is consumed, and all runtime state changes (including applied EIP-7702
+    /// delegations) are reverted, exactly like an out-of-gas halt inside a
+    /// frame.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub runtime_oog: bool,
 }
 
 impl InitialAndFloorGas {
@@ -388,6 +399,7 @@ impl InitialAndFloorGas {
             initial_state_gas: 0,
             state_refund: 0,
             floor_gas,
+            runtime_oog: false,
         }
     }
 
@@ -403,6 +415,7 @@ impl InitialAndFloorGas {
             initial_state_gas,
             state_refund: 0,
             floor_gas,
+            runtime_oog: false,
         }
     }
 
@@ -527,6 +540,52 @@ impl InitialAndFloorGas {
         reservoir += self.state_refund;
 
         (regular_gas_limit, reservoir)
+    }
+
+    /// Checked variant of [`Self::initial_gas_and_reservoir`].
+    ///
+    /// Returns `None` when the initial gas does not fit the transaction's gas
+    /// limit — either the regular gas exceeds `min(tx_gas_limit,
+    /// tx_gas_limit_cap)` or the state gas spilling out of the reservoir
+    /// exceeds the remaining regular budget. Used by the EIP-2780 runtime
+    /// phase, where state-dependent charges are folded into the initial gas
+    /// after validation and may exceed the supplied gas (an out-of-gas halt,
+    /// not an invalid transaction).
+    pub fn checked_initial_gas_and_reservoir(
+        &self,
+        tx_gas_limit: u64,
+        tx_gas_limit_cap: u64,
+    ) -> Option<(u64, u64)> {
+        let execution_gas = tx_gas_limit.checked_sub(self.initial_regular_gas())?;
+
+        // System calls pass InitialAndFloorGas with all zeros and should not be
+        // subject to the TX_MAX_GAS_LIMIT cap.
+        let tx_gas_limit_cap = if self.initial_total_gas() == 0 {
+            u64::MAX
+        } else {
+            tx_gas_limit_cap
+        };
+
+        let mut regular_gas_limit = core::cmp::min(tx_gas_limit, tx_gas_limit_cap)
+            .checked_sub(self.initial_regular_gas())?;
+        let mut reservoir = execution_gas - regular_gas_limit;
+
+        // Deduct initial state gas from the reservoir. When the reservoir is
+        // insufficient, the deficit is charged from the regular gas budget.
+        if reservoir >= self.initial_state_gas {
+            reservoir -= self.initial_state_gas;
+        } else {
+            regular_gas_limit =
+                regular_gas_limit.checked_sub(self.initial_state_gas - reservoir)?;
+            reservoir = 0;
+        }
+
+        // EIP-7702 state gas refund for existing authorities goes directly to
+        // the reservoir. In the Python spec, set_delegation adds this refund to
+        // state_gas_reservoir so it stays as state gas (not regular gas).
+        reservoir += self.state_refund;
+
+        Some((regular_gas_limit, reservoir))
     }
 }
 

--- a/crates/context/interface/src/cfg/gas.rs
+++ b/crates/context/interface/src/cfg/gas.rs
@@ -386,6 +386,17 @@ pub struct InitialAndFloorGas {
     /// frame.
     #[cfg_attr(feature = "serde", serde(default))]
     pub runtime_oog: bool,
+    /// EIP-2780: state gas decided at the runtime gas phase to be recorded on
+    /// the first frame's gas tracker — the recipient new-account leaf charge
+    /// of a value transfer, or the account-creation charge of a create
+    /// transaction whose deployment target does not exist.
+    ///
+    /// Charged on the frame (rather than folded into `initial_state_gas`) so
+    /// a revert or halt of the frame refills it. Its affordability was
+    /// verified at the runtime phase; an unaffordable charge sets
+    /// [`runtime_oog`](Self::runtime_oog) instead.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub first_frame_state_gas: u64,
 }
 
 impl InitialAndFloorGas {
@@ -400,6 +411,7 @@ impl InitialAndFloorGas {
             state_refund: 0,
             floor_gas,
             runtime_oog: false,
+            first_frame_state_gas: 0,
         }
     }
 
@@ -416,6 +428,7 @@ impl InitialAndFloorGas {
             state_refund: 0,
             floor_gas,
             runtime_oog: false,
+            first_frame_state_gas: 0,
         }
     }
 

--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -894,6 +894,13 @@ impl GasParams {
         self.get(GasId::tx_eip7702_regular_refund())
     }
 
+    /// EIP-8037: state gas for one 23-byte EIP-7702 delegation indicator
+    /// (`STATE_BYTES_PER_AUTH_BASE × CPSB`). Zero before AMSTERDAM.
+    #[inline]
+    pub fn tx_eip7702_state_gas_bytecode(&self) -> u64 {
+        self.get(GasId::tx_eip7702_state_gas_bytecode())
+    }
+
     /// Used in [GasParams::initial_tx_gas] to calculate the token non zero byte multiplier.
     #[inline]
     pub fn tx_token_non_zero_byte_multiplier(&self) -> u64 {
@@ -1091,12 +1098,25 @@ impl GasParams {
             get_tokens_in_calldata(input, self.tx_token_non_zero_byte_multiplier());
 
         // EIP-7702: Compute auth list costs.
-        // Under EIP-8037, tx_eip7702_per_empty_account_cost bundles regular + state gas.
-        // We split them: regular goes in initial_regular_gas, state goes in initial_state_gas.
-        let auth_total_cost = authorization_list_num * self.tx_eip7702_per_empty_account_cost();
-        let auth_state_gas = authorization_list_num * self.tx_eip7702_state_gas();
-
-        let auth_regular_cost = auth_total_cost - auth_state_gas;
+        //
+        // Under EIP-2780 the intrinsic per-auth charge is the state-independent
+        // `REGULAR_PER_AUTH_BASE_COST` only; the state-dependent remainder
+        // (`ACCOUNT_WRITE` plus the new-account / delegation-bytes state gas) is
+        // charged at the runtime phase, per authority that incurs it.
+        //
+        // Otherwise, under EIP-8037, tx_eip7702_per_empty_account_cost bundles
+        // regular + state gas. We split them: regular goes in
+        // initial_regular_gas, state goes in initial_state_gas.
+        let (auth_regular_cost, auth_state_gas) = if eip2780.is_some() {
+            (
+                authorization_list_num * eip8038::EIP7702_PER_AUTH_BASE_REGULAR,
+                0,
+            )
+        } else {
+            let auth_total_cost = authorization_list_num * self.tx_eip7702_per_empty_account_cost();
+            let auth_state_gas = authorization_list_num * self.tx_eip7702_state_gas();
+            (auth_total_cost - auth_state_gas, auth_state_gas)
+        };
 
         let base_and_to_and_value_gas = match eip2780 {
             None => {
@@ -1128,7 +1148,13 @@ impl GasParams {
 
             // EIP-8037: State gas for CREATE transactions.
             // create_state_gas covers both account creation and contract metadata.
-            initial_state_gas += self.create_state_gas();
+            //
+            // Under EIP-2780 this charge moves to the runtime phase and is
+            // applied only when the deployment target does not already exist
+            // (see `EthFrame::make_create_frame`).
+            if eip2780.is_none() {
+                initial_state_gas += self.create_state_gas();
+            }
         }
 
         // Calculate gas floor. Introduced by EIP-7623, updated by EIP-7976, and
@@ -1857,6 +1883,51 @@ mod tests {
         assert_eq!(call_gas.initial_state_gas_final(), 0);
         // initial_gas should be unchanged for calls
         assert_eq!(call_gas.initial_total_gas(), gas_params.tx_base_stipend());
+    }
+
+    #[test]
+    fn test_initial_tx_gas_eip2780_runtime_split() {
+        let gas_params = GasParams::new_spec(SpecId::AMSTERDAM);
+        let info = || Eip2780TxInfo {
+            value: U256::ZERO,
+            is_self_transfer: false,
+        };
+
+        // Create transaction: the new-account state gas is no longer intrinsic —
+        // it moves to the runtime phase, charged only when the deployment
+        // target does not already exist.
+        let create_gas = gas_params.initial_tx_gas(b"", true, 0, 0, 0, Some(info()));
+        assert_eq!(create_gas.initial_state_gas, 0);
+        assert_eq!(
+            create_gas.initial_regular_gas,
+            eip2780::TX_BASE_COST + eip8038::CREATE_ACCESS
+        );
+
+        // EIP-7702 authorizations: intrinsic per-auth charge is the
+        // state-independent REGULAR_PER_AUTH_BASE_COST (7,816) only; the
+        // ACCOUNT_WRITE and state-gas portions are runtime charges.
+        let auth_gas = gas_params.initial_tx_gas(b"", false, 0, 0, 2, Some(info()));
+        assert_eq!(auth_gas.initial_state_gas, 0);
+        assert_eq!(
+            auth_gas.initial_regular_gas,
+            eip2780::TX_BASE_COST
+                + eip8038::COLD_ACCOUNT_ACCESS
+                + 2 * eip8038::EIP7702_PER_AUTH_BASE_REGULAR
+        );
+
+        // Without EIP-2780 the pessimistic model is unchanged: per-auth
+        // regular 15,816 plus per-auth state gas, and intrinsic create state
+        // gas.
+        let legacy_auth_gas = gas_params.initial_tx_gas(b"", false, 0, 0, 1, None);
+        assert_eq!(
+            legacy_auth_gas.initial_state_gas,
+            gas_params.tx_eip7702_state_gas()
+        );
+        let legacy_create_gas = gas_params.initial_tx_gas(b"", true, 0, 0, 0, None);
+        assert_eq!(
+            legacy_create_gas.initial_state_gas,
+            gas_params.create_state_gas()
+        );
     }
 
     #[test]

--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -1118,7 +1118,7 @@ impl GasParams {
             (auth_total_cost - auth_state_gas, auth_state_gas)
         };
 
-        let base_and_to_and_value_gas = match eip2780 {
+        let base_and_to_and_value_gas = match &eip2780 {
             None => {
                 let mut base = self.tx_base_stipend();
                 if is_create {
@@ -1127,7 +1127,7 @@ impl GasParams {
                 }
                 base
             }
-            Some(info) => self.eip2780_base_to_value_gas(is_create, &info),
+            Some(info) => self.eip2780_base_to_value_gas(is_create, info),
         };
 
         let mut initial_regular_gas = tokens_in_calldata * self.tx_token_cost()
@@ -1159,10 +1159,19 @@ impl GasParams {
 
         // Calculate gas floor. Introduced by EIP-7623, updated by EIP-7976, and
         // extended by EIP-7981 to include access-list data alongside calldata.
+        //
+        // Under EIP-2780 the floor is anchored on the decomposed regular-gas
+        // intrinsic base (`TX_BASE + to-based + value-based`, the same sum used
+        // for `base_and_to_and_value_gas` above) rather than the flat
+        // `tx_floor_cost_base_gas`, so it never undercuts the transaction's own
+        // intrinsic base.
         let access_list_floor_tokens =
             self.tx_floor_tokens_in_access_list(access_list_accounts, access_list_storages);
-        let floor_gas =
+        let mut floor_gas =
             self.tx_floor_cost(input) + access_list_floor_tokens * self.tx_floor_cost_per_token();
+        if eip2780.is_some() {
+            floor_gas = floor_gas - self.tx_floor_cost_base_gas() + base_and_to_and_value_gas;
+        }
 
         InitialAndFloorGas::default()
             .with_initial_regular_gas(initial_regular_gas)

--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -844,18 +844,6 @@ impl GasParams {
         regular.saturating_add(state)
     }
 
-    /// EIP-7702 authorization refund per existing account.
-    ///
-    /// Pre-Amsterdam this is a fixed regular-gas refund (`PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST`).
-    /// Under EIP-8037 the refund is fully state gas, equal to the per-account
-    /// state-gas portion.
-    #[inline]
-    pub fn tx_eip7702_auth_refund(&self) -> u64 {
-        let regular = self.get(GasId::tx_eip7702_regular_refund());
-        let state = self.new_account_state_gas();
-        regular.saturating_add(state)
-    }
-
     /// EIP-8037: State gas per EIP-7702 authorization (pessimistic).
     ///
     /// Sums the new-account and bytecode state-gas portions. Used for
@@ -1103,19 +1091,10 @@ impl GasParams {
         // `REGULAR_PER_AUTH_BASE_COST` only; the state-dependent remainder
         // (`ACCOUNT_WRITE` plus the new-account / delegation-bytes state gas) is
         // charged at the runtime phase, per authority that incurs it.
-        //
-        // Otherwise, under EIP-8037, tx_eip7702_per_empty_account_cost bundles
-        // regular + state gas. We split them: regular goes in
-        // initial_regular_gas, state goes in initial_state_gas.
-        let (auth_regular_cost, auth_state_gas) = if eip2780.is_some() {
-            (
-                authorization_list_num * eip8038::EIP7702_PER_AUTH_BASE_REGULAR,
-                0,
-            )
+        let auth_regular_cost = if eip2780.is_some() {
+            authorization_list_num * eip8038::EIP7702_PER_AUTH_BASE_REGULAR
         } else {
-            let auth_total_cost = authorization_list_num * self.tx_eip7702_per_empty_account_cost();
-            let auth_state_gas = authorization_list_num * self.tx_eip7702_state_gas();
-            (auth_total_cost - auth_state_gas, auth_state_gas)
+            authorization_list_num * self.tx_eip7702_per_empty_account_cost()
         };
 
         let base_and_to_and_value_gas = match &eip2780 {
@@ -1139,22 +1118,9 @@ impl GasParams {
             // EIP-7702: Only the regular portion of auth list cost
             + auth_regular_cost;
 
-        // EIP-8037: Track auth list state gas separately for reservoir handling.
-        let mut initial_state_gas = auth_state_gas;
-
         if is_create {
             // EIP-3860: Limit and meter initcode
             initial_regular_gas += self.tx_initcode_cost(input.len());
-
-            // EIP-8037: State gas for CREATE transactions.
-            // create_state_gas covers both account creation and contract metadata.
-            //
-            // Under EIP-2780 this charge moves to the runtime phase and is
-            // applied only when the deployment target does not already exist
-            // (see `EthFrame::make_create_frame`).
-            if eip2780.is_none() {
-                initial_state_gas += self.create_state_gas();
-            }
         }
 
         // Calculate gas floor. Introduced by EIP-7623, updated by EIP-7976, and
@@ -1173,9 +1139,11 @@ impl GasParams {
             floor_gas = floor_gas - self.tx_floor_cost_base_gas() + base_and_to_and_value_gas;
         }
 
+        // `initial_state_gas` stays zero at the intrinsic phase: state-dependent
+        // charges are applied at the EIP-2780 runtime gas phase
+        // (`apply_eip2780_runtime_gas`), which adds them to `initial_state_gas`.
         InitialAndFloorGas::default()
             .with_initial_regular_gas(initial_regular_gas)
-            .with_initial_state_gas(initial_state_gas)
             .with_floor_gas(floor_gas)
     }
 
@@ -1867,24 +1835,19 @@ mod tests {
 
     #[test]
     fn test_initial_state_gas_for_create() {
-        // Use AMSTERDAM spec since EIP-8037 state gas is only enabled starting from Amsterdam.
+        // State-dependent charges are applied at the EIP-2780 runtime gas
+        // phase, so the intrinsic state gas is zero even for CREATE
+        // transactions at AMSTERDAM.
         let gas_params = GasParams::new_spec(SpecId::AMSTERDAM);
         // Test CREATE transaction (is_create = true)
         let create_gas = gas_params.initial_tx_gas(b"", true, 0, 0, 0, None);
-        let expected_state_gas = gas_params.create_state_gas();
+        assert_eq!(create_gas.initial_state_gas_final(), 0);
 
-        assert_eq!(create_gas.initial_state_gas_final(), expected_state_gas);
-        assert_eq!(
-            create_gas.initial_state_gas_final(),
-            eip8037::NEW_ACCOUNT_BYTES * eip8037::CPSB_GLAMSTERDAM
-        );
-
-        // initial_total_gas() returns both regular and state gas combined
         let create_cost = gas_params.tx_create_cost();
         let initcode_cost = gas_params.tx_initcode_cost(0);
         assert_eq!(
             create_gas.initial_total_gas(),
-            gas_params.tx_base_stipend() + create_cost + initcode_cost + expected_state_gas
+            gas_params.tx_base_stipend() + create_cost + initcode_cost
         );
 
         // Test CALL transaction (is_create = false)
@@ -1924,19 +1887,16 @@ mod tests {
                 + 2 * eip8038::EIP7702_PER_AUTH_BASE_REGULAR
         );
 
-        // Without EIP-2780 the pessimistic model is unchanged: per-auth
-        // regular 15,816 plus per-auth state gas, and intrinsic create state
-        // gas.
+        // Without EIP-2780 (pre-Amsterdam semantics) the intrinsic state gas
+        // is zero as well: the per-auth charge is the bundled regular cost.
         let legacy_auth_gas = gas_params.initial_tx_gas(b"", false, 0, 0, 1, None);
+        assert_eq!(legacy_auth_gas.initial_state_gas, 0);
         assert_eq!(
-            legacy_auth_gas.initial_state_gas,
-            gas_params.tx_eip7702_state_gas()
+            legacy_auth_gas.initial_regular_gas,
+            gas_params.tx_base_stipend() + gas_params.tx_eip7702_per_empty_account_cost()
         );
         let legacy_create_gas = gas_params.initial_tx_gas(b"", true, 0, 0, 0, None);
-        assert_eq!(
-            legacy_create_gas.initial_state_gas,
-            gas_params.create_state_gas()
-        );
+        assert_eq!(legacy_create_gas.initial_state_gas, 0);
     }
 
     #[test]

--- a/crates/context/interface/src/host.rs
+++ b/crates/context/interface/src/host.rs
@@ -69,9 +69,6 @@ pub trait Host {
     /// Returns whether state gas (EIP-8037) is enabled.
     fn is_amsterdam_eip8037_enabled(&self) -> bool;
 
-    /// Returns whether the EIP-2780 runtime gas phase is enabled.
-    fn is_amsterdam_eip2780_enabled(&self) -> bool;
-
     /* Database */
 
     /// Block hash, calls `ContextTr::journal_mut().db().block_hash(number)`
@@ -243,10 +240,6 @@ impl Host for DummyHost {
     }
 
     fn is_amsterdam_eip8037_enabled(&self) -> bool {
-        false
-    }
-
-    fn is_amsterdam_eip2780_enabled(&self) -> bool {
         false
     }
 

--- a/crates/context/interface/src/host.rs
+++ b/crates/context/interface/src/host.rs
@@ -69,6 +69,9 @@ pub trait Host {
     /// Returns whether state gas (EIP-8037) is enabled.
     fn is_amsterdam_eip8037_enabled(&self) -> bool;
 
+    /// Returns whether the EIP-2780 runtime gas phase is enabled.
+    fn is_amsterdam_eip2780_enabled(&self) -> bool;
+
     /* Database */
 
     /// Block hash, calls `ContextTr::journal_mut().db().block_hash(number)`
@@ -240,6 +243,10 @@ impl Host for DummyHost {
     }
 
     fn is_amsterdam_eip8037_enabled(&self) -> bool {
+        false
+    }
+
+    fn is_amsterdam_eip2780_enabled(&self) -> bool {
         false
     }
 

--- a/crates/context/interface/src/journaled_state/account.rs
+++ b/crates/context/interface/src/journaled_state/account.rs
@@ -430,8 +430,11 @@ impl<'a, DB: Database, ENTRY: JournalEntryTr> JournaledAccountTr
     #[inline]
     fn set_code(&mut self, code_hash: B256, code: Bytecode) {
         self.touch();
+        let had_code_hash = self.account.info.code_hash;
+        let had_code = self.account.info.code.take();
         self.account.info.set_code_and_hash(code, code_hash);
-        self.journal_entries.push(ENTRY::code_changed(self.address));
+        self.journal_entries
+            .push(ENTRY::code_changed(self.address, had_code_hash, had_code));
     }
 
     /// Sets the code of the account. Calculates hash of the code.

--- a/crates/context/interface/src/journaled_state/entry.rs
+++ b/crates/context/interface/src/journaled_state/entry.rs
@@ -5,8 +5,8 @@
 //! They are created when there is change to the state from loading (making it warm), changes to the balance,
 //! or removal of the storage slot. Check [`JournalEntryTr`] for more details.
 
-use primitives::{Address, StorageKey, StorageValue, KECCAK_EMPTY, PRECOMPILE3, U256};
-use state::{EvmState, TransientStorage};
+use primitives::{Address, StorageKey, StorageValue, B256, PRECOMPILE3, U256};
+use state::{Bytecode, EvmState, TransientStorage};
 
 /// Trait for tracking and reverting state changes in the EVM.
 /// Journal entry contains information about state changes that can be reverted.
@@ -61,7 +61,12 @@ pub trait JournalEntryTr {
     ) -> Self;
 
     /// Creates a journal entry for when an account's code is modified
-    fn code_changed(address: Address) -> Self;
+    ///
+    /// Records the previous code hash and bytecode for reverting: since
+    /// EIP-7702 the code of an already-delegated account can be changed (and
+    /// the change reverted), so the revert cannot assume the previous code was
+    /// empty.
+    fn code_changed(address: Address, had_code_hash: B256, had_code: Option<Bytecode>) -> Self;
 
     /// Reverts the state change recorded by this journal entry
     ///
@@ -225,6 +230,10 @@ pub enum JournalEntry {
     CodeChange {
         /// Address of account that had its code changed.
         address: Address,
+        /// Previous code hash of the account.
+        had_code_hash: B256,
+        /// Previous bytecode of the account (`None` if it was not loaded).
+        had_code: Option<Bytecode>,
     },
 }
 
@@ -304,8 +313,12 @@ impl JournalEntryTr for JournalEntry {
         }
     }
 
-    fn code_changed(address: Address) -> Self {
-        JournalEntry::CodeChange { address }
+    fn code_changed(address: Address, had_code_hash: B256, had_code: Option<Bytecode>) -> Self {
+        JournalEntry::CodeChange {
+            address,
+            had_code_hash,
+            had_code,
+        }
     }
 
     fn revert(
@@ -427,10 +440,14 @@ impl JournalEntryTr for JournalEntry {
                     transient_storage.insert_value(address, key, had_value);
                 }
             }
-            JournalEntry::CodeChange { address } => {
+            JournalEntry::CodeChange {
+                address,
+                had_code_hash,
+                had_code,
+            } => {
                 let acc = state.get_mut(&address).unwrap();
-                acc.info.code_hash = KECCAK_EMPTY;
-                acc.info.code = None;
+                acc.info.code_hash = had_code_hash;
+                acc.info.code = had_code;
             }
         }
     }

--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -467,6 +467,10 @@ impl<
         self.cfg().is_amsterdam_eip8037_enabled()
     }
 
+    fn is_amsterdam_eip2780_enabled(&self) -> bool {
+        self.cfg().is_amsterdam_eip2780_enabled()
+    }
+
     fn block_number(&self) -> U256 {
         self.block().number()
     }

--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -467,10 +467,6 @@ impl<
         self.cfg().is_amsterdam_eip8037_enabled()
     }
 
-    fn is_amsterdam_eip2780_enabled(&self) -> bool {
-        self.cfg().is_amsterdam_eip2780_enabled()
-    }
-
     fn block_number(&self) -> U256 {
         self.block().number()
     }

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -380,7 +380,10 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         let account = self.state.get_mut(&address).unwrap();
         Self::touch_account(&mut self.journal, address, account);
 
-        self.journal.push(ENTRY::code_changed(address));
+        let had_code_hash = account.info.code_hash;
+        let had_code = account.info.code.take();
+        self.journal
+            .push(ENTRY::code_changed(address, had_code_hash, had_code));
 
         account.info.code_hash = hash;
         account.info.code = Some(code);

--- a/crates/ee-tests/src/eip2780.rs
+++ b/crates/ee-tests/src/eip2780.rs
@@ -336,8 +336,10 @@ fn test_eip2780_auth_new_authority_runtime_charges() {
 
 #[test]
 fn test_eip2780_auth_existing_authority_runtime_charges() {
-    // An existing authority pays neither the new-account state gas nor
-    // ACCOUNT_WRITE; only the net-new delegation bytes are charged.
+    // An existing authority does not pay the new-account state gas, but the
+    // authorization is still the transaction's first write to its leaf, so
+    // ACCOUNT_WRITE is charged (EIPs#11891) along with the net-new delegation
+    // bytes.
     let to = address!("0x00000000000000000000000000000000000000aa");
     let authority = address!("0x00000000000000000000000000000000000000cc");
     let delegate = address!("0x00000000000000000000000000000000000000dd");
@@ -363,6 +365,7 @@ fn test_eip2780_auth_existing_authority_runtime_charges() {
         eip2780::TX_BASE_COST
             + eip8038::COLD_ACCOUNT_ACCESS
             + eip8038::EIP7702_PER_AUTH_BASE_REGULAR
+            + eip8038::ACCOUNT_WRITE
     );
 }
 

--- a/crates/ee-tests/src/eip2780.rs
+++ b/crates/ee-tests/src/eip2780.rs
@@ -1,8 +1,12 @@
 //! EIP-2780 integration tests.
 //!
 //! Verifies the decomposed intrinsic gas model (`TX_BASE_COST` + to-based +
-//! value-based) and the top-level execution charges (state gas for empty
-//! recipient with value, extra cold access for EIP-7702-delegated recipients).
+//! value-based) and the runtime gas phase (ethereum/EIPs#11844): state gas for
+//! an empty recipient with value, the warm/cold delegation-target access for
+//! EIP-7702-delegated recipients, the conditional create-transaction
+//! new-account state gas, the per-authority EIP-7702 runtime charges, and the
+//! included-as-halt behavior when gas covers the intrinsic cost but not a
+//! runtime charge.
 //!
 //! Self-transfers (`tx.to == sender`) are special-cased per execution-specs:
 //! they pay only `TX_BASE_COST` with no `to`- or `value`-based charge. The
@@ -11,13 +15,16 @@
 
 use revm::{
     context::TxEnv,
-    database::{BenchmarkDB, BENCH_CALLER},
+    context_interface::transaction::{
+        AccessList, AccessListItem, Authorization, RecoveredAuthority, RecoveredAuthorization,
+    },
+    database::{BenchmarkDB, CacheDB, EmptyDB, BENCH_CALLER},
     handler::{MainnetContext, MainnetEvm},
     primitives::{
-        address, eip2780, eip8037, eip8037::CPSB_GLAMSTERDAM, eip8038, hardfork::SpecId, TxKind,
-        U256,
+        address, eip2780, eip8037, eip8037::CPSB_GLAMSTERDAM, eip8038, hardfork::SpecId, Address,
+        TxKind, KECCAK_EMPTY, U256,
     },
-    state::Bytecode,
+    state::{AccountInfo, Bytecode},
     Context, ExecuteEvm, MainBuilder, MainContext,
 };
 
@@ -142,4 +149,252 @@ fn test_eip2780_legacy_base_when_disabled() {
     let to = address!("0x00000000000000000000000000000000000000aa");
     let gas = run(&mut evm, TxKind::Call(to), U256::ZERO);
     assert_eq!(gas.total_gas_spent(), LEGACY_BASE);
+}
+
+/// State gas for one 23-byte EIP-7702 delegation indicator (23 × 1530 = 35_190).
+const STATE_BYTES_PER_AUTH_BASE: u64 = eip8037::AUTH_BASE_BYTES * CPSB_GLAMSTERDAM;
+
+type CacheEvm = MainnetEvm<MainnetContext<CacheDB<EmptyDB>>>;
+
+/// Builds an EVM at AMSTERDAM (EIP-2780 enabled) over a prepared [`CacheDB`].
+fn evm_with_db(db: CacheDB<EmptyDB>) -> CacheEvm {
+    Context::mainnet()
+        .modify_cfg_chained(|cfg| {
+            cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
+            cfg.tx_gas_limit_cap = Some(u64::MAX);
+        })
+        .with_db(db)
+        .build_mainnet()
+}
+
+fn recovered_auth(authority: Address, delegate: Address, nonce: u64) -> RecoveredAuthorization {
+    RecoveredAuthorization::new_unchecked(
+        Authorization {
+            chain_id: U256::ZERO,
+            address: delegate,
+            nonce,
+        },
+        RecoveredAuthority::Valid(authority),
+    )
+}
+
+fn tx_7702(to: Address, gas_limit: u64, auth: RecoveredAuthorization) -> TxEnv {
+    let mut tx = TxEnv::builder_for_bench()
+        .kind(TxKind::Call(to))
+        .value(U256::ZERO)
+        .gas_price(0)
+        .gas_limit(gas_limit)
+        .build_fill();
+    tx.set_recovered_authorization(vec![auth]);
+    tx.derive_tx_type().unwrap();
+    tx
+}
+
+#[test]
+fn test_eip2780_create_to_existing_target_no_state_gas() {
+    // A create transaction whose deployment target already exists
+    // (balance-only leaf) pays no new-account state gas: the charge is applied
+    // at runtime, conditional on the target's existence.
+    let created_address = BENCH_CALLER.create(0);
+    let mut db = CacheDB::<EmptyDB>::default();
+    db.insert_account_info(
+        created_address,
+        AccountInfo::new(U256::from(1u64), 0, KECCAK_EMPTY, Bytecode::new()),
+    );
+    let mut evm = evm_with_db(db);
+
+    let result = evm.transact_one(tx(TxKind::Create, U256::ZERO)).unwrap();
+    assert!(result.is_success());
+    let gas = result.gas();
+    assert_eq!(gas.state_gas_spent_final(), 0);
+    assert_eq!(
+        gas.total_gas_spent(),
+        eip2780::TX_BASE_COST + eip8038::CREATE_ACCESS
+    );
+}
+
+#[test]
+fn test_eip2780_create_runtime_state_gas_oog_is_included() {
+    // Gas covers the intrinsic cost (TX_BASE + CREATE_ACCESS = 23,000) but not
+    // the runtime new-account state gas: the transaction stays valid and is
+    // included as an out-of-gas halt consuming all supplied gas.
+    let gas_limit = eip2780::TX_BASE_COST + eip8038::CREATE_ACCESS;
+    let mut evm = evm_with_db(CacheDB::<EmptyDB>::default());
+
+    let tx = TxEnv::builder_for_bench()
+        .kind(TxKind::Create)
+        .value(U256::ZERO)
+        .gas_price(0)
+        .gas_limit(gas_limit)
+        .build_fill();
+    let result = evm.transact_one(tx).unwrap();
+    assert!(result.is_halt());
+    assert_eq!(result.gas().total_gas_spent(), gas_limit);
+}
+
+#[test]
+fn test_eip2780_call_runtime_state_gas_oog_is_included() {
+    // Value transfer to a non-existent recipient funded only for the intrinsic
+    // 21,000: valid, included, halts out-of-gas in the runtime phase.
+    let to = address!("0x00000000000000000000000000000000000000ab");
+    let gas_limit = eip2780::TX_BASE_COST
+        + eip8038::COLD_ACCOUNT_ACCESS
+        + eip2780::TRANSFER_LOG_COST
+        + eip2780::TX_VALUE_COST;
+    let mut evm = evm();
+
+    let tx = TxEnv::builder_for_bench()
+        .kind(TxKind::Call(to))
+        .value(U256::from(1u64))
+        .gas_price(0)
+        .gas_limit(gas_limit)
+        .build_fill();
+    let result = evm.transact_one(tx).unwrap();
+    assert!(result.is_halt());
+    assert_eq!(result.gas().total_gas_spent(), gas_limit);
+}
+
+#[test]
+fn test_eip2780_delegated_recipient_cold_target() {
+    // The delegation-target access is a runtime charge following the standard
+    // EIP-2929 warm/cold model: a cold target pays COLD_ACCOUNT_ACCESS.
+    let to = address!("0x00000000000000000000000000000000000000ac");
+    let target = address!("0x00000000000000000000000000000000000000bb");
+    let code = Bytecode::new_eip7702(target);
+    let mut db = CacheDB::<EmptyDB>::default();
+    db.insert_account_info(to, AccountInfo::new(U256::ZERO, 1, code.hash_slow(), code));
+    let mut evm = evm_with_db(db);
+
+    let gas = run_cache(&mut evm, tx(TxKind::Call(to), U256::ZERO));
+    // TX_BASE + COLD (recipient, intrinsic) + COLD (delegation target, runtime)
+    // = 18,000; the empty target code executes as an immediate stop.
+    assert_eq!(
+        gas.total_gas_spent(),
+        eip2780::TX_BASE_COST + 2 * eip8038::COLD_ACCOUNT_ACCESS
+    );
+}
+
+#[test]
+fn test_eip2780_delegated_recipient_warm_target() {
+    // A delegation target pre-warmed by the access list pays WARM_ACCESS
+    // instead of COLD_ACCOUNT_ACCESS.
+    let to = address!("0x00000000000000000000000000000000000000ac");
+    let target = address!("0x00000000000000000000000000000000000000bb");
+    let code = Bytecode::new_eip7702(target);
+    let mut db = CacheDB::<EmptyDB>::default();
+    db.insert_account_info(to, AccountInfo::new(U256::ZERO, 1, code.hash_slow(), code));
+    let mut evm = evm_with_db(db);
+
+    let mut tx = tx(TxKind::Call(to), U256::ZERO);
+    tx.access_list = AccessList::from(vec![AccessListItem {
+        address: target,
+        storage_keys: vec![],
+    }]);
+    tx.derive_tx_type().unwrap();
+    let gas = run_cache(&mut evm, tx);
+    // TX_BASE + COLD (recipient) + access-list item + WARM (delegation target).
+    let access_list_item_cost = eip8038::ACCESS_LIST_ADDRESS_COST + 20 * 64;
+    assert_eq!(
+        gas.total_gas_spent(),
+        eip2780::TX_BASE_COST
+            + eip8038::COLD_ACCOUNT_ACCESS
+            + access_list_item_cost
+            + eip8038::WARM_ACCESS
+    );
+}
+
+#[test]
+fn test_eip2780_auth_new_authority_runtime_charges() {
+    // A non-existent authority pays, at runtime, the new-account state gas
+    // plus ACCOUNT_WRITE regular gas, and the net-new delegation bytes.
+    let to = address!("0x00000000000000000000000000000000000000aa");
+    let authority = address!("0x00000000000000000000000000000000000000cc");
+    let delegate = address!("0x00000000000000000000000000000000000000dd");
+    let mut evm = evm_with_db(CacheDB::<EmptyDB>::default());
+
+    let result = evm
+        .transact_one(tx_7702(
+            to,
+            TX_GAS_LIMIT,
+            recovered_auth(authority, delegate, 0),
+        ))
+        .unwrap();
+    assert!(result.is_success());
+    let gas = result.gas();
+    assert_eq!(
+        gas.state_gas_spent_final(),
+        STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE
+    );
+    assert_eq!(
+        regular_spent(gas),
+        eip2780::TX_BASE_COST
+            + eip8038::COLD_ACCOUNT_ACCESS
+            + eip8038::EIP7702_PER_AUTH_BASE_REGULAR
+            + eip8038::ACCOUNT_WRITE
+    );
+}
+
+#[test]
+fn test_eip2780_auth_existing_authority_runtime_charges() {
+    // An existing authority pays neither the new-account state gas nor
+    // ACCOUNT_WRITE; only the net-new delegation bytes are charged.
+    let to = address!("0x00000000000000000000000000000000000000aa");
+    let authority = address!("0x00000000000000000000000000000000000000cc");
+    let delegate = address!("0x00000000000000000000000000000000000000dd");
+    let mut db = CacheDB::<EmptyDB>::default();
+    db.insert_account_info(
+        authority,
+        AccountInfo::new(U256::from(1u64), 0, KECCAK_EMPTY, Bytecode::new()),
+    );
+    let mut evm = evm_with_db(db);
+
+    let result = evm
+        .transact_one(tx_7702(
+            to,
+            TX_GAS_LIMIT,
+            recovered_auth(authority, delegate, 0),
+        ))
+        .unwrap();
+    assert!(result.is_success());
+    let gas = result.gas();
+    assert_eq!(gas.state_gas_spent_final(), STATE_BYTES_PER_AUTH_BASE);
+    assert_eq!(
+        regular_spent(gas),
+        eip2780::TX_BASE_COST
+            + eip8038::COLD_ACCOUNT_ACCESS
+            + eip8038::EIP7702_PER_AUTH_BASE_REGULAR
+    );
+}
+
+#[test]
+fn test_eip2780_auth_runtime_oog_reverts_delegation() {
+    // Gas covers the intrinsic cost but not the authority's runtime charges:
+    // the transaction is included as an out-of-gas halt, all gas is consumed,
+    // and the applied delegation is reverted.
+    let to = address!("0x00000000000000000000000000000000000000aa");
+    let authority = address!("0x00000000000000000000000000000000000000cc");
+    let delegate = address!("0x00000000000000000000000000000000000000dd");
+    let gas_limit = eip2780::TX_BASE_COST
+        + eip8038::COLD_ACCOUNT_ACCESS
+        + eip8038::EIP7702_PER_AUTH_BASE_REGULAR;
+    let mut evm = evm_with_db(CacheDB::<EmptyDB>::default());
+
+    let out = evm
+        .transact(tx_7702(
+            to,
+            gas_limit,
+            recovered_auth(authority, delegate, 0),
+        ))
+        .unwrap();
+    assert!(out.result.is_halt());
+    assert_eq!(out.result.gas().total_gas_spent(), gas_limit);
+    // The delegation (and the authority's nonce bump) must not survive.
+    if let Some(acc) = out.state.get(&authority) {
+        assert_eq!(acc.info.nonce, 0);
+        assert!(acc.info.is_empty_code_hash());
+    }
+}
+
+fn run_cache(evm: &mut CacheEvm, tx: TxEnv) -> revm::context_interface::result::ResultGas {
+    *evm.transact_one(tx).unwrap().gas()
 }

--- a/crates/ee-tests/src/eip8037.rs
+++ b/crates/ee-tests/src/eip8037.rs
@@ -49,6 +49,24 @@ fn state_gas_evm(bytecode: Bytecode, cap: u64) -> MainEvm {
         .build_mainnet()
 }
 
+/// Builds an EVM with state gas, the EIP-2780 runtime gas phase (the devnet-7
+/// Amsterdam configuration), and custom gas params.
+fn devnet7_state_gas_evm(bytecode: Bytecode, cap: u64) -> MainEvm {
+    Context::mainnet()
+        .modify_cfg_chained(|cfg| {
+            cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
+            cfg.tx_gas_limit_cap = Some(cap);
+            cfg.gas_params.override_gas([
+                (GasId::sstore_set_state_gas(), STATE_GAS_SSTORE_SET),
+                (GasId::new_account_state_gas(), STATE_GAS_NEW_ACCOUNT),
+                (GasId::code_deposit_state_gas(), STATE_GAS_CODE_DEPOSIT),
+                (GasId::create_state_gas(), STATE_GAS_CREATE),
+            ]);
+        })
+        .with_db(BenchmarkDB::new_bytecode(bytecode))
+        .build_mainnet()
+}
+
 /// Builds an EVM without state gas (standard behavior, no cap).
 fn baseline_evm(bytecode: Bytecode) -> MainEvm {
     Context::mainnet()
@@ -2093,12 +2111,13 @@ fn init_code_sstore_and_selfdestruct(beneficiary: [u8; 20]) -> Vec<u8> {
 
 /// Tx-kind Create whose initcode does SSTORE(0,1) then INVALID.
 ///
-/// Initcode halts → all state changes are rolled back. The SSTORE state gas
-/// charged during execution is returned to the reservoir via
-/// `last_frame_result`'s halt branch, and the intrinsic `create_state_gas` is
-/// refilled by the same function's `create_failed` branch. Net result:
-/// `state_gas_spent_final == 0` and the caller pays less than the baseline by
-/// exactly the state gas that was refunded.
+/// Initcode halts → all state changes are rolled back. Under the EIP-2780
+/// runtime gas phase the `create_state_gas` for the (non-existent) deployment
+/// target is recorded on the first frame's gas tracker, so the halt unwinds it
+/// via `rollback_state_gas` together with the SSTORE state gas charged during
+/// execution. Net result: `state_gas_spent_final == 0`, and with an uncapped
+/// transaction (empty reservoir, every state charge spills into regular gas)
+/// the halt consumes the full gas limit — exactly like the baseline.
 #[test]
 fn test_eip8037_tx_create_initcode_halts() {
     let init = init_code_sstore_and_invalid();
@@ -2114,7 +2133,7 @@ fn test_eip8037_tx_create_initcode_halts() {
         )
         .unwrap();
 
-    let mut evm = state_gas_evm(Bytecode::new(), u64::MAX);
+    let mut evm = devnet7_state_gas_evm(Bytecode::new(), u64::MAX);
     let result = evm
         .transact_one(
             TxEnv::builder_for_bench()
@@ -2135,15 +2154,15 @@ fn test_eip8037_tx_create_initcode_halts() {
         _ => panic!("Expected Halt variant"),
     }
 
-    // No state gas should be reported as spent: execution state gas (SSTORE)
-    // is rolled back on halt, and the intrinsic create_state_gas is refilled
-    // to the reservoir via the `create_failed` branch.
+    // No state gas should be reported as spent: both the runtime-phase
+    // create_state_gas and the execution state gas (SSTORE) are rolled back
+    // on halt.
     assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
     assert_eq!(result.gas().state_gas_spent_final(), 0);
 
-    // The state-gas variant pays less than the baseline because the refilled
-    // reservoir is reimbursed back to the caller.
-    assert!(result.tx_gas_used() < baseline_result.tx_gas_used());
+    // With no cap there is no reservoir: the halt consumes the entire gas
+    // limit in both variants.
+    assert_eq!(result.tx_gas_used(), baseline_result.tx_gas_used());
     crate::assert_sorted_json_snapshot!(&(baseline_result, result));
 }
 
@@ -2151,18 +2170,17 @@ fn test_eip8037_tx_create_initcode_halts() {
 ///
 /// Per EIP-6780 the contract is erased at tx end (created and self-destructed
 /// in the same transaction). Per EIP-8037 the state gas charged for that
-/// account — both the intrinsic `create_state_gas` and the execution-time
+/// account — the runtime-phase `create_state_gas` and the execution-time
 /// SSTORE — should ideally be refunded to the reservoir, so the caller is not
 /// billed for state gas.
 ///
 /// However, the journal-based selfdestruct state-gas refund was removed (it
 /// drew on the journal's destroyed-accounts list), so the SSTORE state gas
-/// is no longer refunded. The intrinsic `create_state_gas` is also not
-/// refunded: `return_create` rewrites the frame's `SelfDestruct` result to
-/// `Return` before `last_frame_result` runs, so `create_failed` evaluates to
-/// false and the `create_failed` branch that would refill `create_state_gas`
-/// never fires. The caller therefore pays both the intrinsic state gas and
-/// the SSTORE state gas even though the contract was erased.
+/// is no longer refunded. The `create_state_gas` charged at the EIP-2780
+/// runtime phase is not refunded either: the create completes successfully
+/// (SELFDESTRUCT in initcode deploys empty code), so the charge is never
+/// rolled back even though EIP-6780 erases the account at tx end. The caller
+/// therefore pays both state-gas charges.
 #[test]
 fn test_eip8037_tx_create_initcode_selfdestruct_after_sstore() {
     // Use BENCH_CALLER as beneficiary so we don't trigger new_account_state_gas.
@@ -2179,7 +2197,7 @@ fn test_eip8037_tx_create_initcode_selfdestruct_after_sstore() {
         )
         .unwrap();
 
-    let mut evm = state_gas_evm(Bytecode::new(), u64::MAX);
+    let mut evm = devnet7_state_gas_evm(Bytecode::new(), u64::MAX);
     let result = evm
         .transact_one(
             TxEnv::builder_for_bench()
@@ -2196,9 +2214,7 @@ fn test_eip8037_tx_create_initcode_selfdestruct_after_sstore() {
     assert!(result.is_success());
 
     // Per EIP-8037 + EIP-6780 the user expects state_gas_spent_final == 0 here,
-    // but the journal-based selfdestruct refund was removed, so the SSTORE state
-    // gas is now also retained alongside the intrinsic `create_state_gas` —
-    // see the doc comment above.
+    // but neither charge is refunded — see the doc comment above.
     assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
     assert_eq!(
         result.gas().state_gas_spent_final(),
@@ -2216,12 +2232,14 @@ fn test_eip8037_tx_create_initcode_selfdestruct_after_sstore() {
 /// into `last_frame_result`:
 /// - The halt fully consumes regular gas: `erase_cost(remaining)` is gated on
 ///   `is_ok_or_revert()` and is skipped, so `gas.remaining == 0`.
-/// - `create_failed` matches (Create + not `is_ok_without_selfdestruct`), so
-///   the intrinsic `create_state_gas` is refilled to the reservoir.
+/// - The EIP-2780 runtime phase charges `create_state_gas` only when the
+///   deployment target does not exist; the collision target exists, so no
+///   state gas is charged (the existence check and the collision check are
+///   independent — existence is by non-emptiness, collision by nonce/code).
 /// - `state_gas_spent` is reset to 0 (halt branch).
 ///
-/// Net: the EIP-8037 variant pays exactly `STATE_GAS_CREATE` less than the
-/// baseline.
+/// Net: both variants consume their full regular gas budget; the EIP-8037
+/// variant's extra 10 gas above the cap sits in the reservoir and is returned.
 #[test]
 fn test_eip8037_tx_create_collision() {
     use revm::{
@@ -2277,12 +2295,12 @@ fn test_eip8037_tx_create_collision() {
         .build_mainnet();
     let baseline_result = baseline.transact_one(build_tx(TX_GAS_LIMIT_CAP)).unwrap();
 
-    // State-gas variant: EIP-8037 enabled with gas-table overrides interpreted
-    // as final amounts.
+    // State-gas variant: EIP-8037 and the EIP-2780 runtime gas phase enabled
+    // (devnet-7 configuration) with gas-table overrides interpreted as final
+    // amounts.
     let mut evm = Context::mainnet()
         .modify_cfg_chained(|cfg| {
             cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
-            cfg.enable_amsterdam_eip2780 = false;
             cfg.gas_params.override_gas([
                 (GasId::sstore_set_state_gas(), STATE_GAS_SSTORE_SET),
                 (GasId::new_account_state_gas(), STATE_GAS_NEW_ACCOUNT),
@@ -2315,15 +2333,13 @@ fn test_eip8037_tx_create_collision() {
     assert_eq!(baseline_result.gas().state_gas_spent_final(), 0);
     assert_eq!(result.gas().state_gas_spent_final(), 0);
 
-    // Halt consumes the regular gas budget in full. The intrinsic
-    // create_state_gas equals STATE_GAS_CREATE, and the state-gas
-    // variant's total gas spent is exactly that much less than the baseline,
-    // because the create_failed branch refills the reservoir with it.
-    //
-    // -10 as additional gas was added to tx.gas_limit to cover reservoir handling.
+    // Halt consumes the regular gas budget in full in both variants. The
+    // EIP-2780 runtime phase charges no create_state_gas (the target exists),
+    // and the 10 gas above the cap sits in the reservoir and is returned, so
+    // both spend exactly the regular budget (the cap).
     assert_eq!(
-        baseline_result.gas().total_gas_spent() - result.gas().total_gas_spent(),
-        STATE_GAS_CREATE - 10,
+        baseline_result.gas().total_gas_spent(),
+        result.gas().total_gas_spent(),
     );
 
     crate::assert_sorted_json_snapshot!(&(baseline_result, result));

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_collision.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_collision.snap
@@ -19,10 +19,10 @@ expression: "&(baseline_result, result)"
     "Halt": {
       "reason": "CreateCollision",
       "gas": {
-        "gas_spent": 16447226,
+        "gas_spent": 16777216,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 12384
+        "floor_gas": 23384
       },
       "logs": []
     }

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_halts.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_halts.snap
@@ -19,10 +19,10 @@ expression: "&(baseline_result, result)"
     "Halt": {
       "reason": "InvalidFEOpcode",
       "gas": {
-        "gas_spent": 999670000,
+        "gas_spent": 1000000000,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 12384
+        "floor_gas": 23384
       },
       "logs": []
     }

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_selfdestruct_after_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_selfdestruct_after_sstore.snap
@@ -25,10 +25,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Return",
       "gas": {
-        "gas_spent": 580431,
+        "gas_spent": 571431,
         "state_gas_spent": 530000,
         "gas_refunded": 0,
-        "floor_gas": 13728
+        "floor_gas": 24728
       },
       "logs": [],
       "output": {

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -21,7 +21,6 @@ use interpreter::{
 };
 use primitives::{
     constants::CALL_STACK_LIMIT,
-    eip8038,
     hardfork::SpecId::{self, HOMESTEAD, LONDON, SPURIOUS_DRAGON},
     Address, Bytes, U256,
 };
@@ -160,42 +159,28 @@ impl EthFrame<EthInterpreter> {
             Gas::new_with_regular_gas_and_reservoir(inputs.gas_limit, reservoir_remaining_gas);
 
         // EIP-2780 top-level execution charges. Applied before any state changes
-        // so the recipient's pre-call state determines the charge.
+        // so the recipient's pre-call state determines the charge. The
+        // delegation-target access is charged at the runtime gas phase
+        // (`apply_eip2780_runtime_gas`, warm/cold aware); only the new-account
+        // state gas is charged here, on the frame's tracker, so a revert rolls
+        // it back via the `state_gas_spent`/reservoir reconciliation in
+        // `last_frame_result`. Its affordability was already checked in the
+        // runtime gas phase, so the out-of-gas branch is a defensive backstop.
         let mut early_halt: Option<InstructionResult> = None;
         if depth == 0 && ctx.cfg().is_amsterdam_eip2780_enabled() {
-            // Load the recipient account *with code* so the EIP-7702 delegation
-            // designator can be read (`load_account` alone does not populate
-            // `info.code`).
-            let acc_info = ctx
+            let recipient_is_empty = ctx
                 .journal_mut()
-                .load_account_with_code(inputs.target_address)
-                .ok()
-                .map(|a| a.info.clone());
+                .load_account(inputs.target_address)
+                .map(|a| a.info.is_empty())
+                .unwrap_or(false);
 
-            if let Some(info) = acc_info {
-                // 7702 delegation: additional COLD_ACCOUNT_ACCESS regular gas.
-                let is_7702_delegated = info
-                    .code
-                    .as_ref()
-                    .and_then(Bytecode::eip7702_address)
-                    .is_some();
-                if is_7702_delegated && !gas.record_regular_cost(eip8038::COLD_ACCOUNT_ACCESS) {
-                    early_halt = Some(InstructionResult::OutOfGas);
-                }
-
-                // Empty recipient + nonzero value: charge `new_account_state_gas`.
-                // Refunded on revert via the existing `state_gas_spent`/reservoir
-                // reconciliation in `last_frame_result`.
-                if early_halt.is_none() {
-                    if let CallValue::Transfer(value) = inputs.value {
-                        if !value.is_zero() && info.is_empty() {
-                            let charge = ctx.cfg().gas_params().new_account_state_gas();
-                            if !gas.record_state_cost(charge) {
-                                early_halt = Some(InstructionResult::OutOfGas);
-                            } else {
-                                charged_new_account_state_gas = true;
-                            }
-                        }
+            if let CallValue::Transfer(value) = inputs.value {
+                if !value.is_zero() && recipient_is_empty {
+                    let charge = ctx.cfg().gas_params().new_account_state_gas();
+                    if !gas.record_state_cost(charge) {
+                        early_halt = Some(InstructionResult::OutOfGas);
+                    } else {
+                        charged_new_account_state_gas = true;
                     }
                 }
             }
@@ -391,6 +376,24 @@ impl EthFrame<EthInterpreter> {
             !acc.info.is_empty()
         };
 
+        // EIP-2780: a top-level create transaction pays the new-account state
+        // gas at runtime, only when the deployment target does not already
+        // exist. Charged on this frame's tracker so an initcode revert or halt
+        // refills it in LIFO order via `rollback_state_gas` (the spilled
+        // portion back to `gas_left`, the remainder to the reservoir).
+        // Pre-EIP-2780 the charge is part of the intrinsic gas instead.
+        let mut gas =
+            Gas::new_with_regular_gas_and_reservoir(inputs.gas_limit(), reservoir_remaining_gas);
+        if depth == 0 && !target_was_alive && context.cfg().is_amsterdam_eip2780_enabled() {
+            let charge = context.cfg().gas_params().create_state_gas();
+            if !gas.record_state_cost(charge) {
+                // Runtime out-of-gas: the transaction stays valid and halts
+                // before the frame is entered; `last_frame_result` consumes the
+                // remaining gas.
+                return return_error(InstructionResult::OutOfGas);
+            }
+        }
+
         // Create account, transfer funds and make the journal checkpoint.
         let checkpoint = match context.journal_mut().create_account_checkpoint(
             inputs.caller(),
@@ -416,7 +419,8 @@ impl EthFrame<EthInterpreter> {
         };
         let gas_limit = inputs.gas_limit();
 
-        this.get(EthFrame::invalid).clear(
+        let frame = this.get(EthFrame::invalid);
+        frame.clear(
             FrameData::Create(CreateFrame {
                 created_address,
                 target_was_alive,
@@ -432,6 +436,12 @@ impl EthFrame<EthInterpreter> {
             reservoir_remaining_gas,
             checkpoint,
         );
+        // `clear` rebuilds the interpreter's gas from `gas_limit`/reservoir,
+        // which discards the EIP-2780 depth-0 create state-gas charge applied
+        // to `gas` above. Carry it over (same limit and reservoir, so this
+        // preserves the charge's effect on `remaining`, `reservoir`, and the
+        // state-gas counters).
+        frame.interpreter.gas = gas;
 
         Ok(ItemOrResult::Item(this.consume()))
     }

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -323,7 +323,6 @@ impl EthFrame<EthInterpreter> {
                     output: Bytes::new(),
                 },
                 address: None,
-                target_was_alive: false,
                 charged_create_state_gas,
             })))
         };
@@ -358,13 +357,7 @@ impl EthFrame<EthInterpreter> {
         drop(caller_info); // Drop caller info to avoid borrow checker issues.
 
         // warm load account.
-        // EIP-8037: capture whether the target leaf is already alive (existing,
-        // non-empty) before creation, so a successful create at a pre-existing
-        // balance-only account refunds the upfront `create_state_gas`.
-        let target_was_alive = {
-            let acc = journal.load_account(created_address)?;
-            !acc.info.is_empty()
-        };
+        journal.load_account(created_address)?;
 
         // EIP-2780 first-frame charge decided at the runtime gas phase
         // (`apply_eip2780_runtime_gas`): a top-level create transaction pays
@@ -409,10 +402,7 @@ impl EthFrame<EthInterpreter> {
 
         let frame = this.get(EthFrame::invalid);
         frame.clear(
-            FrameData::Create(CreateFrame {
-                created_address,
-                target_was_alive,
-            }),
+            FrameData::Create(CreateFrame { created_address }),
             FrameInput::Create(inputs),
             depth,
             memory,
@@ -532,7 +522,6 @@ impl EthFrame<EthInterpreter> {
 
                 let mut create_outcome =
                     CreateOutcome::new(interpreter_result, Some(frame.created_address));
-                create_outcome.target_was_alive = frame.target_was_alive;
                 create_outcome.charged_create_state_gas = match &self.input {
                     FrameInput::Create(inputs) => inputs.charged_create_state_gas(),
                     _ => false,

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -323,6 +323,7 @@ impl EthFrame<EthInterpreter> {
         // applied uniformly in `return_result` when the create fails (revert,
         // halt, or early-fail with `address == None`), so early-fail results
         // only carry the reservoir they inherited from the parent.
+        let charged_create_state_gas = inputs.charged_create_state_gas();
         let return_error = |e| {
             Ok(ItemOrResult::Result(FrameResult::Create(CreateOutcome {
                 result: InterpreterResult {
@@ -335,6 +336,7 @@ impl EthFrame<EthInterpreter> {
                 },
                 address: None,
                 target_was_alive: false,
+                charged_create_state_gas,
             })))
         };
 
@@ -533,6 +535,10 @@ impl EthFrame<EthInterpreter> {
                 let mut create_outcome =
                     CreateOutcome::new(interpreter_result, Some(frame.created_address));
                 create_outcome.target_was_alive = frame.target_was_alive;
+                create_outcome.charged_create_state_gas = match &self.input {
+                    FrameInput::Create(inputs) => inputs.charged_create_state_gas(),
+                    _ => false,
+                };
                 ItemOrResult::Result(FrameResult::Create(create_outcome))
             }
         };
@@ -630,19 +636,29 @@ impl EthFrame<EthInterpreter> {
                 // EIP-8037: The CREATE opcode charged `create_state_gas` upfront on
                 // this frame's tracker. Refund it via `refill_reservoir` (matching
                 // 0→x→0 storage restoration) when no new account leaf ends up
-                // created: either the child failed to deploy (revert, halt, or
-                // early-fail paths that return `address == None` such as nonce
-                // overflow, depth, OutOfFunds — the nonce-overflow path reports
+                // created: the child failed to deploy (revert, halt, or early-fail
+                // paths that return `address == None` such as nonce overflow,
+                // depth, OutOfFunds — the nonce-overflow path reports
                 // `InstructionResult::Return` (ok) with `address == None`, so gate
-                // on address rather than the result), or it succeeded at a
-                // pre-existing alive (balance-only) target.
+                // on address rather than the result).
+                //
+                // Under the devnet-7 rules (EIP-2780 enabled) the opcode only
+                // charged when the destination did not exist, so the refund is
+                // gated on that charge. Pre-devnet-7 the charge was unconditional,
+                // so a success at a pre-existing alive (balance-only) target also
+                // refunds it.
                 let create_failed = outcome.address.is_none() || !instruction_result.is_ok();
 
-                if (create_failed || outcome.target_was_alive)
-                    && ctx.cfg().is_amsterdam_eip8037_enabled()
-                {
-                    let state_gas_charged = ctx.cfg().gas_params().create_state_gas();
-                    this_gas.refill_reservoir(state_gas_charged);
+                if ctx.cfg().is_amsterdam_eip8037_enabled() {
+                    let refund = if ctx.cfg().is_amsterdam_eip2780_enabled() {
+                        create_failed && outcome.charged_create_state_gas
+                    } else {
+                        create_failed || outcome.target_was_alive
+                    };
+                    if refund {
+                        let state_gas_charged = ctx.cfg().gas_params().create_state_gas();
+                        this_gas.refill_reservoir(state_gas_charged);
+                    }
                 }
 
                 let stack_item = if instruction_result.is_ok() {

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -152,37 +152,25 @@ impl EthFrame<EthInterpreter> {
         depth: usize,
         memory: SharedMemory,
         inputs: Box<CallInputs>,
+        state_gas_charge: u64,
     ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR> {
         let reservoir_remaining_gas = inputs.reservoir;
         let mut charged_new_account_state_gas = inputs.charged_new_account_state_gas;
         let mut gas =
             Gas::new_with_regular_gas_and_reservoir(inputs.gas_limit, reservoir_remaining_gas);
 
-        // EIP-2780 top-level execution charges. Applied before any state changes
-        // so the recipient's pre-call state determines the charge. The
-        // delegation-target access is charged at the runtime gas phase
-        // (`apply_eip2780_runtime_gas`, warm/cold aware); only the new-account
-        // state gas is charged here, on the frame's tracker, so a revert rolls
+        // EIP-2780 first-frame charge decided at the runtime gas phase
+        // (`apply_eip2780_runtime_gas`): the recipient new-account state gas of
+        // a value transfer. Recorded on the frame's tracker so a revert rolls
         // it back via the `state_gas_spent`/reservoir reconciliation in
-        // `last_frame_result`. Its affordability was already checked in the
+        // `last_frame_result`. Its affordability was already checked at the
         // runtime gas phase, so the out-of-gas branch is a defensive backstop.
         let mut early_halt: Option<InstructionResult> = None;
-        if depth == 0 && ctx.cfg().is_amsterdam_eip2780_enabled() {
-            let recipient_is_empty = ctx
-                .journal_mut()
-                .load_account(inputs.target_address)
-                .map(|a| a.info.is_empty())
-                .unwrap_or(false);
-
-            if let CallValue::Transfer(value) = inputs.value {
-                if !value.is_zero() && recipient_is_empty {
-                    let charge = ctx.cfg().gas_params().new_account_state_gas();
-                    if !gas.record_state_cost(charge) {
-                        early_halt = Some(InstructionResult::OutOfGas);
-                    } else {
-                        charged_new_account_state_gas = true;
-                    }
-                }
+        if state_gas_charge != 0 {
+            if gas.record_state_cost(state_gas_charge) {
+                charged_new_account_state_gas = true;
+            } else {
+                early_halt = Some(InstructionResult::OutOfGas);
             }
         }
 
@@ -236,18 +224,17 @@ impl EthFrame<EthInterpreter> {
         let gas_limit = inputs.gas_limit;
 
         if let Some(mut result) = precompiles.run(ctx, &inputs).map_err(ERROR::from_string)? {
-            // EIP-2780 depth-0 `new_account_state_gas` was charged to the local
-            // `gas` above, but the precompile path returns its own result gas, so
-            // re-apply that charge here (drawing from the reservoir). Only at depth
-            // 0: a precompile reached by a CALL opcode (depth > 0) already had the
-            // charge applied on the parent's tracker. Precompiles are never EIP-7702
-            // delegated, so only the state-gas portion applies.
-            if depth == 0 && charged_new_account_state_gas && result.result.is_ok() {
-                let charge = ctx.cfg().gas_params().new_account_state_gas();
-                if !result.gas.record_state_cost(charge) {
-                    result.gas.spend_all();
-                    result.result = InstructionResult::OutOfGas;
-                }
+            // The EIP-2780 first-frame charge was recorded on the local `gas`
+            // above, but the precompile path returns its own result gas, so
+            // re-apply that charge here (drawing from the reservoir). Nested
+            // precompile calls carry a zero `state_gas_charge`: their charge was
+            // applied on the parent's tracker by the CALL opcode.
+            if state_gas_charge != 0
+                && result.result.is_ok()
+                && !result.gas.record_state_cost(state_gas_charge)
+            {
+                result.gas.spend_all();
+                result.result = InstructionResult::OutOfGas;
             }
             let mut logs = Vec::new();
             if result.result.is_ok() {
@@ -316,6 +303,7 @@ impl EthFrame<EthInterpreter> {
         depth: usize,
         memory: SharedMemory,
         inputs: Box<CreateInputs>,
+        state_gas_charge: u64,
     ) -> Result<ItemOrResult<FrameToken, FrameResult>, ERROR> {
         let reservoir_remaining_gas = inputs.reservoir();
         let spec = context.cfg().spec().into();
@@ -378,22 +366,20 @@ impl EthFrame<EthInterpreter> {
             !acc.info.is_empty()
         };
 
-        // EIP-2780: a top-level create transaction pays the new-account state
-        // gas at runtime, only when the deployment target does not already
-        // exist. Charged on this frame's tracker so an initcode revert or halt
-        // refills it in LIFO order via `rollback_state_gas` (the spilled
-        // portion back to `gas_left`, the remainder to the reservoir).
-        // Pre-EIP-2780 the charge is part of the intrinsic gas instead.
+        // EIP-2780 first-frame charge decided at the runtime gas phase
+        // (`apply_eip2780_runtime_gas`): a top-level create transaction pays
+        // the new-account state gas at runtime, only when the deployment
+        // target does not already exist. Recorded on this frame's tracker so
+        // an initcode revert or halt refills it in LIFO order via
+        // `rollback_state_gas` (the spilled portion back to `gas_left`, the
+        // remainder to the reservoir). Its affordability was already checked
+        // at the runtime gas phase, so the out-of-gas branch is a defensive
+        // backstop. Pre-EIP-2780 the charge is part of the intrinsic gas
+        // instead.
         let mut gas =
             Gas::new_with_regular_gas_and_reservoir(inputs.gas_limit(), reservoir_remaining_gas);
-        if depth == 0 && !target_was_alive && context.cfg().is_amsterdam_eip2780_enabled() {
-            let charge = context.cfg().gas_params().create_state_gas();
-            if !gas.record_state_cost(charge) {
-                // Runtime out-of-gas: the transaction stays valid and halts
-                // before the frame is entered; `last_frame_result` consumes the
-                // remaining gas.
-                return return_error(InstructionResult::OutOfGas);
-            }
+        if state_gas_charge != 0 && !gas.record_state_cost(state_gas_charge) {
+            return return_error(InstructionResult::OutOfGas);
         }
 
         // Create account, transfer funds and make the journal checkpoint.
@@ -466,13 +452,22 @@ impl EthFrame<EthInterpreter> {
             depth,
             memory,
             frame_input,
+            state_gas_charge,
         } = frame_init;
 
         match frame_input {
-            FrameInput::Call(inputs) => {
-                Self::make_call_frame(this, ctx, precompiles, depth, memory, inputs)
+            FrameInput::Call(inputs) => Self::make_call_frame(
+                this,
+                ctx,
+                precompiles,
+                depth,
+                memory,
+                inputs,
+                state_gas_charge,
+            ),
+            FrameInput::Create(inputs) => {
+                Self::make_create_frame(this, ctx, depth, memory, inputs, state_gas_charge)
             }
-            FrameInput::Create(inputs) => Self::make_create_frame(this, ctx, depth, memory, inputs),
             FrameInput::Empty => unreachable!(),
         }
     }
@@ -497,6 +492,9 @@ impl EthFrame<EthInterpreter> {
                     frame_input,
                     depth,
                     memory: self.interpreter.memory.new_child_context(),
+                    // Nested frames carry no first-frame charge: their state
+                    // gas is applied by the CALL/CREATE opcodes.
+                    state_gas_charge: 0,
                 }));
             }
             InterpreterAction::Return(result) => result,
@@ -634,31 +632,19 @@ impl EthFrame<EthInterpreter> {
                 handle_reservoir_remaining_gas(instruction_result, this_gas, &mut create_gas);
 
                 // EIP-8037: The CREATE opcode charged `create_state_gas` upfront on
-                // this frame's tracker. Refund it via `refill_reservoir` (matching
-                // 0→x→0 storage restoration) when no new account leaf ends up
-                // created: the child failed to deploy (revert, halt, or early-fail
-                // paths that return `address == None` such as nonce overflow,
-                // depth, OutOfFunds — the nonce-overflow path reports
+                // this frame's tracker, only when the destination did not exist at
+                // access time. Refund it via `refill_reservoir` (matching 0→x→0
+                // storage restoration) when no new account leaf ends up created:
+                // the child failed to deploy (revert, halt, or early-fail paths
+                // that return `address == None` such as nonce overflow, depth,
+                // OutOfFunds — the nonce-overflow path reports
                 // `InstructionResult::Return` (ok) with `address == None`, so gate
                 // on address rather than the result).
-                //
-                // Under the devnet-7 rules (EIP-2780 enabled) the opcode only
-                // charged when the destination did not exist, so the refund is
-                // gated on that charge. Pre-devnet-7 the charge was unconditional,
-                // so a success at a pre-existing alive (balance-only) target also
-                // refunds it.
                 let create_failed = outcome.address.is_none() || !instruction_result.is_ok();
 
-                if ctx.cfg().is_amsterdam_eip8037_enabled() {
-                    let refund = if ctx.cfg().is_amsterdam_eip2780_enabled() {
-                        create_failed && outcome.charged_create_state_gas
-                    } else {
-                        create_failed || outcome.target_was_alive
-                    };
-                    if refund {
-                        let state_gas_charged = ctx.cfg().gas_params().create_state_gas();
-                        this_gas.refill_reservoir(state_gas_charged);
-                    }
+                if create_failed && outcome.charged_create_state_gas {
+                    let state_gas_charged = ctx.cfg().gas_params().create_state_gas();
+                    this_gas.refill_reservoir(state_gas_charged);
                 }
 
                 let stack_item = if instruction_result.is_ok() {

--- a/crates/handler/src/frame_data.rs
+++ b/crates/handler/src/frame_data.rs
@@ -17,10 +17,6 @@ pub struct CallFrame {
 pub struct CreateFrame {
     /// Create frame has a created address.
     pub created_address: Address,
-    /// EIP-8037: whether the created address was already alive (existing,
-    /// non-empty) before this CREATE. When true, no new account leaf is created,
-    /// so the upfront `create_state_gas` is refunded on a successful create.
-    pub target_was_alive: bool,
 }
 
 /// Frame Data
@@ -128,10 +124,7 @@ impl FrameResult {
 impl FrameData {
     /// Creates a new create frame data.
     pub const fn new_create(created_address: Address) -> Self {
-        Self::Create(CreateFrame {
-            created_address,
-            target_was_alive: false,
-        })
+        Self::Create(CreateFrame { created_address })
     }
 
     /// Creates a new call frame data.

--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -414,16 +414,6 @@ pub trait Handler {
     ) -> Result<(), Self::Error> {
         let instruction_result = frame_result.interpreter_result().result;
 
-        // Detect a top-level CREATE that creates no new account leaf — either it
-        // failed, or it succeeded at a pre-existing alive (balance-only) target —
-        // so the intrinsic `create_state_gas` charged at tx entry can be unwound
-        // below. Mirrors the condition used in `EthFrame::return_result` for
-        // nested creates.
-        let create_refunds_state_gas = match &frame_result {
-            FrameResult::Create(outcome) => !instruction_result.is_ok() || outcome.target_was_alive,
-            _ => false,
-        };
-
         let gas = frame_result.gas_mut();
 
         // Settle the top frame's own gas (mirrors `handle_reservoir_remaining_gas`'s
@@ -456,29 +446,6 @@ pub trait Handler {
         if instruction_result.is_ok() {
             gas.record_refund(refunded);
             gas.set_state_gas_spent(state_gas_spent);
-        }
-
-        // EIP-8037: for a failed top-level CREATE (or one that self-destructs
-        // in init code, see EIP-6780), refund the intrinsic `create_state_gas`
-        // to the reservoir. The nested-create equivalent is
-        // `EthFrame::return_result`'s `refill_reservoir(create_state_gas)`; at
-        // the top level the same charge is deducted in
-        // `initial_gas_and_reservoir` rather than via `record_state_cost`, so
-        // it would otherwise stay consumed when the deployment is rolled back
-        // or erased.
-        //
-        // Under EIP-2780 the charge is instead applied at runtime on the first
-        // frame's gas tracker, only when the deployment target does not
-        // already exist (`EthFrame::make_create_frame`), so a failure is
-        // already unwound by `rollback_state_gas` above and no extra refill
-        // must happen here.
-        if create_refunds_state_gas
-            && evm.ctx().cfg().is_amsterdam_eip8037_enabled()
-            && !evm.ctx().cfg().is_amsterdam_eip2780_enabled()
-        {
-            let ctx = evm.ctx();
-            let state_gas_charged = ctx.cfg().gas_params().create_state_gas();
-            gas.refill_reservoir(state_gas_charged);
         }
 
         Ok(())

--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -15,8 +15,11 @@ use context_interface::{
     result::{HaltReasonTr, InvalidHeader, InvalidTransaction, ResultGas},
     Cfg, ContextTr, Database, JournalTr, Transaction,
 };
-use interpreter::{interpreter_action::FrameInit, Gas, InitialAndFloorGas, SharedMemory};
-use primitives::U256;
+use interpreter::{
+    interpreter_action::FrameInit, CallOutcome, CreateOutcome, Gas, InitialAndFloorGas,
+    SharedMemory,
+};
+use primitives::{TxKind, U256};
 
 /// Trait for errors that can occur during EVM execution.
 ///
@@ -210,6 +213,20 @@ pub trait Handler {
         evm: &mut Self::Evm,
         init_and_floor_gas: &InitialAndFloorGas,
     ) -> Result<FrameResult, Self::Error> {
+        // EIP-2780: the transaction is valid but its gas cannot cover the
+        // state-dependent runtime charges. It is included as an out-of-gas
+        // halt: execution is skipped, all gas is consumed, and the runtime
+        // state changes were already reverted in the runtime gas phase.
+        if init_and_floor_gas.runtime_oog {
+            let tx_gas_limit = evm.ctx().tx().gas_limit();
+            let mut frame_result = match evm.ctx().tx().kind() {
+                TxKind::Call(_) => FrameResult::Call(CallOutcome::new_oog(tx_gas_limit, 0..0, 0)),
+                TxKind::Create => FrameResult::Create(CreateOutcome::new_oog(tx_gas_limit, 0)),
+            };
+            self.last_frame_result(evm, &mut frame_result)?;
+            return Ok(frame_result);
+        }
+
         // Compute the regular gas budget and EIP-8037 reservoir for the first frame.
         let (gas_limit, reservoir) = init_and_floor_gas.initial_gas_and_reservoir(
             evm.ctx().tx().gas_limit(),
@@ -434,7 +451,16 @@ pub trait Handler {
         // `initial_gas_and_reservoir` rather than via `record_state_cost`, so
         // it would otherwise stay consumed when the deployment is rolled back
         // or erased.
-        if create_refunds_state_gas && evm.ctx().cfg().is_amsterdam_eip8037_enabled() {
+        //
+        // Under EIP-2780 the charge is instead applied at runtime on the first
+        // frame's gas tracker, only when the deployment target does not
+        // already exist (`EthFrame::make_create_frame`), so a failure is
+        // already unwound by `rollback_state_gas` above and no extra refill
+        // must happen here.
+        if create_refunds_state_gas
+            && evm.ctx().cfg().is_amsterdam_eip8037_enabled()
+            && !evm.ctx().cfg().is_amsterdam_eip2780_enabled()
+        {
             let ctx = evm.ctx();
             let state_gas_charged = ctx.cfg().gas_params().create_state_gas();
             gas.refill_reservoir(state_gas_charged);

--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -213,29 +213,39 @@ pub trait Handler {
         evm: &mut Self::Evm,
         init_and_floor_gas: &InitialAndFloorGas,
     ) -> Result<FrameResult, Self::Error> {
-        // EIP-2780: the transaction is valid but its gas cannot cover the
-        // state-dependent runtime charges. It is included as an out-of-gas
-        // halt: execution is skipped, all gas is consumed, and the runtime
-        // state changes were already reverted in the runtime gas phase.
-        if init_and_floor_gas.runtime_oog {
-            let tx_gas_limit = evm.ctx().tx().gas_limit();
-            let mut frame_result = match evm.ctx().tx().kind() {
-                TxKind::Call(_) => FrameResult::Call(CallOutcome::new_oog(tx_gas_limit, 0..0, 0)),
-                TxKind::Create => FrameResult::Create(CreateOutcome::new_oog(tx_gas_limit, 0)),
-            };
-            self.last_frame_result(evm, &mut frame_result)?;
-            return Ok(frame_result);
-        }
-
         // Compute the regular gas budget and EIP-8037 reservoir for the first frame.
         let (gas_limit, reservoir) = init_and_floor_gas.initial_gas_and_reservoir(
             evm.ctx().tx().gas_limit(),
             evm.ctx().cfg().tx_gas_limit_cap(),
         );
 
+        // EIP-2780: the transaction is valid but its gas cannot cover the
+        // state-dependent runtime charges. It is included as an out-of-gas
+        // halt: execution is skipped, all regular gas is consumed (the
+        // reservoir is returned), and the runtime state changes were already
+        // reverted in the runtime gas phase.
+        if init_and_floor_gas.runtime_oog {
+            let tx_gas_limit = evm.ctx().tx().gas_limit();
+            let mut frame_result = match evm.ctx().tx().kind() {
+                TxKind::Call(_) => {
+                    FrameResult::Call(CallOutcome::new_oog(tx_gas_limit, 0..0, reservoir))
+                }
+                TxKind::Create => {
+                    FrameResult::Create(CreateOutcome::new_oog(tx_gas_limit, reservoir))
+                }
+            };
+            self.last_frame_result(evm, &mut frame_result)?;
+            return Ok(frame_result);
+        }
+
         // Create first frame action
         // Note: first_frame_input now handles state gas deduction from the reservoir
-        let first_frame_input = self.first_frame_input(evm, gas_limit, reservoir)?;
+        let first_frame_input = self.first_frame_input(
+            evm,
+            gas_limit,
+            reservoir,
+            init_and_floor_gas.first_frame_state_gas,
+        )?;
 
         // Run execution loop
         let mut frame_result = self.run_exec_loop(evm, first_frame_input)?;
@@ -370,12 +380,16 @@ pub trait Handler {
     /* EXECUTION */
 
     /// Creates initial frame input using transaction parameters, gas limit and configuration.
+    ///
+    /// `state_gas_charge` is the EIP-2780 runtime charge decided at the
+    /// runtime gas phase to be recorded on the first frame's gas tracker.
     #[inline]
     fn first_frame_input(
         &mut self,
         evm: &mut Self::Evm,
         gas_limit: u64,
         reservoir: u64,
+        state_gas_charge: u64,
     ) -> Result<FrameInit, Self::Error> {
         let ctx = evm.ctx_mut();
         let mut memory = SharedMemory::new_with_buffer(ctx.local().shared_memory_buffer().clone());
@@ -387,6 +401,7 @@ pub trait Handler {
             depth: 0,
             memory,
             frame_input,
+            state_gas_charge,
         })
     }
 

--- a/crates/handler/src/post_execution.rs
+++ b/crates/handler/src/post_execution.rs
@@ -18,16 +18,12 @@ pub fn build_result_gas(
     // `state_gas_spent` is tracked as i64 to allow a child frame's count to go
     // negative on 0→x→0 restoration; at the top level, post-reconciliation it
     // is expected to be >= 0 and is clamped defensively before combining with
-    // intrinsic state gas.
-    //
-    // Per the spec, tx_state_gas = intrinsic_state_gas + execution_state_gas,
-    // then reduced by the EIP-7702 per-authorization state-gas refund (which
-    // was also added back to the reservoir budget at tx start).
+    // the state gas charged before the first frame (the EIP-2780 runtime gas
+    // phase).
     let state_gas = gas
         .state_gas_spent()
         .saturating_add_unsigned(init_and_floor_gas.initial_state_gas)
         .max(0) as u64;
-    let state_gas = state_gas.saturating_sub(init_and_floor_gas.state_refund);
 
     ResultGas::default()
         .with_total_gas_spent(

--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -218,27 +218,16 @@ pub fn apply_eip7702_auth_list<
     }
 
     let chain_id = context.cfg().chain_id();
-    let is_eip8037 = context.cfg().is_amsterdam_eip8037_enabled();
     let (tx, journal) = context.tx_journal_mut();
 
     // Return if not EIP-7702 transaction.
     if tx.tx_type() != TransactionType::Eip7702 {
         return Ok(0);
     }
-    let (number_of_refunded_accounts, number_of_refunded_bytecodes) =
-        apply_auth_list::<_, ERROR>(chain_id, tx.authorization_list(), journal, is_eip8037)?;
+    let number_of_refunded_accounts =
+        apply_auth_list::<_, ERROR>(chain_id, tx.authorization_list(), journal)?;
 
     let params = context.cfg().gas_params();
-
-    // EIP-8037: Split per-auth refund into state and regular components. The
-    // state portion is credited back to the reservoir by reducing
-    // `initial_state_gas` (which is what `initial_gas_and_reservoir` deducts
-    // from the reservoir). The regular portion is returned and routed through
-    // the standard refund counter, subject to the 1/5 cap.
-    if is_eip8037 {
-        init_and_floor_gas.state_refund += params
-            .tx_eip7702_state_refund(number_of_refunded_accounts, number_of_refunded_bytecodes);
-    }
 
     let regular_gas_refund = params
         .tx_eip7702_auth_refund_regular()
@@ -606,11 +595,11 @@ pub fn apply_auth_list_eip2780<
 ///
 /// It is more granular function from [`apply_eip7702_auth_list`] function as it takes only the list, journal and chain id.
 ///
-/// The `refund_per_auth` parameter specifies the gas refund per existing account authorization.
-/// By default this is `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST` (25000 - 12500 = 12500),
-/// but can be configured via [`GasParams::tx_eip7702_auth_refund`](context_interface::cfg::gas_params::GasParams::tx_eip7702_auth_refund).
+/// The refund per existing account authorization is
+/// `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST` (25000 - 12500 = 12500), see
+/// [`GasParams::tx_eip7702_auth_refund_regular`](context_interface::cfg::gas_params::GasParams::tx_eip7702_auth_refund_regular).
 ///
-/// Return number of refunded account and number of refunded bytecodes (Delegation length is already fixed).
+/// Returns the number of refunded (already existing) accounts.
 #[inline]
 pub fn apply_auth_list<
     JOURNAL: JournalTr,
@@ -619,40 +608,24 @@ pub fn apply_auth_list<
     chain_id: u64,
     auth_list: impl Iterator<Item = impl AuthorizationTr>,
     journal: &mut JOURNAL,
-    is_eip8037: bool,
-) -> Result<(u64, u64), ERROR> {
+) -> Result<u64, ERROR> {
     let mut refunded_accounts = 0;
-    let mut refunded_bytecodes = 0;
-    // EIP-8037: a rejected authorization had its full pessimistic intrinsic cost
-    // charged (regular ACCOUNT_WRITE plus per-account NEW_ACCOUNT and per-bytecode
-    // AUTH_BASE state gas), none of which is needed, so all of it is refunded.
-    // Counting both refund slots credits the regular ACCOUNT_WRITE and both
-    // state-gas portions. Before EIP-8037 rejected authorizations refund nothing.
-    macro_rules! reject {
-        () => {{
-            if is_eip8037 {
-                refunded_accounts += 1;
-                refunded_bytecodes += 1;
-            }
-            continue;
-        }};
-    }
     for authorization in auth_list {
         // 1. Verify the chain id is either 0 or the chain's current ID.
         let auth_chain_id = authorization.chain_id();
         if !auth_chain_id.is_zero() && auth_chain_id != U256::from(chain_id) {
-            reject!();
+            continue;
         }
 
         // 2. Verify the `nonce` is less than `2**64 - 1`.
         if authorization.nonce() == u64::MAX {
-            reject!();
+            continue;
         }
 
         // recover authority and authorized addresses.
         // 3. `authority = ecrecover(keccak(MAGIC || rlp([chain_id, address, nonce])), y_parity, r, s]`
         let Some(authority) = authorization.authority() else {
-            reject!();
+            continue;
         };
 
         // warm authority account and check nonce.
@@ -664,54 +637,22 @@ pub fn apply_auth_list<
         if let Some(bytecode) = &authority_acc_info.code {
             // if it is not empty and it is not eip7702
             if !bytecode.is_empty() && !bytecode.is_eip7702() {
-                reject!();
+                continue;
             }
         }
 
         // 6. Verify the nonce of `authority` is equal to `nonce`. In case `authority` does not exist in the trie, verify that `nonce` is equal to `0`.
         if authorization.nonce() != authority_acc_info.nonce {
-            reject!();
+            continue;
         }
 
-        // Refund-relevant facts for this accepted authorization (mirrors
-        // execution-specs `set_delegation` / evm2 `apply_one_auth`).
-        //   existed             — the authority account already existed in state.
-        //   delegated_now       — its current code is a delegation (non-empty code
-        //                          is necessarily EIP-7702 here, having passed the
-        //                          validity check above).
-        //   delegated_before_tx — its code at the start of the transaction was a
-        //                          delegation (may differ from `delegated_now` when
-        //                          an earlier authorization in this tx cleared it).
-        //   clearing            — this authorization clears the delegation.
+        // 7. Add `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST` gas to the global refund counter if `authority` exists in the trie.
         let existed = !(authority_acc_info.is_empty()
             && authority_acc
                 .account()
                 .is_loaded_as_not_existing_not_touched());
-        let delegated_now = !authority_acc_info.is_code_hash_empty_or_zero();
-        let delegated_before_tx = authority_acc
-            .account()
-            .original_info()
-            .code
-            .as_ref()
-            .is_some_and(Bytecode::is_eip7702);
-        let clearing = authorization.address().is_zero();
-
-        // Existing authority: the worst-case `ACCOUNT_WRITE` regular gas and the
-        // per-account `NEW_ACCOUNT` state gas were not needed.
         if existed {
             refunded_accounts += 1;
-        }
-
-        // Bytecode (`AUTH_BASE`) state-gas refunds.
-        if clearing {
-            refunded_bytecodes += 1;
-            // Clearing a delegation freshly installed earlier in this transaction
-            // refills the bytecode state gas a second time.
-            if delegated_now && !delegated_before_tx {
-                refunded_bytecodes += 1;
-            }
-        } else if delegated_now || delegated_before_tx {
-            refunded_bytecodes += 1;
         }
 
         // 8. Set the code of `authority` to be `0xef0100 || address`. This is a delegation designation.
@@ -721,7 +662,7 @@ pub fn apply_auth_list<
         authority_acc.delegate(authorization.address());
     }
 
-    Ok((refunded_accounts, refunded_bytecodes))
+    Ok(refunded_accounts)
 }
 
 #[cfg(test)]

--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -288,6 +288,7 @@ pub fn apply_eip2780_runtime_gas<
     let account_write_cost = params.tx_account_write_cost();
     let per_new_account_state_gas = params.new_account_state_gas();
     let delegation_bytes_state_gas = params.tx_eip7702_state_gas_bytecode();
+    let create_state_gas = params.create_state_gas();
     let (tx, journal) = context.tx_journal_mut();
 
     // The recipient is read when the message is prepared (its access was
@@ -313,6 +314,9 @@ pub fn apply_eip2780_runtime_gas<
 
     let mut runtime_regular_gas: u64 = 0;
     let mut runtime_state_gas: u64 = 0;
+    // State gas to be recorded on the first frame's gas tracker (rather than
+    // folded into the initial gas) so a revert or halt of the frame refills it.
+    let mut first_frame_state_gas: u64 = 0;
     let mut oog = false;
 
     // Apply EIP-7702 authorizations, charging the per-authority runtime
@@ -371,16 +375,17 @@ pub fn apply_eip2780_runtime_gas<
             };
 
             // Value transfer to a non-existent recipient grows the state by
-            // one account leaf. The charge itself is applied on the first
-            // frame's gas tracker so a revert rolls it back; only checked for
-            // affordability here. Checked before the delegation resolution,
-            // matching the spec's `prepare_dispatch` order.
-            if is_eip8037
-                && !tx.value().is_zero()
-                && recipient_is_empty
-                && !gas.record_state_cost(per_new_account_state_gas)
-            {
-                oog = true;
+            // one account leaf. The charge is recorded on the first frame's
+            // gas tracker (`EthFrame::make_call_frame`) so a revert rolls it
+            // back; here it is checked for affordability and decided. Checked
+            // before the delegation resolution, matching the spec's
+            // `prepare_dispatch` order.
+            if is_eip8037 && !tx.value().is_zero() && recipient_is_empty {
+                if gas.record_state_cost(per_new_account_state_gas) {
+                    first_frame_state_gas = per_new_account_state_gas;
+                } else {
+                    oog = true;
+                }
             }
 
             // EIP-7702 delegated recipient: resolving the delegation loads the
@@ -418,11 +423,37 @@ pub fn apply_eip2780_runtime_gas<
         }
     }
 
+    // A create transaction pays the account-creation state gas at runtime,
+    // only when the deployment target does not already exist. The single read
+    // that decides the charge (also warming the target) matches the spec's
+    // `prepare_dispatch`; the charge is recorded on the first frame's gas
+    // tracker (`EthFrame::make_create_frame`) so an initcode revert or halt
+    // refills it in LIFO order.
+    if !oog && is_eip8037 && tx.kind().is_create() {
+        let nonce = journal.load_account(tx.caller())?.info.nonce;
+        let created_address = tx.caller().create(nonce);
+        let target_is_empty = journal.load_account(created_address)?.info.is_empty();
+        if target_is_empty {
+            if gas.record_state_cost(create_state_gas) {
+                first_frame_state_gas = create_state_gas;
+            } else {
+                oog = true;
+            }
+        }
+    }
+
     if oog {
         // Out-of-gas in the runtime phase: the transaction stays valid and
         // included, but halts before the first frame is entered and all
         // runtime state changes (including applied delegations) are reverted.
         journal.checkpoint_revert(checkpoint);
+        // A create transaction still bumps the sender nonce: the increment
+        // precedes message processing and survives the halt. (Calls bump it in
+        // `validate_against_state_and_deduct_caller`; creates at frame
+        // creation, which the runtime halt never reaches.)
+        if tx.kind().is_create() {
+            journal.load_account_mut(tx.caller())?.data.bump_nonce();
+        }
         init_and_floor_gas.runtime_oog = true;
         return Ok(());
     }
@@ -430,6 +461,7 @@ pub fn apply_eip2780_runtime_gas<
     journal.checkpoint_commit();
     init_and_floor_gas.initial_regular_gas += runtime_regular_gas;
     init_and_floor_gas.initial_state_gas += runtime_state_gas;
+    init_and_floor_gas.first_frame_state_gas = first_frame_state_gas;
     Ok(())
 }
 

--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -5,7 +5,7 @@
 use crate::{EvmTr, PrecompileProvider};
 use bytecode::Bytecode;
 use context_interface::{
-    journaled_state::{account::JournaledAccountTr, JournalTr},
+    journaled_state::{account::JournaledAccountTr, JournalLoadError, JournalTr},
     result::InvalidTransaction,
     transaction::{AccessListItemTr, AuthorizationTr, Transaction, TransactionType},
     Block, Cfg, ContextTr, Database,
@@ -290,85 +290,135 @@ pub fn apply_eip2780_runtime_gas<
     let delegation_bytes_state_gas = params.tx_eip7702_state_gas_bytecode();
     let (tx, journal) = context.tx_journal_mut();
 
+    // The recipient is read when the message is prepared (its access was
+    // already charged at the cold rate at the intrinsic phase), before the
+    // runtime charges are applied, so the read stays in the EIP-7928 block
+    // access list even if the runtime phase runs out of gas.
+    if let TxKind::Call(target) = tx.kind() {
+        journal.load_account_with_code(target)?;
+    }
+
     // All runtime state changes are reverted wholesale if the transaction
     // cannot afford the runtime charges.
     let checkpoint = journal.checkpoint();
 
+    // The runtime charges draw from the same gas the first frame will see.
+    // Track them on a real gas tracker so the phase stops at the first
+    // unaffordable charge: later authorities must not be loaded (observable
+    // through the EIP-7928 block access list).
+    let mut gas = init_and_floor_gas
+        .checked_initial_gas_and_reservoir(tx.gas_limit(), tx_gas_limit_cap)
+        .map(|(gas_limit, reservoir)| Gas::new_with_regular_gas_and_reservoir(gas_limit, reservoir))
+        .unwrap_or_else(|| Gas::new_with_regular_gas_and_reservoir(0, 0));
+
     let mut runtime_regular_gas: u64 = 0;
     let mut runtime_state_gas: u64 = 0;
+    let mut oog = false;
 
-    // Apply EIP-7702 authorizations, accumulating the per-authority runtime
-    // charges.
+    // Apply EIP-7702 authorizations, charging the per-authority runtime
+    // charges as the authorizations are applied.
     if tx.tx_type() == TransactionType::Eip7702 {
-        let (regular, state) = apply_auth_list_eip2780::<_, ERROR>(
+        // Accounts this transaction has already written (their `ACCOUNT_WRITE`
+        // is already paid): the sender's leaf is written at inclusion (priced
+        // into `TX_BASE`), and the recipient's when value is transferred
+        // (priced into `TX_VALUE_COST`).
+        let mut written_accounts: HashSet<Address> = HashSet::default();
+        written_accounts.insert(tx.caller());
+        if let TxKind::Call(target) = tx.kind() {
+            if !tx.value().is_zero() {
+                written_accounts.insert(target);
+            }
+        }
+        let (regular, state, auth_oog) = apply_auth_list_eip2780::<_, ERROR>(
             chain_id,
             tx.authorization_list(),
             journal,
             account_write_cost,
-            per_new_account_state_gas,
-            delegation_bytes_state_gas,
+            if is_eip8037 {
+                per_new_account_state_gas
+            } else {
+                0
+            },
+            if is_eip8037 {
+                delegation_bytes_state_gas
+            } else {
+                0
+            },
+            &mut written_accounts,
+            &mut gas,
         )?;
         runtime_regular_gas += regular;
         runtime_state_gas += state;
+        oog = auth_oog;
     }
 
-    // Load the recipient (adding it to `accessed_addresses`) and evaluate the
-    // recipient runtime charges. Evaluated after authorizations so a recipient
-    // materialized or delegated by an authorization in this transaction is
-    // seen in its post-authorization state. A self-transfer recipient is the
-    // (non-empty) sender, so the new-account charge never fires for it, while
-    // a delegated sender still pays for resolving its delegation.
-    let mut new_account_state_gas = 0u64;
-    if let TxKind::Call(target) = tx.kind() {
-        let (recipient_is_empty, delegation_target) = {
-            let acc = journal.load_account_with_code(target)?;
-            (
-                acc.info.is_empty(),
-                acc.info.code.as_ref().and_then(Bytecode::eip7702_address),
-            )
-        };
-
-        // EIP-7702 delegated recipient: resolving the delegation loads the
-        // target's code, charged per the standard EIP-2929 warm/cold model.
-        if let Some(delegated) = delegation_target {
-            let is_cold = journal.load_account(delegated)?.is_cold;
-            runtime_regular_gas += if is_cold {
-                eip8038::COLD_ACCOUNT_ACCESS
-            } else {
-                eip8038::WARM_ACCESS
+    // Evaluate the recipient runtime charges (the recipient itself was loaded
+    // and warmed with the access list; its access was already charged at the
+    // cold rate at the intrinsic phase). Evaluated after authorizations so a
+    // recipient materialized or delegated by an authorization in this
+    // transaction is seen in its post-authorization state. A self-transfer
+    // recipient is the (non-empty) sender, so the new-account charge never
+    // fires for it, while a delegated sender still pays for resolving its
+    // delegation.
+    if !oog {
+        if let TxKind::Call(target) = tx.kind() {
+            let (recipient_is_empty, delegation_target) = {
+                let acc = journal.load_account_with_code(target)?;
+                (
+                    acc.info.is_empty(),
+                    acc.info.code.as_ref().and_then(Bytecode::eip7702_address),
+                )
             };
-        }
 
-        // Value transfer to a non-existent recipient grows the state by one
-        // account leaf. The charge itself is applied on the first frame's gas
-        // tracker so a revert rolls it back; only checked for affordability
-        // here.
-        if !tx.value().is_zero() && recipient_is_empty {
-            new_account_state_gas = per_new_account_state_gas;
+            // Value transfer to a non-existent recipient grows the state by
+            // one account leaf. The charge itself is applied on the first
+            // frame's gas tracker so a revert rolls it back; only checked for
+            // affordability here. Checked before the delegation resolution,
+            // matching the spec's `prepare_dispatch` order.
+            if is_eip8037
+                && !tx.value().is_zero()
+                && recipient_is_empty
+                && !gas.record_state_cost(per_new_account_state_gas)
+            {
+                oog = true;
+            }
+
+            // EIP-7702 delegated recipient: resolving the delegation loads the
+            // target's code, charged per the standard EIP-2929 warm/cold model.
+            // The charge must be covered before the delegate is read, so an
+            // out-of-gas here leaves a cold delegate out of the block access
+            // list.
+            if !oog {
+                if let Some(delegated) = delegation_target {
+                    if gas.remaining() < eip8038::WARM_ACCESS {
+                        // The access cost cannot be covered whether the
+                        // delegate is warm or cold: fail without reading it.
+                        oog = true;
+                    } else {
+                        let skip_cold_load = gas.remaining() < eip8038::COLD_ACCOUNT_ACCESS;
+                        match journal.load_account_mut_skip_cold_load(delegated, skip_cold_load) {
+                            Ok(acc) => {
+                                let cost = if acc.is_cold {
+                                    eip8038::COLD_ACCOUNT_ACCESS
+                                } else {
+                                    eip8038::WARM_ACCESS
+                                };
+                                if gas.record_regular_cost(cost) {
+                                    runtime_regular_gas += cost;
+                                } else {
+                                    oog = true;
+                                }
+                            }
+                            Err(JournalLoadError::ColdLoadSkipped) => oog = true,
+                            Err(JournalLoadError::DBError(e)) => return Err(e.into()),
+                        }
+                    }
+                }
+            }
         }
     }
 
-    // Without EIP-8037 there is no state-gas metering.
-    if !is_eip8037 {
-        runtime_state_gas = 0;
-        new_account_state_gas = 0;
-    }
-
-    // Affordability: the runtime charges draw from the same gas the
-    // transaction supplies, exactly as the first frame will see it.
-    let mut probe = *init_and_floor_gas;
-    probe.initial_regular_gas += runtime_regular_gas;
-    probe.initial_state_gas += runtime_state_gas;
-    let affordable = probe
-        .checked_initial_gas_and_reservoir(tx.gas_limit(), tx_gas_limit_cap)
-        .map(|(gas_limit, reservoir)| {
-            new_account_state_gas == 0
-                || Gas::new_with_regular_gas_and_reservoir(gas_limit, reservoir)
-                    .record_state_cost(new_account_state_gas)
-        })
-        .unwrap_or(false);
-
-    if !affordable {
+    if oog {
         // Out-of-gas in the runtime phase: the transaction stays valid and
         // included, but halts before the first frame is entered and all
         // runtime state changes (including applied delegations) are reverted.
@@ -392,8 +442,19 @@ pub fn apply_eip2780_runtime_gas<
 /// performs (calldata, recovery, authority access), so there is nothing to
 /// refund either.
 ///
-/// Returns the accumulated `(regular_gas, state_gas)` runtime charges.
+/// `written_accounts` holds the accounts whose leaf write is already paid for
+/// (the sender, and the recipient of a value-bearing transaction); applying an
+/// authorization to any other authority pays `ACCOUNT_WRITE` on the first
+/// write to that authority within the transaction.
+///
+/// The charges are recorded on `gas` as the authorizations are applied, so
+/// the phase stops at the first unaffordable charge without loading the
+/// remaining authorities (observable through the EIP-7928 block access list).
+///
+/// Returns the accumulated `(regular_gas, state_gas, out_of_gas)` runtime
+/// charges.
 #[inline]
+#[allow(clippy::too_many_arguments)]
 pub fn apply_auth_list_eip2780<
     JOURNAL: JournalTr,
     ERROR: From<InvalidTransaction> + From<<JOURNAL::Database as Database>::Error>,
@@ -404,7 +465,9 @@ pub fn apply_auth_list_eip2780<
     account_write_cost: u64,
     new_account_state_gas: u64,
     delegation_bytes_state_gas: u64,
-) -> Result<(u64, u64), ERROR> {
+    written_accounts: &mut HashSet<Address>,
+    gas: &mut Gas,
+) -> Result<(u64, u64, bool), ERROR> {
     let mut regular_gas: u64 = 0;
     let mut state_gas: u64 = 0;
     // EIP-8037 per-authority rules: each charge is applied at most once per
@@ -463,11 +526,24 @@ pub fn apply_auth_list_eip2780<
             .is_some_and(Bytecode::is_eip7702);
         let clearing = authorization.address().is_zero();
 
-        // Non-existent authority: pay for the new account leaf — its state
-        // bytes plus the `ACCOUNT_WRITE` that materializes it.
+        // Non-existent authority: pay for the new account leaf's state bytes.
         if !existed {
+            if !gas.record_state_cost(new_account_state_gas) {
+                return Ok((regular_gas, state_gas, true));
+            }
             state_gas += new_account_state_gas;
+        }
+
+        // First write to the authority's leaf within the transaction pays
+        // `ACCOUNT_WRITE`, unless that write is already paid for (the sender at
+        // inclusion, the recipient of a value-bearing transaction, or a
+        // preceding valid authorization on the same authority).
+        if !written_accounts.contains(&authority) {
+            if !gas.record_regular_cost(account_write_cost) {
+                return Ok((regular_gas, state_gas, true));
+            }
             regular_gas += account_write_cost;
+            written_accounts.insert(authority);
         }
 
         // Net-new delegation bytes: the 23-byte delegation indicator written
@@ -475,9 +551,13 @@ pub fn apply_auth_list_eip2780<
         if !clearing
             && !delegated_now
             && !delegated_before_tx
-            && charged_delegation_bytes.insert(authority)
+            && !charged_delegation_bytes.contains(&authority)
         {
+            if !gas.record_state_cost(delegation_bytes_state_gas) {
+                return Ok((regular_gas, state_gas, true));
+            }
             state_gas += delegation_bytes_state_gas;
+            charged_delegation_bytes.insert(authority);
         }
 
         // 8. Set the code of `authority` to be `0xef0100 || address`. This is a delegation designation.
@@ -487,7 +567,7 @@ pub fn apply_auth_list_eip2780<
         authority_acc.delegate(authorization.address());
     }
 
-    Ok((regular_gas, state_gas))
+    Ok((regular_gas, state_gas, false))
 }
 
 /// Apply EIP-7702 style auth list and return number gas refund on already created accounts.

--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -11,8 +11,10 @@ use context_interface::{
     Block, Cfg, ContextTr, Database,
 };
 use core::cmp::Ordering;
-use interpreter::InitialAndFloorGas;
-use primitives::{hardfork::SpecId, AddressMap, HashSet, StorageKey, U256};
+use interpreter::{Gas, InitialAndFloorGas};
+use primitives::{
+    eip8038, hardfork::SpecId, Address, AddressMap, HashSet, StorageKey, TxKind, U256,
+};
 use state::AccountInfo;
 
 /// Loads and warms accounts for execution, including precompiles and access list.
@@ -193,6 +195,12 @@ pub fn validate_against_state_and_deduct_caller<
 /// If you need to apply auth list for other transaction types, use [`apply_auth_list`] function.
 ///
 /// Internally uses [`apply_auth_list`] function.
+///
+/// Under EIP-2780 this instead runs the runtime gas phase
+/// ([`apply_eip2780_runtime_gas`]): state-dependent charges are metered as the
+/// authorizations are applied and the recipient is loaded, and no refund is
+/// returned (the pessimistic intrinsic charge and its refund are replaced by
+/// conditional runtime charges).
 #[inline]
 pub fn apply_eip7702_auth_list<
     CTX: ContextTr,
@@ -201,6 +209,14 @@ pub fn apply_eip7702_auth_list<
     context: &mut CTX,
     init_and_floor_gas: &mut InitialAndFloorGas,
 ) -> Result<u64, ERROR> {
+    // EIP-2780: state-dependent charges (authority creation, delegation bytes,
+    // delegation-target access, recipient new-account state gas) are charged at
+    // the runtime phase instead of pessimistically at the intrinsic phase.
+    if context.cfg().is_amsterdam_eip2780_enabled() {
+        apply_eip2780_runtime_gas::<CTX, ERROR>(context, init_and_floor_gas)?;
+        return Ok(0);
+    }
+
     let chain_id = context.cfg().chain_id();
     let is_eip8037 = context.cfg().is_amsterdam_eip8037_enabled();
     let (tx, journal) = context.tx_journal_mut();
@@ -229,6 +245,249 @@ pub fn apply_eip7702_auth_list<
         .saturating_mul(number_of_refunded_accounts);
 
     Ok(regular_gas_refund)
+}
+
+/// EIP-2780 runtime gas phase (ethereum/EIPs#11844).
+///
+/// Once the transaction has passed the state-independent intrinsic gas check,
+/// the state-dependent charges are applied here, before the first frame is
+/// entered, drawing from the same gas the transaction supplies:
+///
+/// - While processing each valid EIP-7702 authorization (at most once per
+///   authority): a non-existent authority pays `STATE_BYTES_PER_NEW_ACCOUNT ×
+///   CPSB` state gas plus `ACCOUNT_WRITE` regular gas for the new account
+///   leaf, and writing the 23-byte delegation indicator into a previously
+///   empty slot pays `STATE_BYTES_PER_AUTH_BASE × CPSB` state gas.
+/// - The recipient is then loaded (its access was already charged at the cold
+///   rate at the intrinsic phase). If it is EIP-7702 delegated, the
+///   delegation-target access is charged following the standard EIP-2929
+///   warm/cold model (`COLD_ACCOUNT_ACCESS` if cold, `WARM_ACCESS` if warm).
+/// - A value transfer to a non-existent recipient additionally requires
+///   `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` state gas; that charge is applied on
+///   the first frame's gas tracker (see `EthFrame::make_call_frame`) so a
+///   revert rolls it back, but its affordability is checked here.
+///
+/// The affordable charges are folded into `init_and_floor_gas` so
+/// [`InitialAndFloorGas::initial_gas_and_reservoir`] deducts them before the
+/// first frame is entered. Running out of gas here does **not** invalidate the
+/// transaction: `runtime_oog` is set, all runtime state changes — including
+/// applied delegations — are reverted, and the caller turns the transaction
+/// into an out-of-gas halt that consumes all gas.
+#[inline]
+pub fn apply_eip2780_runtime_gas<
+    CTX: ContextTr,
+    ERROR: From<InvalidTransaction> + From<<CTX::Db as Database>::Error>,
+>(
+    context: &mut CTX,
+    init_and_floor_gas: &mut InitialAndFloorGas,
+) -> Result<(), ERROR> {
+    let chain_id = context.cfg().chain_id();
+    let is_eip8037 = context.cfg().is_amsterdam_eip8037_enabled();
+    let tx_gas_limit_cap = context.cfg().tx_gas_limit_cap();
+    let params = context.cfg().gas_params();
+    let account_write_cost = params.tx_account_write_cost();
+    let per_new_account_state_gas = params.new_account_state_gas();
+    let delegation_bytes_state_gas = params.tx_eip7702_state_gas_bytecode();
+    let (tx, journal) = context.tx_journal_mut();
+
+    // All runtime state changes are reverted wholesale if the transaction
+    // cannot afford the runtime charges.
+    let checkpoint = journal.checkpoint();
+
+    let mut runtime_regular_gas: u64 = 0;
+    let mut runtime_state_gas: u64 = 0;
+
+    // Apply EIP-7702 authorizations, accumulating the per-authority runtime
+    // charges.
+    if tx.tx_type() == TransactionType::Eip7702 {
+        let (regular, state) = apply_auth_list_eip2780::<_, ERROR>(
+            chain_id,
+            tx.authorization_list(),
+            journal,
+            account_write_cost,
+            per_new_account_state_gas,
+            delegation_bytes_state_gas,
+        )?;
+        runtime_regular_gas += regular;
+        runtime_state_gas += state;
+    }
+
+    // Load the recipient (adding it to `accessed_addresses`) and evaluate the
+    // recipient runtime charges. Evaluated after authorizations so a recipient
+    // materialized or delegated by an authorization in this transaction is
+    // seen in its post-authorization state. A self-transfer recipient is the
+    // (non-empty) sender, so the new-account charge never fires for it, while
+    // a delegated sender still pays for resolving its delegation.
+    let mut new_account_state_gas = 0u64;
+    if let TxKind::Call(target) = tx.kind() {
+        let (recipient_is_empty, delegation_target) = {
+            let acc = journal.load_account_with_code(target)?;
+            (
+                acc.info.is_empty(),
+                acc.info.code.as_ref().and_then(Bytecode::eip7702_address),
+            )
+        };
+
+        // EIP-7702 delegated recipient: resolving the delegation loads the
+        // target's code, charged per the standard EIP-2929 warm/cold model.
+        if let Some(delegated) = delegation_target {
+            let is_cold = journal.load_account(delegated)?.is_cold;
+            runtime_regular_gas += if is_cold {
+                eip8038::COLD_ACCOUNT_ACCESS
+            } else {
+                eip8038::WARM_ACCESS
+            };
+        }
+
+        // Value transfer to a non-existent recipient grows the state by one
+        // account leaf. The charge itself is applied on the first frame's gas
+        // tracker so a revert rolls it back; only checked for affordability
+        // here.
+        if !tx.value().is_zero() && recipient_is_empty {
+            new_account_state_gas = per_new_account_state_gas;
+        }
+    }
+
+    // Without EIP-8037 there is no state-gas metering.
+    if !is_eip8037 {
+        runtime_state_gas = 0;
+        new_account_state_gas = 0;
+    }
+
+    // Affordability: the runtime charges draw from the same gas the
+    // transaction supplies, exactly as the first frame will see it.
+    let mut probe = *init_and_floor_gas;
+    probe.initial_regular_gas += runtime_regular_gas;
+    probe.initial_state_gas += runtime_state_gas;
+    let affordable = probe
+        .checked_initial_gas_and_reservoir(tx.gas_limit(), tx_gas_limit_cap)
+        .map(|(gas_limit, reservoir)| {
+            new_account_state_gas == 0
+                || Gas::new_with_regular_gas_and_reservoir(gas_limit, reservoir)
+                    .record_state_cost(new_account_state_gas)
+        })
+        .unwrap_or(false);
+
+    if !affordable {
+        // Out-of-gas in the runtime phase: the transaction stays valid and
+        // included, but halts before the first frame is entered and all
+        // runtime state changes (including applied delegations) are reverted.
+        journal.checkpoint_revert(checkpoint);
+        init_and_floor_gas.runtime_oog = true;
+        return Ok(());
+    }
+
+    journal.checkpoint_commit();
+    init_and_floor_gas.initial_regular_gas += runtime_regular_gas;
+    init_and_floor_gas.initial_state_gas += runtime_state_gas;
+    Ok(())
+}
+
+/// Applies an EIP-7702 auth list under EIP-2780, accumulating the
+/// state-dependent runtime charges instead of the pessimistic
+/// intrinsic-charge/refund bookkeeping of [`apply_auth_list`].
+///
+/// Rejected authorizations charge nothing here: the intrinsic
+/// `REGULAR_PER_AUTH_BASE_COST` already covers the work every authorization
+/// performs (calldata, recovery, authority access), so there is nothing to
+/// refund either.
+///
+/// Returns the accumulated `(regular_gas, state_gas)` runtime charges.
+#[inline]
+pub fn apply_auth_list_eip2780<
+    JOURNAL: JournalTr,
+    ERROR: From<InvalidTransaction> + From<<JOURNAL::Database as Database>::Error>,
+>(
+    chain_id: u64,
+    auth_list: impl Iterator<Item = impl AuthorizationTr>,
+    journal: &mut JOURNAL,
+    account_write_cost: u64,
+    new_account_state_gas: u64,
+    delegation_bytes_state_gas: u64,
+) -> Result<(u64, u64), ERROR> {
+    let mut regular_gas: u64 = 0;
+    let mut state_gas: u64 = 0;
+    // EIP-8037 per-authority rules: each charge is applied at most once per
+    // authority. The new-account charges self-limit (after the first
+    // application the authority exists), the delegation-bytes charge is
+    // tracked explicitly to cover a set-clear-set sequence within one
+    // transaction.
+    let mut charged_delegation_bytes: HashSet<Address> = HashSet::default();
+
+    for authorization in auth_list {
+        // 1. Verify the chain id is either 0 or the chain's current ID.
+        let auth_chain_id = authorization.chain_id();
+        if !auth_chain_id.is_zero() && auth_chain_id != U256::from(chain_id) {
+            continue;
+        }
+
+        // 2. Verify the `nonce` is less than `2**64 - 1`.
+        if authorization.nonce() == u64::MAX {
+            continue;
+        }
+
+        // recover authority and authorized addresses.
+        // 3. `authority = ecrecover(keccak(MAGIC || rlp([chain_id, address, nonce])), y_parity, r, s]`
+        let Some(authority) = authorization.authority() else {
+            continue;
+        };
+
+        // warm authority account and check nonce.
+        // 4. Add `authority` to `accessed_addresses` (as defined in [EIP-2929](./eip-2929.md).)
+        let mut authority_acc = journal.load_account_with_code_mut(authority)?;
+        let authority_acc_info = &authority_acc.account().info;
+
+        // 5. Verify the code of `authority` is either empty or already delegated.
+        if let Some(bytecode) = &authority_acc_info.code {
+            // if it is not empty and it is not eip7702
+            if !bytecode.is_empty() && !bytecode.is_eip7702() {
+                continue;
+            }
+        }
+
+        // 6. Verify the nonce of `authority` is equal to `nonce`. In case `authority` does not exist in the trie, verify that `nonce` is equal to `0`.
+        if authorization.nonce() != authority_acc_info.nonce {
+            continue;
+        }
+
+        let existed = !(authority_acc_info.is_empty()
+            && authority_acc
+                .account()
+                .is_loaded_as_not_existing_not_touched());
+        let delegated_now = !authority_acc_info.is_code_hash_empty_or_zero();
+        let delegated_before_tx = authority_acc
+            .account()
+            .original_info()
+            .code
+            .as_ref()
+            .is_some_and(Bytecode::is_eip7702);
+        let clearing = authorization.address().is_zero();
+
+        // Non-existent authority: pay for the new account leaf — its state
+        // bytes plus the `ACCOUNT_WRITE` that materializes it.
+        if !existed {
+            state_gas += new_account_state_gas;
+            regular_gas += account_write_cost;
+        }
+
+        // Net-new delegation bytes: the 23-byte delegation indicator written
+        // into a previously empty slot.
+        if !clearing
+            && !delegated_now
+            && !delegated_before_tx
+            && charged_delegation_bytes.insert(authority)
+        {
+            state_gas += delegation_bytes_state_gas;
+        }
+
+        // 8. Set the code of `authority` to be `0xef0100 || address`. This is a delegation designation.
+        //  * As a special case, if `address` is `0x0000000000000000000000000000000000000000` do not write the designation.
+        //    Clear the accounts code and reset the account's code hash to the empty hash `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`.
+        // 9. Increase the nonce of `authority` by one.
+        authority_acc.delegate(authorization.address());
+    }
+
+    Ok((regular_gas, state_gas))
 }
 
 /// Apply EIP-7702 style auth list and return number gas refund on already created accounts.

--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -81,25 +81,35 @@ where
         evm: &mut Self::Evm,
         init_and_floor_gas: &InitialAndFloorGas,
     ) -> Result<FrameResult, Self::Error> {
+        // Compute the regular gas budget and EIP-8037 reservoir for the first frame.
+        let (gas_limit, reservoir) = init_and_floor_gas.initial_gas_and_reservoir(
+            evm.ctx().tx().gas_limit(),
+            evm.ctx().cfg().tx_gas_limit_cap(),
+        );
+
         // EIP-2780: the transaction is valid but its gas cannot cover the
         // state-dependent runtime charges — include it as an out-of-gas halt
         // without entering the first frame (mirrors `Handler::execution`).
         if init_and_floor_gas.runtime_oog {
             let tx_gas_limit = evm.ctx().tx().gas_limit();
             let mut frame_result = match evm.ctx().tx().kind() {
-                TxKind::Call(_) => FrameResult::Call(CallOutcome::new_oog(tx_gas_limit, 0..0, 0)),
-                TxKind::Create => FrameResult::Create(CreateOutcome::new_oog(tx_gas_limit, 0)),
+                TxKind::Call(_) => {
+                    FrameResult::Call(CallOutcome::new_oog(tx_gas_limit, 0..0, reservoir))
+                }
+                TxKind::Create => {
+                    FrameResult::Create(CreateOutcome::new_oog(tx_gas_limit, reservoir))
+                }
             };
             self.last_frame_result(evm, &mut frame_result)?;
             return Ok(frame_result);
         }
 
-        // Compute the regular gas budget and EIP-8037 reservoir for the first frame.
-        let (gas_limit, reservoir) = init_and_floor_gas.initial_gas_and_reservoir(
-            evm.ctx().tx().gas_limit(),
-            evm.ctx().cfg().tx_gas_limit_cap(),
-        );
-        let first_frame_input = self.first_frame_input(evm, gas_limit, reservoir)?;
+        let first_frame_input = self.first_frame_input(
+            evm,
+            gas_limit,
+            reservoir,
+            init_and_floor_gas.first_frame_state_gas,
+        )?;
 
         // Run execution loop
         let mut frame_result = self.inspect_run_exec_loop(evm, first_frame_input)?;

--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -6,10 +6,10 @@ use handler::{
 use interpreter::{
     instructions::{GasTable, InstructionTable},
     interpreter_types::{Jumps, LoopControl},
-    FrameInput, Host, InitialAndFloorGas, InstructionResult, Interpreter, InterpreterAction,
-    InterpreterTypes,
+    CallOutcome, CreateOutcome, FrameInput, Host, InitialAndFloorGas, InstructionResult,
+    Interpreter, InterpreterAction, InterpreterTypes,
 };
-use primitives::hints_util::cold_path;
+use primitives::{hints_util::cold_path, TxKind};
 use state::bytecode::opcode;
 
 /// Trait that extends [`Handler`] with inspection functionality.
@@ -81,6 +81,19 @@ where
         evm: &mut Self::Evm,
         init_and_floor_gas: &InitialAndFloorGas,
     ) -> Result<FrameResult, Self::Error> {
+        // EIP-2780: the transaction is valid but its gas cannot cover the
+        // state-dependent runtime charges — include it as an out-of-gas halt
+        // without entering the first frame (mirrors `Handler::execution`).
+        if init_and_floor_gas.runtime_oog {
+            let tx_gas_limit = evm.ctx().tx().gas_limit();
+            let mut frame_result = match evm.ctx().tx().kind() {
+                TxKind::Call(_) => FrameResult::Call(CallOutcome::new_oog(tx_gas_limit, 0..0, 0)),
+                TxKind::Create => FrameResult::Create(CreateOutcome::new_oog(tx_gas_limit, 0)),
+            };
+            self.last_frame_result(evm, &mut frame_result)?;
+            return Ok(frame_result);
+        }
+
         // Compute the regular gas budget and EIP-8037 reservoir for the first frame.
         let (gas_limit, reservoir) = init_and_floor_gas.initial_gas_and_reservoir(
             evm.ctx().tx().gas_limit(),

--- a/crates/interpreter/src/instructions/contract.rs
+++ b/crates/interpreter/src/instructions/contract.rs
@@ -9,7 +9,7 @@ use crate::{
     instructions::utility::IntoAddress,
     interpreter_action::FrameInput,
     interpreter_types::{
-        InputsTr, InterpreterTypes as ITy, LoopControl, MemoryTr, RuntimeFlag, StackTr,
+        InputsTr, InterpreterTypes as ITy, LoopControl, MemoryTr, ReturnData, RuntimeFlag, StackTr,
     },
     CallInput, CallInputs, CallScheme, CallValue, CreateInputs, Host,
     InstructionExecResult as Result, InstructionResult, InterpreterAction,
@@ -86,14 +86,62 @@ pub fn create<const IS_CREATE2: bool, IT: ITy, H: Host + ?Sized>(
         CreateScheme::Create
     };
 
+    // Build the inputs before the gas split so the created address (and the
+    // CREATE2 init-code hash) is computed once and cached for frame creation.
+    let mut create_inputs = CreateInputs::new(
+        context.interpreter.input.target_address(),
+        scheme,
+        value,
+        code,
+        0,
+        0,
+    );
+
     // State gas for account creation + contract metadata (EIP-8037).
-    // Charged upfront on the parent's tracker; `return_create` refunds the same
-    // amount (derived from cfg) on entry and re-records it on a successful commit.
     if context.host.is_amsterdam_eip8037_enabled() {
-        state_gas!(
-            context.interpreter,
-            context.host.gas_params().create_state_gas()
-        );
+        if context.host.is_amsterdam_eip2780_enabled() {
+            // Devnet-7 (#11858): the charge is conditional at access, applied in
+            // the creating frame before the 63/64 split. The destination is read
+            // (and charged for) only after the pre-access checks — endowment
+            // balance and sender nonce overflow — pass; failing those pushes 0
+            // without touching the destination. (The call-depth pre-access check
+            // lives at frame creation; its failure path refunds the charge.)
+            let caller = create_inputs.caller();
+            let caller_info = context
+                .host
+                .load_account_info_skip_cold_load(caller, false, false)?;
+            let caller_balance = caller_info.account.balance;
+            let caller_nonce = caller_info.account.nonce;
+            if caller_balance < value || caller_nonce == u64::MAX {
+                context.interpreter.return_data.clear();
+                push!(context.interpreter, U256::ZERO);
+                return Ok(());
+            }
+
+            // Single read of the destination: decides the charge by existence
+            // alone (independently of the collision outcome checked at frame
+            // creation) and adds it to the accessed addresses.
+            let created_address = create_inputs.created_address(caller_nonce);
+            let destination_alive = !context
+                .host
+                .load_account_info_skip_cold_load(created_address, false, false)?
+                .is_empty;
+            if !destination_alive {
+                state_gas!(
+                    context.interpreter,
+                    context.host.gas_params().create_state_gas()
+                );
+                create_inputs.set_charged_create_state_gas(true);
+            }
+        } else {
+            // Pre-devnet-7 rules: charged upfront on the parent's tracker;
+            // `return_result` refunds the same amount when the create fails or
+            // the target was already alive.
+            state_gas!(
+                context.interpreter,
+                context.host.gas_params().create_state_gas()
+            );
+        }
     }
 
     let mut gas_limit = context.interpreter.gas.remaining();
@@ -110,15 +158,8 @@ pub fn create<const IS_CREATE2: bool, IT: ITy, H: Host + ?Sized>(
     }
     gas!(context.interpreter, gas_limit);
 
-    // Call host to interact with target contract
-    let create_inputs = CreateInputs::new(
-        context.interpreter.input.target_address(),
-        scheme,
-        value,
-        code,
-        gas_limit,
-        context.interpreter.gas.reservoir(),
-    );
+    create_inputs.set_gas_limit(gas_limit);
+    create_inputs.set_reservoir(context.interpreter.gas.reservoir());
     context
         .interpreter
         .bytecode

--- a/crates/interpreter/src/instructions/contract.rs
+++ b/crates/interpreter/src/instructions/contract.rs
@@ -99,48 +99,38 @@ pub fn create<const IS_CREATE2: bool, IT: ITy, H: Host + ?Sized>(
 
     // State gas for account creation + contract metadata (EIP-8037).
     if context.host.is_amsterdam_eip8037_enabled() {
-        if context.host.is_amsterdam_eip2780_enabled() {
-            // Devnet-7 (#11858): the charge is conditional at access, applied in
-            // the creating frame before the 63/64 split. The destination is read
-            // (and charged for) only after the pre-access checks — endowment
-            // balance and sender nonce overflow — pass; failing those pushes 0
-            // without touching the destination. (The call-depth pre-access check
-            // lives at frame creation; its failure path refunds the charge.)
-            let caller = create_inputs.caller();
-            let caller_info = context
-                .host
-                .load_account_info_skip_cold_load(caller, false, false)?;
-            let caller_balance = caller_info.account.balance;
-            let caller_nonce = caller_info.account.nonce;
-            if caller_balance < value || caller_nonce == u64::MAX {
-                context.interpreter.return_data.clear();
-                push!(context.interpreter, U256::ZERO);
-                return Ok(());
-            }
+        // Devnet-7 (#11858): the charge is conditional at access, applied in
+        // the creating frame before the 63/64 split. The destination is read
+        // (and charged for) only after the pre-access checks — endowment
+        // balance and sender nonce overflow — pass; failing those pushes 0
+        // without touching the destination. (The call-depth pre-access check
+        // lives at frame creation; its failure path refunds the charge.)
+        let caller = create_inputs.caller();
+        let caller_info = context
+            .host
+            .load_account_info_skip_cold_load(caller, false, false)?;
+        let caller_balance = caller_info.account.balance;
+        let caller_nonce = caller_info.account.nonce;
+        if caller_balance < value || caller_nonce == u64::MAX {
+            context.interpreter.return_data.clear();
+            push!(context.interpreter, U256::ZERO);
+            return Ok(());
+        }
 
-            // Single read of the destination: decides the charge by existence
-            // alone (independently of the collision outcome checked at frame
-            // creation) and adds it to the accessed addresses.
-            let created_address = create_inputs.created_address(caller_nonce);
-            let destination_alive = !context
-                .host
-                .load_account_info_skip_cold_load(created_address, false, false)?
-                .is_empty;
-            if !destination_alive {
-                state_gas!(
-                    context.interpreter,
-                    context.host.gas_params().create_state_gas()
-                );
-                create_inputs.set_charged_create_state_gas(true);
-            }
-        } else {
-            // Pre-devnet-7 rules: charged upfront on the parent's tracker;
-            // `return_result` refunds the same amount when the create fails or
-            // the target was already alive.
+        // Single read of the destination: decides the charge by existence
+        // alone (independently of the collision outcome checked at frame
+        // creation) and adds it to the accessed addresses.
+        let created_address = create_inputs.created_address(caller_nonce);
+        let destination_alive = !context
+            .host
+            .load_account_info_skip_cold_load(created_address, false, false)?
+            .is_empty;
+        if !destination_alive {
             state_gas!(
                 context.interpreter,
                 context.host.gas_params().create_state_gas()
             );
+            create_inputs.set_charged_create_state_gas(true);
         }
     }
 

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -233,14 +233,22 @@ where
     );
 
     let state_load = if spec_id.is_enabled_in(BERLIN) {
-        // Note: the slot is always cold-loaded (warmed), even when there is not
-        // enough gas to pay the cold cost. Skipping the load would avoid a DB
-        // read on a certain out-of-gas, but EIP-7928 (block access lists) records
-        // the slot access regardless of the subsequent OOG, so the warming must
-        // happen. The OOG outcome is unchanged: the cold charge below still fails.
+        // EIP-8038/7928 (devnet-7, EIPs#11854): the frame must cover the slot's
+        // access cost before the implicit storage read; if it cannot, SSTORE
+        // fails without the slot appearing in the block access list. The warm
+        // access portion is covered by the static gas charged above, so only
+        // the cold-additional cost is checked here; a cold load is skipped
+        // (and turned into an out-of-gas) when it cannot be paid.
+        //
+        // Pre-devnet-7 the slot is always cold-loaded (warmed), even when there
+        // is not enough gas to pay the cold cost, and the cold charge below
+        // fails afterwards.
+        let skip_cold_load = context.host.is_amsterdam_eip8037_enabled()
+            && context.host.is_amsterdam_eip2780_enabled()
+            && context.interpreter.gas.remaining() < context.host.gas_params().cold_storage_cost();
         context
             .host
-            .sstore_skip_cold_load(target, index, value, false)?
+            .sstore_skip_cold_load(target, index, value, skip_cold_load)?
     } else {
         context
             .host

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -233,19 +233,8 @@ where
     );
 
     let state_load = if spec_id.is_enabled_in(BERLIN) {
-        // EIP-8038/7928 (devnet-7, EIPs#11854): the frame must cover the slot's
-        // access cost before the implicit storage read; if it cannot, SSTORE
-        // fails without the slot appearing in the block access list. The warm
-        // access portion is covered by the static gas charged above, so only
-        // the cold-additional cost is checked here; a cold load is skipped
-        // (and turned into an out-of-gas) when it cannot be paid.
-        //
-        // Pre-devnet-7 the slot is always cold-loaded (warmed), even when there
-        // is not enough gas to pay the cold cost, and the cold charge below
-        // fails afterwards.
-        let skip_cold_load = context.host.is_amsterdam_eip8037_enabled()
-            && context.host.is_amsterdam_eip2780_enabled()
-            && context.interpreter.gas.remaining() < context.host.gas_params().cold_storage_cost();
+        let skip_cold_load =
+            context.interpreter.gas.remaining() < context.host.gas_params().cold_storage_cost();
         context
             .host
             .sstore_skip_cold_load(target, index, value, skip_cold_load)?

--- a/crates/interpreter/src/interpreter_action.rs
+++ b/crates/interpreter/src/interpreter_action.rs
@@ -34,6 +34,11 @@ pub struct FrameInit {
     pub memory: SharedMemory,
     /// Data needed as input for Interpreter.
     pub frame_input: FrameInput,
+    /// EIP-2780: state gas to record on the frame's gas tracker at creation,
+    /// decided at the runtime gas phase for the first frame (recipient
+    /// new-account leaf or the create transaction's account-creation charge).
+    /// Zero for nested frames (their charges are applied by the opcodes).
+    pub state_gas_charge: u64,
 }
 
 impl FrameInput {

--- a/crates/interpreter/src/interpreter_action/create_inputs.rs
+++ b/crates/interpreter/src/interpreter_action/create_inputs.rs
@@ -18,6 +18,11 @@ pub struct CreateInputs {
     gas_limit: u64,
     /// State gas reservoir (EIP-8037). Passed from parent frame to child frame.
     reservoir: u64,
+    /// EIP-8037 (devnet-7): whether the CREATE opcode charged the conditional
+    /// `create_state_gas` on the parent's tracker (the destination did not
+    /// exist at access time). Propagated onto [`crate::CreateOutcome`] so the
+    /// parent refunds the charge when the create fails.
+    charged_create_state_gas: bool,
     /// Cached created address. This is computed lazily and cached to avoid
     /// redundant keccak computations when inspectors call `created_address`.
     #[cfg_attr(feature = "serde", serde(skip))]
@@ -46,6 +51,7 @@ impl CreateInputs {
             init_code,
             gas_limit,
             reservoir,
+            charged_create_state_gas: false,
             cached_address: OnceCell::new(),
             cached_init_code_hash: OnceCell::new(),
         }
@@ -133,7 +139,19 @@ impl CreateInputs {
         self.reservoir
     }
 
-    /// Set the state gas reservoir (EIP-8037).
+    /// Returns whether the CREATE opcode charged the conditional
+    /// `create_state_gas` (EIP-8037, devnet-7).
+    pub const fn charged_create_state_gas(&self) -> bool {
+        self.charged_create_state_gas
+    }
+
+    /// Marks that the CREATE opcode charged the conditional `create_state_gas`
+    /// on the parent's tracker (EIP-8037, devnet-7).
+    pub const fn set_charged_create_state_gas(&mut self, charged: bool) {
+        self.charged_create_state_gas = charged;
+    }
+
+    /// Sets the state gas reservoir (EIP-8037).
     pub const fn set_reservoir(&mut self, reservoir: u64) {
         self.reservoir = reservoir;
     }

--- a/crates/interpreter/src/interpreter_action/create_outcome.rs
+++ b/crates/interpreter/src/interpreter_action/create_outcome.rs
@@ -18,6 +18,10 @@ pub struct CreateOutcome {
     /// address no new account leaf is created, so the upfront `create_state_gas`
     /// is refunded to the parent's reservoir.
     pub target_was_alive: bool,
+    /// EIP-8037 (devnet-7): whether the CREATE opcode charged the conditional
+    /// `create_state_gas` on the parent's tracker (the destination did not
+    /// exist at access time). When the create fails the parent refunds it.
+    pub charged_create_state_gas: bool,
 }
 
 impl CreateOutcome {
@@ -36,6 +40,7 @@ impl CreateOutcome {
             result,
             address,
             target_was_alive: false,
+            charged_create_state_gas: false,
         }
     }
 

--- a/crates/interpreter/src/interpreter_action/create_outcome.rs
+++ b/crates/interpreter/src/interpreter_action/create_outcome.rs
@@ -13,11 +13,6 @@ pub struct CreateOutcome {
     pub result: InterpreterResult,
     /// An optional address associated with the create operation
     pub address: Option<Address>,
-    /// EIP-8037: whether the created address was already alive (existing,
-    /// non-empty) before this CREATE. When the create succeeds at such an
-    /// address no new account leaf is created, so the upfront `create_state_gas`
-    /// is refunded to the parent's reservoir.
-    pub target_was_alive: bool,
     /// EIP-8037 (devnet-7): whether the CREATE opcode charged the conditional
     /// `create_state_gas` on the parent's tracker (the destination did not
     /// exist at access time). When the create fails the parent refunds it.
@@ -39,7 +34,6 @@ impl CreateOutcome {
         Self {
             result,
             address,
-            target_was_alive: false,
             charged_create_state_gas: false,
         }
     }

--- a/crates/primitives/src/eip8038.rs
+++ b/crates/primitives/src/eip8038.rs
@@ -66,18 +66,30 @@ pub const EIP7702_ECRECOVER_COST: u64 = 3_000;
 /// Calldata floor rate per token under EIP-7976 (Amsterdam).
 pub const TX_DATA_TOKEN_FLOOR: u64 = 16;
 
+/// `REGULAR_PER_AUTH_BASE_COST`: the state-independent regular-gas base charged
+/// per EIP-7702 authorization at the intrinsic phase under EIP-2780
+/// (ethereum/EIPs#11844).
+///
+/// `AUTH_TUPLE_BYTES * TX_DATA_TOKEN_FLOOR + PRECOMPILE_ECRECOVER + COLD_ACCOUNT_ACCESS + 2 * WARM_ACCESS`
+/// = `101*16 + 3,000 + 3,000 + 200 = 7,816`. Covers the authorization's calldata,
+/// the ECDSA recovery, the authority's cold access, and the warm writes every
+/// authorization performs. The state-dependent remainder (`ACCOUNT_WRITE` and the
+/// new-account / delegation-bytes state gas) is charged at runtime, only for the
+/// authorities that incur it.
+pub const EIP7702_PER_AUTH_BASE_REGULAR: u64 = EIP7702_AUTH_TUPLE_BYTES * TX_DATA_TOKEN_FLOOR
+    + EIP7702_ECRECOVER_COST
+    + COLD_ACCOUNT_ACCESS
+    + 2 * WARM_ACCESS;
+
 /// Regular-gas portion of EIP-7702 `PER_EMPTY_ACCOUNT_COST` under EIP-8038.
 ///
-/// Per execution-specs, the regular per-auth charge is
-/// `ACCOUNT_WRITE + REGULAR_PER_AUTH_BASE_COST`, where
-/// `REGULAR_PER_AUTH_BASE_COST = AUTH_TUPLE_BYTES * TX_DATA_TOKEN_FLOOR + PRECOMPILE_ECRECOVER + COLD_ACCOUNT_ACCESS + 2 * WARM_ACCESS`.
-/// Evaluates to `8,000 + (101*16 + 3,000 + 3,000 + 200) = 8,000 + 7,816 = 15,816`.
+/// Per execution-specs, the pessimistic regular per-auth charge is
+/// `ACCOUNT_WRITE + REGULAR_PER_AUTH_BASE_COST` = `8,000 + 7,816 = 15,816`.
 /// (The per-auth state gas — `NEW_ACCOUNT + AUTH_BASE` — is charged separately.)
-pub const EIP7702_PER_EMPTY_ACCOUNT_REGULAR: u64 = ACCOUNT_WRITE
-    + (EIP7702_AUTH_TUPLE_BYTES * TX_DATA_TOKEN_FLOOR
-        + EIP7702_ECRECOVER_COST
-        + COLD_ACCOUNT_ACCESS
-        + 2 * WARM_ACCESS);
+/// Used when EIP-2780 is disabled; with EIP-2780 only
+/// [`EIP7702_PER_AUTH_BASE_REGULAR`] is intrinsic and `ACCOUNT_WRITE` moves to
+/// the runtime phase.
+pub const EIP7702_PER_EMPTY_ACCOUNT_REGULAR: u64 = ACCOUNT_WRITE + EIP7702_PER_AUTH_BASE_REGULAR;
 
 #[cfg(test)]
 mod tests {
@@ -96,6 +108,7 @@ mod tests {
         assert_eq!(ACCESS_LIST_ADDRESS_COST, 3_000);
         assert_eq!(ACCESS_LIST_STORAGE_KEY_COST, 3_000);
         assert_eq!(CALL_VALUE, 10_300);
+        assert_eq!(EIP7702_PER_AUTH_BASE_REGULAR, 7_816);
         assert_eq!(EIP7702_PER_EMPTY_ACCOUNT_REGULAR, 15_816);
     }
 

--- a/crates/statetest-types/src/test.rs
+++ b/crates/statetest-types/src/test.rs
@@ -59,12 +59,22 @@ impl Test {
     /// - The private key cannot be used to recover the sender address
     /// - The transaction type is invalid and no exception is expected
     pub fn tx_env(&self, unit: &TestUnit) -> Result<TxEnv, TestError> {
+        // State tests are unsigned; the secret key stands in for a valid
+        // signature. A fixture without one models an invalidly-signed
+        // transaction (e.g. bad v/r/s values) and must be rejected.
+        let Some(secret_key) = unit.transaction.secret_key else {
+            return Err(TestError::UnexpectedException {
+                expected_exception: self.expect_exception.clone(),
+                got_exception: Some("Missing secret key".to_string()),
+            });
+        };
+
         // Setup sender
         let caller = if let Some(address) = unit.transaction.sender {
             address
         } else {
-            recover_address(unit.transaction.secret_key.as_slice())
-                .ok_or(TestError::UnknownPrivateKey(unit.transaction.secret_key))?
+            recover_address(secret_key.as_slice())
+                .ok_or(TestError::UnknownPrivateKey(secret_key))?
         };
 
         // Transaction specific fields
@@ -101,7 +111,18 @@ impl Test {
             tx_type: tx_type as u8,
             gas_limit: unit.transaction.gas_limit[self.indexes.gas].saturating_to(),
             data: unit.transaction.data[self.indexes.data].clone(),
-            nonce: u64::try_from(unit.transaction.nonce).unwrap(),
+            nonce: u64::try_from(unit.transaction.nonce).map_err(|_| {
+                TestError::UnexpectedException {
+                    expected_exception: self.expect_exception.clone(),
+                    got_exception: Some("Nonce overflow".to_string()),
+                }
+            })?,
+            chain_id: Some(
+                unit.transaction
+                    .chain_id
+                    .map(|id| id.try_into().unwrap_or(u64::MAX))
+                    .unwrap_or(1),
+            ),
             value: unit.transaction.value[self.indexes.value],
             access_list: unit
                 .transaction
@@ -125,7 +146,6 @@ impl Test {
                 Some(add) => TxKind::Call(add),
                 None => TxKind::Create,
             },
-            ..TxEnv::default()
         };
 
         Ok(tx)

--- a/crates/statetest-types/src/test_unit.rs
+++ b/crates/statetest-types/src/test_unit.rs
@@ -166,11 +166,12 @@ mod tests {
             post: BTreeMap::default(),
             transaction: TransactionParts {
                 tx_type: None,
+                chain_id: None,
                 data: vec![],
                 gas_limit: vec![],
                 gas_price: None,
                 nonce: U256::ZERO,
-                secret_key: B256::ZERO,
+                secret_key: Some(B256::ZERO),
                 sender: None,
                 to: None,
                 value: vec![],

--- a/crates/statetest-types/src/transaction.rs
+++ b/crates/statetest-types/src/transaction.rs
@@ -11,6 +11,9 @@ pub struct TransactionParts {
     /// Transaction type (0=Legacy, 1=EIP-2930, 2=EIP-1559, 3=EIP-4844, 4=EIP-7702)
     #[serde(rename = "type")]
     pub tx_type: Option<u8>,
+    /// Chain id of the transaction. If it differs from the network chain id the
+    /// transaction is expected to be rejected with `INVALID_CHAINID`.
+    pub chain_id: Option<U256>,
     /// Transaction data/input (multiple variants for different test cases)
     pub data: Vec<Bytes>,
     /// Gas limit values (multiple variants for different test cases)
@@ -19,8 +22,12 @@ pub struct TransactionParts {
     pub gas_price: Option<U256>,
     /// Transaction nonce
     pub nonce: U256,
-    /// Private key for signing the transaction
-    pub secret_key: B256,
+    /// Private key for signing the transaction.
+    ///
+    /// State tests are unsigned; the secret key stands in for a valid
+    /// signature. A fixture without one models an invalidly-signed
+    /// transaction (e.g. `test_bad_v_r_s`) and is expected to be rejected.
+    pub secret_key: Option<B256>,
     /// if sender is not present we need to derive it from secret key.
     #[serde(default)]
     pub sender: Option<Address>,


### PR DESCRIPTION
Implements the EIP-2780 update from [ethereum/EIPs#11844](https://github.com/ethereum/EIPs/pull/11844) (head `9d2e4e17`): state-dependent transaction charges move from the intrinsic phase to a **runtime gas phase**, applied as the first frame is entered. Intrinsic gas stays the sole input to the validity check.

Everything is gated on the existing `CfgEnv::enable_amsterdam_eip2780`; older forks and 2780-disabled Amsterdam keep the previous code paths (the `eip8037.rs` ee-tests, which disable the flag, pass unchanged).

## Changes

- **Create transactions**: `create_state_gas` (183,600) is no longer intrinsic. It is charged in `make_create_frame` at depth 0, on the frame's gas tracker, only when the deployment target does not already exist — so a create to a pre-existing (balance-only) target pays no new-account state gas, and an initcode revert/halt unwinds the charge LIFO via `rollback_state_gas`. The old top-level refill in `last_frame_result` is gated to the non-2780 path.
- **EIP-7702 decomposition**: the pessimistic per-auth intrinsic charge (15,816 regular + 218,790 state) and its refunds are replaced by an intrinsic `REGULAR_PER_AUTH_BASE_COST = 7,816` (new `eip8038::EIP7702_PER_AUTH_BASE_REGULAR`) plus runtime charges accumulated while applying the auth list (`apply_auth_list_eip2780`): a non-existent authority pays `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` state + `ACCOUNT_WRITE` regular; net-new delegation bytes pay `STATE_BYTES_PER_AUTH_BASE × CPSB` state, at most once per authority. No refunds.
- **Delegated recipient**: the delegation-target access follows the standard EIP-2929 warm/cold model (`WARM_ACCESS` if pre-warmed, e.g. by an access list) instead of a flat `COLD_ACCOUNT_ACCESS`, charged in the runtime phase (`apply_eip2780_runtime_gas`).
- **Runtime out-of-gas is a halt, not invalidity**: `apply_eip2780_runtime_gas` checks affordability of the whole runtime phase (new `InitialAndFloorGas::checked_initial_gas_and_reservoir`). On OOG it reverts a checkpoint spanning the runtime phase — undoing applied delegations — and sets `InitialAndFloorGas::runtime_oog`; `Handler::execution` / `inspect_execution` then include the transaction as an out-of-gas halt consuming all gas without entering the first frame.
- Affordable runtime charges are folded into `initial_regular_gas` / `initial_state_gas`, so they are deducted pre-frame and survive in-frame reverts (delegations persist on in-frame failure). The recipient new-account state gas stays on the frame tracker so a revert rolls it back with the transfer.

## Spec notes / ambiguities

- The PR body on ethereum/EIPs is stale (describes a warm-access-floor split); the head spec charges the recipient/authority at the cold rate unconditionally at intrinsic — implemented per the head.
- The `ACCOUNT_WRITE` bullet's "(i.e. the authority differs from `tx.to`)" parenthetical conflicts with Test Case 8 and the Interactions section ("`ACCOUNT_WRITE` for a non-existent authority"); implemented as `!existed`, matching the old model's net charges.
- Delegation set→clear→set on one authority within a tx charges the indicator bytes once, with no refund on clear ("at most once per authority").

## Testing

- 9 new ee-tests covering the reference cases: create to existing target (no state gas), included-as-halt runtime OOG for create/call/7702 (with delegation reverted), warm vs cold delegation target, new vs existing authority charges; plus a `gas_params` unit test for the intrinsic split.
- `cargo nextest run --workspace` (default / all / no-default features), clippy, fmt, typos: clean.
- Fixtures: pre-Amsterdam fork suites identical to main. `for_amsterdam`: 2663/2666 — the 3 failures (stInitCodeTest create-halt tests) encode the old devnet-6 refill-on-halt semantics; under the new spec the gas_left-drawn portion of the LIFO refill is consumed by the exceptional halt. Fixtures need regeneration for the updated spec.

Follow-up: op-revm needs alignment with the `runtime_oog` execution path.