### PR TITLE
feat(examples): add custom frame in my_evm example

### DIFF
--- a/examples/my_evm/README.md
+++ b/examples/my_evm/README.md
@@ -5,12 +5,13 @@ specifically by disabling the beneficiary reward mechanism.
 
 ## Core Components
 
-To implement a custom EVM variant, two key components are needed:
+To implement a custom EVM variant, three key components are needed:
 
-1. A custom EVM struct ([`crate::MyEvm`] in [`crate::evm`]) that implements [`revm::handler::EvmTr`]
-2. A custom handler ([`MyHandler`]) in [`crate::handler`] that controls execution behavior and implements [`revm::handler::Handler`]
+1. A custom frame ([`crate::frame::MyFrame`]) that wraps [`revm::handler::EthFrame`] as a field and implements [`revm::handler::evm::FrameTr`]
+2. A custom EVM struct ([`crate::MyEvm`] in [`crate::evm`]) that implements [`revm::handler::EvmTr`] and drives the frame lifecycle by delegating to the wrapped [`revm::handler::EthFrame`]
+3. A custom handler ([`MyHandler`]) in [`crate::handler`] that controls execution behavior and implements [`revm::handler::Handler`]
 
-Basic usage after implementing these two components:
+Basic usage after implementing these three components:
 ```rust,ignore
 let mut my_evm = MyEvm::new(Context::mainnet(), ());
 let _res = MyHandler::default().run(&mut my_evm);
@@ -18,8 +19,9 @@ let _res = MyHandler::default().run(&mut my_evm);
 
 ## Adding Inspector Support
 
-To enable transaction inspection capabilities, implement two additional traits:
+To enable transaction inspection capabilities, implement three additional traits:
 
+- [`revm::inspector::InspectorFrame`] on [`crate::frame::MyFrame`], returning the wrapped [`revm::handler::EthFrame`] so the inspector machinery can trace through the custom frame
 - [`revm::inspector::InspectorEvmTr`] on [`MyEvm`]
 - [`revm::inspector::InspectorHandler`] on [`MyHandler`]
 

--- a/examples/my_evm/src/api.rs
+++ b/examples/my_evm/src/api.rs
@@ -32,11 +32,11 @@ where
     type Block = <CTX as ContextTr>::Block;
 
     fn set_block(&mut self, block: Self::Block) {
-        self.0.ctx.set_block(block);
+        self.ctx.set_block(block);
     }
 
     fn transact_one(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
-        self.0.ctx.set_tx(tx);
+        self.ctx.set_tx(tx);
         let mut handler = MyHandler::default();
         handler.run(self)
     }
@@ -75,11 +75,11 @@ where
     type Inspector = INSP;
 
     fn set_inspector(&mut self, inspector: Self::Inspector) {
-        self.0.inspector = inspector;
+        self.inspector = inspector;
     }
 
     fn inspect_one_tx(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
-        self.0.ctx.set_tx(tx);
+        self.ctx.set_tx(tx);
         let mut handler = MyHandler::default();
         handler.inspect_run(self)
     }

--- a/examples/my_evm/src/evm.rs
+++ b/examples/my_evm/src/evm.rs
@@ -1,70 +1,57 @@
+use crate::frame::MyFrame;
 use revm::{
-    context::{ContextError, ContextSetters, ContextTr, Evm, FrameStack},
+    context::{ContextSetters, ContextTr, FrameStack, OutFrame},
     handler::{
-        evm::FrameTr, instructions::EthInstructions, EthFrame, EthPrecompiles, EvmTr,
-        FrameInitOrResult, ItemOrResult,
+        evm::{ContextDbError, FrameInitResult, FrameTr},
+        instructions::{EthInstructions, InstructionProvider},
+        EthFrame, EthPrecompiles, EvmTr, FrameInitOrResult,
     },
     inspector::{InspectorEvmTr, JournalExt},
     interpreter::interpreter::EthInterpreter,
     primitives::hardfork::SpecId,
-    Database, Inspector,
+    Inspector,
 };
 
 /// MyEvm variant of the EVM.
 ///
-/// This struct demonstrates how to create a custom EVM implementation by wrapping
-/// the standard REVM components. It combines a context (CTX), an inspector (INSP),
-/// and the standard Ethereum instructions, precompiles, and frame execution logic.
-///
-/// The generic parameters allow for flexibility in the underlying database and
-/// inspection capabilities while maintaining the standard Ethereum execution semantics.
+/// Implements [`EvmTr`] manually as the stock implementation is only provided
+/// for `Evm` parameterized with [`EthFrame`]. Frame handling is delegated to
+/// the [`EthFrame`] wrapped inside [`MyFrame`].
 #[derive(Debug)]
-pub struct MyEvm<CTX, INSP>(
-    pub  Evm<
-        CTX,
-        INSP,
-        EthInstructions<EthInterpreter, CTX>,
-        EthPrecompiles,
-        EthFrame<EthInterpreter>,
-    >,
-);
+pub struct MyEvm<CTX, INSP> {
+    /// [`ContextTr`] of the EVM, it is used to fetch data from database.
+    pub ctx: CTX,
+    /// Inspector of the EVM it is used to inspect the EVM.
+    /// Its trait are defined in revm-inspector crate.
+    pub inspector: INSP,
+    /// Instructions provider of the EVM it is used to execute instructions.
+    /// `InstructionProvider` trait is defined in revm-handler crate.
+    pub instruction: EthInstructions<EthInterpreter, CTX>,
+    /// Precompile provider of the EVM it is used to execute precompiles.
+    /// `PrecompileProvider` trait is defined in revm-handler crate.
+    pub precompiles: EthPrecompiles,
+    /// The custom frame stack that is going to be executed.
+    pub frame_stack: FrameStack<MyFrame>,
+}
 
 impl<CTX: ContextTr, INSP> MyEvm<CTX, INSP> {
     /// Creates a new instance of MyEvm with the provided context and inspector.
-    ///
-    /// # Arguments
-    ///
-    /// * `ctx` - The execution context that manages state, environment, and journaling
-    /// * `inspector` - The inspector for debugging and tracing execution
-    ///
-    /// # Returns
-    ///
-    /// A new MyEvm instance configured with:
-    /// - The provided context and inspector
-    /// - Mainnet instruction set
-    /// - Default Ethereum precompiles
-    /// - A fresh frame stack for execution
     pub fn new(ctx: CTX, inspector: INSP) -> Self {
-        Self(Evm {
+        Self {
             ctx,
             inspector,
             instruction: EthInstructions::new_mainnet_with_spec(SpecId::default()),
             precompiles: EthPrecompiles::new(SpecId::default()),
             frame_stack: FrameStack::new(),
-            #[cfg(feature = "asyncdb")]
-            async_stack: revm::database_interface::async_db::FiberStack::default(),
-        })
+        }
     }
 }
 
-impl<CTX: ContextTr, INSP> EvmTr for MyEvm<CTX, INSP>
-where
-    CTX: ContextTr,
-{
+impl<CTX: ContextTr, INSP> EvmTr for MyEvm<CTX, INSP> {
     type Context = CTX;
     type Instructions = EthInstructions<EthInterpreter, CTX>;
     type Precompiles = EthPrecompiles;
-    type Frame = EthFrame<EthInterpreter>;
+    type Frame = MyFrame;
 
     #[inline]
     fn all(
@@ -75,7 +62,12 @@ where
         &Self::Precompiles,
         &FrameStack<Self::Frame>,
     ) {
-        self.0.all()
+        (
+            &self.ctx,
+            &self.instruction,
+            &self.precompiles,
+            &self.frame_stack,
+        )
     }
 
     #[inline]
@@ -87,39 +79,91 @@ where
         &mut Self::Precompiles,
         &mut FrameStack<Self::Frame>,
     ) {
-        self.0.all_mut()
+        (
+            &mut self.ctx,
+            &mut self.instruction,
+            &mut self.precompiles,
+            &mut self.frame_stack,
+        )
     }
 
+    /// Initializes the frame for the given frame input. Frame is pushed to the frame stack.
     #[inline]
     fn frame_init(
         &mut self,
         frame_input: <Self::Frame as FrameTr>::FrameInit,
-    ) -> Result<
-        ItemOrResult<&mut Self::Frame, <Self::Frame as FrameTr>::FrameResult>,
-        ContextError<<<Self::Context as ContextTr>::Db as Database>::Error>,
-    > {
-        self.0.frame_init(frame_input)
+    ) -> Result<FrameInitResult<'_, Self::Frame>, ContextDbError<CTX>> {
+        let is_first_init = self.frame_stack.index().is_none();
+        let mut new_frame = if is_first_init {
+            self.frame_stack.start_init()
+        } else {
+            self.frame_stack.get_next()
+        };
+
+        // Materialize the custom frame and initialize the wrapped EthFrame in place.
+        // `invalid()` must stay allocation-free as an early result overwrites it without drop.
+        let frame = new_frame.get(MyFrame::invalid);
+        let res = EthFrame::init_with_context(
+            OutFrame::new_init(&mut frame.eth_frame),
+            &mut self.ctx,
+            &mut self.precompiles,
+            frame_input,
+        )?;
+        let token = new_frame.consume();
+
+        Ok(res.map_item(|_inner_token| {
+            if is_first_init {
+                unsafe { self.frame_stack.end_init(token) };
+            } else {
+                unsafe { self.frame_stack.push(token) };
+            }
+            self.frame_stack.get()
+        }))
     }
 
+    /// Run the frame from the top of the stack. Returns the frame init or result.
+    ///
+    /// If frame has returned result it would mark it as finished.
     #[inline]
-    fn frame_run(
-        &mut self,
-    ) -> Result<
-        FrameInitOrResult<Self::Frame>,
-        ContextError<<<Self::Context as ContextTr>::Db as Database>::Error>,
-    > {
-        self.0.frame_run()
+    fn frame_run(&mut self) -> Result<FrameInitOrResult<Self::Frame>, ContextDbError<CTX>> {
+        let frame = self.frame_stack.get();
+        let context = &mut self.ctx;
+        let instructions = &mut self.instruction;
+
+        let action = frame.eth_frame.interpreter.run_plain(
+            instructions.instruction_table(),
+            instructions.gas_table(),
+            context,
+        );
+
+        frame
+            .eth_frame
+            .process_next_action(context, action)
+            .inspect(|i| {
+                if i.is_result() {
+                    frame.eth_frame.set_finished(true);
+                }
+            })
     }
 
+    /// Returns the result of the frame to the caller. Frame is popped from the frame stack.
+    /// Consumes the frame result or returns it if there is more frames to run.
     #[inline]
     fn frame_return_result(
         &mut self,
-        frame_result: <Self::Frame as FrameTr>::FrameResult,
-    ) -> Result<
-        Option<<Self::Frame as FrameTr>::FrameResult>,
-        ContextError<<<Self::Context as ContextTr>::Db as Database>::Error>,
-    > {
-        self.0.frame_return_result(frame_result)
+        result: <Self::Frame as FrameTr>::FrameResult,
+    ) -> Result<Option<<Self::Frame as FrameTr>::FrameResult>, ContextDbError<Self::Context>> {
+        if self.frame_stack.get().is_finished() {
+            self.frame_stack.pop();
+        }
+        if self.frame_stack.index().is_none() {
+            return Ok(Some(result));
+        }
+        self.frame_stack
+            .get()
+            .eth_frame
+            .return_result::<_, ContextDbError<Self::Context>>(&mut self.ctx, result)?;
+        Ok(None)
     }
 }
 
@@ -139,7 +183,13 @@ where
         &FrameStack<Self::Frame>,
         &Self::Inspector,
     ) {
-        self.0.all_inspector()
+        (
+            &self.ctx,
+            &self.instruction,
+            &self.precompiles,
+            &self.frame_stack,
+            &self.inspector,
+        )
     }
 
     fn all_mut_inspector(
@@ -151,6 +201,12 @@ where
         &mut FrameStack<Self::Frame>,
         &mut Self::Inspector,
     ) {
-        self.0.all_mut_inspector()
+        (
+            &mut self.ctx,
+            &mut self.instruction,
+            &mut self.precompiles,
+            &mut self.frame_stack,
+            &mut self.inspector,
+        )
     }
 }

--- a/examples/my_evm/src/frame.rs
+++ b/examples/my_evm/src/frame.rs
@@ -1,0 +1,44 @@
+//! Custom frame that wraps [`EthFrame`](revm::handler::EthFrame).
+//!
+//! Useful when a custom EVM variant needs to carry additional per-call-frame
+//! state or intercept frame creation, execution, or return.
+use revm::{
+    handler::{evm::FrameTr, EthFrame, FrameResult},
+    inspector::InspectorFrame,
+    interpreter::{interpreter::EthInterpreter, interpreter_action::FrameInit},
+};
+
+/// A custom frame that wraps [`EthFrame`] and delegates execution to it.
+#[derive(Debug)]
+pub struct MyFrame {
+    /// The wrapped Ethereum frame that performs the actual execution.
+    pub eth_frame: EthFrame<EthInterpreter>,
+}
+
+impl MyFrame {
+    /// Creates a new invalid [`MyFrame`].
+    pub fn invalid() -> Self {
+        Self {
+            eth_frame: EthFrame::invalid(),
+        }
+    }
+
+    /// Returns true if the frame has finished execution.
+    pub const fn is_finished(&self) -> bool {
+        self.eth_frame.is_finished()
+    }
+}
+
+impl FrameTr for MyFrame {
+    type FrameResult = FrameResult;
+    type FrameInit = FrameInit;
+}
+
+/// Exposes the inner [`EthFrame`] so inspectors can trace through the custom frame.
+impl InspectorFrame for MyFrame {
+    type IT = EthInterpreter;
+
+    fn eth_frame(&mut self) -> Option<&mut EthFrame<EthInterpreter>> {
+        Some(&mut self.eth_frame)
+    }
+}

--- a/examples/my_evm/src/lib.rs
+++ b/examples/my_evm/src/lib.rs
@@ -14,5 +14,9 @@ pub mod evm;
 /// including how transactions are processed and how the EVM interacts with inspectors.
 pub mod handler;
 
+/// Custom frame implementation for MyEvm.
+/// This module contains MyFrame, which wraps the standard EthFrame with custom frame handling.
+pub mod frame;
+
 pub use evm::*;
 pub use handler::*;


### PR DESCRIPTION
> AI disclosure: This changes have been made with Claude Opus 5 but I have manually reviewed them and I take responsibility for its correctness.

Closes #2984

Example half of #3009, re-expressed against the current API (its library plumbing landed in #3036/#3037/#3038). Zero library changes - everything is inside `examples/my_evm`.

- `frame.rs` (new): `MyFrame` wraps `EthFrame`, implements `FrameTr` + `InspectorFrame` (returning the inner frame keeps it inspectable).
- `evm.rs`: `MyEvm` holds `FrameStack<MyFrame>` and implements `EvmTr`/`InspectorEvmTr` directly, since the stock impl only exists for `Evm` with `EthFrame`. The frame lifecycle delegates to the wrapped `EthFrame`: `init_with_context` via an `OutFrame::new_init(&mut frame.eth_frame)` projection, `run_plain` + `process_next_action`, `return_result`.
- `README.md`: documents the custom frame as the third component.

`handler.rs` and `main.rs` compile unchanged. Besides the stock example run (clippy/doc clean), I verified off-branch that a nested CALL executed twice on one `MyEvm` works — child frames, result propagation, and pooled frame-slot reuse all behave through the wrapper.

Open question: `frame_run`/`frame_return_result` are near-copies of the stock bodies, which any custom frame currently has to duplicate. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
