### PR TITLE
fix: validate SharedMemory ranges in release builds

### DIFF
--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -283,11 +283,17 @@ impl SharedMemory {
     }
 
     /// Resizes the memory in-place so that `len` is equal to `new_len`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the checkpoint plus the new size overflows.
     #[inline]
     pub fn resize(&mut self, new_size: usize) {
-        self.buffer()
-            .dbg_borrow_mut()
-            .resize(self.my_checkpoint + new_size, 0);
+        let new_len = self
+            .my_checkpoint
+            .checked_add(new_size)
+            .expect("memory resize overflow");
+        self.buffer().dbg_borrow_mut().resize(new_len, 0);
     }
 
     /// Returns a byte slice of the memory region at the given offset.
@@ -338,22 +344,20 @@ impl SharedMemory {
     ///
     /// # Panics
     ///
-    /// Panics on out of bounds access in debug builds only.
-    ///
-    /// # Safety
-    ///
-    /// In release builds, calling this method with out-of-bounds parameters triggers undefined
-    /// behavior. Callers must ensure that `offset + size` does not exceed the length of the
-    /// memory.
+    /// Panics on out of bounds access.
     #[inline]
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn slice_mut(&mut self, offset: usize, size: usize) -> RefMut<'_, [u8]> {
+        let start = self
+            .my_checkpoint
+            .checked_add(offset)
+            .expect("memory write offset overflow");
+        let end = start
+            .checked_add(size)
+            .expect("memory write length overflow");
         let buffer = self.buffer_ref_mut();
         RefMut::map(buffer, |b| {
-            match b.get_mut(self.my_checkpoint + offset..self.my_checkpoint + offset + size) {
-                Some(slice) => slice,
-                None => debug_unreachable!("slice OOB: {offset}..{}", offset + size),
-            }
+            b.get_mut(start..end).expect("memory write out of bounds")
         })
     }
 
@@ -443,7 +447,7 @@ impl SharedMemory {
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn set_data(&mut self, memory_offset: usize, data_offset: usize, len: usize, data: &[u8]) {
         let mut dst = self.context_memory_mut();
-        unsafe { set_data(dst.as_mut(), data, memory_offset, data_offset, len) };
+        set_data(dst.as_mut(), data, memory_offset, data_offset, len);
     }
 
     /// Set data from global memory to local memory. If global range is smaller than len, zeroes the rest.
@@ -463,7 +467,7 @@ impl SharedMemory {
         } else {
             src.get_mut(data_range).unwrap()
         };
-        unsafe { set_data(dst, src, memory_offset, data_offset, len) };
+        set_data(dst, src, memory_offset, data_offset, len);
     }
 
     /// Copies elements from one part of the memory to another part of itself.
