### PR TITLE
fix(bytecode): preserve iterator position after truncated push

### DIFF
--- a/crates/bytecode/src/iter.rs
+++ b/crates/bytecode/src/iter.rs
@@ -59,12 +59,8 @@ impl<'a> BytecodeIterator<'a> {
 
         // Advance the iterator by the immediate size
         if immediate_size > 0 {
-            self.bytes = self
-                .bytes
-                .as_slice()
-                .get(immediate_size..)
-                .unwrap_or_default()
-                .iter();
+            let remaining = self.bytes.as_slice();
+            self.bytes = remaining[immediate_size.min(remaining.len())..].iter();
         }
     }
 
@@ -256,5 +252,15 @@ mod tests {
         let bytecode = Bytecode::new_legacy(Bytes::from_static(&[opcode::PUSH1]));
         let opcodes: Vec<u8> = bytecode.iter_opcodes().collect();
         assert_eq!(opcodes, vec![opcode::PUSH1]);
+    }
+
+    #[test]
+    fn test_position_after_truncated_push() {
+        let bytecode = Bytecode::new_legacy(Bytes::from_static(&[opcode::PUSH2, 0x01]));
+        let mut iter = bytecode.iter_opcodes();
+
+        assert_eq!(iter.next(), Some(opcode::PUSH2));
+        assert_eq!(iter.position(), 2);
+        assert_eq!(iter.next(), None);
     }
 }


### PR DESCRIPTION
## Summary

Make `BytecodeIterator::skip_immediate` consume at most the bytes that remain, keeping an exhausted iterator anchored to the original bytecode slice.

This is a follow-up to #3792.

## Problem

After #3792 switched `BytecodeIterator` to the original unpadded legacy bytecode, a truncated `PUSH` can make `get(immediate_size..)` return `None`.

The previous `unwrap_or_default()` fallback then creates an empty slice unrelated to the original bytecode allocation. A later call to `position()` uses `offset_from_unsigned` relative to the original start pointer, which requires both pointers to belong to the same allocation.

## Fix

Slice at `min(immediate_size, remaining.len())` instead. This preserves the existing iteration behavior—all available immediate bytes are consumed and iteration ends—while retaining the original slice provenance.

A regression test covers calling `position()` after a partially truncated `PUSH2`.

## Testing

- `cargo fmt --all --check`
- `cargo test -p revm-bytecode --all-features`
- `cargo clippy -p revm-bytecode --all-targets --all-features -- -D warnings`
- `cargo check -p revm-bytecode --no-default-features`