### PR TITLE
fix: check call depth in CREATE pre-access checks (EIP-8037)

### DIFF
--- a/crates/context/interface/src/host.rs
+++ b/crates/context/interface/src/host.rs
@@ -210,6 +210,7 @@ pub trait Host {
 #[derive(Default, Debug)]
 pub struct DummyHost {
     gas_params: GasParams,
+    spec: SpecId,
 }
 
 impl DummyHost {
@@ -217,6 +218,7 @@ impl DummyHost {
     pub fn new(spec: SpecId) -> Self {
         Self {
             gas_params: GasParams::new_spec(spec),
+            spec,
         }
     }
 }
@@ -239,7 +241,7 @@ impl Host for DummyHost {
     }
 
     fn is_amsterdam_eip8037_enabled(&self) -> bool {
-        false
+        self.spec.is_enabled_in(SpecId::AMSTERDAM)
     }
 
     fn difficulty(&self) -> U256 {

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -199,6 +199,7 @@ impl EthFrame<EthInterpreter> {
             bytecode_address: Some(inputs.bytecode_address),
             input: inputs.input.clone(),
             call_value: inputs.value.get(),
+            depth,
         };
         let is_static = inputs.is_static;
         let gas_limit = inputs.gas_limit;
@@ -341,6 +342,7 @@ impl EthFrame<EthInterpreter> {
             bytecode_address: None,
             input: CallInput::Bytes(Bytes::new()),
             call_value: inputs.value(),
+            depth,
         };
         let gas_limit = inputs.gas_limit();
 

--- a/crates/interpreter/src/instructions/contract.rs
+++ b/crates/interpreter/src/instructions/contract.rs
@@ -15,7 +15,7 @@ use crate::{
     InstructionExecResult as Result, InstructionResult, InterpreterAction,
 };
 use context_interface::CreateScheme;
-use primitives::{hardfork::SpecId, Bytes, U256};
+use primitives::{constants::CALL_STACK_LIMIT, hardfork::SpecId, Bytes, U256};
 use std::boxed::Box;
 
 use crate::InstructionContext as Ictx;
@@ -102,16 +102,19 @@ pub fn create<const IS_CREATE2: bool, IT: ITy, H: Host + ?Sized>(
         // The charge is conditional at access, applied in
         // the creating frame before the 63/64 split. The destination is read
         // (and charged for) only after the pre-access checks — endowment
-        // balance and sender nonce overflow — pass; failing those pushes 0
-        // without touching the destination. (The call-depth pre-access check
-        // lives at frame creation; its failure path refunds the charge.)
+        // balance, sender nonce overflow, and call depth — pass; failing those
+        // pushes 0 without touching the destination, keeping it out of the
+        // EIP-7928 block access list and the warm set.
         let caller = create_inputs.caller();
         let caller_info = context
             .host
             .load_account_info_skip_cold_load(caller, false, false)?;
         let caller_balance = caller_info.account.balance;
         let caller_nonce = caller_info.account.nonce;
-        if caller_balance < value || caller_nonce == u64::MAX {
+        if caller_balance < value
+            || caller_nonce == u64::MAX
+            || context.interpreter.input.depth() + 1 > CALL_STACK_LIMIT as usize
+        {
             context.interpreter.return_data.clear();
             push!(context.interpreter, U256::ZERO);
             return Ok(());
@@ -241,4 +244,44 @@ pub fn call<const KIND: u8, IT: ITy, H: Host + ?Sized>(mut context: Ictx<'_, H, 
             },
         ))));
     Err(InstructionResult::Suspend)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        host::DummyHost,
+        instructions::{gas_table, instruction_table},
+        interpreter::{EthInterpreter, ExtBytecode, InputsImpl, SharedMemory},
+        Interpreter, InterpreterAction,
+    };
+    use bytecode::opcode::*;
+    use bytecode::Bytecode;
+    use primitives::{constants::CALL_STACK_LIMIT, hardfork::SpecId, Bytes, U256};
+
+    #[test]
+    fn create_too_deep_pushes_zero_without_destination_access_eip8037() {
+        // EIP-8037: the depth pre-check fails in the opcode itself, pushing 0 without
+        // requesting a create frame or reading the destination account, which would
+        // otherwise leak the address into the EIP-7928 block access list.
+        let bytecode =
+            Bytecode::new_raw(Bytes::copy_from_slice(&[PUSH0, PUSH0, PUSH0, CREATE, STOP]));
+        let mut interpreter = Interpreter::<EthInterpreter>::new(
+            SharedMemory::new(),
+            ExtBytecode::new(bytecode),
+            InputsImpl {
+                depth: CALL_STACK_LIMIT as usize,
+                ..Default::default()
+            },
+            false,
+            SpecId::AMSTERDAM,
+            1_000_000,
+        );
+        let table = instruction_table::<EthInterpreter, DummyHost>();
+        let gas = gas_table();
+        let mut host = DummyHost::new(SpecId::AMSTERDAM);
+        let action = interpreter.run_plain(&table, &gas, &mut host);
+        assert!(!matches!(action, InterpreterAction::NewFrame(_)));
+        assert_eq!(interpreter.stack.len(), 1);
+        assert_eq!(interpreter.stack.data()[0], U256::ZERO);
+    }
 }

--- a/crates/interpreter/src/interpreter/input.rs
+++ b/crates/interpreter/src/interpreter/input.rs
@@ -18,11 +18,17 @@ pub struct InputsImpl {
     pub input: CallInput,
     /// Value of the call.
     pub call_value: U256,
+    /// Call depth of the frame this interpreter executes (0 for the first frame).
+    pub depth: usize,
 }
 
 impl InputsTr for InputsImpl {
     fn target_address(&self) -> Address {
         self.target_address
+    }
+
+    fn depth(&self) -> usize {
+        self.depth
     }
 
     fn caller_address(&self) -> Address {

--- a/crates/interpreter/src/interpreter_types.rs
+++ b/crates/interpreter/src/interpreter_types.rs
@@ -52,6 +52,8 @@ pub trait InputsTr {
     fn input(&self) -> &CallInput;
     /// Returns call value of the call.
     fn call_value(&self) -> U256;
+    /// Returns the call depth of the frame this interpreter executes (0 for the first frame).
+    fn depth(&self) -> usize;
 }
 
 /// Trait needed for legacy bytecode.


### PR DESCRIPTION
## Summary

Moves the call-depth limit check from frame creation into the CREATE opcode's pre-access checks. Under EIP-8037, a too-deep CREATE now pushes 0 without reading the destination account, keeping the derived address out of the EIP-7928 block access list and the warm set.

- Add `depth` to `InputsTr`/`InputsImpl` and thread it through frame creation so the opcode can see the current call depth
- `DummyHost` now reports EIP-8037 as enabled when constructed with an Amsterdam spec
- Add a test asserting that a CREATE at the depth limit pushes 0 without requesting a new frame

## Testing

- `cargo nextest run -p revm-interpreter create_too_deep`
- `cargo clippy --workspace --all-targets --all-features`
- `cargo fmt --all --check`