### PR TITLE
bump: prep v114 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
 
+# v114
+date: 23.07.2026
+
+Glamsterdam devnet-7 support, with all crates bumped in lockstep to **42.0.0**.
+
+Highlights:
+* Glamsterdam devnet-7 alignment: EIP-2780 runtime gas phase, fixtures v7.0.0 ([#3795](https://github.com/bluealloy/revm/pull/3795))
+* Glamsterdam devnet-6 gas accounting & EIP alignment ([#3782](https://github.com/bluealloy/revm/pull/3782))
+* EIP-8246 delayed clear replaces the EIP-7708 delayed burn config ([#3782](https://github.com/bluealloy/revm/pull/3782))
+* Database fallback mode for BAL misses ([#3754](https://github.com/bluealloy/revm/pull/3754))
+* Configurable max refund quotient ([#3757](https://github.com/bluealloy/revm/pull/3757))
+* Fallible refund: `Handler::refund` now returns a value ([#3758](https://github.com/bluealloy/revm/pull/3758))
+* Validate state before tracking gas ([#3815](https://github.com/bluealloy/revm/pull/3815))
+* Forward EIP-7708 transfer logs to the inspector ([#3816](https://github.com/bluealloy/revm/pull/3816))
+* Fix gas tracker used-gas underflow ([#3813](https://github.com/bluealloy/revm/pull/3813))
+* Fix journal finalization on error to prevent EIP-2929 warm set leak ([#3780](https://github.com/bluealloy/revm/pull/3780))
+* Ignore stale selfdestruct journal entries in the inspector ([#3805](https://github.com/bluealloy/revm/pull/3805))
+* Keep `is_empty` on EIP-7702 accounts in `load_account_delegated` ([#3802](https://github.com/bluealloy/revm/pull/3802))
+* Bytecode iterator fixes for truncated pushes and legacy padding ([#3800](https://github.com/bluealloy/revm/pull/3800), [#3792](https://github.com/bluealloy/revm/pull/3792))
+* `asm-sha2` feature removed from `revm` and `revm-precompile`
+
+See [MIGRATION_GUIDE.md](./MIGRATION_GUIDE.md) for the full list of breaking changes.
+
+* `revm-primitives`: 41.0.0 -> 42.0.0 (⚠ API breaking changes)
+* `revm-bytecode`: 41.0.0 -> 42.0.0 (✓ API compatible changes)
+* `revm-state`: 41.0.0 -> 42.0.0 (✓ API compatible changes)
+* `revm-database-interface`: 41.0.0 -> 42.0.0 (⚠ API breaking changes)
+* `revm-context-interface`: 41.0.0 -> 42.0.0 (⚠ API breaking changes)
+* `revm-context`: 41.0.0 -> 42.0.0 (⚠ API breaking changes)
+* `revm-database`: 41.0.0 -> 42.0.0 (✓ API compatible changes)
+* `revm-interpreter`: 41.0.0 -> 42.0.0 (⚠ API breaking changes)
+* `revm-precompile`: 41.0.0 -> 42.0.0 (⚠ API breaking changes)
+* `revm-handler`: 41.0.0 -> 42.0.0 (⚠ API breaking changes)
+* `revm-inspector`: 41.0.0 -> 42.0.0 (⚠ API breaking changes)
+* `revm-statetest-types`: 41.0.0 -> 42.0.0 (⚠ API breaking changes)
+* `revm`: 41.0.0 -> 42.0.0 (⚠ API breaking changes)
+* `revm-ee-tests`: 41.0.0 -> 42.0.0 (✓ dependency bump)
+* `revme`: 41.0.0 -> 42.0.0 (✓ API compatible changes)
+
 # v113
 date: 11.06.2026
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3884,7 +3884,7 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "41.0.1"
+version = "42.0.0"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -3928,7 +3928,7 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "41.1.0"
+version = "42.0.0"
 dependencies = [
  "alloy-eips",
  "alloy-provider",
@@ -3959,7 +3959,7 @@ dependencies = [
 
 [[package]]
 name = "revm-ee-tests"
-version = "41.0.0"
+version = "42.0.0"
 dependencies = [
  "insta",
  "revm",
@@ -4055,7 +4055,7 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "41.1.0"
+version = "42.0.0"
 dependencies = [
  "alloy-eip7928 0.4.0",
  "bitflags",
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "revme"
-version = "41.1.0"
+version = "42.0.0"
 dependencies = [
  "alloy-rlp",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,10 @@ default-members = ["crates/revm"]
 # revm
 revm = { path = "crates/revm", version = "42.0.0", default-features = false }
 primitives = { path = "crates/primitives", package = "revm-primitives", version = "42.0.0", default-features = false }
-bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "41.0.1", default-features = false }
-database = { path = "crates/database", package = "revm-database", version = "41.1.0", default-features = false }
+bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "42.0.0", default-features = false }
+database = { path = "crates/database", package = "revm-database", version = "42.0.0", default-features = false }
 database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "42.0.0", default-features = false }
-state = { path = "crates/state", package = "revm-state", version = "41.1.0", default-features = false }
+state = { path = "crates/state", package = "revm-state", version = "42.0.0", default-features = false }
 interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "42.0.0", default-features = false }
 inspector = { path = "crates/inspector", package = "revm-inspector", version = "42.0.0", default-features = false }
 precompile = { path = "crates/precompile", package = "revm-precompile", version = "42.0.0", default-features = false }
@@ -54,7 +54,7 @@ statetest-types = { path = "crates/statetest-types", package = "revm-statetest-t
 context = { path = "crates/context", package = "revm-context", version = "42.0.0", default-features = false }
 context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "42.0.0", default-features = false }
 handler = { path = "crates/handler", package = "revm-handler", version = "42.0.0", default-features = false }
-ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "41.0.0", default-features = false }
+ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "42.0.0", default-features = false }
 
 # alloy
 alloy-eip2930 = { version = "0.2.3", default-features = false }

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,6 +1,34 @@
 
 # Unreleased
 
+# v114 tag (all crates v42.0.0)
+
+Released by [#3814](https://github.com/bluealloy/revm/pull/3814). Breaking changes below, grouped by crate; `revm-bytecode`, `revm-state`, `revm-database` and `revme` are API compatible with v41.
+
+### EIP-8246 replaces EIP-7708 delayed burn (`revm-context`, `revm-context-interface`)
+* `Cfg::is_eip7708_delayed_burn_disabled` → `Cfg::is_eip8246_delayed_clear_disabled`; `CfgEnv.amsterdam_eip7708_delayed_burn_disabled` → `amsterdam_eip8246_delayed_clear_disabled` and `JournalCfg.eip7708_delayed_burn_disabled` → `eip8246_delayed_clear_disabled` (breaks literal construction).
+* Removed `JournalInner::eip7708_emit_burn_remaining_balance_logs` and `JournalInner::eip7708_burn_log`.
+* New required `Cfg` method `is_amsterdam_eip2780_enabled` (implement it on custom `Cfg`s alongside the rename).
+
+### Gas API (`revm-primitives`, `revm-context-interface`, `revm-handler`)
+* Removed: `primitives::EIP7702_PER_EMPTY_ACCOUNT_REGULAR`; `GasParams::tx_eip7702_auth_refund` / `tx_eip7702_state_gas` / `tx_eip7702_state_refund` and the matching `GasId` variants; `InitialAndFloorGas.state_refund`.
+* Arity changes: `calculate_initial_tx_gas` 6→7, `calculate_initial_tx_gas_for_tx` 2→3, `GasParams::initial_tx_gas` 5→6, `GasParams::initial_tx_gas_for_tx` 1→2, `validate_initial_tx_gas` 5→6, `validate_initial_tx_gas_with_gas_params` 6→7.
+* `Handler::refund` now returns a value instead of `()` (fallible refund, [#3758](https://github.com/bluealloy/revm/pull/3758)).
+
+### Handler / inspector execution split
+* `Handler::execution` 2→3 params and `InspectorHandler::inspect_execution` 2→3; `Handler::first_frame_input` 3→2; `execution::create_init_frame` 3→2.
+
+### Journal code-change entry (`revm-context-interface`)
+* `JournalEntry::CodeChange` gained `had_code_hash` and `had_code` fields; `JournalEntryTr::code_changed` 1→3 params.
+
+### New struct fields (break literal construction)
+* `BalState.allow_db_fallback` (`revm-database-interface`) — database fallback for BAL misses ([#3754](https://github.com/bluealloy/revm/pull/3754)).
+* `CreateOutcome.charged_create_state_gas` (`revm-interpreter`).
+* `TransactionParts.chain_id` (`revm-statetest-types`).
+
+### Features
+* `asm-sha2` feature removed from `revm` and `revm-precompile`.
+
 ### EIP-2780 runtime gas phase (ethereum/EIPs#11844)
 
 Gated on `CfgEnv::enable_amsterdam_eip2780`; older forks and 2780-disabled configs are unchanged.

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revme"
 description = "Rust Ethereum Virtual Machine Executable"
-version = "41.1.0"
+version = "42.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/bytecode/Cargo.toml
+++ b/crates/bytecode/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-bytecode"
 description = "EVM Bytecodes"
-version = "41.0.1"
+version = "42.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-database"
 description = "Revm Database implementations"
-version = "41.1.0"
+version = "42.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/ee-tests/Cargo.toml
+++ b/crates/ee-tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-ee-tests"
 description = "Common test utilities for REVM crates"
-version = "41.0.0"
+version = "42.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-state"
 description = "Revm state types"
-version = "41.1.0"
+version = "42.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
Prepares the v114 tag: all crates versioned in lockstep at **42.0.0**.

* Bumps `revm-bytecode` (41.0.1), `revm-database` / `revm-state` / `revme` (41.1.0) and `revm-ee-tests` (41.0.0) to 42.0.0, so every crate matches the versions released in #3814. Workspace dependency versions and `Cargo.lock` updated accordingly.
* `CHANGELOG.md`: new `# v114` entry — Glamsterdam devnet-7 support, highlights, and the per-crate version table.
* `MIGRATION_GUIDE.md`: new `# v114 tag (all crates v42.0.0)` section summarizing the breaking changes reported in #3814 (EIP-8246 replacing the EIP-7708 delayed burn config, gas API removals/arity changes, `Handler::refund` returning a value, handler/inspector execution arity, `JournalEntry::CodeChange` fields, new struct fields, `asm-sha2` removal). The previously-unreleased EIP-2780 notes now sit under this section.