### PR TITLE
bump: prep v115 tag, revm v42.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3864,7 +3864,7 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "42.0.0"
+version = "42.0.1"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3967,7 +3967,7 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "42.0.0"
+version = "42.0.1"
 dependencies = [
  "alloy-signer",
  "alloy-signer-local",
@@ -3987,7 +3987,7 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "42.0.0"
+version = "42.0.1"
 dependencies = [
  "auto_impl",
  "either",
@@ -4016,7 +4016,7 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "42.0.0"
+version = "42.0.1"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "revme"
-version = "42.0.0"
+version = "42.0.1"
 dependencies = [
  "alloy-rlp",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,19 +41,19 @@ default-members = ["crates/revm"]
 
 [workspace.dependencies]
 # revm
-revm = { path = "crates/revm", version = "42.0.0", default-features = false }
+revm = { path = "crates/revm", version = "42.0.1", default-features = false }
 primitives = { path = "crates/primitives", package = "revm-primitives", version = "42.0.0", default-features = false }
 bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "42.0.0", default-features = false }
 database = { path = "crates/database", package = "revm-database", version = "42.0.0", default-features = false }
 database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "42.0.0", default-features = false }
 state = { path = "crates/state", package = "revm-state", version = "42.0.0", default-features = false }
 interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "42.0.0", default-features = false }
-inspector = { path = "crates/inspector", package = "revm-inspector", version = "42.0.0", default-features = false }
-precompile = { path = "crates/precompile", package = "revm-precompile", version = "42.0.0", default-features = false }
+inspector = { path = "crates/inspector", package = "revm-inspector", version = "42.0.1", default-features = false }
+precompile = { path = "crates/precompile", package = "revm-precompile", version = "42.0.1", default-features = false }
 statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "42.0.0", default-features = false }
 context = { path = "crates/context", package = "revm-context", version = "42.0.0", default-features = false }
 context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "42.0.0", default-features = false }
-handler = { path = "crates/handler", package = "revm-handler", version = "42.0.0", default-features = false }
+handler = { path = "crates/handler", package = "revm-handler", version = "42.0.1", default-features = false }
 ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "42.0.0", default-features = false }
 
 # alloy

--- a/bins/revme/CHANGELOG.md
+++ b/bins/revme/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [42.0.1](https://github.com/bluealloy/revm/compare/revme-v42.0.0...revme-v42.0.1) - 2026-07-23
+
+### Other
+
+- updated the following local packages: revm
+
 ## [41.1.0](https://github.com/bluealloy/revm/compare/revme-v41.0.0...revme-v41.1.0) - 2026-07-22
 
 ### Added

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revme"
 description = "Rust Ethereum Virtual Machine Executable"
-version = "42.0.0"
+version = "42.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/handler/CHANGELOG.md
+++ b/crates/handler/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [42.0.1](https://github.com/bluealloy/revm/compare/revm-handler-v42.0.0...revm-handler-v42.0.1) - 2026-07-23
+
+### Fixed
+
+- *(handler)* forward a precompile's spilled state gas to the frame gas tracker ([#3821](https://github.com/bluealloy/revm/pull/3821))
+
+### Other
+
+- *(handler)* simplify `precompile_output_to_interpreter_result` ([#3821](https://github.com/bluealloy/revm/pull/3821))
+- updated the following local packages: revm-precompile
+
 ## [42.0.0](https://github.com/bluealloy/revm/compare/revm-handler-v41.0.0...revm-handler-v42.0.0) - 2026-07-22
 
 ### Added

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-handler"
 description = "Revm handler crates"
-version = "42.0.0"
+version = "42.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/inspector/CHANGELOG.md
+++ b/crates/inspector/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [42.0.1](https://github.com/bluealloy/revm/compare/revm-inspector-v42.0.0...revm-inspector-v42.0.1) - 2026-07-23
+
+### Other
+
+- updated the following local packages: revm-handler
+
 ## [42.0.0](https://github.com/bluealloy/revm/compare/revm-inspector-v41.0.0...revm-inspector-v42.0.0) - 2026-07-22
 
 ### Added

--- a/crates/inspector/Cargo.toml
+++ b/crates/inspector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-inspector"
 description = "Revm inspector interface"
-version = "42.0.0"
+version = "42.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/precompile/CHANGELOG.md
+++ b/crates/precompile/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [42.0.1](https://github.com/bluealloy/revm/compare/revm-precompile-v42.0.0...revm-precompile-v42.0.1) - 2026-07-23
+
+### Added
+
+- *(precompile)* track spilled state gas in `PrecompileOutput` ([#3821](https://github.com/bluealloy/revm/pull/3821))
+- *(precompile)* `PrecompileOutput::{from_gas_tracker, set_gas, to_gas_tracker}` ([#3821](https://github.com/bluealloy/revm/pull/3821))
+
 ## [42.0.0](https://github.com/bluealloy/revm/compare/revm-precompile-v41.0.0...revm-precompile-v42.0.0) - 2026-07-22
 
 ### Other

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-precompile"
 description = "Revm Precompiles - Ethereum compatible precompiled contracts"
-version = "42.0.0"
+version = "42.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/revm/CHANGELOG.md
+++ b/crates/revm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [42.0.1](https://github.com/bluealloy/revm/compare/revm-v42.0.0...revm-v42.0.1) - 2026-07-23
+
+### Other
+
+- updated the following local packages: revm-precompile, revm-handler, revm-inspector
+
 ## [42.0.0](https://github.com/bluealloy/revm/compare/revm-v41.0.0...revm-v42.0.0) - 2026-07-22
 
 ### Other

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm"
 description = "Revm - Rust Ethereum Virtual Machine"
-version = "42.0.0"
+version = "42.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
Release prep for the **v115** tag — a patch release, **revm v42.0.1**.

## Bumped crates

Only `revm-precompile` and `revm-handler` changed since 42.0.0 (`PrecompileOutput::state_gas_spilled` and its wiring, #3820). The other three are republished because their manifests now require the bumped versions.

| crate | 42.0.0 → 42.0.1 | reason |
|---|---|---|
| `revm-precompile` | ✔ | changed |
| `revm-handler` | ✔ | changed |
| `revm-inspector` | ✔ | depends on `revm-handler` |
| `revm` | ✔ | depends on all three |
| `revme` | ✔ | depends on `revm` |

Everything else stays at 42.0.0: `revm-primitives`, `revm-bytecode`, `revm-state`, `revm-database-interface`, `revm-context-interface`, `revm-interpreter`, `revm-database`, `revm-context`, `revm-statetest-types`. `revm-ee-tests` is not published.

Versions set with `release-plz set-version`; root `[workspace.dependencies]`, the five crate manifests, `Cargo.lock` and the changelogs are updated.

`revm-interpreter` deliberately stays at 42.0.0: the handler now builds the precompile frame gas through the existing `Gas::tracker_mut()` instead of the `Gas::from_tracker` constructor added in #3820, so the interpreter crate is byte-identical to what is already published.

## Verification

- Source diff vs the published 42.0.0 (`bc8ab332e`) touches only `crates/precompile` and `crates/handler`.
- fmt + clippy (`--all-targets --all-features`) clean; `cargo nextest run --workspace` 393 passed; `./scripts/run-tests.sh` 61,606 passed, 0 failed.