### PR TITLE
bench(precompile): cover BLS MSM sizes where blst switches algorithm

### DIFF
--- a/crates/precompile/bench/eip2537.rs
+++ b/crates/precompile/bench/eip2537.rs
@@ -171,7 +171,7 @@ pub fn add_g2_add_benches<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
 pub fn add_g1_msm_benches<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     use revm_precompile::bls12_381::g1_msm::PRECOMPILE;
 
-    let sizes_to_bench = [MAX_MSM_SIZE, MAX_MSM_SIZE / 2, 2, 1];
+    let sizes_to_bench = [MAX_MSM_SIZE, MAX_MSM_SIZE / 2, 31, 16, 8, 4, 2, 1];
 
     for size in sizes_to_bench {
         let mut rng = StdRng::seed_from_u64(RNG_SEED);
@@ -214,7 +214,7 @@ fn g2_msm_test_vectors(msm_size: usize, rng: &mut StdRng) -> PrecompileInput {
 pub fn add_g2_msm_benches<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     use revm_precompile::bls12_381::g2_msm::PRECOMPILE;
 
-    let sizes_to_bench = [MAX_MSM_SIZE, MAX_MSM_SIZE / 2, 2, 1];
+    let sizes_to_bench = [MAX_MSM_SIZE, MAX_MSM_SIZE / 2, 31, 16, 8, 4, 2, 1];
 
     for size in sizes_to_bench {
         let mut rng = StdRng::seed_from_u64(RNG_SEED);


### PR DESCRIPTION
The G1/G2 MSM benchmarks only cover k = 1, 2, 128 and 256, which leaves blst's small-input path almost entirely unmeasured.

blst's MultiPoint::mult picks between three strategies at runtime
a single-threaded Pippenger when fewer than two CPUs are visible, 
one scalar multiplication per point spread over its global thread pool for 2..31 points, 
and a tiled parallel Pippenger from 32 points up. 
Only k = 2 currently falls in the middle range, and k = 1 never reaches mult() at all. So the window where blst abandons Pippenger has exactly one data point, at the size where the bucket method has the least to offer.

Add k = 4, 8, 16 and 31 to both groups. i left the existing benchmarks so its still carried.