### PR TITLE
bench(precompile): benchmark KZG verify arkworks/blst backends directly

### DIFF
--- a/crates/precompile/bench/eip4844.rs
+++ b/crates/precompile/bench/eip4844.rs
@@ -1,23 +1,63 @@
 //! Benchmarks for the KZG point evaluation precompile
-use criterion::{measurement::Measurement, BenchmarkGroup};
+use criterion::{black_box, measurement::Measurement, BenchmarkGroup};
 use primitives::{eip4844::VERSIONED_HASH_VERSION_KZG, hex};
-use revm_precompile::kzg_point_evaluation::run;
+use revm_precompile::kzg_point_evaluation::{arkworks, run};
 use sha2::{Digest, Sha256};
 
 /// Add benches for the KZG point evaluation precompile
 pub fn add_benches<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    // KZG Point Evaluation Precompile
-    let commitment = hex!("8f59a8d2a1a625a17f3fea0fe5eb8c896db3764f3185481bc22f91b4aaffcca25f26936857bc3a7c2539ea8ec3a952b7").to_vec();
-    let mut versioned_hash = Sha256::digest(&commitment).to_vec();
+    // Valid proof from the c-kzg suite (verify_kzg_proof_case_correct_proof_4_4):
+    // a full, non-degenerate pairing check (no early parse rejection).
+    let commitment =
+        hex!("8f59a8d2a1a625a17f3fea0fe5eb8c896db3764f3185481bc22f91b4aaffcca25f26936857bc3a7c2539ea8ec3a952b7");
+    let z = hex!("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000");
+    let y = hex!("1522a4a7f34e1ea350ae07c29c96c7e79655aa926122e95fe69fcbd932ca49e9");
+    let proof =
+        hex!("a62ad71d14c5719385c0686f1871430475bf3a00f0aa3f7b8dd99a9abc2160744faf0070725e00b60ad9a026a15b1a8c");
+
+    // Full precompile entry point. With the `c-kzg` feature enabled (the default)
+    // the dispatcher routes here to the external c-kzg backend.
+    let mut versioned_hash = Sha256::digest(commitment).to_vec();
     versioned_hash[0] = VERSIONED_HASH_VERSION_KZG;
-    let z = hex!("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000").to_vec();
-    let y = hex!("1522a4a7f34e1ea350ae07c29c96c7e79655aa926122e95fe69fcbd932ca49e9").to_vec();
-    let proof = hex!("a62ad71d14c5719385c0686f1871430475bf3a00f0aa3f7b8dd99a9abc2160744faf0070725e00b60ad9a026a15b1a8c").to_vec();
-
-    let kzg_input = [versioned_hash, z, y, commitment, proof].concat();
-    let gas = 50000;
-
+    let kzg_input = [
+        versioned_hash,
+        z.to_vec(),
+        y.to_vec(),
+        commitment.to_vec(),
+        proof.to_vec(),
+    ]
+    .concat();
+    let gas = 50_000;
     group.bench_function("kzg precompile", |b| {
-        b.iter(|| run(&kzg_input, gas).unwrap())
+        b.iter(|| run(black_box(&kzg_input), gas).unwrap())
     });
+
+    // Pure-Rust backends, benchmarked directly: the precompile dispatcher prefers
+    // c-kzg when that feature is on, so these paths are otherwise never measured.
+    // arkworks is what `no_std` builds fall back to, blst what non-c-kzg builds use.
+    group.bench_function("kzg verify/arkworks", |b| {
+        b.iter(|| {
+            arkworks::verify_kzg_proof(
+                black_box(&commitment),
+                black_box(&z),
+                black_box(&y),
+                black_box(&proof),
+            )
+        })
+    });
+
+    #[cfg(feature = "blst")]
+    {
+        use revm_precompile::kzg_point_evaluation::blst;
+        group.bench_function("kzg verify/blst", |b| {
+            b.iter(|| {
+                blst::verify_kzg_proof(
+                    black_box(&commitment),
+                    black_box(&z),
+                    black_box(&y),
+                    black_box(&proof),
+                )
+            })
+        });
+    }
 }


### PR DESCRIPTION
The only KZG bench, "kzg precompile", routes through `run`, which dispatches to c-kzg on default features. The two pure-Rust backends are therefore never measured, even though they are what real builds use: arkworks is the `no_std` fallback that zkVM consumers compile, and blst is what any build without the `c-kzg` feature selects.

Add "kzg verify/arkworks" and "kzg verify/blst", calling each backend's `verify_kzg_proof` directly so the dispatcher cannot route past them. Both use the c-kzg suite's verify_kzg_proof_case_correct_proof_4_4 vector, a valid proof, so the full pairing check runs rather than an early parse rejection.

The existing precompile bench of kzg is left under its own name => its history carries over.