### PR TITLE
bench(precompile): measure the blake2 portable compression path

### DIFF
--- a/crates/precompile/bench/blake2.rs
+++ b/crates/precompile/bench/blake2.rs
@@ -69,4 +69,47 @@ pub fn add_benches(group: &mut BenchmarkGroup<'_, criterion::measurement::WallTi
         let input = black_box(&inputs[8]); // 200000 rounds
         b.iter(|| blake2::run(input, u64::MAX).unwrap());
     });
+
+    add_portable_benches(group);
+}
+
+/// Benches for the portable compression function, called directly.
+///
+/// The `blake2/*_rounds` benches above go through `blake2::run` -> `blake2::compress`, which
+/// detects AVX2 at runtime. On the x86_64 CI runner they therefore only ever measure the AVX2
+/// implementation, leaving the portable one -- what `no_std`, zkVM and non-x86 targets run --
+/// unmeasured. These call it directly so it is timed on every host.
+fn add_portable_benches(group: &mut BenchmarkGroup<'_, criterion::measurement::WallTime>) {
+    // EIP-152 test vector 4: BLAKE2b-512 of "abc", the standard 12-round case.
+    let h_in: [u64; 8] = [
+        0x6a09_e667_f2bd_c948,
+        0xbb67_ae85_84ca_a73b,
+        0x3c6e_f372_fe94_f82b,
+        0xa54f_f53a_5f1d_36f1,
+        0x510e_527f_ade6_82d1,
+        0x9b05_688c_2b3e_6c1f,
+        0x1f83_d9ab_fb41_bd6b,
+        0x5be0_cd19_137e_2179,
+    ];
+    let mut m = [0u64; 16];
+    m[0] = 0x0000_0000_0063_6261; // "abc"
+    let t = [3u64, 0u64];
+
+    // SIGMA has period 10, so the round count decides how the schedule tiles: 2 is a partial
+    // tile, 10 exactly one, 12 one plus a remainder (standard BLAKE2b), 64 several.
+    for rounds in [2u32, 10, 12, 64] {
+        group.bench_function(format!("blake2 portable/{rounds}_rounds"), |b| {
+            b.iter(|| {
+                let mut h = h_in;
+                blake2::compress_portable(
+                    black_box(rounds),
+                    &mut h,
+                    black_box(&m),
+                    black_box(&t),
+                    black_box(true),
+                );
+                h
+            });
+        });
+    }
 }

--- a/crates/precompile/src/blake2/mod.rs
+++ b/crates/precompile/src/blake2/mod.rs
@@ -70,6 +70,19 @@ pub fn compress(rounds: u32, h: &mut [Word; 8], m: &[Word; 16], t: &[Word; 2], f
     portable::compress(rounds, h, m, t, f);
 }
 
+/// The portable (non-SIMD) compression function, reachable directly.
+///
+/// Not public API -- use [`compress`], which always selects the fastest implementation for the
+/// target. This exists so benchmarks can measure the portable path on any host: [`compress`]
+/// detects AVX2 at runtime, so on an x86_64 CI runner a benchmark going through it measures the
+/// AVX2 path only, and the portable code that `no_std`, zkVM and non-x86 builds actually run is
+/// never timed.
+#[doc(hidden)]
+#[inline]
+pub fn compress_portable(rounds: u32, h: &mut [Word; 8], m: &[Word; 16], t: &[Word; 2], f: bool) {
+    portable::compress(rounds, h, m, t, f);
+}
+
 eth_precompile_fn!(blake2_precompile, run);
 
 /// Blake2 precompile


### PR DESCRIPTION
The blake2 benches call `run`, which reaches the compression function through `compress`. On x86 that detects AVX2 at runtime and returns before the portable implementation, so on the x86_64 CI runner the `blake2/*_rounds` benches only ever time the AVX2 code. The portable one is what `no_std`, zkVM and non-x86 targets actually execute, and it is currently unmeasured everywhere except on hosts with no SIMD path.

Add `blake2 portable/{2,10,12,64}_rounds`, calling the portable function directly so it is timed on every host (regardless of what the dispatcher would pick). The round counts cover how SIGMA's period-10 schedule tiles: 2 is a partial tile, 10 exactly one, 12 one plus a remainder (standard BLAKE2b), 64 several..

Reaching it needs `compress_portable`, a `#[doc(hidden)]` wrapper. The dispatcher is the only supported entry point, so the wrapper documents that it is not public API and exists for measurement.

Existing benchmark names are left untouched so their histories are carried.