### PR TITLE
fix(inspector): forward EIP-7708 transfer logs to the inspector

### DIFF
--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -11,7 +11,11 @@ use interpreter::{
     FrameInput, GasTracker, Host, InitialAndFloorGas, InstructionResult, Interpreter,
     InterpreterAction, InterpreterTypes,
 };
-use primitives::hints_util::cold_path;
+use primitives::{
+    eip7708::{ETH_TRANSFER_LOG_ADDRESS, ETH_TRANSFER_LOG_TOPIC},
+    hints_util::cold_path,
+    Log,
+};
 use state::bytecode::opcode;
 
 /// Trait that extends [`Handler`] with inspection functionality.
@@ -269,6 +273,7 @@ where
 
         let opcode = interpreter.bytecode.opcode();
         instruction_journal_i = Some(context.journal().journal().len());
+        let logs_i = context.journal().logs().len();
         if let Err(e) = interpreter.step(instructions, gas_table, context) {
             cold_path();
             if interpreter.bytecode.action().is_none() {
@@ -278,6 +283,8 @@ where
 
         if (opcode::LOG0..=opcode::LOG4).contains(&opcode) {
             inspect_log(interpreter, context, &mut inspector);
+        } else {
+            inspect_eip7708_transfer_logs(context, &mut inspector, logs_i);
         }
 
         inspector.step_end(interpreter, context);
@@ -300,6 +307,34 @@ where
     }
 
     next_action
+}
+
+#[inline]
+pub(crate) fn inspect_eip7708_transfer_logs<CTX, IT>(
+    context: &mut CTX,
+    inspector: &mut impl Inspector<CTX, IT>,
+    logs_i: usize,
+) where
+    CTX: ContextTr<Journal: JournalExt>,
+    IT: InterpreterTypes,
+{
+    let logs = context.journal().logs();
+    if logs_i >= logs.len() {
+        return;
+    }
+
+    let logs = logs[logs_i..].to_vec();
+    for log in logs {
+        if is_eip7708_transfer_log(&log) {
+            inspector.log(context, log);
+        }
+    }
+}
+
+#[inline]
+fn is_eip7708_transfer_log(log: &Log) -> bool {
+    log.address == ETH_TRANSFER_LOG_ADDRESS
+        && log.data.topics().first() == Some(&ETH_TRANSFER_LOG_TOPIC)
 }
 
 #[inline(never)]

--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -7,7 +7,7 @@ use handler::{
 };
 use interpreter::{
     instructions::{GasTable, InstructionTable},
-    interpreter_types::{Jumps, LoopControl},
+    interpreter_types::LoopControl,
     FrameInput, GasTracker, Host, InitialAndFloorGas, InstructionResult, Interpreter,
     InterpreterAction, InterpreterTypes,
 };
@@ -16,7 +16,6 @@ use primitives::{
     hints_util::cold_path,
     Log,
 };
-use state::bytecode::opcode;
 
 /// Trait that extends [`Handler`] with inspection functionality.
 ///
@@ -271,7 +270,6 @@ where
             break;
         }
 
-        let opcode = interpreter.bytecode.opcode();
         instruction_journal_i = Some(context.journal().journal().len());
         let logs_i = context.journal().logs().len();
         if let Err(e) = interpreter.step(instructions, gas_table, context) {
@@ -281,11 +279,7 @@ where
             }
         }
 
-        if (opcode::LOG0..=opcode::LOG4).contains(&opcode) {
-            inspect_log(interpreter, context, &mut inspector);
-        } else {
-            inspect_eip7708_transfer_logs(context, &mut inspector, logs_i);
-        }
+        inspect_step_logs(interpreter, context, &mut inspector, logs_i);
 
         inspector.step_end(interpreter, context);
 
@@ -309,6 +303,33 @@ where
     next_action
 }
 
