### PR TITLE
refactor(revme): separate bytecode from account in test state

### DIFF
--- a/bins/revme/src/cmd/blockchaintest.rs
+++ b/bins/revme/src/cmd/blockchaintest.rs
@@ -337,15 +337,18 @@ fn validate_post_state(
     }
 
     for (address, expected_account) in expected_post_state {
-        // Load account from final state
-        let actual_account = state
-            .load_cache_account(*address)
-            .map_err(|e| TestExecutionError::Database(format!("Account load failed: {e}")))?;
-        let info = actual_account
-            .account
-            .as_ref()
-            .map(|a| a.info.clone())
-            .unwrap_or_default();
+        // Load account from final state. Info and storage are cloned so the borrow
+        // of `state` ends here and it can be queried again below (e.g. for code).
+        let (info, actual_storage) = {
+            let actual_account = state
+                .load_cache_account(*address)
+                .map_err(|e| TestExecutionError::Database(format!("Account load failed: {e}")))?;
+            let account = actual_account.account.as_ref();
+            (
+                account.map(|a| a.info.clone()).unwrap_or_default(),
+                account.map(|a| a.storage.clone()).unwrap_or_default(),
+            )
+        };
 
         // Validate balance
         if info.balance != expected_account.balance {
@@ -376,9 +379,19 @@ fn validate_post_state(
             );
         }
 
-        // Validate code if present
+        // Validate code if present. The account may carry only the code hash when the
+        // code was never loaded during execution, so fall back to `code_by_hash`.
         if !expected_account.code.is_empty() {
-            if let Some(actual_code) = &info.code {
+            let actual_code = match info.code.clone() {
+                Some(code) => Some(code),
+                None if !info.is_empty_code_hash() => {
+                    Some(Database::code_by_hash(state, info.code_hash).map_err(|e| {
+                        TestExecutionError::Database(format!("Code load failed: {e}"))
+                    })?)
+                }
+                None => None,
+            };
+            if let Some(actual_code) = &actual_code {
                 if actual_code.original_bytes() != expected_account.code {
                     return make_failure(
                         state,
@@ -405,23 +418,21 @@ fn validate_post_state(
             }
         }
 
-        // Check for unexpected storage entries. Avoid allocating a temporary HashMap when the account is None.
-        if let Some(acc) = actual_account.account.as_ref() {
-            for (slot, actual_value) in &acc.storage {
-                let slot = *slot;
-                let actual_value = *actual_value;
-                if !expected_account.storage.contains_key(&slot) && !actual_value.is_zero() {
-                    return make_failure(
-                        state,
-                        debug_info,
-                        expected_post_state,
-                        print_env_on_error,
-                        *address,
-                        format!("storage_unexpected[{slot}]"),
-                        "0x0".to_string(),
-                        format!("{actual_value}"),
-                    );
-                }
+        // Check for unexpected storage entries.
+        for (slot, actual_value) in &actual_storage {
+            let slot = *slot;
+            let actual_value = *actual_value;
+            if !expected_account.storage.contains_key(&slot) && !actual_value.is_zero() {
+                return make_failure(
+                    state,
+                    debug_info,
+                    expected_post_state,
+                    print_env_on_error,
+                    *address,
+                    format!("storage_unexpected[{slot}]"),
+                    "0x0".to_string(),
+                    format!("{actual_value}"),
+                );
             }
         }
 
@@ -669,20 +680,38 @@ fn execute_blockchain_test(
     // Capture pre-state for debug info
     let mut pre_state_debug = AddressMap::default();
 
-    // Insert genesis state into database
+    // Insert genesis state into database. Bytecode is stored separately from the
+    // account (in the contracts map, keyed by code hash) so that execution has to
+    // fetch it through `Database::code_by_hash`, like a node's state provider would
+    // serve it.
     let genesis_state = test_case.pre.clone().into_genesis_state();
     for (address, account) in genesis_state {
+        let code_hash = revm::primitives::keccak256(&account.code);
+        let bytecode = (!account.code.is_empty()).then(|| Bytecode::new_raw(account.code.clone()));
         let account_info = AccountInfo {
             balance: account.balance,
             nonce: account.nonce,
-            code_hash: revm::primitives::keccak256(&account.code),
-            code: Some(Bytecode::new_raw(account.code.clone())),
+            code_hash,
+            code: None,
             account_id: None,
         };
 
-        // Store for debug info
+        if let Some(bytecode) = &bytecode {
+            state.cache.contracts.insert(code_hash, bytecode.clone());
+        }
+
+        // Store for debug info, with the code inlined so it shows up in the debug print.
         if print_env_on_error {
-            pre_state_debug.insert(address, (account_info.clone(), account.storage.clone()));
+            pre_state_debug.insert(
+                address,
+                (
+                    AccountInfo {
+                        code: bytecode,
+                        ..account_info.clone()
+                    },
+                    account.storage.clone(),
+                ),
+            );
         }
 
         state.insert_account_with_storage(address, account_info, account.storage);

--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -311,18 +311,23 @@ pub fn apply_auth_list<
         //   delegated_before_tx — its code at the start of the transaction was a
         //                          delegation (may differ from `delegated_now` when
         //                          an earlier authorization in this tx cleared it).
+        //                          Derived from the code hash because the original
+        //                          info carries no bytecode when the database serves
+        //                          code separately from the account; a non-empty
+        //                          hash is necessarily a delegation here, since code
+        //                          only changes within a transaction through earlier
+        //                          accepted authorizations, which keep it
+        //                          empty-or-delegation.
         //   clearing            — this authorization clears the delegation.
         let existed = !(authority_acc_info.is_empty()
             && authority_acc
                 .account()
                 .is_loaded_as_not_existing_not_touched());
         let delegated_now = !authority_acc_info.is_code_hash_empty_or_zero();
-        let delegated_before_tx = authority_acc
+        let delegated_before_tx = !authority_acc
             .account()
             .original_info()
-            .code
-            .as_ref()
-            .is_some_and(Bytecode::is_eip7702);
+            .is_code_hash_empty_or_zero();
         let clearing = authorization.address().is_zero();
 
         // Existing authority: the worst-case `ACCOUNT_WRITE` regular gas and the

--- a/crates/statetest-types/src/test_unit.rs
+++ b/crates/statetest-types/src/test_unit.rs
@@ -60,19 +60,26 @@ impl TestUnit {
     /// This function uses [`TestUnit::pre`] to prepare the pre-state from the test unit.
     /// It creates a new cache state and inserts the accounts from the test unit.
     ///
+    /// Bytecode is stored separately from the account (in the contracts map, keyed by
+    /// code hash) so that execution has to fetch it through `Database::code_by_hash`,
+    /// like a node's state provider would serve it.
+    ///
     /// # Returns
     ///
-    /// A [`CacheState`] object containing the pre-state accounts and storages.
+    /// A [`CacheState`] object containing the pre-state accounts, storages and contracts.
     pub fn state(&self) -> CacheState {
         let mut cache_state = CacheState::new();
         for (address, info) in &self.pre {
             let code_hash = keccak256(&info.code);
-            let bytecode = Bytecode::new_raw_checked(info.code.clone())
-                .unwrap_or(Bytecode::new_legacy(info.code.clone()));
+            if !info.code.is_empty() {
+                let bytecode = Bytecode::new_raw_checked(info.code.clone())
+                    .unwrap_or(Bytecode::new_legacy(info.code.clone()));
+                cache_state.contracts.insert(code_hash, bytecode);
+            }
             let acc_info = state::AccountInfo {
                 balance: info.balance,
                 code_hash,
-                code: Some(bytecode),
+                code: None,
                 nonce: info.nonce,
                 ..Default::default()
             };


### PR DESCRIPTION
## Motivation

A recent bug (delegate bytecode not loaded at first-frame creation, found as a glamsterdam-devnet-7 gas divergence) went unnoticed by the fixture suites because the revme test databases inline bytecode into `AccountInfo`, so `Database::basic` always returns code and paths that forget to fetch it through `code_by_hash` are masked. Real node providers (e.g. reth) serve code separately.

## Changes

- **statetest / blockchaintest pre-state**: accounts are seeded with `code: None` and the bytecode goes into the cache's contracts map keyed by code hash. Execution now has to fetch code through `Database::code_by_hash`, so the standard fixtures exercise every code-loading path.
- **blockchaintest post-state validation** falls back to `code_by_hash` when the final account carries only a code hash (untouched accounts no longer have code inline). The `--print-env-on-error` pre-state dump keeps code inlined for readable output.
- **fix(handler)**: the refactor immediately exposed a latent bug — the EIP-8037 auth-refund bookkeeping derived `delegated_before_tx` from `original_info().code`, which is `None` with a provider-style database, so clearing a pre-existing delegation under-counted the refund. It now derives the fact from the original code hash (sound because an accepted authorization's code is guaranteed empty-or-delegation).

## Testing

- devnet state tests: failure set byte-identical to main baseline (the pre-existing fixture divergences); without the handler fix the refactor surfaces 5 delegation-clearing failures, confirming the added coverage works.
- devnet blockchain tests: 71509 passed, 0 failed.
- legacy Cancun + Constantinople GeneralStateTests: all pass.
- `cargo nextest run --workspace`, clippy all-features and fmt are clean.