### PR TITLE
fix(inspector): ignore stale SELFDESTRUCT journal entries

### DIFF
--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -269,6 +269,7 @@ where
     CTX: ContextTr<Journal: JournalExt> + Host,
     IT: InterpreterTypes,
 {
+    let mut instruction_journal_i = None;
     loop {
         inspector.step(interpreter, context);
         if interpreter.bytecode.is_end() {
@@ -277,6 +278,7 @@ where
         }
 
         let opcode = interpreter.bytecode.opcode();
+        instruction_journal_i = Some(context.journal().journal().len());
         if let Err(e) = interpreter.step(instructions, gas_table, context) {
             cold_path();
             if interpreter.bytecode.action().is_none() {
@@ -301,7 +303,9 @@ where
     // Handle selfdestruct.
     if let InterpreterAction::Return(result) = &next_action {
         if result.result == InstructionResult::SelfDestruct {
-            inspect_selfdestruct(context, &mut inspector);
+            if let Some(journal_i) = instruction_journal_i {
+                inspect_selfdestruct(context, &mut inspector, journal_i);
+            }
         }
     }
 
@@ -334,11 +338,20 @@ fn inspect_log<CTX, IT>(
 
 #[inline(never)]
 #[cold]
-fn inspect_selfdestruct<CTX, IT>(context: &mut CTX, inspector: &mut impl Inspector<CTX, IT>)
-where
+fn inspect_selfdestruct<CTX, IT>(
+    context: &mut CTX,
+    inspector: &mut impl Inspector<CTX, IT>,
+    journal_i: usize,
+) where
     CTX: ContextTr<Journal: JournalExt> + Host,
     IT: InterpreterTypes,
 {
+    let entry = context
+        .journal_mut()
+        .journal()
+        .get(journal_i..)
+        .and_then(|entries| entries.last());
+
     if let Some(
         JournalEntry::AccountDestroyed {
             address: contract,
@@ -352,7 +365,7 @@ where
             balance,
             ..
         },
-    ) = context.journal_mut().journal().last()
+    ) = entry
     {
         inspector.selfdestruct(*contract, *to, *balance);
     }

--- a/crates/inspector/src/inspector_tests.rs
+++ b/crates/inspector/src/inspector_tests.rs
@@ -3,10 +3,10 @@ mod tests {
     use crate::{
         InspectCommitEvm, InspectEvm, InspectSystemCallEvm, InspectorEvent, TestInspector,
     };
-    use context::{Context, TxEnv};
+    use context::{CfgEnv, Context, TxEnv};
     use database::{BenchmarkDB, BENCH_CALLER, BENCH_TARGET};
     use handler::{ExecuteEvm, MainBuilder, MainContext};
-    use primitives::{address, Address, Bytes, TxKind, U256};
+    use primitives::{address, hardfork::SpecId, Address, Bytes, TxKind, U256};
     use state::{bytecode::opcode, AccountInfo, Bytecode};
 
     #[test]
@@ -448,6 +448,37 @@ mod tests {
         );
         let (_address, event_beneficiary, _value) = selfdestruct_events[0];
         assert_eq!(*event_beneficiary, beneficiary);
+    }
+
+    #[test]
+    fn cancun_selfdestruct_to_self_does_not_reuse_prior_journal_entry() {
+        let code = Bytes::from(vec![opcode::ADDRESS, opcode::SELFDESTRUCT]);
+        let ctx = Context::mainnet()
+            .with_cfg(CfgEnv::new_with_spec(SpecId::CANCUN))
+            .with_db(BenchmarkDB::new_bytecode(Bytecode::new_legacy(code)));
+        let mut evm = ctx.build_mainnet_with_inspector(TestInspector::new());
+
+        let result = evm
+            .inspect_one_tx(
+                TxEnv::builder()
+                    .caller(BENCH_CALLER)
+                    .kind(TxKind::Call(BENCH_TARGET))
+                    .value(U256::from(459))
+                    .gas_limit(100_000)
+                    .gas_price(0)
+                    .build()
+                    .unwrap(),
+            )
+            .unwrap();
+        assert!(result.is_success());
+
+        assert!(
+            !evm.inspector
+                .get_events()
+                .iter()
+                .any(|event| matches!(event, InspectorEvent::Selfdestruct { .. })),
+            "Cancun selfdestruct-to-self must not reuse the transaction value-transfer journal entry"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Record the journal index before SELFDESTRUCT and derive callback metadata only from entries produced by that instruction.

This branch is retargeted onto `glam-devnet-7` / #3795.

## Sequencing

This is the standalone version of the stale-SELFDESTRUCT journal fix. #3796 currently carries the same logical fix as a prerequisite for its Amsterdam preserved-value fix. If this PR lands first, #3796 should be rebased and its duplicate stale-journal commit dropped. If #3796 lands first as the combined inspector series, this PR can be closed as a subset.

## Impact

For an EIP-6780 no-op SELFDESTRUCT, no new destruction entry is appended. Reading `journal.last()` could therefore reuse an unrelated earlier balance transfer or destruction and report the wrong contract, beneficiary, and value to tracer consumers. Execution, state, and receipts are unaffected.

## Testing

- `cargo +nightly test -p revm-inspector selfdestruct_to_self` on the #3795 base
- Standalone fallback patch applies cleanly to #3795
- Before retargeting, all 17 saved artifacts across six buckets replayed cleanly with this fix
