### PR TITLE
fix(inspector): preserve selfdestruct trace payload

### DIFF
--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -6,12 +6,13 @@ use handler::{
     FrameResult, Handler, ItemOrResult,
 };
 use interpreter::{
-    instructions::{GasTable, InstructionTable},
-    interpreter_types::LoopControl,
+    instructions::{utility::IntoAddress, GasTable, InstructionTable},
+    interpreter_types::{InputsTr, Jumps, LoopControl, StackTr},
     FrameInput, GasTracker, Host, InitialAndFloorGas, InstructionResult, Interpreter,
     InterpreterAction, InterpreterTypes,
 };
-use primitives::hints_util::cold_path;
+use primitives::{hints_util::cold_path, Address, U256};
+use state::bytecode::opcode;
 
 /// Trait that extends [`Handler`] with inspection functionality.
 ///
@@ -259,11 +260,25 @@ where
     IT: InterpreterTypes,
 {
     let mut instruction_journal_i = None;
+    let mut selfdestruct;
     loop {
+        selfdestruct = None;
         inspector.step(interpreter, context);
         if interpreter.bytecode.is_end() {
             cold_path();
             break;
+        }
+
+        if interpreter.bytecode.opcode() == opcode::SELFDESTRUCT {
+            cold_path();
+            // SELFDESTRUCT pops its beneficiary and the journal only records state changes. In
+            // particular, EIP-6780 selfdestruct-to-self leaves no journal entry, so preserve the
+            // complete tracing payload before executing the opcode.
+            let contract = interpreter.input.target_address();
+            selfdestruct = interpreter.stack.top().and_then(|beneficiary| {
+                let balance = context.journal().evm_state().get(&contract)?.info.balance;
+                Some((contract, beneficiary.into_address(), balance))
+            });
         }
 
         instruction_journal_i = Some(context.journal().journal().len());
@@ -294,7 +309,7 @@ where
     if let InterpreterAction::Return(result) = &next_action {
         if result.result == InstructionResult::SelfDestruct {
             if let Some(journal_i) = instruction_journal_i {
-                inspect_selfdestruct(context, &mut inspector, journal_i);
+                inspect_selfdestruct(context, &mut inspector, journal_i, selfdestruct);
             }
         }
     }
@@ -343,6 +358,7 @@ fn inspect_selfdestruct<CTX, IT>(
     context: &mut CTX,
     inspector: &mut impl Inspector<CTX, IT>,
     journal_i: usize,
+    selfdestruct: Option<(Address, Address, U256)>,
 ) where
     CTX: ContextTr<Journal: JournalExt> + Host,
     IT: InterpreterTypes,
@@ -353,7 +369,9 @@ fn inspect_selfdestruct<CTX, IT>(
         .get(journal_i..)
         .and_then(|entries| entries.last());
 
-    if let Some(
+    if let Some((contract, beneficiary, balance)) = selfdestruct {
+        inspector.selfdestruct(contract, beneficiary, balance);
+    } else if let Some(
         JournalEntry::AccountDestroyed {
             address: contract,
             target: to,

--- a/crates/inspector/src/inspector.rs
+++ b/crates/inspector/src/inspector.rs
@@ -138,7 +138,10 @@ pub trait Inspector<CTX, INTR: InterpreterTypes = EthInterpreter, FI = FrameInpu
         let _ = outcome;
     }
 
-    /// Called when a contract has been self-destructed with funds transferred to target.
+    /// Called after a contract successfully executes `SELFDESTRUCT`.
+    ///
+    /// `value` is the contract's balance immediately before the opcode executes. It can be
+    /// non-zero even when no funds move, such as a post-Cancun selfdestruct-to-self.
     #[inline]
     fn selfdestruct(&mut self, contract: Address, target: Address, value: U256) {
         let _ = contract;

--- a/crates/inspector/src/inspector_tests.rs
+++ b/crates/inspector/src/inspector_tests.rs
@@ -4,7 +4,7 @@ mod tests {
         InspectCommitEvm, InspectEvm, InspectSystemCallEvm, InspectorEvent, TestInspector,
     };
     use context::{CfgEnv, Context, TxEnv};
-    use database::{BenchmarkDB, BENCH_CALLER, BENCH_TARGET};
+    use database::{BenchmarkDB, BENCH_CALLER, BENCH_TARGET, BENCH_TARGET_BALANCE};
     use handler::{ExecuteEvm, MainBuilder, MainContext};
     use primitives::{
         address,
@@ -534,19 +534,20 @@ mod tests {
     }
 
     #[test]
-    fn cancun_selfdestruct_to_self_does_not_reuse_prior_journal_entry() {
+    fn cancun_selfdestruct_to_self_reports_pre_opcode_balance() {
         let code = Bytes::from(vec![opcode::ADDRESS, opcode::SELFDESTRUCT]);
         let ctx = Context::mainnet()
             .with_cfg(CfgEnv::new_with_spec(SpecId::CANCUN))
             .with_db(BenchmarkDB::new_bytecode(Bytecode::new_legacy(code)));
         let mut evm = ctx.build_mainnet_with_inspector(TestInspector::new());
+        let tx_value = U256::from(459);
 
         let result = evm
             .inspect_one_tx(
                 TxEnv::builder()
                     .caller(BENCH_CALLER)
                     .kind(TxKind::Call(BENCH_TARGET))
-                    .value(U256::from(459))
+                    .value(tx_value)
                     .gas_limit(100_000)
                     .gas_price(0)
                     .build()
@@ -555,13 +556,92 @@ mod tests {
             .unwrap();
         assert!(result.is_success());
 
-        assert!(
-            !evm.inspector
-                .get_events()
-                .iter()
-                .any(|event| matches!(event, InspectorEvent::Selfdestruct { .. })),
-            "Cancun selfdestruct-to-self must not reuse the transaction value-transfer journal entry"
+        let events = selfdestruct_events(&evm.inspector);
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0],
+            (BENCH_TARGET, BENCH_TARGET, BENCH_TARGET_BALANCE + tx_value),
+            "must report the pre-opcode balance, not the transaction value-transfer journal entry"
         );
+    }
+
+    #[test]
+    fn cancun_delegatecall_selfdestruct_to_self_is_reported() {
+        let implementation = address!("1000000000000000000000000000000000000000");
+        let implementation_code = Bytes::from(vec![opcode::ADDRESS, opcode::SELFDESTRUCT]);
+
+        // DELEGATECALL with empty input/output. The implementation executes ADDRESS, so the
+        // beneficiary is the delegator whose storage and balance are in use.
+        let mut delegator_code = vec![
+            opcode::PUSH0,
+            opcode::PUSH0,
+            opcode::PUSH0,
+            opcode::PUSH0,
+            opcode::PUSH20,
+        ];
+        delegator_code.extend_from_slice(implementation.as_slice());
+        delegator_code.extend_from_slice(&[
+            opcode::PUSH2,
+            0xff,
+            0xff,
+            opcode::DELEGATECALL,
+            opcode::STOP,
+        ]);
+        let delegator_code = Bytes::from(delegator_code);
+
+        let mut db = database::InMemoryDB::default();
+        db.insert_account_info(BENCH_TARGET, account_with_code(delegator_code, U256::ZERO));
+        db.insert_account_info(
+            implementation,
+            account_with_code(implementation_code, U256::ZERO),
+        );
+
+        let ctx = Context::mainnet()
+            .with_cfg(CfgEnv::new_with_spec(SpecId::CANCUN))
+            .with_db(db);
+        let mut evm = ctx.build_mainnet_with_inspector(TestInspector::new());
+
+        let result = evm
+            .inspect_one_tx(
+                TxEnv::builder()
+                    .caller(BENCH_CALLER)
+                    .kind(TxKind::Call(BENCH_TARGET))
+                    .gas_limit(100_000)
+                    .gas_price(0)
+                    .build()
+                    .unwrap(),
+            )
+            .unwrap();
+        assert!(result.is_success());
+
+        let events = selfdestruct_events(&evm.inspector);
+        assert_eq!(events, [(BENCH_TARGET, BENCH_TARGET, U256::ZERO)]);
+    }
+
+    fn account_with_code(code: Bytes, balance: U256) -> AccountInfo {
+        AccountInfo {
+            balance,
+            nonce: 1,
+            code_hash: primitives::keccak256(&code),
+            code: Some(Bytecode::new_raw(code)),
+            ..Default::default()
+        }
+    }
+
+    /// Collects every selfdestruct the inspector was told about.
+    fn selfdestruct_events(inspector: &TestInspector) -> Vec<(Address, Address, U256)> {
+        inspector
+            .get_events()
+            .iter()
+            .filter_map(|event| match event {
+                InspectorEvent::Selfdestruct {
+                    address,
+                    beneficiary,
+                    value,
+                } => Some((*address, *beneficiary, *value)),
+                _ => None,
+            })
+            .collect()
     }
 
     #[test]


### PR DESCRIPTION
Closes #3834

## Context

After Cancun, `SELFDESTRUCT` has no state effect when a contract that was not created in the current transaction names itself as the beneficiary. In that case, `JournalInner::selfdestruct` correctly records no journal entry.

`Inspector::selfdestruct` is currently reconstructed from those journal entries, so the hook never fires for this case. `revm-inspectors` still observes the successful `InstructionResult::SelfDestruct` and emits a callTracer frame from unset fields: `from` becomes the zero address, while `to` and `value` are absent. Geth instead invokes its tracer unconditionally with the executing account, beneficiary, and pre-opcode balance.

This is a follow-up to #1746, which added support for the `BalanceTransfer` journal entry but could not cover a selfdestruct that produces no entry at all. The issue is particularly easy to hit through `DELEGATECALL`, where the account executing the opcode differs from the address whose code is running.

## Fix

Capture the tracing payload immediately before executing `SELFDESTRUCT`, while all of it is still available:

- the executing account from `input.target_address()`, which preserves the correct identity under `DELEGATECALL`;
- the beneficiary from the top of the stack;
- the executing account's balance before the opcode.

After a successful `SELFDESTRUCT`, the inspector hook prefers this captured payload. The journal-derived path remains as a compatibility fallback for custom instruction tables. Failed selfdestructs still emit no event, and the non-inspected execution path is unchanged.

## Semantics

`Inspector::selfdestruct` now consistently exposes `value` as the executing account's balance immediately before the opcode, rather than the amount by which state changed. This restores the original inspector behavior and matches geth: `value` can be non-zero even when no funds move.

As a result:

- post-Cancun selfdestruct-to-self is reported instead of being silently dropped;
- delegated execution reports the delegator, not the code address;
- under Amsterdam/EIP-8246, created-in-transaction selfdestruct-to-self reports the pre-opcode balance instead of the journal entry's zero `had_balance`.
