### PR TITLE
perf(precompile): reformulate kzg verify to drop the G2 scalar mul

### DIFF
--- a/crates/precompile/src/kzg_point_evaluation.rs
+++ b/crates/precompile/src/kzg_point_evaluation.rs
@@ -176,4 +176,46 @@ mod tests {
         let t = verify_kzg_proof(&commitment, &z, &y, &proof);
         assert!(!t);
     }
+
+    /// A correct proof with the claimed evaluation `y` perturbed by one bit must
+    /// be rejected. All points are finite, so both pairing pairs are non-trivial:
+    /// this pins the reformulated pairing check (`e(D, -G2)·e(proof, [τ]G2) == 1`,
+    /// `D = commitment - [y]G1 + [z]·proof`) to the exact correct relation, using
+    /// the c-kzg `basic_test` vector as an independent oracle.
+    #[test]
+    fn test_correct_vector_tampered_y_invalid() {
+        let commitment = hex!("8f59a8d2a1a625a17f3fea0fe5eb8c896db3764f3185481bc22f91b4aaffcca25f26936857bc3a7c2539ea8ec3a952b7");
+        let z = hex!("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000");
+        // basic_test's correct y (1522…49e9) with its lowest bit flipped. The
+        // result (…49e8) is still far below the modulus, hence canonical, so it is
+        // rejected by the pairing check and not by the canonical-scalar guard.
+        let mut y =
+            hex!("1522a4a7f34e1ea350ae07c29c96c7e79655aa926122e95fe69fcbd932ca49e9").to_vec();
+        y[31] ^= 0x01;
+        let y: [u8; 32] = y.try_into().unwrap();
+        let proof = hex!("a62ad71d14c5719385c0686f1871430475bf3a00f0aa3f7b8dd99a9abc2160744faf0070725e00b60ad9a026a15b1a8c");
+
+        assert!(!verify_kzg_proof(&commitment, &z, &y, &proof));
+    }
+
+    /// Mirror of [`test_infinity_proof_invalid`] for the reformulated check: here
+    /// `D = commitment - [y]G1 + [z]·proof` is the point at infinity while `proof`
+    /// is finite, so the *D* pair is the one filtered out and the *proof* pair is
+    /// kept. With commitment = proof = the compressed G1 generator, `y = 0` and
+    /// `z = r - 1`, we have `[z]·proof = [r-1]G1 = -G1`, hence `D = G1 - 0 + (-G1) = ∞`
+    /// but `proof = G1 ≠ ∞`. A `D = ∞` proof is only valid when `proof = ∞` too, so
+    /// this must be rejected. (Holds identically under the pre-reformulation form,
+    /// so it is also a regression guard.)
+    #[test]
+    fn test_d_infinity_finite_proof_invalid() {
+        // Compressed BLS12-381 G1 generator.
+        let g1 = hex!("97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb");
+        let commitment = g1;
+        let proof = g1;
+        // r - 1, canonical.
+        let z = hex!("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000");
+        let y = hex!("0000000000000000000000000000000000000000000000000000000000000000");
+
+        assert!(!verify_kzg_proof(&commitment, &z, &y, &proof));
+    }
 }

--- a/crates/precompile/src/kzg_point_evaluation/arkworks.rs
+++ b/crates/precompile/src/kzg_point_evaluation/arkworks.rs
@@ -1,13 +1,14 @@
 //! KZG point evaluation precompile using Arkworks BLS12-381 implementation.
-use crate::{
-    bls12_381::arkworks::pairing_check, bls12_381_const::TRUSTED_SETUP_TAU_G2_BYTES, PrecompileHalt,
-};
-use ark_bls12_381::{Fr, G1Affine, G2Affine};
-use ark_ec::{AffineRepr, CurveGroup};
-use ark_ff::{BigInteger, PrimeField};
+use crate::{bls12_381_const::TRUSTED_SETUP_TAU_G2_BYTES, PrecompileHalt};
+use ark_bls12_381::{Bls12_381, Fr, G1Affine, G2Affine};
+use ark_ec::{pairing::Pairing, AffineRepr, CurveGroup};
+use ark_ff::{BigInteger, One, PrimeField};
 use ark_serialize::CanonicalDeserialize;
 use core::ops::Neg;
 use primitives::OnceLock;
+
+/// Miller-loop-prepared G2 point (the `Pairing` associated type; not a root export).
+type G2Prepared = <Bls12_381 as Pairing>::G2Prepared;
 
 /// Verify KZG proof using BLS12-381 implementation.
 ///
