### PR TITLE
fix(bytecode): avoid iterating legacy padding opcodes

### DIFF
--- a/crates/bytecode/src/iter.rs
+++ b/crates/bytecode/src/iter.rs
@@ -17,7 +17,7 @@ impl<'a> BytecodeIterator<'a> {
     #[inline]
     pub fn new(bytecode: &'a Bytecode) -> Self {
         let bytes = if bytecode.is_legacy() {
-            &bytecode.bytecode()[..]
+            bytecode.original_byte_slice()
         } else {
             &[]
         };
@@ -249,5 +249,12 @@ mod tests {
         let bytecode = Bytecode::new_legacy(Bytes::from_static(&[opcode::STOP]));
         let opcodes: Vec<u8> = bytecode.iter_opcodes().collect();
         assert_eq!(opcodes, vec![opcode::STOP]);
+    }
+
+    #[test]
+    fn test_truncated_push_does_not_iterate_padding() {
+        let bytecode = Bytecode::new_legacy(Bytes::from_static(&[opcode::PUSH1]));
+        let opcodes: Vec<u8> = bytecode.iter_opcodes().collect();
+        assert_eq!(opcodes, vec![opcode::PUSH1]);
     }
 }


### PR DESCRIPTION

## Summary

`BytecodeIterator` now iterates over the original legacy bytecode slice instead of the padded execution buffer.

Legacy analysis may append padding bytes so the interpreter can safely decode truncated immediates. Those bytes are not part of the user-provided bytecode, so `iter_opcodes()` should not expose them as real opcodes.


I hava tested by the following cmd:

- `cargo test -p revm-bytecode`
- `cargo test -p revm-bytecode --all-features`
- `cargo clippy -p revm-bytecode --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `cargo check -p revm-bytecode --no-default-features`