### PR TITLE
fix(inspector): forward EIP-7708 transfer logs

### DIFF
--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -12,7 +12,11 @@ use interpreter::{
     CallOutcome, CreateOutcome, FrameInput, Host, InitialAndFloorGas, InstructionResult,
     Interpreter, InterpreterAction, InterpreterTypes,
 };
-use primitives::{hints_util::cold_path, TxKind};
+use primitives::{
+    eip7708::{ETH_TRANSFER_LOG_ADDRESS, ETH_TRANSFER_LOG_TOPIC},
+    hints_util::cold_path,
+    Log, TxKind,
+};
 use state::bytecode::opcode;
 
 /// Trait that extends [`Handler`] with inspection functionality.
@@ -277,6 +281,7 @@ where
         }
 
         let opcode = interpreter.bytecode.opcode();
+        let logs_i = context.journal().logs().len();
         if let Err(e) = interpreter.step(instructions, gas_table, context) {
             cold_path();
             if interpreter.bytecode.action().is_none() {
@@ -286,6 +291,8 @@ where
 
         if (opcode::LOG0..=opcode::LOG4).contains(&opcode) {
             inspect_log(interpreter, context, &mut inspector);
+        } else {
+            inspect_eip7708_transfer_logs(context, &mut inspector, logs_i);
         }
 
         inspector.step_end(interpreter, context);
@@ -306,6 +313,34 @@ where
     }
 
     next_action
+}
+
+#[inline]
+pub(crate) fn inspect_eip7708_transfer_logs<CTX, IT>(
+    context: &mut CTX,
+    inspector: &mut impl Inspector<CTX, IT>,
+    logs_i: usize,
+) where
+    CTX: ContextTr<Journal: JournalExt>,
+    IT: InterpreterTypes,
+{
+    let logs = context.journal().logs();
+    if logs_i >= logs.len() {
+        return;
+    }
+
+    let logs = logs[logs_i..].to_vec();
+    for log in logs {
+        if is_eip7708_transfer_log(&log) {
+            inspector.log(context, log);
+        }
+    }
+}
+
+#[inline]
+fn is_eip7708_transfer_log(log: &Log) -> bool {
+    log.address == ETH_TRANSFER_LOG_ADDRESS
+        && log.data.topics().first() == Some(&ETH_TRANSFER_LOG_TOPIC)
 }
 
 #[inline(never)]

