### PR TITLE
perf(precompile): unroll blake2 portable rounds to const-fold the message schedule

### DIFF
--- a/crates/precompile/src/blake2/mod.rs
+++ b/crates/precompile/src/blake2/mod.rs
@@ -51,6 +51,10 @@ const SIGMA: [[u8; 16]; 10] = [
 /// BLAKE2b compression function F (EIP-152).
 ///
 /// Dispatches to the best available implementation (AVX2 or portable).
+// On targets with no SIMD path the cfgs below collapse to the single `portable::compress` call,
+// which is `const`, so clippy suggests making this `const` too. It cannot be: on x86 this performs
+// runtime AVX2 feature detection and calls an `unsafe` intrinsic implementation.
+#[allow(clippy::missing_const_for_fn)]
 pub fn compress(rounds: u32, h: &mut [Word; 8], m: &[Word; 16], t: &[Word; 2], f: bool) {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {

--- a/crates/precompile/src/blake2/mod.rs
+++ b/crates/precompile/src/blake2/mod.rs
@@ -83,7 +83,13 @@ pub fn compress(rounds: u32, h: &mut [Word; 8], m: &[Word; 16], t: &[Word; 2], f
 /// never timed.
 #[doc(hidden)]
 #[inline]
-pub fn compress_portable(rounds: u32, h: &mut [Word; 8], m: &[Word; 16], t: &[Word; 2], f: bool) {
+pub const fn compress_portable(
+    rounds: u32,
+    h: &mut [Word; 8],
+    m: &[Word; 16],
+    t: &[Word; 2],
+    f: bool,
+) {
     portable::compress(rounds, h, m, t, f);
 }
 

--- a/crates/precompile/src/blake2/mod.rs
+++ b/crates/precompile/src/blake2/mod.rs
@@ -136,3 +136,156 @@ pub fn run(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
 
     Ok(EthPrecompileOutput::new(gas_used, out.into()))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Reference implementation: the compression function written with a runtime round index,
+    /// as it stood before the rounds were unrolled with a constant schedule. Deliberately kept
+    /// naive so that it is easy to check against RFC 7693 §3.2 by eye.
+    fn reference_compress(
+        rounds: u32,
+        words: &mut [Word; 8],
+        m: &[Word; 16],
+        t: &[Word; 2],
+        f: bool,
+    ) {
+        fn g(v: &mut [Word; 16], a: usize, b: usize, c: usize, d: usize, x: Word, y: Word) {
+            v[a] = v[a].wrapping_add(v[b]).wrapping_add(x);
+            v[d] = (v[d] ^ v[a]).rotate_right(32);
+            v[c] = v[c].wrapping_add(v[d]);
+            v[b] = (v[b] ^ v[c]).rotate_right(24);
+            v[a] = v[a].wrapping_add(v[b]).wrapping_add(y);
+            v[d] = (v[d] ^ v[a]).rotate_right(16);
+            v[c] = v[c].wrapping_add(v[d]);
+            v[b] = (v[b] ^ v[c]).rotate_right(63);
+        }
+
+        let mut v = [
+            words[0],
+            words[1],
+            words[2],
+            words[3],
+            words[4],
+            words[5],
+            words[6],
+            words[7],
+            IV[0],
+            IV[1],
+            IV[2],
+            IV[3],
+            IV[4] ^ t[0],
+            IV[5] ^ t[1],
+            IV[6] ^ if f { !0 } else { 0 },
+            IV[7],
+        ];
+
+        for r in 0..rounds as usize {
+            let s = SIGMA[r % 10];
+            g(&mut v, 0, 4, 8, 12, m[s[0] as usize], m[s[1] as usize]);
+            g(&mut v, 1, 5, 9, 13, m[s[2] as usize], m[s[3] as usize]);
+            g(&mut v, 2, 6, 10, 14, m[s[4] as usize], m[s[5] as usize]);
+            g(&mut v, 3, 7, 11, 15, m[s[6] as usize], m[s[7] as usize]);
+            g(&mut v, 0, 5, 10, 15, m[s[8] as usize], m[s[9] as usize]);
+            g(&mut v, 1, 6, 11, 12, m[s[10] as usize], m[s[11] as usize]);
+            g(&mut v, 2, 7, 8, 13, m[s[12] as usize], m[s[13] as usize]);
+            g(&mut v, 3, 4, 9, 14, m[s[14] as usize], m[s[15] as usize]);
+        }
+
+        for i in 0..8 {
+            words[i] ^= v[i] ^ v[i + 8];
+        }
+    }
+
+    /// splitmix64, so the inputs are varied but the failures are reproducible.
+    struct Rng(u64);
+
+    impl Rng {
+        fn next(&mut self) -> u64 {
+            self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+            let mut z = self.0;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+            z ^ (z >> 31)
+        }
+    }
+
+    /// The unrolled portable implementation must agree with the runtime-index reference for
+    /// every round count, not just multiples of ten. Round counts 0..=40 cover an empty run, a
+    /// partial first tile, the wraparound at ten, and a full second tile; the larger counts
+    /// check that nothing drifts after many tiles.
+    ///
+    /// Note this calls `portable::compress` directly rather than the `compress` dispatcher, so
+    /// the portable path is exercised on every target, including those that would otherwise
+    /// dispatch to AVX2.
+    #[test]
+    fn portable_matches_runtime_index_reference() {
+        let mut rng = Rng(0x0DDB_1A5E_5BAD_5EED);
+
+        for rounds in (0u32..=40).chain([100, 101, 109, 110, 111, 1000, 4096]) {
+            for _ in 0..64 {
+                let mut h = [0u64; 8];
+                for w in h.iter_mut() {
+                    *w = rng.next();
+                }
+                let mut m = [0u64; 16];
+                for w in m.iter_mut() {
+                    *w = rng.next();
+                }
+                let t = [rng.next(), rng.next()];
+                let f = rng.next() & 1 == 0;
+
+                let mut got = h;
+                let mut want = h;
+                portable::compress(rounds, &mut got, &m, &t, f);
+                reference_compress(rounds, &mut want, &m, &t, f);
+
+                assert_eq!(
+                    got, want,
+                    "mismatch at rounds={rounds} f={f} h={h:?} m={m:?} t={t:?}"
+                );
+            }
+        }
+    }
+
+    /// EIP-152 test vector 4: an oracle independent of both implementations above. Twelve
+    /// rounds over "abc", the standard BLAKE2b parameters.
+    #[test]
+    fn eip152_vector_4() {
+        let h_in: [u64; 8] = [
+            0x6a09_e667_f2bd_c948,
+            0xbb67_ae85_84ca_a73b,
+            0x3c6e_f372_fe94_f82b,
+            0xa54f_f53a_5f1d_36f1,
+            0x510e_527f_ade6_82d1,
+            0x9b05_688c_2b3e_6c1f,
+            0x1f83_d9ab_fb41_bd6b,
+            0x5be0_cd19_137e_2179,
+        ];
+        let mut m = [0u64; 16];
+        m[0] = 0x0000_0000_0063_6261; // "abc"
+        let t = [3u64, 0u64];
+
+        let expected: [u64; 8] = [
+            0x0d4d_1c98_3fa5_80ba,
+            0xe9f6_129f_b697_276a,
+            0xb7c4_5a68_142f_214c,
+            0xd1a2_ffdb_6fbb_124b,
+            0x2d79_ab2a_39c5_877d,
+            0x95cc_3345_ded5_52c2,
+            0x5a92_f1db_a88a_d318,
+            0x2399_00d4_ed86_23b9,
+        ];
+
+        let mut h = h_in;
+        portable::compress(12, &mut h, &m, &t, true);
+        assert_eq!(h, expected, "portable");
+
+        // And through the dispatcher, so whichever implementation this target selects is
+        // checked against the same vector.
+        let mut h = h_in;
+        compress(12, &mut h, &m, &t, true);
+        assert_eq!(h, expected, "dispatched");
+    }
+}

--- a/crates/precompile/src/blake2/portable.rs
+++ b/crates/precompile/src/blake2/portable.rs
@@ -84,66 +84,19 @@ pub(crate) const fn compress(
     // SIGMA rows 0 and 1. `remaining` is checked before each round so that EIP-152's arbitrary
     // round count (including 0) terminates at the right point.
     let mut remaining = rounds;
+    macro_rules! rounds {
+        ($($r:literal),*) => {
+            $(
+                if remaining == 0 {
+                    break;
+                }
+                remaining -= 1;
+                round::<$r>(m, &mut v);
+            )*
+        };
+    }
     loop {
-        if remaining == 0 {
-            break;
-        }
-        remaining -= 1;
-        round::<0>(m, &mut v);
-
-        if remaining == 0 {
-            break;
-        }
-        remaining -= 1;
-        round::<1>(m, &mut v);
-
-        if remaining == 0 {
-            break;
-        }
-        remaining -= 1;
-        round::<2>(m, &mut v);
-
-        if remaining == 0 {
-            break;
-        }
-        remaining -= 1;
-        round::<3>(m, &mut v);
-
-        if remaining == 0 {
-            break;
-        }
-        remaining -= 1;
-        round::<4>(m, &mut v);
-
-        if remaining == 0 {
-            break;
-        }
-        remaining -= 1;
-        round::<5>(m, &mut v);
-
-        if remaining == 0 {
-            break;
-        }
-        remaining -= 1;
-        round::<6>(m, &mut v);
-
-        if remaining == 0 {
-            break;
-        }
-        remaining -= 1;
-        round::<7>(m, &mut v);
-
-        if remaining == 0 {
-            break;
-        }
-        remaining -= 1;
-        round::<8>(m, &mut v);
-
-        if remaining == 0 {
-            break;
-        }
-        remaining -= 1;
-        round::<9>(m, &mut v);
+        rounds!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
     }
 
     words[0] ^= v[0] ^ v[8];

--- a/crates/precompile/src/blake2/portable.rs
+++ b/crates/precompile/src/blake2/portable.rs
@@ -6,7 +6,9 @@
 // - Removed compress1_loop and all Finalize/LastNode/Stride/Count machinery.
 // - Changed compress_block signature for EIP-152: takes (rounds, words, m, t, f) with pre-parsed
 //   Word arrays instead of raw bytes, and variable round count.
-// - Replaced 12 hardcoded round() calls with a for loop.
+// - Replaced 12 hardcoded round() calls with a loop over 10 unrolled rounds using a remaining
+//   counter, mirroring avx2.rs. The round index stays a compile-time constant so that each
+//   round's SIGMA row const-folds into immediate message offsets.
 
 use super::{Word, IV, SIGMA};
 
@@ -28,10 +30,14 @@ const fn g(v: &mut [Word; 16], a: usize, b: usize, c: usize, d: usize, x: Word, 
     v[b] = (v[b] ^ v[c]).rotate_right(63);
 }
 
+// R is the *physical* round index, always a compile-time constant in the range 0..10. Keeping it
+// const is what lets the compiler fold `SIGMA[R]` into literals, so each `m[s[j]]` becomes a load
+// at an immediate offset instead of a byte load of the schedule followed by a dependent load of
+// the message word.
 #[inline(always)]
-const fn round(r: usize, m: &[Word; 16], v: &mut [Word; 16]) {
+const fn round<const R: usize>(m: &[Word; 16], v: &mut [Word; 16]) {
     // Select the message schedule based on the round.
-    let s = SIGMA[r % 10];
+    let s = SIGMA[R];
 
     // Mix the columns.
     g(v, 0, 4, 8, 12, m[s[0] as usize], m[s[1] as usize]);
@@ -46,7 +52,13 @@ const fn round(r: usize, m: &[Word; 16], v: &mut [Word; 16]) {
     g(v, 3, 4, 9, 14, m[s[14] as usize], m[s[15] as usize]);
 }
 
-pub(crate) fn compress(rounds: u32, words: &mut [Word; 8], m: &[Word; 16], t: &[Word; 2], f: bool) {
+pub(crate) const fn compress(
+    rounds: u32,
+    words: &mut [Word; 8],
+    m: &[Word; 16],
+    t: &[Word; 2],
+    f: bool,
+) {
     // Initialize the compression state.
     let mut v = [
         words[0],
@@ -67,8 +79,71 @@ pub(crate) fn compress(rounds: u32, words: &mut [Word; 8], m: &[Word; 16], t: &[
         IV[7],
     ];
 
-    for i in 0..rounds as usize {
-        round(i, m, &mut v);
+    // SIGMA has spec period 10 (RFC 7693 §2.7), so ten physically distinct rounds tile any round
+    // count: the loop re-enters at R = 0, which is how standard BLAKE2b's rounds 10 and 11 reuse
+    // SIGMA rows 0 and 1. `remaining` is checked before each round so that EIP-152's arbitrary
+    // round count (including 0) terminates at the right point.
+    let mut remaining = rounds;
+    loop {
+        if remaining == 0 {
+            break;
+        }
+        remaining -= 1;
+        round::<0>(m, &mut v);
+
+        if remaining == 0 {
+            break;
+        }
+        remaining -= 1;
+        round::<1>(m, &mut v);
+
+        if remaining == 0 {
+            break;
+        }
+        remaining -= 1;
+        round::<2>(m, &mut v);
+
+        if remaining == 0 {
+            break;
+        }
+        remaining -= 1;
+        round::<3>(m, &mut v);
+
+        if remaining == 0 {
+            break;
+        }
+        remaining -= 1;
+        round::<4>(m, &mut v);
+
+        if remaining == 0 {
+            break;
+        }
+        remaining -= 1;
+        round::<5>(m, &mut v);
+
+        if remaining == 0 {
+            break;
+        }
+        remaining -= 1;
+        round::<6>(m, &mut v);
+
+        if remaining == 0 {
+            break;
+        }
+        remaining -= 1;
+        round::<7>(m, &mut v);
+
+        if remaining == 0 {
+            break;
+        }
+        remaining -= 1;
+        round::<8>(m, &mut v);
+
+        if remaining == 0 {
+            break;
+        }
+        remaining -= 1;
+        round::<9>(m, &mut v);
     }
 
     words[0] ^= v[0] ^ v[8];


### PR DESCRIPTION
Closes #3837 

`portable::round` took the round index as a runtime `usize`, so `SIGMA[r % 10]` was resolved at runtime. It now takes the index as a `const` generic, and `compress` unrolls ten physical rounds with a `remaining` counter for EIP-152's variable round count.. the structure `avx2.rs` already uses. SIGMA has spec period 10 (RFC 7693 §2.7), so ten rounds tile any count, and re-entering the loop at round 0 is how standard BLAKE2b's rounds 10 and 11 reuse rows 0 and 1.

(No public API change.)

**In the emitted code** (aarch64, same function, same flags): the 16 `ldrb` schedule loads per round and the `umulh`/`madd` modulo are gone entirely, message loads drop from 16 per round to ~6 across all ten, and the loop goes from 157 to ~120 instructions per round. The dependent `ldrb → index → ldr` chain disappears because constant indices let the compiler keep most message words in registers. Cost is a ~5x larger function (252 → 1309 instructions), worth noting for icache pressure.

**In wall time**  native aarch64 runner (`ubuntu-24.04-arm`), existing `bench/blake2.rs` unchanged, baseline on `main` and comparison on this branch in the same job on the same VM:

| benchmark | main | this PR | change | 95% CI |
| --- | --- | --- | --- | --- |
| 2 rounds | 57.21 ns | 49.63 ns | −13.26% | [−13.28%, −13.24%] |
| 4 rounds | 84.35 ns | 72.50 ns | −14.05% | [−14.16%, −13.99%] |
| 10 rounds | 174.39 ns | 139.34 ns | −20.10% | [−20.15%, −20.07%] |
| 12 rounds | 204.00 ns | 160.39 ns | −21.38% | [−21.38%, −21.37%] |
| 64 rounds | 985.36 ns | 736.77 ns | −25.23% | [−25.28%, −25.18%] |
| 512 rounds | 7.7102 µs | 5.7014 µs | −26.05% | [−26.07%, −26.03%] |
| 1024 rounds | 15.3916 µs | 11.3850 µs | −26.03% | [−26.04%, −26.02%] |
| 100K rounds | 1.5000 ms | 1.1034 ms | −26.44% | [−26.48%, −26.39%] |
| 200K rounds | 2.9999 ms | 2.2071 ms | −26.43% | [−26.45%, −26.40%] |

All p < 0.05.

Two things stand out. The gain **scales with round count and plateaus near −26%**: at 2–12 rounds the fixed costs (213-byte input parse, plus the `crypto()` -> `dyn Crypto::blake2_compress` vtable hop that cannot be inlined into `run`) dilute it; from 512 rounds up the loop dominates and the measurement converges on the loop's own improvement. And that asymptote **agrees with the static instruction count** (−23.6% per round), which owes nothing to the machine that ran it.. the measurement landing slightly ahead is what you would expect when the removed instructions are serialized dependent loads rather than average ones.

## Tests

The compression function had no unit tests.. it was covered only indirectly through the execution-spec state tests. This PR adds:

- a **differential test** against a reference implementation using the previous runtime round
  index, over round counts `0..=40` plus 100/101/109/110/111/1000/4096, 64 pseudorandom
  `(h, m, t, f)` inputs each. Those counts cover an empty run, a partial tile, the wraparound at
  ten, and a full second tile. It calls `portable::compress` directly, so the portable path is
  exercised even on targets that would otherwise select AVX2.
- **EIP-152 vector 4** as an oracle independent of both implementations, checked against the
  portable path and the dispatcher.

Both were mutation-checked: mis-numbering one unrolled round (`round::<9>` → `round::<8>`) fails the differential test at exactly `rounds = 10` and fails the EIP-152 vector too.