@@ -520,37 +524,32 @@ impl SharedMemory {
 ///
 /// If src does not have enough data, it nullifies the rest of dst that is not copied.
 ///
-/// # Safety
-///
-/// Assumes that dst has enough space to copy the data.
-/// Assumes that src has enough data to copy.
-/// Assumes that dst_offset and src_offset are in bounds.
-/// Assumes that dst and src are valid.
-/// Assumes that dst and src do not overlap.
-unsafe fn set_data(dst: &mut [u8], src: &[u8], dst_offset: usize, src_offset: usize, len: usize) {
+fn set_data(dst: &mut [u8], src: &[u8], dst_offset: usize, src_offset: usize, len: usize) {
     if len == 0 {
         return;
     }
+    let dst_end = dst_offset
+        .checked_add(len)
+        .filter(|&end| end <= dst.len())
+        .expect("memory write out of bounds");
     if src_offset >= src.len() {
         // Nullify all memory slots
-        dst.get_mut(dst_offset..dst_offset + len).unwrap().fill(0);
+        dst[dst_offset..dst_end].fill(0);
         return;
     }
-    let src_end = min(src_offset + len, src.len());
+    let src_end = src_offset + min(len, src.len() - src_offset);
     let src_len = src_end - src_offset;
-    debug_assert!(src_offset < src.len() && src_end <= src.len());
+    debug_assert!(src_end <= src.len());
     let data = unsafe { src.get_unchecked(src_offset..src_end) };
+    // SAFETY: `dst_end` was checked against `dst.len()` above, and `src_len <= len`.
     unsafe {
         dst.get_unchecked_mut(dst_offset..dst_offset + src_len)
             .copy_from_slice(data)
     };
 
     // Nullify rest of memory slots
-    // SAFETY: Memory is assumed to be valid, and it is commented where this assumption is made.
-    unsafe {
-        dst.get_unchecked_mut(dst_offset + src_len..dst_offset + len)
-            .fill(0)
-    };
+    // SAFETY: `dst_end` was checked against `dst.len()` above.
+    unsafe { dst.get_unchecked_mut(dst_offset + src_len..dst_end).fill(0) };
 }
 
 /// Returns number of words what would fit to provided number of bytes,
@@ -688,6 +687,30 @@ mod tests {
         assert_eq!(sm1.buffer_ref().len(), 32);
         assert_eq!(sm1.len(), 32);
         assert_eq!(sm1.buffer_ref().get(0..32), Some(&[0_u8; 32] as &[u8]));
+    }
+
+    #[test]
+    #[should_panic(expected = "memory resize overflow")]
+    fn resize_overflow_panics() {
+        let mut parent = SharedMemory::new();
+        parent.resize(1);
+        parent.new_child_context().resize(usize::MAX);
+    }
+
+    #[test]
+    #[should_panic(expected = "memory write out of bounds")]
+    fn set_out_of_bounds_panics() {
+        let mut memory = SharedMemory::new();
+        memory.resize(1);
+        memory.set(1, &[0xFF]);
+    }
+
+    #[test]
+    #[should_panic(expected = "memory write out of bounds")]
+    fn set_data_out_of_bounds_panics() {
+        let mut memory = SharedMemory::new();
+        memory.resize(1);
+        memory.set_data(1, 0, 1, &[0xFF]);
     }
 
     #[cfg(feature = "memory_limit")]

--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -449,8 +449,8 @@ impl SharedMemory {
         }
     }
 
-    /// Set memory from data. Our memory offset+len is expected to be correct but we
-    /// are doing bound checks on data/data_offeset/len and zeroing parts that is not copied.
+    /// Set memory from data. The destination range is validated, and source bytes outside
+    /// `data` are written as zeroes.
     ///
     /// # Panics
     ///
@@ -813,9 +813,23 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "memory write length overflow")]
-    fn set_offset_overflow_panics() {
+    fn set_length_overflow_panics() {
         let mut memory = SharedMemory::new();
         memory.set(usize::MAX, &[0xFF; 8]);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn child_set_offset_overflow_is_atomic() {
+        let mut parent = SharedMemory::new();
+        parent.resize(1);
+        parent.set_byte(0, 0xA5);
+        let mut child = parent.new_child_context();
+
+        let result = catch_unwind(AssertUnwindSafe(|| child.set(usize::MAX, &[0xFF])));
+
+        assert_eq!(&*parent.context_memory(), &[0xA5]);
+        assert_panic_message(result, "memory write offset overflow");
     }
 
     #[test]

--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -33,10 +33,7 @@ impl<T> RefcellExt<T> for RefCell<T> {
     }
 }
 
-/// A sequential memory shared between calls, which uses
-/// a `Vec` for internal representation.
-/// A [SharedMemory] instance should always be obtained using
-/// the `new` static method to ensure memory safety.
+/// Sequential memory shared between call contexts and backed by a `Vec`.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SharedMemory {
@@ -152,7 +149,10 @@ impl SharedMemory {
         }
     }
 
