### PR TITLE
refactor(handler): build precompile frame gas without touching the interpreter crate

### DIFF
--- a/crates/handler/src/precompile_provider.rs
+++ b/crates/handler/src/precompile_provider.rs
@@ -103,7 +103,8 @@ pub fn precompile_output_to_interpreter_result(
     // Gas used, refund, state gas (with its spilled portion, so a later rollback
     // credits it back to regular gas per EIP-8037) and the reservoir all come from
     // the precompile's own accounting.
-    let mut gas = Gas::from_tracker(output.to_gas_tracker(gas_limit));
+    let mut gas = Gas::new(gas_limit);
+    *gas.tracker_mut() = output.to_gas_tracker(gas_limit);
 
     // Only a success or revert returns output bytes and keeps its unspent gas.
     if result.is_halt() {

--- a/crates/interpreter/src/gas.rs
+++ b/crates/interpreter/src/gas.rs
@@ -35,18 +35,6 @@ impl Gas {
         }
     }
 
-    /// Creates a new `Gas` struct from an existing [`GasTracker`].
-    ///
-    /// Used to lift gas accounting done outside the interpreter (a precompile,
-    /// for example) into a frame's gas.
-    #[inline]
-    pub const fn from_tracker(tracker: GasTracker) -> Self {
-        Self {
-            tracker,
-            memory: MemoryGas::new(),
-        }
-    }
-
     /// Returns the tracker for gas during execution.
     #[inline]
     pub const fn tracker(&self) -> &GasTracker {


### PR DESCRIPTION
Removes `Gas::from_tracker` from the interpreter crate and builds the precompile frame's gas in `precompile_provider.rs` instead:

```rust
let mut gas = Gas::new(gas_limit);
*gas.tracker_mut() = output.to_gas_tracker(gas_limit);
```

Same behavior — the tracker is fully overwritten and `memory` starts empty in both paths — but the interpreter no longer needs a constructor that exists only for the handler's benefit.