@@ -20,18 +21,15 @@ pub fn verify_kzg_proof(
     y: &[u8; 32],
     proof: &[u8; 48],
 ) -> bool {
-    // Parse the commitment (G1 point)
+    // Parse the commitment and proof (G1 points)
     let Ok(commitment_point) = parse_g1_compressed(commitment) else {
         return false;
     };
-
-    // Parse the proof (G1 point)
     let Ok(proof_point) = parse_g1_compressed(proof) else {
         return false;
     };
 
-    // Parse z and y as field elements (Fr, scalar field)
-    // We expect 32-byte big-endian scalars that must be canonical
+    // Parse z and y as canonical scalar field elements (Fr)
     let Ok(z_fr) = read_scalar_canonical(z) else {
         return false;
     };
@@ -39,26 +37,42 @@ pub fn verify_kzg_proof(
         return false;
     };
 
-    // Get the trusted setup G2 point [τ]₂
-    let tau_g2 = get_trusted_setup_g2();
+    // Reformulated single-proof KZG check. Starting from the standard
+    //   e(commitment - [y]G1, -G2) · e(proof, [τ]G2 - [z]G2) == 1
+    // and applying bilinearity `e(proof, -[z]G2) = e([z]·proof, -G2)` to move z
+    // out of G2, both G2 pairing inputs collapse to the compile-time constants
+    // -G2 and [τ]G2:
+    //   e(D, -G2) · e(proof, [τ]G2) == 1,   D = commitment - [y]G1 + [z]·proof
+    // This trades the per-call G2 scalar multiplication for a cheaper G1 one and
+    // lets the two constant G2 points be prepared for the Miller loop just once.
+    let g1 = G1Affine::generator();
+    let y_g1 = g1.mul_bigint(y_fr.into_bigint());
+    let z_proof = proof_point.mul_bigint(z_fr.into_bigint());
+    // Accumulate in projective coordinates and normalize to affine exactly once.
+    let d = (commitment_point.into_group() - y_g1 + z_proof).into_affine();
 
-    // Get generators
-    let g1 = get_g1_generator();
-    let g2 = get_g2_generator();
+    // `multi_miller_loop` drops any pair whose G1 or G2 point is the identity, so
+    // an infinity `d` or `proof` is handled here (the two G2 points are never
+    // infinity). One shared final exponentiation covers both pairs.
+    let mll = Bls12_381::multi_miller_loop(
+        [d, proof_point],
+        [neg_g2_prepared().clone(), tau_g2_prepared().clone()],
+    );
+    Bls12_381::final_exponentiation(mll)
+        .map(|out| out.0.is_one())
+        .unwrap_or(false)
+}
 
-    // Compute P_minus_y = commitment - [y]G₁
-    let y_g1 = p1_scalar_mul(&g1, &y_fr);
-    let p_minus_y = p1_sub_affine(&commitment_point, &y_g1);
+/// Miller-loop preparation of the constant `-G2` generator, computed once.
+fn neg_g2_prepared() -> &'static G2Prepared {
+    static NEG_G2: OnceLock<G2Prepared> = OnceLock::new();
+    NEG_G2.get_or_init(|| G2Prepared::from(G2Affine::generator().neg()))
+}
 
-    // Compute X_minus_z = [τ]G₂ - [z]G₂
-    let z_g2 = p2_scalar_mul(&g2, &z_fr);
-    let x_minus_z = p2_sub_affine(tau_g2, &z_g2);
-
-    // Verify: P - y = Q * (X - z)
-    // Using pairing check: e(P - y, -G₂) * e(proof, X - z) == 1
-    let neg_g2 = p2_neg(&g2);
-
-    pairing_check(&[(p_minus_y, neg_g2), (proof_point, x_minus_z)])
+/// Miller-loop preparation of the trusted-setup point `[τ]G2`, computed once.
+fn tau_g2_prepared() -> &'static G2Prepared {
+    static TAU_G2: OnceLock<G2Prepared> = OnceLock::new();
+    TAU_G2.get_or_init(|| G2Prepared::from(*get_trusted_setup_g2()))
 }
 
 /// Get the trusted setup G2 point `[τ]₂` from the Ethereum KZG ceremony.
