### PR TITLE
test(bytecode): cover InvalidMagic and verify EIP-7702 magic constants

### DIFF
--- a/crates/bytecode/src/bytecode/mod.rs
+++ b/crates/bytecode/src/bytecode/mod.rs
@@ -472,6 +472,39 @@ mod tests {
     }
 
     #[test]
+    fn eip7702_invalid_magic() {
+        let raw1 = bytes!("ee0101deadbeef00000000000000000000000000000000");
+        assert_eq!(
+            Bytecode::new_eip7702_raw(raw1),
+            Err(Eip7702DecodeError::InvalidMagic)
+        );
+
+        let raw2 = bytes!("ef0001deadbeef00000000000000000000000000000000");
+        assert_eq!(
+            Bytecode::new_eip7702_raw(raw2),
+            Err(Eip7702DecodeError::InvalidMagic)
+        );
+    }
+
+    #[test]
+    fn new_raw_checked_dispatch() {
+        let raw = bytes!("ef0100deadbeef00000000000000000000000000000000");
+        let bytecode = Bytecode::new_raw_checked(raw).unwrap();
+        assert!(bytecode.is_eip7702());
+
+        assert_eq!(
+            Bytecode::new_raw_checked(bytes!("ef01")),
+            Err(BytecodeDecodeError::Eip7702(
+                Eip7702DecodeError::InvalidLength
+            ))
+        );
+
+        let bytecode = Bytecode::new_raw_checked(bytes!("ef00")).unwrap();
+        assert!(bytecode.is_legacy());
+        assert_eq!(bytecode.eip7702_address(), None);
+    }
+
+    #[test]
     fn is_default() {
         assert!(Bytecode::default().is_default());
     }

--- a/crates/bytecode/src/eip7702.rs
+++ b/crates/bytecode/src/eip7702.rs
@@ -49,3 +49,19 @@ impl fmt::Display for Eip7702DecodeError {
 }
 
 impl core::error::Error for Eip7702DecodeError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use primitives::keccak256;
+
+    #[test]
+    fn verify_magic_hash() {
+        assert_eq!(keccak256(EIP7702_MAGIC_BYTES), EIP7702_MAGIC_HASH);
+    }
+
+    #[test]
+    fn verify_magic_bytes() {
+        assert_eq!(EIP7702_MAGIC.to_be_bytes(), EIP7702_MAGIC_BYTES);
+    }
+}


### PR DESCRIPTION
The `InvalidMagic` variant of `Eip7702DecodeError` had no test coverage, and nothing verified that `EIP7702_MAGIC_HASH` matches `keccak256(EIP7702_MAGIC_BYTES)` or that the `u16` and byte-array forms of the magic agree.

- `eip7702_invalid_magic`: 23-byte inputs with the first (`ee01..`) or second (`ef00..`) magic byte wrong return `InvalidMagic`. Both existing decode tests only exercised `InvalidLength` and `UnsupportedVersion`.
- `verify_magic_hash` / `verify_magic_bytes` (new tests module in `eip7702.rs`): pin `EIP7702_MAGIC_HASH` to `keccak256(EIP7702_MAGIC_BYTES)` and `EIP7702_MAGIC` to its byte form, so the constants can't silently drift from their derivations.
- `new_raw_checked_dispatch`: `ef01`-prefixed bytes route to the EIP-7702 decoder (with errors converting through `From<Eip7702DecodeError>`), non-designator inputs fall through to legacy, and legacy bytecode returns `None` from `eip7702_address()`.

Test-only change; no behavior affected.