-    /// Creates a new memory instance with a given shared buffer.
+    /// Creates a new memory instance with the given shared buffer.
+    ///
+    /// Other owners can shrink the buffer and invalidate context checkpoints. Operations
+    /// validate checkpoints before accessing the buffer.
     pub const fn new_with_buffer(buffer: Rc<RefCell<Vec<u8>>>) -> Self {
         Self {
             buffer: Some(buffer),
@@ -249,14 +249,13 @@ impl SharedMemory {
         SharedMemory {
             buffer: Some(self.buffer().clone()),
             my_checkpoint: new_checkpoint,
-            // child_checkpoint is same as my_checkpoint
             child_checkpoint: None,
             #[cfg(feature = "memory_limit")]
             memory_limit: self.memory_limit,
         }
     }
 
-    /// Prepares the shared memory for returning from child context. Do nothing if there is no child context.
+    /// Restores the parent memory after a child context. Does nothing if there is no child.
     ///
     /// # Panics
     ///
@@ -303,7 +302,7 @@ impl SharedMemory {
         self.len() == 0
     }
 
-    /// Resizes the memory in-place so that `len` is equal to `new_len`.
+    /// Resizes the current memory range to `new_size` bytes.
     ///
     /// # Panics
     ///
@@ -454,12 +453,12 @@ impl SharedMemory {
         }
     }
 
-    /// Set memory from data. The destination range is validated, and source bytes outside
-    /// `data` are written as zeroes.
+    /// Copies `len` bytes from `data` into memory at `memory_offset`, starting at
+    /// `data_offset` and zero-filling the destination if the source is shorter.
     ///
     /// # Panics
     ///
-    /// Panics if memory is out of bounds.
+    /// Panics if the checkpoint or destination range is out of bounds.
     #[inline]
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn set_data(&mut self, memory_offset: usize, data_offset: usize, len: usize, data: &[u8]) {
@@ -533,10 +532,9 @@ impl SharedMemory {
     }
 }
 
-/// Copies data from src to dst taking into account the offsets and len.
+/// Copies `len` bytes from `src` to `dst`, applying both offsets.
 ///
-/// If src does not have enough data, it nullifies the rest of dst that is not copied.
-///
+/// Zero-fills the destination if the source is shorter than `len`.
 fn set_data(dst: &mut [u8], src: &[u8], dst_offset: usize, src_offset: usize, len: usize) {
     if len == 0 {
         return;
@@ -546,7 +544,6 @@ fn set_data(dst: &mut [u8], src: &[u8], dst_offset: usize, src_offset: usize, le
         .filter(|&end| end <= dst.len())
         .expect("memory write out of bounds");
     if src_offset >= src.len() {
-        // Nullify all memory slots
         dst[dst_offset..dst_end].fill(0);
         return;
     }
@@ -560,7 +557,6 @@ fn set_data(dst: &mut [u8], src: &[u8], dst_offset: usize, src_offset: usize, le
             .copy_from_slice(data)
     };
 
-    // Nullify rest of memory slots
     // SAFETY: `dst_end` was checked against `dst.len()` above.
     unsafe { dst.get_unchecked_mut(dst_offset + src_len..dst_end).fill(0) };
 }

--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -179,7 +179,7 @@ impl SharedMemory {
     }
 
     #[inline]
-    fn buffer(&self) -> &Rc<RefCell<Vec<u8>>> {
+    const fn buffer(&self) -> &Rc<RefCell<Vec<u8>>> {
         self.buffer
             .as_ref()
             .expect("cannot access invalid shared memory")

--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -229,11 +229,8 @@ impl SharedMemory {
                 .end
                 .checked_add(base)
                 .expect("memory read length overflow");
-            let range = start..end;
-            match b.get(range.clone()) {
-                Some(slice) => slice,
-                None => panic!("slice OOB: {range:?}; len: {}", b.len()),
-            }
+            b.get(start..end)
+                .unwrap_or_else(|| panic!("slice OOB: {start}..{end}; len: {}", b.len()))
         })
     }
 
@@ -501,9 +498,9 @@ impl SharedMemory {
     #[inline]
     pub fn context_memory(&self) -> Ref<'_, [u8]> {
         let buffer = self.buffer_ref();
-        Ref::map(buffer, |b| match b.get(self.my_checkpoint..) {
-            Some(slice) => slice,
-            None => panic!("shared memory checkpoint out of bounds"),
+        Ref::map(buffer, |b| {
+            b.get(self.my_checkpoint..)
+                .expect("shared memory checkpoint out of bounds")
         })
     }
 
@@ -515,9 +512,9 @@ impl SharedMemory {
     #[inline]
     pub fn context_memory_mut(&mut self) -> RefMut<'_, [u8]> {
         let buffer = self.buffer_ref_mut();
-        RefMut::map(buffer, |b| match b.get_mut(self.my_checkpoint..) {
-            Some(slice) => slice,
-            None => panic!("shared memory checkpoint out of bounds"),
+        RefMut::map(buffer, |b| {
+            b.get_mut(self.my_checkpoint..)
+                .expect("shared memory checkpoint out of bounds")
         })
     }
 }
@@ -830,14 +827,6 @@ mod tests {
 
         assert_eq!(&*parent.context_memory(), &[0xA5]);
         assert_panic_message(result, "memory write offset overflow");
-    }
-
-    #[test]
-    #[should_panic(expected = "memory write out of bounds")]
-    fn set_data_out_of_bounds_panics() {
-        let mut memory = SharedMemory::new();
-        memory.resize(1);
-        memory.set_data(1, 0, 1, &[0xFF]);
     }
 
     #[test]

--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -278,6 +278,10 @@ impl SharedMemory {
     }
 
     /// Returns the length of the current memory range.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this context's checkpoint is beyond the shared buffer.
     #[inline]
     pub fn len(&self) -> usize {
         self.full_len()
@@ -290,6 +294,10 @@ impl SharedMemory {
     }
 
     /// Returns `true` if the current memory range is empty.
+    ///
+    /// # Panics
+    ///
+    /// Panics under the same conditions as [`Self::len`].
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
@@ -459,7 +467,13 @@ impl SharedMemory {
         set_data(dst.as_mut(), data, memory_offset, data_offset, len);
     }
 
-    /// Set data from global memory to local memory. If global range is smaller than len, zeroes the rest.
+    /// Copies data from a global memory range to local memory, zero-filling the destination
+    /// if the selected source is shorter than `len`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the checkpoint, a non-empty global range, or the destination range is out
+    /// of bounds.
     #[inline]
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn global_to_local_set_data(

--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -42,10 +42,11 @@ impl<T> RefcellExt<T> for RefCell<T> {
 pub struct SharedMemory {
     /// The underlying buffer.
     buffer: Option<Rc<RefCell<Vec<u8>>>>,
-    /// Memory checkpoints for each depth.
-    /// Invariant: these are always in bounds of `data`.
+    /// Memory checkpoint for this context.
+    /// This is in bounds during normal context sequencing. Shared aliases or externally
+    /// supplied buffers can invalidate it, so consumers validate it before use.
     my_checkpoint: usize,
-    /// Child checkpoint that we need to free context to.
+    /// Child checkpoint used to restore the parent context.
     child_checkpoint: Option<usize>,
     /// Memory limit. See [`Cfg`](context_interface::Cfg).
     #[cfg(feature = "memory_limit")]
@@ -302,7 +303,7 @@ impl SharedMemory {
     /// # Panics
     ///
     /// Panics if the checkpoint plus the new size overflows or if resizing would
-    /// invalidate a live child checkpoint.
+    /// invalidate the child checkpoint recorded by this handle.
     #[inline]
     pub fn resize(&mut self, new_size: usize) {
         let new_len = self
@@ -607,6 +608,18 @@ fn resize_memory_cold<Memory: MemoryTr>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "std")]
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+
+    #[cfg(feature = "std")]
+    fn assert_panic_message(result: std::thread::Result<()>, expected: &str) {
+        let payload = result.expect_err("operation should panic");
+        let message = payload
+            .downcast_ref::<&str>()
+            .copied()
+            .or_else(|| payload.downcast_ref::<String>().map(String::as_str));
+        assert_eq!(message, Some(expected));
+    }
 
     #[test]
     fn test_num_words() {
@@ -698,13 +711,19 @@ mod tests {
         parent.new_child_context().resize(usize::MAX);
     }
 
+    #[cfg(feature = "std")]
     #[test]
-    #[should_panic(expected = "memory resize below child checkpoint")]
-    fn parent_resize_below_child_checkpoint_panics() {
+    fn parent_resize_below_child_checkpoint_is_atomic() {
         let mut parent = SharedMemory::new();
         parent.resize(1);
+        parent.set_byte(0, 0xA5);
         let _child = parent.new_child_context();
-        parent.resize(0);
+
+        let result = catch_unwind(AssertUnwindSafe(|| parent.resize(0)));
+
+        assert_panic_message(result, "memory resize below child checkpoint");
+        assert_eq!(parent.buffer_ref().as_slice(), &[0xA5]);
+        assert_eq!(parent.child_checkpoint, Some(1));
     }
 
     #[test]
@@ -717,14 +736,63 @@ mod tests {
         let _ = child.context_memory();
     }
 
+    #[cfg(feature = "std")]
     #[test]
-    #[should_panic(expected = "shared memory buffer is below child checkpoint")]
-    fn free_child_context_with_invalid_checkpoint_panics() {
+    fn free_child_context_with_invalid_checkpoint_is_retryable() {
         let buffer = Rc::new(RefCell::new(vec![0]));
         let mut parent = SharedMemory::new_with_buffer(buffer.clone());
         let _child = parent.new_child_context();
         *buffer.borrow_mut() = Vec::new();
+
+        let result = catch_unwind(AssertUnwindSafe(|| parent.free_child_context()));
+
+        assert_panic_message(result, "shared memory buffer is below child checkpoint");
+        assert_eq!(parent.child_checkpoint, Some(1));
+        assert!(buffer.borrow().is_empty());
+
+        buffer.borrow_mut().extend_from_slice(&[0xA5, 0x5A]);
         parent.free_child_context();
+
+        assert_eq!(parent.child_checkpoint, None);
+        assert_eq!(buffer.borrow().as_slice(), &[0xA5]);
+    }
+
+    #[test]
+    #[should_panic(expected = "memory read offset overflow")]
+    fn child_slice_start_overflow_panics() {
+        let mut parent = SharedMemory::new();
+        parent.resize(1);
+        let child = parent.new_child_context();
+        let _ = child.slice_range(usize::MAX..usize::MAX);
+    }
+
+    #[test]
+    #[should_panic(expected = "memory read length overflow")]
+    fn child_slice_end_overflow_panics() {
+        let mut parent = SharedMemory::new();
+        parent.resize(1);
+        let child = parent.new_child_context();
+        let _ = child.slice_range(0..usize::MAX);
+    }
+
+    #[test]
+    #[should_panic(expected = "shared memory checkpoint out of bounds")]
+    fn invalid_checkpoint_len_panics() {
+        let buffer = Rc::new(RefCell::new(vec![0]));
+        let mut parent = SharedMemory::new_with_buffer(buffer.clone());
+        let child = parent.new_child_context();
+        buffer.borrow_mut().clear();
+        let _ = child.len();
+    }
+
+    #[test]
+    #[should_panic(expected = "shared memory checkpoint out of bounds")]
+    fn invalid_checkpoint_context_memory_mut_panics() {
+        let buffer = Rc::new(RefCell::new(vec![0]));
+        let mut parent = SharedMemory::new_with_buffer(buffer.clone());
+        let mut child = parent.new_child_context();
+        buffer.borrow_mut().clear();
+        let _ = child.context_memory_mut();
     }
 
     #[test]
@@ -744,11 +812,38 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "memory write length overflow")]
+    fn set_offset_overflow_panics() {
+        let mut memory = SharedMemory::new();
+        memory.set(usize::MAX, &[0xFF; 8]);
+    }
+
+    #[test]
     #[should_panic(expected = "memory write out of bounds")]
     fn set_data_out_of_bounds_panics() {
         let mut memory = SharedMemory::new();
         memory.resize(1);
         memory.set_data(1, 0, 1, &[0xFF]);
+    }
+
+    #[test]
+    #[should_panic(expected = "memory write out of bounds")]
+    fn set_data_range_overflow_panics() {
+        let mut memory = SharedMemory::new();
+        memory.set_data(usize::MAX, 0, usize::MAX, &[0xFF; 8]);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn set_data_out_of_bounds_is_atomic() {
+        let mut memory = SharedMemory::new();
+        memory.resize(2);
+        memory.set(0, &[0xA5, 0x5A]);
+
+        let result = catch_unwind(AssertUnwindSafe(|| memory.set_data(1, 0, 2, &[0xFF, 0xFF])));
+
+        assert_panic_message(result, "memory write out of bounds");
+        assert_eq!(&*memory.context_memory(), &[0xA5, 0x5A]);
     }
 
     #[cfg(feature = "memory_limit")]

--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -180,19 +180,26 @@ impl SharedMemory {
 
     #[inline]
     const fn buffer(&self) -> &Rc<RefCell<Vec<u8>>> {
-        self.buffer
-            .as_ref()
-            .expect("cannot access invalid shared memory")
+        match self.buffer.as_ref() {
+            Some(buffer) => buffer,
+            None => panic!("cannot access invalid shared memory"),
+        }
     }
 
     #[inline]
     fn buffer_ref(&self) -> Ref<'_, Vec<u8>> {
-        self.buffer().borrow()
+        match self.buffer().try_borrow() {
+            Ok(buffer) => buffer,
+            Err(error) => panic!("{error}"),
+        }
     }
 
     #[inline]
     fn buffer_ref_mut(&self) -> RefMut<'_, Vec<u8>> {
-        self.buffer().borrow_mut()
+        match self.buffer().try_borrow_mut() {
+            Ok(buffer) => buffer,
+            Err(error) => panic!("{error}"),
+        }
     }
 
     /// Returns a byte slice of the backing buffer, applying `base` to `range`.
@@ -218,13 +225,18 @@ impl SharedMemory {
     ///
     /// # Panics
     ///
-    /// Panics if this function was already called without freeing child context.
+    /// Panics if this function was already called without freeing child context or if
+    /// this context's checkpoint is beyond the shared buffer.
     #[inline]
     pub fn new_child_context(&mut self) -> SharedMemory {
         if self.child_checkpoint.is_some() {
             panic!("new_child_context was already called without freeing child context");
         }
         let new_checkpoint = self.full_len();
+        assert!(
+            new_checkpoint >= self.my_checkpoint,
+            "shared memory checkpoint out of bounds"
+        );
         self.child_checkpoint = Some(new_checkpoint);
         SharedMemory {
             buffer: Some(self.buffer().clone()),
@@ -286,21 +298,32 @@ impl SharedMemory {
     ///
     /// # Panics
     ///
-    /// Panics if the checkpoint plus the new size overflows or if resizing would
-    /// invalidate the child checkpoint recorded by this handle.
+    /// Panics if the checkpoint plus the new size overflows, if a checkpoint is beyond
+    /// the shared buffer, or if resizing would invalidate the child checkpoint recorded
+    /// by this handle.
     #[inline]
     pub fn resize(&mut self, new_size: usize) {
-        let new_len = self
-            .my_checkpoint
+        let my_checkpoint = self.my_checkpoint;
+        let child_checkpoint = self.child_checkpoint;
+        let new_len = my_checkpoint
             .checked_add(new_size)
             .expect("memory resize overflow");
-        if self
-            .child_checkpoint
-            .is_some_and(|child_checkpoint| new_len < child_checkpoint)
-        {
-            panic!("memory resize below child checkpoint");
+        let mut buffer = self.buffer_ref_mut();
+        assert!(
+            buffer.len() >= my_checkpoint,
+            "shared memory checkpoint out of bounds"
+        );
+        if let Some(child_checkpoint) = child_checkpoint {
+            assert!(
+                buffer.len() >= child_checkpoint,
+                "shared memory buffer is below child checkpoint"
+            );
+            assert!(
+                new_len >= child_checkpoint,
+                "memory resize below child checkpoint"
+            );
         }
-        self.buffer_ref_mut().resize(new_len, 0);
+        buffer.resize(new_len, 0);
     }
 
     /// Returns a byte slice of the memory region at the given offset.
@@ -630,7 +653,7 @@ mod tests {
         assert_eq!(sm1.buffer_ref().len(), 0);
         assert_eq!(sm1.my_checkpoint, 0);
 
-        unsafe { sm1.buffer_ref_mut().set_len(32) };
+        sm1.resize(32);
         assert_eq!(sm1.len(), 32);
         let mut sm2 = sm1.new_child_context();
 
@@ -638,7 +661,7 @@ mod tests {
         assert_eq!(sm2.my_checkpoint, 32);
         assert_eq!(sm2.len(), 0);
 
-        unsafe { sm2.buffer_ref_mut().set_len(96) };
+        sm2.resize(64);
         assert_eq!(sm2.len(), 64);
         let mut sm3 = sm2.new_child_context();
 
@@ -646,7 +669,7 @@ mod tests {
         assert_eq!(sm3.my_checkpoint, 96);
         assert_eq!(sm3.len(), 0);
 
-        unsafe { sm3.buffer_ref_mut().set_len(128) };
+        sm3.resize(32);
         let sm4 = sm3.new_child_context();
         assert_eq!(sm4.buffer_ref().len(), 128);
         assert_eq!(sm4.my_checkpoint, 128);
@@ -711,6 +734,55 @@ mod tests {
         assert_panic_message(result, "memory resize below child checkpoint");
         assert_eq!(parent.buffer_ref().as_slice(), &[0xA5]);
         assert_eq!(parent.child_checkpoint, Some(1));
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn stale_child_resize_is_atomic() {
+        let buffer = Rc::new(RefCell::new(vec![0xA5]));
+        let mut parent = SharedMemory::new_with_buffer(buffer.clone());
+        let mut child = parent.new_child_context();
+        buffer.borrow_mut().clear();
+        let before = buffer.borrow().clone();
+
+        let result = catch_unwind(AssertUnwindSafe(|| child.resize(1)));
+
+        assert_panic_message(result, "shared memory checkpoint out of bounds");
+        assert_eq!(*buffer.borrow(), before);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn parent_resize_with_stale_child_checkpoint_is_atomic() {
+        let buffer = Rc::new(RefCell::new(vec![0xA5]));
+        let mut parent = SharedMemory::new_with_buffer(buffer.clone());
+        let _child = parent.new_child_context();
+        buffer.borrow_mut().clear();
+        let before = buffer.borrow().clone();
+
+        let result = catch_unwind(AssertUnwindSafe(|| parent.resize(1)));
+
+        assert_panic_message(result, "shared memory buffer is below child checkpoint");
+        assert_eq!(*buffer.borrow(), before);
+        assert_eq!(parent.child_checkpoint, Some(1));
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn stale_handle_cannot_create_child() {
+        let buffer = Rc::new(RefCell::new(vec![0xA5]));
+        let mut parent = SharedMemory::new_with_buffer(buffer.clone());
+        let mut child = parent.new_child_context();
+        buffer.borrow_mut().clear();
+        let before = buffer.borrow().clone();
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            child.new_child_context();
+        }));
+
+        assert_panic_message(result, "shared memory checkpoint out of bounds");
+        assert_eq!(*buffer.borrow(), before);
+        assert_eq!(child.child_checkpoint, None);
     }
 
     #[test]

--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -107,12 +107,7 @@ impl MemoryTr for SharedMemory {
     ///
     /// # Panics
     ///
-    /// Panics on out of bounds access in debug builds only.
-    ///
-    /// # Safety
-    ///
-    /// In release builds, calling this method with an out-of-bounds range triggers undefined
-    /// behavior. Callers must ensure that the range is within the bounds of the buffer.
+    /// Panics on out of bounds access.
     #[inline]
     #[cfg_attr(debug_assertions, track_caller)]
     fn global_slice(&self, range: Range<usize>) -> Ref<'_, [u8]> {
@@ -225,10 +220,18 @@ impl SharedMemory {
     fn slice_range_with_base(&self, range: Range<usize>, base: usize) -> Ref<'_, [u8]> {
         let buffer = self.buffer_ref();
         Ref::map(buffer, |b| {
-            let range = range.start + base..range.end + base;
+            let start = range
+                .start
+                .checked_add(base)
+                .expect("memory read offset overflow");
+            let end = range
+                .end
+                .checked_add(base)
+                .expect("memory read length overflow");
+            let range = start..end;
             match b.get(range.clone()) {
                 Some(slice) => slice,
-                None => debug_unreachable!("slice OOB: {range:?}; len: {}", self.len()),
+                None => panic!("slice OOB: {range:?}; len: {}", b.len()),
             }
         })
     }
@@ -256,20 +259,32 @@ impl SharedMemory {
     }
 
     /// Prepares the shared memory for returning from child context. Do nothing if there is no child context.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the shared buffer was truncated below the child checkpoint.
     #[inline]
     pub fn free_child_context(&mut self) {
-        let Some(child_checkpoint) = self.child_checkpoint.take() else {
+        let Some(child_checkpoint) = self.child_checkpoint else {
             return;
         };
-        unsafe {
-            self.buffer_ref_mut().set_len(child_checkpoint);
+        {
+            let mut buffer = self.buffer_ref_mut();
+            assert!(
+                buffer.len() >= child_checkpoint,
+                "shared memory buffer is below child checkpoint"
+            );
+            buffer.truncate(child_checkpoint);
         }
+        self.child_checkpoint = None;
     }
 
     /// Returns the length of the current memory range.
     #[inline]
     pub fn len(&self) -> usize {
-        self.full_len() - self.my_checkpoint
+        self.full_len()
+            .checked_sub(self.my_checkpoint)
+            .expect("shared memory checkpoint out of bounds")
     }
 
     fn full_len(&self) -> usize {
@@ -286,13 +301,20 @@ impl SharedMemory {
     ///
     /// # Panics
     ///
-    /// Panics if the checkpoint plus the new size overflows.
+    /// Panics if the checkpoint plus the new size overflows or if resizing would
+    /// invalidate a live child checkpoint.
     #[inline]
     pub fn resize(&mut self, new_size: usize) {
         let new_len = self
             .my_checkpoint
             .checked_add(new_size)
             .expect("memory resize overflow");
+        if self
+            .child_checkpoint
+            .is_some_and(|child_checkpoint| new_len < child_checkpoint)
+        {
+            panic!("memory resize below child checkpoint");
+        }
         self.buffer().dbg_borrow_mut().resize(new_len, 0);
     }
 
@@ -311,13 +333,7 @@ impl SharedMemory {
     ///
     /// # Panics
     ///
-    /// Panics on out of bounds access in debug builds only.
-    ///
-    /// # Safety
-    ///
-    /// In release builds, calling this method with an out-of-bounds range triggers undefined
-    /// behavior. Callers must ensure that the range is within the bounds of the memory (i.e.,
-    /// `range.end <= self.len()`).
+    /// Panics on out of bounds access.
     #[inline]
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn slice_range(&self, range: Range<usize>) -> Ref<'_, [u8]> {
@@ -328,12 +344,7 @@ impl SharedMemory {
     ///
     /// # Panics
     ///
-    /// Panics on out of bounds access in debug builds only.
-    ///
-    /// # Safety
-    ///
-    /// In release builds, calling this method with an out-of-bounds range triggers undefined
-    /// behavior. Callers must ensure that the range is within the bounds of the buffer.
+    /// Panics on out of bounds access.
     #[inline]
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn global_slice_range(&self, range: Range<usize>) -> Ref<'_, [u8]> {
@@ -485,18 +496,13 @@ impl SharedMemory {
     ///
     /// # Panics
     ///
-    /// Panics if the checkpoint is invalid in debug builds only.
-    ///
-    /// # Safety
-    ///
-    /// In release builds, calling this method with an invalid checkpoint triggers undefined
-    /// behavior. The checkpoint must be within the bounds of the buffer.
+    /// Panics if the checkpoint is invalid.
     #[inline]
     pub fn context_memory(&self) -> Ref<'_, [u8]> {
         let buffer = self.buffer_ref();
         Ref::map(buffer, |b| match b.get(self.my_checkpoint..) {
             Some(slice) => slice,
-            None => debug_unreachable!("Context memory should be always valid"),
+            None => panic!("shared memory checkpoint out of bounds"),
         })
     }
 
@@ -504,18 +510,13 @@ impl SharedMemory {
     ///
     /// # Panics
     ///
-    /// Panics if the checkpoint is invalid in debug builds only.
-    ///
-    /// # Safety
-    ///
-    /// In release builds, calling this method with an invalid checkpoint triggers undefined
-    /// behavior. The checkpoint must be within the bounds of the buffer.
+    /// Panics if the checkpoint is invalid.
     #[inline]
     pub fn context_memory_mut(&mut self) -> RefMut<'_, [u8]> {
         let buffer = self.buffer_ref_mut();
         RefMut::map(buffer, |b| match b.get_mut(self.my_checkpoint..) {
             Some(slice) => slice,
-            None => debug_unreachable!("Context memory should be always valid"),
+            None => panic!("shared memory checkpoint out of bounds"),
         })
     }
 }
@@ -695,6 +696,43 @@ mod tests {
         let mut parent = SharedMemory::new();
         parent.resize(1);
         parent.new_child_context().resize(usize::MAX);
+    }
+
+    #[test]
+    #[should_panic(expected = "memory resize below child checkpoint")]
+    fn parent_resize_below_child_checkpoint_panics() {
+        let mut parent = SharedMemory::new();
+        parent.resize(1);
+        let _child = parent.new_child_context();
+        parent.resize(0);
+    }
+
+    #[test]
+    #[should_panic(expected = "shared memory checkpoint out of bounds")]
+    fn external_buffer_truncation_panics() {
+        let buffer = Rc::new(RefCell::new(vec![0]));
+        let mut parent = SharedMemory::new_with_buffer(buffer.clone());
+        let child = parent.new_child_context();
+        buffer.borrow_mut().clear();
+        let _ = child.context_memory();
+    }
+
+    #[test]
+    #[should_panic(expected = "shared memory buffer is below child checkpoint")]
+    fn free_child_context_with_invalid_checkpoint_panics() {
+        let buffer = Rc::new(RefCell::new(vec![0]));
+        let mut parent = SharedMemory::new_with_buffer(buffer.clone());
+        let _child = parent.new_child_context();
+        *buffer.borrow_mut() = Vec::new();
+        parent.free_child_context();
+    }
+
+    #[test]
+    #[should_panic(expected = "slice OOB")]
+    fn slice_out_of_bounds_panics() {
+        let mut memory = SharedMemory::new();
+        memory.resize(1);
+        let _ = memory.slice_range(1..2);
     }
 
     #[test]

--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -10,29 +10,6 @@ use core::{
 use primitives::{hex, B256, U256};
 use std::{rc::Rc, vec::Vec};
 
-trait RefcellExt<T> {
-    fn dbg_borrow(&self) -> Ref<'_, T>;
-    fn dbg_borrow_mut(&self) -> RefMut<'_, T>;
-}
-
-impl<T> RefcellExt<T> for RefCell<T> {
-    #[inline]
-    fn dbg_borrow(&self) -> Ref<'_, T> {
-        match self.try_borrow() {
-            Ok(b) => b,
-            Err(e) => debug_unreachable!("{e}"),
-        }
-    }
-
-    #[inline]
-    fn dbg_borrow_mut(&self) -> RefMut<'_, T> {
-        match self.try_borrow_mut() {
-            Ok(b) => b,
-            Err(e) => debug_unreachable!("{e}"),
-        }
-    }
-}
-
 /// Sequential memory shared between call contexts and backed by a `Vec`.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -138,6 +115,8 @@ impl SharedMemory {
     }
 
     /// Creates a new invalid memory instance.
+    ///
+    /// Memory accessors panic when called on this instance.
     #[inline]
     pub const fn invalid() -> Self {
         Self {
@@ -201,18 +180,19 @@ impl SharedMemory {
 
     #[inline]
     fn buffer(&self) -> &Rc<RefCell<Vec<u8>>> {
-        debug_assert!(self.buffer.is_some(), "cannot use SharedMemory::empty");
-        unsafe { self.buffer.as_ref().unwrap_unchecked() }
+        self.buffer
+            .as_ref()
+            .expect("cannot access invalid shared memory")
     }
 
     #[inline]
     fn buffer_ref(&self) -> Ref<'_, Vec<u8>> {
-        self.buffer().dbg_borrow()
+        self.buffer().borrow()
     }
 
     #[inline]
     fn buffer_ref_mut(&self) -> RefMut<'_, Vec<u8>> {
-        self.buffer().dbg_borrow_mut()
+        self.buffer().borrow_mut()
     }
 
     /// Returns a byte slice of the backing buffer, applying `base` to `range`.
@@ -320,7 +300,7 @@ impl SharedMemory {
         {
             panic!("memory resize below child checkpoint");
         }
-        self.buffer().dbg_borrow_mut().resize(new_len, 0);
+        self.buffer_ref_mut().resize(new_len, 0);
     }
 
     /// Returns a byte slice of the memory region at the given offset.
@@ -741,6 +721,28 @@ mod tests {
         let child = parent.new_child_context();
         buffer.borrow_mut().clear();
         let _ = child.context_memory();
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn shared_alias_borrow_conflict_panics() {
+        let memory = SharedMemory::new();
+        let mut alias = memory.clone();
+        let _guard = memory.context_memory();
+
+        let result = catch_unwind(AssertUnwindSafe(|| alias.resize(1)));
+
+        assert!(result.is_err());
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn invalid_memory_access_panics() {
+        let memory = SharedMemory::invalid();
+
+        let result = catch_unwind(AssertUnwindSafe(|| memory.len()));
+
+        assert_panic_message(result.map(|_| ()), "cannot access invalid shared memory");
     }
 
     #[cfg(feature = "std")]


### PR DESCRIPTION
## Summary

- Validate `SharedMemory` read and write ranges, checkpoint arithmetic, and child cleanup so invalid safe inputs panic in every profile instead of reaching unchecked operations.
- Preserve memory and checkpoint state when resize or child cleanup is rejected.
- Keep the checked copy fast path for valid `set_data` calls and cover the reported `usize::MAX`, alias invalidation, and failure-atomicity cases.

Addresses the `SharedMemory` cases in https://github.com/bluealloy/revm/issues/3687. The `ExtBytecode` cases remain out of scope to avoid conflicting with https://github.com/bluealloy/revm/pull/3545.

## Testing

- `cargo test -p revm-interpreter shared_memory::tests`
- `cargo test --release -p revm-interpreter shared_memory::tests`
- `cargo +nightly-2026-07-11 miri test -p revm-interpreter --lib shared_memory::tests`
- `cargo +nightly-2026-07-11 miri test --release -p revm-interpreter --lib shared_memory::tests`
- `cargo test -p revm-interpreter --all-features`
- `cargo check -p revm-interpreter --no-default-features`
- `cargo clippy -p revm-interpreter --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='--cfg docsrs -D warnings' cargo doc -p revm-interpreter --all-features --no-deps --document-private-items`
- `cargo fmt --all --check`
- GitHub CI: stable, nightly, no-default-features, docs, clippy, and 32-bit Ethereum tests
