### PR TITLE
feat(precompile): track spilled state gas in PrecompileOutput

### DIFF
--- a/crates/handler/src/precompile_provider.rs
+++ b/crates/handler/src/precompile_provider.rs
@@ -71,60 +71,47 @@ impl Clone for EthPrecompiles {
     }
 }
 
-/// Converts a [`PrecompileOutput`] into an [`InterpreterResult`].
+/// Converts a [`PrecompileOutput`] into an [`InterpreterResult`] for a call frame
+/// with `gas_limit` regular gas.
 ///
 /// Maps precompile status to the corresponding instruction result:
-/// - `Success` → `InstructionResult::Return`
-/// - `Revert` → `InstructionResult::Revert`
-/// - `Halt(OOG)` → `InstructionResult::PrecompileOOG`
-/// - `Halt(other)` → `InstructionResult::PrecompileError`
+/// - `Success` -> [`InstructionResult::Return`]
+/// - `Revert` -> [`InstructionResult::Revert`]
+/// - `Halt(OOG)` -> [`InstructionResult::PrecompileOOG`]
+/// - `Halt(other)` -> [`InstructionResult::PrecompileError`]
+///
+/// A precompile that reports more gas than it was given is downgraded to
+/// [`InstructionResult::PrecompileOOG`]. Anything but a success or revert consumes
+/// all regular gas and returns no output bytes.
 pub fn precompile_output_to_interpreter_result(
     output: PrecompileOutput,
     gas_limit: u64,
 ) -> InterpreterResult {
-    // set output bytes
-    let bytes = if output.status.is_success_or_revert() {
-        output.bytes
+    // A precompile lying about its usage must not leave the frame with gas it
+    // never had: charging more regular gas than the limit is an OOG halt.
+    let result = if output.gas_used > gas_limit {
+        InstructionResult::PrecompileOOG
     } else {
-        Bytes::new()
-    };
-
-    let mut result = InterpreterResult {
-        result: InstructionResult::Return,
-        gas: Gas::new_with_regular_gas_and_reservoir(gas_limit, output.reservoir),
-        output: bytes,
-    };
-
-    // set state gas, reservoir is already set in the Gas constructor
-    result.gas.set_state_gas_spent(output.state_gas_used);
-    result.gas.record_refund(output.gas_refunded);
-
-    // spend used gas.
-    if output.status.is_success_or_revert() {
-        if !result.gas.record_regular_cost(output.gas_used) {
-            result.gas.spend_all();
-            result.output = Bytes::new();
-            result.result = InstructionResult::PrecompileOOG;
-            return result;
+        match &output.status {
+            PrecompileStatus::Success => InstructionResult::Return,
+            PrecompileStatus::Revert => InstructionResult::Revert,
+            PrecompileStatus::Halt(reason) if reason.is_oog() => InstructionResult::PrecompileOOG,
+            PrecompileStatus::Halt(_) => InstructionResult::PrecompileError,
         }
-    } else {
-        result.gas.spend_all();
+    };
+
+    // Gas used, refund, state gas (with its spilled portion, so a later rollback
+    // credits it back to regular gas per EIP-8037) and the reservoir all come from
+    // the precompile's own accounting.
+    let mut gas = Gas::from_tracker(output.to_gas_tracker(gas_limit));
+
+    // Only a success or revert returns output bytes and keeps its unspent gas.
+    if result.is_halt() {
+        gas.spend_all();
+        return InterpreterResult::new(result, Bytes::new(), gas);
     }
 
-    // set result
-    result.result = match output.status {
-        PrecompileStatus::Success => InstructionResult::Return,
-        PrecompileStatus::Revert => InstructionResult::Revert,
-        PrecompileStatus::Halt(halt_reason) => {
-            if halt_reason.is_oog() {
-                InstructionResult::PrecompileOOG
-            } else {
-                InstructionResult::PrecompileError
-            }
-        }
-    };
-
-    result
+    InterpreterResult::new(result, output.bytes, gas)
 }
 
 impl<CTX: ContextTr> PrecompileProvider<CTX> for EthPrecompiles {
@@ -243,6 +230,7 @@ mod tests {
                     gas_used: u64::MAX,
                     gas_refunded: 0,
                     state_gas_used: 0,
+                    state_gas_spilled: 0,
                     reservoir: inputs.reservoir,
                     bytes: Bytes::from_static(b"unreliable"),
                 };
@@ -257,6 +245,47 @@ mod tests {
         fn warm_addresses(&self) -> &AddressSet {
             &self.warm
         }
+    }
+
+    /// The spilled portion of a precompile's state gas must reach the frame's gas
+    /// tracker, otherwise a rollback credits it to the reservoir instead of regular
+    /// gas (EIP-8037).
+    #[test]
+    fn precompile_output_propagates_spilled_state_gas() {
+        let output = PrecompileOutput {
+            status: PrecompileStatus::Success,
+            // 10 regular + 30 state gas, of which 20 spilled out of the 10 gas reservoir
+            gas_used: 40,
+            gas_refunded: 0,
+            state_gas_used: 30,
+            state_gas_spilled: 20,
+            reservoir: 0,
+            bytes: Bytes::new(),
+        };
+        let mut result = precompile_output_to_interpreter_result(output, 100);
+
+        assert_eq!(result.result, InstructionResult::Return);
+        assert_eq!(result.gas.state_gas_spent(), 30);
+        assert_eq!(result.gas.state_gas_spilled(), 20);
+        assert_eq!(result.gas.remaining(), 60);
+
+        // rollback returns the spilled part to regular gas and the rest to the reservoir
+        result.gas.rollback_state_gas();
+        assert_eq!(result.gas.remaining(), 80);
+        assert_eq!(result.gas.reservoir(), 10);
+        assert_eq!(result.gas.state_gas_spent(), 0);
+        assert_eq!(result.gas.state_gas_spilled(), 0);
+    }
+
+    /// A precompile that reports more gas than its limit is turned into an OOG halt
+    /// with all gas consumed and no output bytes.
+    #[test]
+    fn precompile_output_overspend_is_oog() {
+        let output = PrecompileOutput::new(u64::MAX, Bytes::from_static(b"out"), 0);
+        let result = precompile_output_to_interpreter_result(output, 100);
+        assert_eq!(result.result, InstructionResult::PrecompileOOG);
+        assert_eq!(result.gas.remaining(), 0);
+        assert!(result.output.is_empty());
     }
 
     /// End-to-end regression test for Bug 3. A transaction targets a custom precompile

--- a/crates/interpreter/src/gas.rs
+++ b/crates/interpreter/src/gas.rs
@@ -35,6 +35,18 @@ impl Gas {
         }
     }
 
+    /// Creates a new `Gas` struct from an existing [`GasTracker`].
+    ///
+    /// Used to lift gas accounting done outside the interpreter (a precompile,
+    /// for example) into a frame's gas.
+    #[inline]
+    pub const fn from_tracker(tracker: GasTracker) -> Self {
+        Self {
+            tracker,
+            memory: MemoryGas::new(),
+        }
+    }
+
     /// Returns the tracker for gas during execution.
     #[inline]
     pub const fn tracker(&self) -> &GasTracker {

--- a/crates/precompile/src/interface.rs
+++ b/crates/precompile/src/interface.rs
@@ -1,6 +1,6 @@
 //! Interface for the precompiles. It contains the precompile result type,
 //! the precompile output type, and the precompile error type.
-use context_interface::result::AnyError;
+use context_interface::{cfg::gas::GasTracker, result::AnyError};
 use core::fmt::{self, Debug};
 use primitives::{Bytes, OnceLock};
 use std::{borrow::Cow, boxed::Box, string::String, vec::Vec};
@@ -116,6 +116,14 @@ pub struct PrecompileOutput {
     pub gas_refunded: i64,
     /// State gas used by the precompile.
     pub state_gas_used: i64,
+    /// State gas that was drawn from regular gas because the reservoir was
+    /// empty (EIP-8037's `state_gas_from_gas_left`).
+    ///
+    /// Must be the portion of `state_gas_used` that did not fit in the
+    /// reservoir the precompile was given. It is propagated to the frame's gas
+    /// tracker so that a later revert or halt credits that portion back to
+    /// regular gas instead of the reservoir.
+    pub state_gas_spilled: u64,
     /// Reservoir gas for EIP-8037.
     pub reservoir: u64,
     /// Output bytes.
@@ -137,6 +145,7 @@ impl PrecompileOutput {
             gas_used,
             gas_refunded: 0,
             state_gas_used: 0,
+            state_gas_spilled: 0,
             reservoir,
             bytes,
         }
@@ -149,6 +158,7 @@ impl PrecompileOutput {
             gas_used: 0,
             gas_refunded: 0,
             state_gas_used: 0,
+            state_gas_spilled: 0,
             reservoir,
             bytes: Bytes::new(),
         }
@@ -161,9 +171,61 @@ impl PrecompileOutput {
             gas_used,
             gas_refunded: 0,
             state_gas_used: 0,
+            state_gas_spilled: 0,
             reservoir,
             bytes,
         }
+    }
+
+    /// Returns a precompile output that mirrors the gas accounting of `tracker`.
+    ///
+    /// The regular gas used is `tracker.limit() - tracker.remaining()`; the
+    /// refund, state gas (with its spilled portion) and the reservoir are taken
+    /// as-is. Use this when a precompile drives a [`GasTracker`] internally and
+    /// needs to hand the result back to the provider.
+    pub const fn from_gas_tracker(
+        status: PrecompileStatus,
+        bytes: Bytes,
+        tracker: GasTracker,
+    ) -> Self {
+        let mut output = Self {
+            status,
+            gas_used: 0,
+            gas_refunded: 0,
+            state_gas_used: 0,
+            state_gas_spilled: 0,
+            reservoir: 0,
+            bytes,
+        };
+        output.set_gas(tracker);
+        output
+    }
+
+    /// Overwrites the gas accounting fields from `tracker`, leaving status and
+    /// output bytes untouched.
+    ///
+    /// The regular gas used is `tracker.limit() - tracker.remaining()`; the
+    /// refund, state gas (with its spilled portion) and the reservoir are taken
+    /// as-is. All fields are replaced, not accumulated.
+    pub const fn set_gas(&mut self, tracker: GasTracker) {
+        self.gas_used = tracker.limit().saturating_sub(tracker.remaining());
+        self.gas_refunded = tracker.refunded();
+        self.state_gas_used = tracker.state_gas_spent();
+        self.state_gas_spilled = tracker.state_gas_spilled();
+        self.reservoir = tracker.reservoir();
+    }
+
+    /// Returns a [`GasTracker`] for `gas_limit` that reflects this output.
+    ///
+    /// Inverse of [`from_gas_tracker`](Self::from_gas_tracker): `gas_used` is
+    /// deducted from the regular gas (saturating at zero), and the refund, state
+    /// gas, spilled state gas and reservoir are restored.
+    pub const fn to_gas_tracker(&self, gas_limit: u64) -> GasTracker {
+        let mut tracker = GasTracker::new_used_gas(gas_limit, self.gas_used, self.reservoir);
+        tracker.set_refunded(self.gas_refunded);
+        tracker.set_state_gas_spent(self.state_gas_used);
+        tracker.set_state_gas_spilled(self.state_gas_spilled);
+        tracker
     }
 
     /// Returns `true` if the precompile execution was successful.
@@ -565,3 +627,59 @@ impl fmt::Display for PrecompileError {
 pub struct DefaultCrypto;
 
 impl Crypto for DefaultCrypto {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A tracker that spilled state gas must survive the round trip through
+    /// [`PrecompileOutput`] unchanged.
+    #[test]
+    fn gas_tracker_round_trip() {
+        // 100 regular gas, 10 reservoir. Charge 10 regular and 30 state gas,
+        // 20 of which spills out of the reservoir into regular gas.
+        let mut tracker = GasTracker::new(100, 100, 10);
+        assert!(tracker.record_regular_cost(10));
+        assert!(tracker.record_state_cost(30));
+        tracker.record_refund(5);
+        assert_eq!(
+            (tracker.remaining(), tracker.reservoir()),
+            (70, 0),
+            "10 regular + 20 spilled state gas"
+        );
+
+        let output =
+            PrecompileOutput::from_gas_tracker(PrecompileStatus::Success, Bytes::new(), tracker);
+        assert_eq!(output.gas_used, 30);
+        assert_eq!(output.gas_refunded, 5);
+        assert_eq!(output.state_gas_used, 30);
+        assert_eq!(output.state_gas_spilled, 20);
+        assert_eq!(output.reservoir, 0);
+
+        assert_eq!(output.to_gas_tracker(tracker.limit()), tracker);
+
+        // set_gas replaces the gas fields of an existing output, keeping the rest
+        let mut existing = PrecompileOutput::revert(1, Bytes::from_static(b"out"), 999);
+        existing.set_gas(tracker);
+        assert_eq!(existing.status, PrecompileStatus::Revert);
+        assert_eq!(existing.bytes, Bytes::from_static(b"out"));
+        assert_eq!(
+            (
+                existing.gas_used,
+                existing.gas_refunded,
+                existing.state_gas_used,
+                existing.state_gas_spilled,
+                existing.reservoir
+            ),
+            (30, 5, 30, 20, 0)
+        );
+    }
+
+    /// Gas used above the limit saturates instead of wrapping.
+    #[test]
+    fn to_gas_tracker_saturates_on_overspend() {
+        let mut output = PrecompileOutput::new(0, Bytes::new(), 0);
+        output.gas_used = u64::MAX;
+        assert_eq!(output.to_gas_tracker(100).remaining(), 0);
+    }
+}


### PR DESCRIPTION
`PrecompileOutput` carried `state_gas_used` and `reservoir`, but not the spilled portion of the state gas (EIP-8037's `state_gas_from_gas_left`). The reconstructed frame gas therefore always had `state_gas_spilled == 0`, so:

- a revert or halt of a precompile frame credited the spilled gas back to the *reservoir* instead of regular gas, and
- a successful frame never merged it into the parent (`handle_reservoir_remaining_gas`).

## Changes

- `PrecompileOutput::state_gas_spilled` — new field, forwarded into the frame's `Gas` by `precompile_output_to_interpreter_result`.
- `PrecompileOutput::{from_gas_tracker, set_gas, to_gas_tracker}` — convert between a precompile's gas accounting and a `GasTracker`.
- `Gas::from_tracker(GasTracker)` — lift externally-tracked gas into a frame's gas; pairs with the existing `tracker()`/`tracker_mut()`.
- `precompile_output_to_interpreter_result` simplified on top of those: the status maps to an `InstructionResult` in one flat match, the overspend check becomes `gas_used > gas_limit` (exactly when `record_regular_cost` used to fail), and the gas comes straight from `to_gas_tracker`. Behavior unchanged.

## Breaking

Adding a public field breaks external code that builds `PrecompileOutput` with struct-literal syntax; the `new`/`halt`/`revert` constructors are unaffected. No in-tree precompile sets `state_gas_used` yet.

## Testing

- New: `precompile_output_propagates_spilled_state_gas`, `precompile_output_overspend_is_oog`, `gas_tracker_round_trip`, `to_gas_tracker_saturates_on_overspend`.
- `cargo nextest run --workspace`: 393 passed. `./scripts/run-tests.sh`: 61,606 passed, 0 failed. fmt + clippy (`--all-targets --all-features`) clean.