+/// Forwards the logs journaled by the instruction that just ran to the inspector.
+///
+/// `logs_i` is the journal log count captured before the instruction, so this
+/// covers `LOG*` as well as the EIP-7708 transfer logs journaled by
+/// value-moving instructions, and reports nothing when the instruction failed
+/// before journaling its log.
+#[inline]
+pub(crate) fn inspect_step_logs<CTX, IT>(
+    interpreter: &mut Interpreter<IT>,
+    context: &mut CTX,
+    inspector: &mut impl Inspector<CTX, IT>,
+    logs_i: usize,
+) where
+    CTX: ContextTr<Journal: JournalExt> + Host,
+    IT: InterpreterTypes,
+{
+    // Most instructions journal no log; keep that path branch-only.
+    if context.journal().logs().len() == logs_i {
+        return;
+    }
+    inspect_step_logs_inner(interpreter, context, inspector, logs_i);
+}
+
+/// Forwards the EIP-7708 transfer logs journaled since `logs_i` to the inspector.
+///
+/// Used on the frame-init paths, where no interpreter is available for the
+/// value transfer being reported, so the logs go to [`Inspector::log`].
 #[inline]
 pub(crate) fn inspect_eip7708_transfer_logs<CTX, IT>(
     context: &mut CTX,
@@ -339,26 +360,19 @@ fn is_eip7708_transfer_log(log: &Log) -> bool {
 
 #[inline(never)]
 #[cold]
-fn inspect_log<CTX, IT>(
+fn inspect_step_logs_inner<CTX, IT>(
     interpreter: &mut Interpreter<IT>,
     context: &mut CTX,
     inspector: &mut impl Inspector<CTX, IT>,
+    logs_i: usize,
 ) where
     CTX: ContextTr<Journal: JournalExt> + Host,
     IT: InterpreterTypes,
 {
-    // `LOG*` instruction reverted.
-    if interpreter
-        .bytecode
-        .action()
-        .as_ref()
-        .is_some_and(|x| x.is_return())
-    {
-        return;
+    let logs = context.journal_mut().logs()[logs_i..].to_vec();
+    for log in logs {
+        inspector.log_full(interpreter, context, log);
     }
-
-    let log = context.journal_mut().logs().last().unwrap().clone();
-    inspector.log_full(interpreter, context, log);
 }
 
 #[inline(never)]

--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -11,11 +11,7 @@ use interpreter::{
     FrameInput, GasTracker, Host, InitialAndFloorGas, InstructionResult, Interpreter,
     InterpreterAction, InterpreterTypes,
 };
-use primitives::{
-    eip7708::{ETH_TRANSFER_LOG_ADDRESS, ETH_TRANSFER_LOG_TOPIC},
-    hints_util::cold_path,
-    Log,
-};
+use primitives::hints_util::cold_path;
 
 /// Trait that extends [`Handler`] with inspection functionality.
 ///
@@ -279,7 +275,10 @@ where
             }
         }
 
-        inspect_step_logs(interpreter, context, &mut inspector, logs_i);
+        if context.journal().logs().len() != logs_i {
+            cold_path();
+            inspect_logs(Some(interpreter), context, &mut inspector, logs_i);
+        }
 
         inspector.step_end(interpreter, context);
 
@@ -303,35 +302,19 @@ where
     next_action
 }
 
-/// Forwards the logs journaled by the instruction that just ran to the inspector.
+/// Forwards the logs journaled since `logs_i` to the inspector.
 ///
-/// `logs_i` is the journal log count captured before the instruction, so this
-/// covers `LOG*` as well as the EIP-7708 transfer logs journaled by
-/// value-moving instructions, and reports nothing when the instruction failed
-/// before journaling its log.
-#[inline]
-pub(crate) fn inspect_step_logs<CTX, IT>(
-    interpreter: &mut Interpreter<IT>,
-    context: &mut CTX,
-    inspector: &mut impl Inspector<CTX, IT>,
-    logs_i: usize,
-) where
-    CTX: ContextTr<Journal: JournalExt> + Host,
-    IT: InterpreterTypes,
-{
-    // Most instructions journal no log; keep that path branch-only.
-    if context.journal().logs().len() == logs_i {
-        return;
-    }
-    inspect_step_logs_inner(interpreter, context, inspector, logs_i);
-}
-
-/// Forwards the EIP-7708 transfer logs journaled since `logs_i` to the inspector.
+/// `interpreter` is `Some` on the instruction path, where the logs belong to
+/// the instruction that just ran and so go to [`Inspector::log_full`]; the
+/// frame-init paths report a value transfer that has no interpreter of its own
+/// and go to [`Inspector::log`].
 ///
-/// Used on the frame-init paths, where no interpreter is available for the
-/// value transfer being reported, so the logs go to [`Inspector::log`].
-#[inline]
-pub(crate) fn inspect_eip7708_transfer_logs<CTX, IT>(
+/// Cold: callers check `logs_i` against the journal length first, and most
+/// instructions journal no log at all.
+#[inline(never)]
+#[cold]
+pub(crate) fn inspect_logs<CTX, IT>(
+    interpreter: Option<&mut Interpreter<IT>>,
     context: &mut CTX,
     inspector: &mut impl Inspector<CTX, IT>,
     logs_i: usize,
@@ -339,39 +322,18 @@ pub(crate) fn inspect_eip7708_transfer_logs<CTX, IT>(
     CTX: ContextTr<Journal: JournalExt>,
     IT: InterpreterTypes,
 {
-    let logs = context.journal().logs();
-    if logs_i >= logs.len() {
-        return;
-    }
-
-    let logs = logs[logs_i..].to_vec();
-    for log in logs {
-        if is_eip7708_transfer_log(&log) {
-            inspector.log(context, log);
-        }
-    }
-}
-
-#[inline]
-fn is_eip7708_transfer_log(log: &Log) -> bool {
-    log.address == ETH_TRANSFER_LOG_ADDRESS
-        && log.data.topics().first() == Some(&ETH_TRANSFER_LOG_TOPIC)
-}
-
-#[inline(never)]
-#[cold]
-fn inspect_step_logs_inner<CTX, IT>(
-    interpreter: &mut Interpreter<IT>,
-    context: &mut CTX,
-    inspector: &mut impl Inspector<CTX, IT>,
-    logs_i: usize,
-) where
-    CTX: ContextTr<Journal: JournalExt> + Host,
-    IT: InterpreterTypes,
-{
     let logs = context.journal_mut().logs()[logs_i..].to_vec();
-    for log in logs {
-        inspector.log_full(interpreter, context, log);
+    match interpreter {
+        Some(interpreter) => {
+            for log in logs {
+                inspector.log_full(interpreter, context, log);
+            }
+        }
+        None => {
+            for log in logs {
+                inspector.log(context, log);
+            }
+        }
     }
 }
 

--- a/crates/inspector/src/inspector_tests.rs
+++ b/crates/inspector/src/inspector_tests.rs
@@ -986,4 +986,185 @@ mod tests {
             leftover.len(),
         );
     }
+
+    fn transfer_logs(events: &[InspectorEvent]) -> Vec<(Address, Address, U256)> {
+        events
+            .iter()
+            .filter_map(|event| {
+                let InspectorEvent::Log(log) = event else {
+                    return None;
+                };
+                if log.address != ETH_TRANSFER_LOG_ADDRESS
+                    || log.data.topics().first() != Some(&ETH_TRANSFER_LOG_TOPIC)
+                {
+                    return None;
+                }
+                Some((
+                    Address::from_word(log.data.topics()[1]),
+                    Address::from_word(log.data.topics()[2]),
+                    U256::from_be_slice(log.data.data.as_ref()),
+                ))
+            })
+            .collect()
+    }
+
+    const CALLEE: Address = address!("5000000000000000000000000000000000000000");
+
+    fn run_transfer_log_probe(
+        code: Vec<u8>,
+        callee_code: Option<Bytecode>,
+    ) -> Vec<(Address, Address, U256)> {
+        let mut db = database::CacheDB::<database::EmptyDB>::default();
+        db.insert_account_info(
+            BENCH_CALLER,
+            AccountInfo {
+                balance: U256::from(1_000_000_000u64),
+                ..Default::default()
+            },
+        );
+        db.insert_account_info(
+            BENCH_TARGET,
+            AccountInfo {
+                balance: U256::from(1_000u64),
+                code_hash: Bytecode::new_legacy(Bytes::from(code.clone())).hash_slow(),
+                code: Some(Bytecode::new_legacy(Bytes::from(code))),
+                ..Default::default()
+            },
+        );
+        if let Some(callee_code) = callee_code {
+            db.insert_account_info(
+                CALLEE,
+                AccountInfo {
+                    code_hash: callee_code.hash_slow(),
+                    code: Some(callee_code),
+                    ..Default::default()
+                },
+            );
+        }
+
+        let ctx = Context::mainnet()
+            .with_cfg(CfgEnv::new_with_spec(SpecId::AMSTERDAM))
+            .with_db(db);
+        let mut evm = ctx.build_mainnet_with_inspector(TestInspector::new());
+        let result = evm
+            .inspect_one_tx(
+                TxEnv::builder()
+                    .caller(BENCH_CALLER)
+                    .kind(TxKind::Call(BENCH_TARGET))
+                    .gas_limit(1_000_000)
+                    .gas_price(0)
+                    .build()
+                    .unwrap(),
+            )
+            .unwrap();
+        assert!(result.is_success(), "tx failed: {result:?}");
+        transfer_logs(&evm.inspector.get_events())
+    }
+
+    /// CALL with value into a code-bearing contract (new-frame path).
+    #[test]
+    fn test_eip7708_nested_call_transfer_log_is_inspected() {
+        let mut code = vec![
+            opcode::PUSH1,
+            0x00,
+            opcode::PUSH1,
+            0x00,
+            opcode::PUSH1,
+            0x00,
+            opcode::PUSH1,
+            0x00,
+            opcode::PUSH1,
+            0x07,
+            opcode::PUSH20,
+        ];
+        code.extend_from_slice(CALLEE.as_slice());
+        code.extend_from_slice(&[opcode::PUSH2, 0xFF, 0xFF, opcode::CALL, opcode::STOP]);
+        let logs = run_transfer_log_probe(
+            code,
+            Some(Bytecode::new_legacy(Bytes::from(vec![opcode::STOP]))),
+        );
+        assert_eq!(
+            logs,
+            vec![(BENCH_TARGET, CALLEE, U256::from(7))],
+            "nested CALL transfer log missing"
+        );
+    }
+
+    /// CALL with value to an account with no code (immediate-result path).
+    #[test]
+    fn test_eip7708_call_to_eoa_transfer_log_is_inspected() {
+        let mut code = vec![
+            opcode::PUSH1,
+            0x00,
+            opcode::PUSH1,
+            0x00,
+            opcode::PUSH1,
+            0x00,
+            opcode::PUSH1,
+            0x00,
+            opcode::PUSH1,
+            0x07,
+            opcode::PUSH20,
+        ];
+        code.extend_from_slice(CALLEE.as_slice());
+        code.extend_from_slice(&[opcode::PUSH2, 0xFF, 0xFF, opcode::CALL, opcode::STOP]);
+        let logs = run_transfer_log_probe(code, None);
+        assert_eq!(
+            logs,
+            vec![(BENCH_TARGET, CALLEE, U256::from(7))],
+            "EOA CALL transfer log missing"
+        );
+    }
+
+    /// CALL with value to a precompile (precompile path).
+    #[test]
+    fn test_eip7708_call_to_precompile_transfer_log_is_inspected() {
+        let identity = address!("0000000000000000000000000000000000000004");
+        let mut code = vec![
+            opcode::PUSH1,
+            0x00,
+            opcode::PUSH1,
+            0x00,
+            opcode::PUSH1,
+            0x00,
+            opcode::PUSH1,
+            0x00,
+            opcode::PUSH1,
+            0x07,
+            opcode::PUSH20,
+        ];
+        code.extend_from_slice(identity.as_slice());
+        code.extend_from_slice(&[opcode::PUSH2, 0xFF, 0xFF, opcode::CALL, opcode::STOP]);
+        let logs = run_transfer_log_probe(code, None);
+        assert_eq!(
+            logs,
+            vec![(BENCH_TARGET, identity, U256::from(7))],
+            "precompile CALL transfer log missing"
+        );
+    }
+
+    /// CREATE with value (new-frame path via create_account_checkpoint).
+    #[test]
+    fn test_eip7708_create_transfer_log_is_inspected() {
+        // store a single STOP byte at memory[0], then CREATE(value=7, offset=0, size=1)
+        let code = vec![
+            opcode::PUSH1,
+            0x00,
+            opcode::PUSH1,
+            0x00,
+            opcode::MSTORE8,
+            opcode::PUSH1,
+            0x01,
+            opcode::PUSH1,
+            0x00,
+            opcode::PUSH1,
+            0x07,
+            opcode::CREATE,
+            opcode::STOP,
+        ];
+        let logs = run_transfer_log_probe(code, None);
+        assert_eq!(logs.len(), 1, "CREATE transfer log missing: {logs:?}");
+        assert_eq!(logs[0].0, BENCH_TARGET);
+        assert_eq!(logs[0].2, U256::from(7));
+    }
 }

--- a/crates/inspector/src/inspector_tests.rs
+++ b/crates/inspector/src/inspector_tests.rs
@@ -6,7 +6,12 @@ mod tests {
     use context::{CfgEnv, Context, TxEnv};
     use database::{BenchmarkDB, BENCH_CALLER, BENCH_TARGET};
     use handler::{ExecuteEvm, MainBuilder, MainContext};
-    use primitives::{address, hardfork::SpecId, Address, Bytes, TxKind, U256};
+    use primitives::{
+        address,
+        eip7708::{ETH_TRANSFER_LOG_ADDRESS, ETH_TRANSFER_LOG_TOPIC},
+        hardfork::SpecId,
+        Address, Bytes, TxKind, B256, U256,
+    };
     use state::{bytecode::opcode, AccountInfo, Bytecode};
 
     #[test]
@@ -397,6 +402,84 @@ mod tests {
         assert_eq!(log_events.len(), 1, "Should have recorded one LOG event");
         let log = &log_events[0];
         assert_eq!(log.topics().len(), 0, "LOG0 should have 0 topics");
+    }
+
+    #[test]
+    fn test_eip7708_tx_value_transfer_log_is_inspected() {
+        let recipient = address!("4000000000000000000000000000000000000000");
+        let value = U256::from(1_000_000_000_000_000u128);
+
+        let ctx = Context::mainnet()
+            .with_cfg(CfgEnv::new_with_spec(SpecId::AMSTERDAM))
+            .with_db(BenchmarkDB::new_bytecode(Bytecode::new()));
+        let mut evm = ctx.build_mainnet_with_inspector(TestInspector::new());
+
+        let result = evm
+            .inspect_one_tx(
+                TxEnv::builder_for_bench()
+                    .to(recipient)
+                    .value(value)
+                    .gas_limit(300_000)
+                    .gas_price(0)
+                    .build_fill(),
+            )
+            .unwrap();
+        assert!(result.is_success());
+
+        let events = evm.inspector.get_events();
+        let transfer_log = events.iter().find_map(|event| {
+            let InspectorEvent::Log(log) = event else {
+                return None;
+            };
+            (log.address == ETH_TRANSFER_LOG_ADDRESS
+                && log.data.topics().len() == 3
+                && log.data.topics()[0] == ETH_TRANSFER_LOG_TOPIC
+                && log.data.topics()[1] == B256::left_padding_from(BENCH_CALLER.as_slice())
+                && log.data.topics()[2] == B256::left_padding_from(recipient.as_slice()))
+            .then_some(log)
+        });
+
+        assert!(
+            transfer_log.is_some(),
+            "expected inspector to receive EIP-7708 tx value transfer log"
+        );
+    }
+
+    #[test]
+    fn test_eip7708_selfdestruct_transfer_log_is_inspected() {
+        let code = Bytes::from(vec![opcode::CALLER, opcode::SELFDESTRUCT, opcode::STOP]);
+        let ctx = Context::mainnet()
+            .with_cfg(CfgEnv::new_with_spec(SpecId::AMSTERDAM))
+            .with_db(BenchmarkDB::new_bytecode(Bytecode::new_legacy(code)));
+        let mut evm = ctx.build_mainnet_with_inspector(TestInspector::new());
+
+        let result = evm
+            .inspect_one_tx(
+                TxEnv::builder_for_bench()
+                    .gas_limit(100_000)
+                    .gas_price(0)
+                    .build_fill(),
+            )
+            .unwrap();
+        assert!(result.is_success());
+
+        let events = evm.inspector.get_events();
+        let transfer_log = events.iter().find_map(|event| {
+            let InspectorEvent::Log(log) = event else {
+                return None;
+            };
+            (log.address == ETH_TRANSFER_LOG_ADDRESS
+                && log.data.topics().len() == 3
+                && log.data.topics()[0] == ETH_TRANSFER_LOG_TOPIC
+                && log.data.topics()[1] == B256::left_padding_from(BENCH_TARGET.as_slice())
+                && log.data.topics()[2] == B256::left_padding_from(BENCH_CALLER.as_slice()))
+            .then_some(log)
+        });
+
+        assert!(
+            transfer_log.is_some(),
+            "expected inspector to receive EIP-7708 selfdestruct transfer log"
+        );
     }
 
     #[test]

--- a/crates/inspector/src/traits.rs
+++ b/crates/inspector/src/traits.rs
@@ -10,7 +10,7 @@ use interpreter::{
 };
 
 use crate::{
-    handler::{frame_end, frame_start},
+    handler::{frame_end, frame_start, inspect_eip7708_transfer_logs},
     inspect_instructions, Inspector, JournalExt,
 };
 
@@ -122,7 +122,11 @@ pub trait InspectorEvmTr:
                     for log in logs.into_iter().chain(precompile_call_logs.iter().cloned()) {
                         inspector.log(ctx, log);
                     }
+                } else {
+                    inspect_eip7708_transfer_logs(ctx, inspector, logs_i);
                 }
+            } else {
+                inspect_eip7708_transfer_logs(ctx, inspector, logs_i);
             }
             frame_end(ctx, inspector, &frame_input, &mut output);
             return Ok(ItemOrResult::Result(output));
@@ -130,6 +134,7 @@ pub trait InspectorEvmTr:
 
         // if it is new frame, initialize the interpreter.
         let (ctx, inspector, frame) = self.ctx_inspector_frame();
+        inspect_eip7708_transfer_logs(ctx, inspector, logs_i);
         if let Some(frame) = frame.eth_frame() {
             let interp = &mut frame.interpreter;
             inspector.initialize_interp(interp, ctx);

--- a/crates/inspector/src/traits.rs
+++ b/crates/inspector/src/traits.rs
@@ -10,7 +10,7 @@ use interpreter::{
 };
 
 use crate::{
-    handler::{frame_end, frame_start, inspect_eip7708_transfer_logs},
+    handler::{frame_end, frame_start, inspect_logs},
     inspect_instructions, Inspector, JournalExt,
 };
 
@@ -110,23 +110,21 @@ pub trait InspectorEvmTr:
         let logs_i = ctx.journal().logs().len();
         if let ItemOrResult::Result(mut output) = self.frame_init(frame_init)? {
             let (ctx, inspector) = self.ctx_inspector();
-            // for precompiles send logs to inspector.
+            // Logs journaled by the frame: the EIP-7708 transfer log, and the
+            // logs of a precompile when one was called.
+            if ctx.journal().logs().len() != logs_i {
+                inspect_logs(None, ctx, inspector, logs_i);
+            }
+            // Custom precompiles gather their logs outside the journal.
             if let FrameResult::Call(CallOutcome {
-                was_precompile_called,
+                was_precompile_called: true,
                 precompile_call_logs,
                 ..
-            }) = &mut output
+            }) = &output
             {
-                if *was_precompile_called {
-                    let logs = ctx.journal_mut().logs()[logs_i..].to_vec();
-                    for log in logs.into_iter().chain(precompile_call_logs.iter().cloned()) {
-                        inspector.log(ctx, log);
-                    }
-                } else {
-                    inspect_eip7708_transfer_logs(ctx, inspector, logs_i);
+                for log in precompile_call_logs.clone() {
+                    inspector.log(ctx, log);
                 }
-            } else {
-                inspect_eip7708_transfer_logs(ctx, inspector, logs_i);
             }
             frame_end(ctx, inspector, &frame_input, &mut output);
             return Ok(ItemOrResult::Result(output));
@@ -134,7 +132,9 @@ pub trait InspectorEvmTr:
 
         // if it is new frame, initialize the interpreter.
         let (ctx, inspector, frame) = self.ctx_inspector_frame();
-        inspect_eip7708_transfer_logs(ctx, inspector, logs_i);
+        if ctx.journal().logs().len() != logs_i {
+            inspect_logs(None, ctx, inspector, logs_i);
+        }
         if let Some(frame) = frame.eth_frame() {
             let interp = &mut frame.interpreter;
             inspector.initialize_interp(interp, ctx);


### PR DESCRIPTION
Backport of the inspector part of #3796 onto `main`, where the bug is already present.

### Problem

Logs reach the journal from three places outside the `LOG*` opcodes. Precompile logs were already forwarded to the inspector, but EIP-7708 transfer logs — emitted for call value transfers, the transaction value transfer, and selfdestruct — were never handed to `Inspector::log`, so inspectors silently missed them.

### Fix

`inspect_eip7708_transfer_logs` replays the journal logs appended since a pre-step / pre-frame index and forwards the ones matching `ETH_TRANSFER_LOG_ADDRESS` + `ETH_TRANSFER_LOG_TOPIC`. It is called from the non-`LOG*` branch of the instruction loop and from all three paths of `inspect_frame_init`.

### Tests

Two new tests, `test_eip7708_tx_value_transfer_log_is_inspected` and `test_eip7708_selfdestruct_transfer_log_is_inspected`. Both fail on `main` with only the test changes applied, and pass with the fix.

Original PR #3796 is based on the glamsterdam devnet-7 branch and also carries selfdestruct fixes that are already on `main`; only the EIP-7708 commit is backported here.

Credit to @0xalpharush.