@@ -66,8 +80,8 @@ pub fn verify_kzg_proof(
 fn get_trusted_setup_g2() -> &'static G2Affine {
     static TAU_G2: OnceLock<G2Affine> = OnceLock::new();
     TAU_G2.get_or_init(|| {
-        // Parse the compressed G2 point using unchecked deserialization since we trust this point
-        // This should never fail since we're using a known valid point from the trusted setup
+        // Parse the compressed G2 point using unchecked deserialization since we trust this point.
+        // This should never fail since we're using a known valid point from the trusted setup.
         G2Affine::deserialize_compressed_unchecked(&TRUSTED_SETUP_TAU_G2_BYTES[..])
             .expect("Failed to parse trusted setup G2 point")
     })
@@ -90,46 +104,4 @@ fn read_scalar_canonical(bytes: &[u8; 32]) -> Result<Fr, PrecompileHalt> {
     }
 
     Ok(fr)
-}
-
-/// Get G1 generator point
-#[inline]
-fn get_g1_generator() -> G1Affine {
-    G1Affine::generator()
-}
-
-/// Get G2 generator point
-#[inline]
-fn get_g2_generator() -> G2Affine {
-    G2Affine::generator()
-}
-
-/// Scalar multiplication for G1 points
-#[inline]
-fn p1_scalar_mul(point: &G1Affine, scalar: &Fr) -> G1Affine {
-    point.mul_bigint(scalar.into_bigint()).into_affine()
-}
-
-/// Scalar multiplication for G2 points
-#[inline]
-fn p2_scalar_mul(point: &G2Affine, scalar: &Fr) -> G2Affine {
-    point.mul_bigint(scalar.into_bigint()).into_affine()
-}
-
-/// Subtract two G1 points in affine form
-#[inline]
-fn p1_sub_affine(a: &G1Affine, b: &G1Affine) -> G1Affine {
-    (a.into_group() - b.into_group()).into_affine()
-}
-
-/// Subtract two G2 points in affine form
-#[inline]
-fn p2_sub_affine(a: &G2Affine, b: &G2Affine) -> G2Affine {
-    (a.into_group() - b.into_group()).into_affine()
-}
-
-/// Negate a G2 point
-#[inline]
-fn p2_neg(p: &G2Affine) -> G2Affine {
-    p.neg()
 }

