### PR TITLE
chore(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1623,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Fixes the `deny` CI failure seen on #3803 (and any other recent runs).

A new advisory [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) was published against `crossbeam-epoch` v0.9.18 (invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared`). It reaches the workspace only through the dev-dependency chain `codspeed-criterion-compat → rayon → rayon-core → crossbeam-deque → crossbeam-epoch`.

Fix per the advisory: `cargo update -p crossbeam-epoch` (0.9.18 → 0.9.20). `cargo deny check advisories` passes locally with this change.