--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -382,26 +382,36 @@ fn inspect_selfdestruct<CTX, IT>(
     IT: InterpreterTypes,
 {
     let entry = context
-        .journal_mut()
+        .journal()
         .journal()
         .get(journal_i..)
         .and_then(|entries| entries.last());
 
-    if let Some(
+    let Some((contract, target, value)) = entry.and_then(|entry| match entry {
         JournalEntry::AccountDestroyed {
             address: contract,
-            target: to,
-            had_balance: balance,
+            target,
+            had_balance,
             ..
+        } => {
+            let value = if contract == target && had_balance.is_zero() {
+                context
+                    .journal()
+                    .evm_state()
+                    .get(contract)
+                    .map_or(*had_balance, |account| account.info.balance)
+            } else {
+                *had_balance
+            };
+            Some((*contract, *target, value))
         }
-        | JournalEntry::BalanceTransfer {
-            from: contract,
-            to,
-            balance,
-            ..
-        },
-    ) = entry
-    {
-        inspector.selfdestruct(*contract, *to, *balance);
-    }
+        JournalEntry::BalanceTransfer {
+            from, to, balance, ..
+        } => Some((*from, *to, *balance)),
+        _ => None,
+    }) else {
+        return;
+    };
+
+    inspector.selfdestruct(contract, target, value);
 }

--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -273,6 +273,7 @@ where
     CTX: ContextTr<Journal: JournalExt> + Host,
     IT: InterpreterTypes,
 {
+    let mut instruction_journal_i = None;
     loop {
         inspector.step(interpreter, context);
         if interpreter.bytecode.is_end() {
@@ -282,6 +283,7 @@ where
 
         let opcode = interpreter.bytecode.opcode();
         let logs_i = context.journal().logs().len();
+        instruction_journal_i = Some(context.journal().journal().len());
         if let Err(e) = interpreter.step(instructions, gas_table, context) {
             cold_path();
             if interpreter.bytecode.action().is_none() {
@@ -308,7 +310,9 @@ where
     // Handle selfdestruct.
     if let InterpreterAction::Return(result) = &next_action {
         if result.result == InstructionResult::SelfDestruct {
-            inspect_selfdestruct(context, &mut inspector);
+            if let Some(journal_i) = instruction_journal_i {
+                inspect_selfdestruct(context, &mut inspector, journal_i);
+            }
         }
     }
 
@@ -369,11 +373,20 @@ fn inspect_log<CTX, IT>(
 
 #[inline(never)]
 #[cold]
-fn inspect_selfdestruct<CTX, IT>(context: &mut CTX, inspector: &mut impl Inspector<CTX, IT>)
-where
+fn inspect_selfdestruct<CTX, IT>(
+    context: &mut CTX,
+    inspector: &mut impl Inspector<CTX, IT>,
+    journal_i: usize,
+) where
     CTX: ContextTr<Journal: JournalExt> + Host,
     IT: InterpreterTypes,
 {
+    let entry = context
+        .journal_mut()
+        .journal()
+        .get(journal_i..)
+        .and_then(|entries| entries.last());
+
     if let Some(
         JournalEntry::AccountDestroyed {
             address: contract,
@@ -387,7 +400,7 @@ where
             balance,
             ..
         },
-    ) = context.journal_mut().journal().last()
+    ) = entry
     {
         inspector.selfdestruct(*contract, *to, *balance);
     }

--- a/crates/inspector/src/inspector_tests.rs
+++ b/crates/inspector/src/inspector_tests.rs
@@ -565,6 +565,64 @@ mod tests {
     }
 
     #[test]
+    fn amsterdam_selfdestruct_to_self_reports_preserved_balance() {
+        let value = U256::from(304);
+        let code = Bytes::from(vec![
+            opcode::ADDRESS,
+            opcode::ADDRESS,
+            opcode::SELFDESTRUCT,
+            opcode::STOP,
+        ]);
+        let ctx = Context::mainnet()
+            .with_cfg(CfgEnv::new_with_spec(SpecId::AMSTERDAM))
+            .with_db(BenchmarkDB::new_bytecode(
+                Bytecode::new_legacy(Bytes::new()),
+            ));
+        let mut evm = ctx.build_mainnet_with_inspector(TestInspector::new());
+
+        let result = evm
+            .inspect_one_tx(
+                TxEnv::builder()
+                    .caller(BENCH_CALLER)
+                    .create()
+                    .data(code)
+                    .value(value)
+                    .gas_limit(100_000_000)
+                    .gas_price(0)
+                    .build()
+                    .unwrap(),
+            )
+            .unwrap();
+        assert!(result.is_success());
+
+        let events = evm.inspector.get_events();
+        let selfdestruct_events: Vec<_> = events
+            .iter()
+            .filter_map(|event| {
+                if let InspectorEvent::Selfdestruct {
+                    address,
+                    beneficiary,
+                    value,
+                } = event
+                {
+                    Some((address, beneficiary, value))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        assert_eq!(
+            selfdestruct_events.len(),
+            1,
+            "Should have recorded SELFDESTRUCT event"
+        );
+        let (contract, beneficiary, event_value) = selfdestruct_events[0];
+        assert_eq!(contract, beneficiary);
+        assert_eq!(*event_value, value);
+    }
+
+    #[test]
     fn test_comprehensive_inspector_integration() {
         // Complex contract with multiple operations:
         // 1. PUSH and arithmetic

--- a/crates/inspector/src/inspector_tests.rs
+++ b/crates/inspector/src/inspector_tests.rs
@@ -534,6 +534,37 @@ mod tests {
     }
 
     #[test]
+    fn cancun_selfdestruct_to_self_does_not_reuse_prior_journal_entry() {
+        let code = Bytes::from(vec![opcode::ADDRESS, opcode::SELFDESTRUCT]);
+        let ctx = Context::mainnet()
+            .with_cfg(CfgEnv::new_with_spec(SpecId::CANCUN))
+            .with_db(BenchmarkDB::new_bytecode(Bytecode::new_legacy(code)));
+        let mut evm = ctx.build_mainnet_with_inspector(TestInspector::new());
+
+        let result = evm
+            .inspect_one_tx(
+                TxEnv::builder()
+                    .caller(BENCH_CALLER)
+                    .kind(TxKind::Call(BENCH_TARGET))
+                    .value(U256::from(459))
+                    .gas_limit(100_000)
+                    .gas_price(0)
+                    .build()
+                    .unwrap(),
+            )
+            .unwrap();
+        assert!(result.is_success());
+
+        assert!(
+            !evm.inspector
+                .get_events()
+                .iter()
+                .any(|event| matches!(event, InspectorEvent::Selfdestruct { .. })),
+            "Cancun selfdestruct-to-self must not reuse the transaction value-transfer journal entry"
+        );
+    }
+
+    #[test]
     fn test_comprehensive_inspector_integration() {
         // Complex contract with multiple operations:
         // 1. PUSH and arithmetic

--- a/crates/inspector/src/inspector_tests.rs
+++ b/crates/inspector/src/inspector_tests.rs
@@ -3,10 +3,15 @@ mod tests {
     use crate::{
         InspectCommitEvm, InspectEvm, InspectSystemCallEvm, InspectorEvent, TestInspector,
     };
-    use context::{Context, TxEnv};
+    use context::{CfgEnv, Context, TxEnv};
     use database::{BenchmarkDB, BENCH_CALLER, BENCH_TARGET};
     use handler::{ExecuteEvm, MainBuilder, MainContext};
-    use primitives::{address, Address, Bytes, TxKind, U256};
+    use primitives::{
+        address,
+        eip7708::{ETH_TRANSFER_LOG_ADDRESS, ETH_TRANSFER_LOG_TOPIC},
+        hardfork::SpecId,
+        Address, Bytes, TxKind, B256, U256,
+    };
     use state::{bytecode::opcode, AccountInfo, Bytecode};
 
     #[test]
@@ -397,6 +402,84 @@ mod tests {
         assert_eq!(log_events.len(), 1, "Should have recorded one LOG event");
         let log = &log_events[0];
         assert_eq!(log.topics().len(), 0, "LOG0 should have 0 topics");
+    }
+
+    #[test]
+    fn test_eip7708_tx_value_transfer_log_is_inspected() {
+        let recipient = address!("4000000000000000000000000000000000000000");
+        let value = U256::from(1_000_000_000_000_000u128);
+
+        let ctx = Context::mainnet()
+            .with_cfg(CfgEnv::new_with_spec(SpecId::AMSTERDAM))
+            .with_db(BenchmarkDB::new_bytecode(Bytecode::new()));
+        let mut evm = ctx.build_mainnet_with_inspector(TestInspector::new());
+
+        let result = evm
+            .inspect_one_tx(
+                TxEnv::builder_for_bench()
+                    .to(recipient)
+                    .value(value)
+                    .gas_limit(300_000)
+                    .gas_price(0)
+                    .build_fill(),
+            )
+            .unwrap();
+        assert!(result.is_success());
+
+        let events = evm.inspector.get_events();
+        let transfer_log = events.iter().find_map(|event| {
+            let InspectorEvent::Log(log) = event else {
+                return None;
+            };
+            (log.address == ETH_TRANSFER_LOG_ADDRESS
+                && log.data.topics().len() == 3
+                && log.data.topics()[0] == ETH_TRANSFER_LOG_TOPIC
+                && log.data.topics()[1] == B256::left_padding_from(BENCH_CALLER.as_slice())
+                && log.data.topics()[2] == B256::left_padding_from(recipient.as_slice()))
+            .then_some(log)
+        });
+
+        assert!(
+            transfer_log.is_some(),
+            "expected inspector to receive EIP-7708 tx value transfer log"
+        );
+    }
+
+    #[test]
+    fn test_eip7708_selfdestruct_transfer_log_is_inspected() {
+        let code = Bytes::from(vec![opcode::CALLER, opcode::SELFDESTRUCT, opcode::STOP]);
+        let ctx = Context::mainnet()
+            .with_cfg(CfgEnv::new_with_spec(SpecId::AMSTERDAM))
+            .with_db(BenchmarkDB::new_bytecode(Bytecode::new_legacy(code)));
+        let mut evm = ctx.build_mainnet_with_inspector(TestInspector::new());
+
+        let result = evm
+            .inspect_one_tx(
+                TxEnv::builder_for_bench()
+                    .gas_limit(100_000)
+                    .gas_price(0)
+                    .build_fill(),
+            )
+            .unwrap();
+        assert!(result.is_success());
+
+        let events = evm.inspector.get_events();
+        let transfer_log = events.iter().find_map(|event| {
+            let InspectorEvent::Log(log) = event else {
+                return None;
+            };
+            (log.address == ETH_TRANSFER_LOG_ADDRESS
+                && log.data.topics().len() == 3
+                && log.data.topics()[0] == ETH_TRANSFER_LOG_TOPIC
+                && log.data.topics()[1] == B256::left_padding_from(BENCH_TARGET.as_slice())
+                && log.data.topics()[2] == B256::left_padding_from(BENCH_CALLER.as_slice()))
+            .then_some(log)
+        });
+
+        assert!(
+            transfer_log.is_some(),
+            "expected inspector to receive EIP-7708 selfdestruct transfer log"
+        );
     }
 
     #[test]

--- a/crates/inspector/src/traits.rs
+++ b/crates/inspector/src/traits.rs
@@ -10,7 +10,7 @@ use interpreter::{
 };
 
 use crate::{
-    handler::{frame_end, frame_start},
+    handler::{frame_end, frame_start, inspect_eip7708_transfer_logs},
     inspect_instructions, Inspector, JournalExt,
 };
 
@@ -122,7 +122,11 @@ pub trait InspectorEvmTr:
                     for log in logs.into_iter().chain(precompile_call_logs.iter().cloned()) {
                         inspector.log(ctx, log);
                     }
+                } else {
+                    inspect_eip7708_transfer_logs(ctx, inspector, logs_i);
                 }
+            } else {
+                inspect_eip7708_transfer_logs(ctx, inspector, logs_i);
             }
             frame_end(ctx, inspector, &frame_input, &mut output);
             return Ok(ItemOrResult::Result(output));
@@ -130,6 +134,7 @@ pub trait InspectorEvmTr:
 
         // if it is new frame, initialize the interpreter.
         let (ctx, inspector, frame) = self.ctx_inspector_frame();
+        inspect_eip7708_transfer_logs(ctx, inspector, logs_i);
         if let Some(frame) = frame.eth_frame() {
             let interp = &mut frame.interpreter;
             inspector.initialize_interp(interp, ctx);


### PR DESCRIPTION
## Summary

Forward journal-created EIP-7708 ETH transfer logs through `Inspector::log` for frame initialization and SELFDESTRUCT transfers.

Also fix SELFDESTRUCT inspector callbacks so they use the relevant journal entry and report the correct value:

- ignore stale earlier SELFDESTRUCT journal entries when an account selfdestructs to itself
- report the preserved account balance for Amsterdam SELFDESTRUCT-to-self instead of the journal bookkeeping value

This branch is retargeted onto `glam-devnet-7` / #3795.

## Sequencing

This PR currently carries the stale-SELFDESTRUCT journal fix that is also isolated in #3797, because the Amsterdam preserved-value fix depends on inspecting the correct SELFDESTRUCT journal entry. If #3797 lands first, this branch should be rebased and the duplicate stale-journal commit dropped, leaving only the EIP-7708 log forwarding and Amsterdam preserved-value fixes. If this combined PR lands first, #3797 can be closed as a subset.

## Impact

Receipts already contained the EIP-7708 transfer logs, but revm inspector consumers could miss them because the inspector handler only forwarded LOG opcode and precompile logs. Execution and state were already correct; tracer output was incomplete.

SELFDESTRUCT inspector consumers could also observe misleading callback data in selfdestruct-to-self cases: stale journal entries could be reused, and Amsterdam preserved-balance cases could report `0` even when the account retained value.

## Root Cause

The inspector handler needed to forward journal-created EIP-7708 ETH transfer logs after frame initialization and SELFDESTRUCT transfers.

For SELFDESTRUCT, the inspector path also needed to inspect the most recent relevant `AccountDestroyed` journal entry for the target account. Amsterdam/EIP-8246 selfdestruct-to-self preserves the account balance and records `had_balance = 0` for revert bookkeeping, so the callback value must come from the preserved account balance instead of that journal field.

## Testing

- `cargo +nightly test -p revm-inspector eip7708` on the #3795 base
- `cargo +nightly test -p revm-inspector selfdestruct_to_self` on the #3795 base
- `structured_compare_amsterdam/crash-97865b0ccb6eca1d7c1c70cbe3229bbdb91d8ce6` passes in evm2-fuzzers when pinned to this branch at `09772073`