--- a/crates/precompile/src/kzg_point_evaluation/blst.rs
+++ b/crates/precompile/src/kzg_point_evaluation/blst.rs
@@ -1,8 +1,8 @@
 //! KZG point evaluation precompile using BLST BLS12-381 implementation.
 use crate::{
     bls12_381::blst::{
-        p1_add_or_double, p1_from_affine, p1_scalar_mul, p1_to_affine, p2_add_or_double,
-        p2_from_affine, p2_scalar_mul, p2_to_affine, pairing_check,
+        p1_add_or_double, p1_from_affine, p1_scalar_mul, p1_to_affine, p2_from_affine,
+        p2_to_affine, pairing_check,
     },
     bls12_381_const::TRUSTED_SETUP_TAU_G2_BYTES,
     PrecompileHalt,
@@ -26,17 +26,15 @@ pub fn verify_kzg_proof(
     y: &[u8; 32],
     proof: &[u8; 48],
 ) -> bool {
-    // Parse the commitment (G1 point)
+    // Parse the commitment and proof (G1 points)
     let Ok(commitment_point) = parse_g1_compressed(commitment) else {
         return false;
     };
-
-    // Parse the proof (G1 point)
     let Ok(proof_point) = parse_g1_compressed(proof) else {
         return false;
     };
 
-    // Parse z and y as field elements (Fr, scalar field)
+    // Parse z and y as canonical scalar field elements (Fr)
     let Ok(z_scalar) = read_scalar_canonical(z) else {
         return false;
     };
@@ -44,30 +42,40 @@ pub fn verify_kzg_proof(
         return false;
     };
 
-    // Get the trusted setup G2 point [τ]₂
-    let tau_g2 = get_trusted_setup_g2();
-
-    // Get generators
+    // Get generators and the trusted setup point [τ]G₂.
     let g1 = get_g1_generator();
     let g2 = get_g2_generator();
+    let tau_g2 = get_trusted_setup_g2();
 
-    // Compute P_minus_y = commitment - [y]G₁
+    // Reformulated single-proof KZG check. Starting from the standard
+    //   e(commitment - [y]G1, -G2) · e(proof, [τ]G2 - [z]G2) == 1
+    // and applying bilinearity `e(proof, -[z]G2) = e([z]·proof, -G2)` to move z
+    // out of G2, both G2 pairing inputs become the constants -G2 and [τ]G2:
+    //   e(D, -G2) · e(proof, [τ]G2) == 1,   D = commitment - [y]G1 + [z]·proof
+    // This replaces the per-call G2 scalar multiplication (and the G2 subtraction
+    // and its Fp2 inversion) with a single cheaper G1 scalar multiplication,
+    // while still feeding the fused `pairing_check` (`blst_miller_loop_n`).
     let y_g1 = p1_scalar_mul(&g1, &y_scalar);
-    let p_minus_y = p1_sub_affine(&commitment_point, &y_g1);
+    let z_proof = p1_scalar_mul(&proof_point, &z_scalar);
+    let neg_y_g1 = p1_neg(&y_g1);
 
-    // Compute X_minus_z = [τ]G₂ - [z]G₂
-    let z_g2 = p2_scalar_mul(&g2, &z_scalar);
-    let x_minus_z = p2_sub_affine(tau_g2, &z_g2);
+    // D = commitment + (-[y]G1) + [z]·proof, accumulated in Jacobian coordinates
+    // with a single normalization to affine. `blst_p1_add_or_double_affine`
+    // handles infinity operands (e.g. y = 0 gives [y]G1 = ∞).
+    let mut acc = p1_from_affine(&commitment_point);
+    acc = p1_add_or_double(&acc, &neg_y_g1);
+    acc = p1_add_or_double(&acc, &z_proof);
+    let d = p1_to_affine(&acc);
 
-    // Verify: P - y = Q * (X - z)
-    // Using pairing check: e(P - y, -G₂) * e(proof, X - z) == 1
     let neg_g2 = p2_neg(&g2);
 
     // Skip pairs containing a point at infinity: their pairing is the identity,
     // and `pairing_check` requires infinity-free inputs (`blst_miller_loop_n`,
     // unlike the per-pair `blst_miller_loop`, does not special-case infinity).
-    // E.g. the proof of a constant polynomial is the point at infinity.
-    let pairs: Vec<_> = [(p_minus_y, neg_g2), (proof_point, x_minus_z)]
+    // Only `d`/`proof` (G1) can be infinity here; the G2 points -G2 and [τ]G2 are
+    // fixed and never infinity, but the check stays uniform with the general
+    // `pairing_check` contract.
+    let pairs: Vec<_> = [(d, neg_g2), (proof_point, *tau_g2)]
         .into_iter()
         // SAFETY: both arguments are valid blst types
         .filter(|(g1, g2)| unsafe { !blst_p1_affine_is_inf(g1) && !blst_p2_affine_is_inf(g2) })
@@ -142,34 +150,6 @@ fn read_scalar_canonical(bytes: &[u8; 32]) -> Result<blst_scalar, PrecompileHalt
     }
 
     Ok(scalar)
-}
-
-/// Subtract two G1 points in affine form
-fn p1_sub_affine(a: &blst_p1_affine, b: &blst_p1_affine) -> blst_p1_affine {
-    // Convert first point to Jacobian
-    let a_jacobian = p1_from_affine(a);
-
-    // Negate second point
-    let neg_b = p1_neg(b);
-
-    // Add a + (-b)
-    let result = p1_add_or_double(&a_jacobian, &neg_b);
-
-    p1_to_affine(&result)
-}
-
-/// Subtract two G2 points in affine form
-fn p2_sub_affine(a: &blst_p2_affine, b: &blst_p2_affine) -> blst_p2_affine {
-    // Convert first point to Jacobian
-    let a_jacobian = p2_from_affine(a);
-
-    // Negate second point
-    let neg_b = p2_neg(b);
-
-    // Add a + (-b)
-    let result = p2_add_or_double(&a_jacobian, &neg_b);
-
-    p2_to_affine(&result)
 }
 
 /// Negate a G1 point


### PR DESCRIPTION
Move z from G2 to G1 in the EIP-4844 point-evaluation pairing check via bilinearity `e(proof, -[z]G2) = e([z]·proof, -G2)`, so both G2 pairing inputs collapse to the constants -G2 and [τ]G2:

  e(D, -G2) · e(proof, [τ]G2) == 1,  D = commitment - [y]G1 + [z]·proof

replacing the per-call G2 scalar multiplication (plus a G2 subtraction and its Fp2 inversion) with a single cheaper G1 scalar multiplication, in both the arkworks and blst backends(c-kzg is unchanged (external)).

- arkworks: cache the two now-constant G2 points as G2Prepared (Miller-loop lines computed once) and run multi_miller_loop + one final exponentiation, which still fuses the per-bit squaring across pairs. Fewer G2 ops and cached line prep with no loss of fusion.
- blst: keep the fused pairing_check (blst_miller_loop_n from #3823); only the reformulation applies. Precomputed lines are deliberately not used: blst has no fused-multi-loop-with-precomputed-lines primitive, so precomputing would forfeit the #3823 fusion. That trade is left for a follow-up benchmark.

Tests: add an all-finite tampered-y rejection (pins the pairing relation to the correct evaluation using the c-kzg vector as oracle) and a D=infintiy / finite-proof rejection (exercises the mirror infinity-filter path introduced by moving z to G1).

closes #3835 