### PR TITLE
feat: glamsterdam devnet-8 gas repricing

### DIFF
--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -365,17 +365,17 @@ impl GasParams {
                 gas::ACCESS_LIST_STORAGE_KEY + 32 * 64;
             table[GasId::tx_access_list_floor_byte_multiplier().as_usize()] = 4;
 
-            // EIP-8038: State-access gas cost update (ethereum/EIPs#11802;
-            // preliminary draft values). Constants live in `primitives::eip8038`.
+            // EIP-8038: State-access gas cost update (glamsterdam devnet-8
+            // values). Constants live in `primitives::eip8038`.
             //   WARM_ACCESS                    100 ->    100  (unchanged)
             //   COLD_ACCOUNT_ACCESS          2,600 ->  3,000
-            //   ACCOUNT_WRITE                6,700 ->  8,000
-            //   COLD_STORAGE_ACCESS          2,100 ->  3,000
+            //   ACCOUNT_WRITE                6,700 ->  9,000
+            //   COLD_STORAGE_ACCESS          2,100 ->  2,100  (unchanged)
             //   STORAGE_WRITE                2,800 -> 10,000
-            //   STORAGE_CLEAR_REFUND         4,800 -> 12,480
-            //   CREATE_ACCESS                7,000 -> 11,000  (ACCOUNT_WRITE + COLD_STORAGE_ACCESS)
-            //   ACCESS_LIST_ADDRESS_COST     2,400 ->  3,000  (COLD_ACCOUNT_ACCESS)
-            //   ACCESS_LIST_STORAGE_KEY_COST 1,900 ->  3,000  (COLD_STORAGE_ACCESS)
+            //   STORAGE_CLEAR_REFUND         4,800 -> 11,616
+            //   CREATE_ACCESS                7,000 -> 12,000  (ACCOUNT_WRITE + COLD_ACCOUNT_ACCESS)
+            //   ACCESS_LIST_ADDRESS_COST     2,400 ->  2,900  (COLD_ACCOUNT_ACCESS - WARM_ACCESS)
+            //   ACCESS_LIST_STORAGE_KEY_COST 1,900 ->  2,000  (COLD_STORAGE_ACCESS - WARM_ACCESS)
             //
             // Account access table values.
             table[GasId::warm_storage_read_cost().as_usize()] = eip8038::WARM_ACCESS;
@@ -384,9 +384,9 @@ impl GasParams {
             table[GasId::cold_storage_additional_cost().as_usize()] =
                 eip8038::COLD_STORAGE_ACCESS_ADDITIONAL;
             // EIP-8038 folds the warm base into the cold cost: a cold SSTORE pays
-            // COLD_STORAGE_ACCESS (3000) total, not warm(100)+cold. Since
+            // COLD_STORAGE_ACCESS (2100) total, not warm(100)+cold. Since
             // `sstore_static` (warm, 100) is always charged in `sstore_dynamic_gas`,
-            // the cold add-on here is the premium above warm (2900), unlike pre-8038
+            // the cold add-on here is the premium above warm (2000), unlike pre-8038
             // forks which add the full `COLD_SLOAD_COST` on top of the warm base.
             table[GasId::cold_storage_cost().as_usize()] = eip8038::COLD_STORAGE_ACCESS_ADDITIONAL;
             // CALL_VALUE = ACCOUNT_WRITE + CALL_STIPEND.
@@ -440,7 +440,6 @@ impl GasParams {
             // entries for the additional `to`- and `value`-based charges.
             // ACCOUNT_WRITE / CREATE_ACCESS source from `eip8038` so a single
             // change to the placeholder TBD values propagates everywhere.
-            table[GasId::tx_transfer_log_cost().as_usize()] = eip2780::TRANSFER_LOG_COST;
             table[GasId::tx_account_write_cost().as_usize()] = eip8038::ACCOUNT_WRITE;
             table[GasId::tx_create_access_cost().as_usize()] = eip8038::CREATE_ACCESS;
         }
@@ -977,13 +976,6 @@ impl GasParams {
         self.get(GasId::tx_base_stipend())
     }
 
-    /// EIP-2780: regular gas cost of the EIP-7708 transfer log emitted on
-    /// every nonzero-value transfer to a different account. Zero before AMSTERDAM.
-    #[inline]
-    pub fn tx_transfer_log_cost(&self) -> u64 {
-        self.get(GasId::tx_transfer_log_cost())
-    }
-
     /// EIP-2780/EIP-8038: regular gas cost of an account-leaf write, added
     /// when `tx.value > 0` and the recipient differs from the sender.
     /// Zero before AMSTERDAM.
@@ -1116,16 +1108,14 @@ impl GasParams {
         let mut gas = eip2780::TX_BASE_COST;
 
         if is_create {
-            // tx.to charge: contract-creation access cost.
+            // tx.to charge: contract-creation access cost. Since glamsterdam
+            // devnet-8, creates pay no value-based charge.
             gas += self.tx_create_access_cost();
-            if !info.value.is_zero() {
-                gas += self.tx_transfer_log_cost();
-            }
         } else if !info.is_self_transfer {
             // tx.to charge: cold account access of the recipient.
             gas += eip8038::COLD_ACCOUNT_ACCESS;
             if !info.value.is_zero() {
-                gas += self.tx_transfer_log_cost() + eip2780::TX_VALUE_COST;
+                gas += eip2780::TX_VALUE_COST;
             }
         }
 
@@ -1292,7 +1282,6 @@ impl GasId {
             x if x == Self::tx_access_list_floor_byte_multiplier().as_u8() => {
                 "tx_access_list_floor_byte_multiplier"
             }
-            x if x == Self::tx_transfer_log_cost().as_u8() => "tx_transfer_log_cost",
             x if x == Self::tx_account_write_cost().as_u8() => "tx_account_write_cost",
             x if x == Self::tx_create_access_cost().as_u8() => "tx_create_access_cost",
             _ => "unknown",
@@ -1367,7 +1356,6 @@ impl GasId {
             "tx_access_list_floor_byte_multiplier" => {
                 Some(Self::tx_access_list_floor_byte_multiplier())
             }
-            "tx_transfer_log_cost" => Some(Self::tx_transfer_log_cost()),
             "tx_account_write_cost" => Some(Self::tx_account_write_cost()),
             "tx_create_access_cost" => Some(Self::tx_create_access_cost()),
             _ => None,
@@ -1634,24 +1622,18 @@ impl GasId {
         Self::new(46)
     }
 
-    /// EIP-2780: regular gas cost of the EIP-7708 transfer log emitted on every
-    /// nonzero-value transfer to a different account. Zero before AMSTERDAM.
-    pub const fn tx_transfer_log_cost() -> GasId {
-        Self::new(48)
-    }
-
     /// EIP-2780/EIP-8038: regular gas cost of an account-leaf write at the
     /// intrinsic level (added when `tx.value > 0` and the recipient differs
     /// from the sender). Zero before AMSTERDAM.
     pub const fn tx_account_write_cost() -> GasId {
-        Self::new(49)
+        Self::new(48)
     }
 
     /// EIP-2780/EIP-8038: regular gas cost of a top-level CREATE access, in
     /// addition to [`Self::tx_base_stipend`] and the EIP-8037 state gas.
     /// Zero before AMSTERDAM.
     pub const fn tx_create_access_cost() -> GasId {
-        Self::new(50)
+        Self::new(49)
     }
 }
 
@@ -1723,11 +1705,11 @@ mod tests {
             "Not all unique names are resolvable via from_str"
         );
 
-        // We should have exactly 50 known GasIds (based on the indices 1-50 used)
+        // We should have exactly 49 known GasIds (based on the indices 1-49 used)
         assert_eq!(
             unique_names.len(),
-            50,
-            "Expected 50 unique GasIds, found {}",
+            49,
+            "Expected 49 unique GasIds, found {}",
             unique_names.len()
         );
     }
@@ -1869,15 +1851,16 @@ mod tests {
     fn test_eip7981_access_list_cost_amsterdam() {
         // EIP-7981 folds a 64 gas/byte data charge into the per-item access-list cost
         // and adds 4 floor tokens per access-list byte on top of the EIP-7976 floor.
-        // EIP-8038 sets the per-item base to COLD_ACCOUNT_ACCESS / COLD_STORAGE_ACCESS
-        // (both 3,000).
+        // EIP-8038 sets the per-item base to the cold-minus-warm premium:
+        // COLD_ACCOUNT_ACCESS - WARM_ACCESS (2,900) per address and
+        // COLD_STORAGE_ACCESS - WARM_ACCESS (2,000) per storage key.
         let params = GasParams::new_spec(SpecId::AMSTERDAM);
 
         // Per-item intrinsic cost: base + bytes * 64
-        assert_eq!(params.tx_access_list_address_cost(), 3000 + 20 * 64);
-        assert_eq!(params.tx_access_list_storage_key_cost(), 3000 + 32 * 64);
-        assert_eq!(params.tx_access_list_cost(1, 0), 3000 + 20 * 64);
-        assert_eq!(params.tx_access_list_cost(0, 1), 3000 + 32 * 64);
+        assert_eq!(params.tx_access_list_address_cost(), 2900 + 20 * 64);
+        assert_eq!(params.tx_access_list_storage_key_cost(), 2000 + 32 * 64);
+        assert_eq!(params.tx_access_list_cost(1, 0), 2900 + 20 * 64);
+        assert_eq!(params.tx_access_list_cost(0, 1), 2000 + 32 * 64);
 
         // Floor multiplier activates at AMSTERDAM.
         assert_eq!(params.tx_access_list_floor_byte_multiplier(), 4);

--- a/crates/ee-tests/src/eip2780.rs
+++ b/crates/ee-tests/src/eip2780.rs
@@ -108,13 +108,11 @@ fn test_eip2780_call_empty_with_value() {
     let mut evm = evm();
     let to = address!("0x00000000000000000000000000000000000000ab");
     let gas = run(&mut evm, TxKind::Call(to), U256::from(1u64));
-    // Intrinsic regular: TX_BASE_COST + COLD_ACCOUNT_ACCESS + TRANSFER_LOG_COST + TX_VALUE_COST = 21_000.
+    // Intrinsic regular: TX_BASE_COST + COLD_ACCOUNT_ACCESS + TX_VALUE_COST = 21_000.
     // The ACCOUNT_WRITE for creating the empty recipient is not charged as regular
     // gas (only the NEW_ACCOUNT state gas is). Top-level state gas: 183_600.
-    let expected_regular = eip2780::TX_BASE_COST
-        + eip8038::COLD_ACCOUNT_ACCESS
-        + eip2780::TRANSFER_LOG_COST
-        + eip2780::TX_VALUE_COST;
+    let expected_regular =
+        eip2780::TX_BASE_COST + eip8038::COLD_ACCOUNT_ACCESS + eip2780::TX_VALUE_COST;
     assert_eq!(regular_spent(&gas), expected_regular);
     assert_eq!(gas.state_gas_spent_final(), STATE_BYTES_PER_NEW_ACCOUNT);
 }
@@ -123,7 +121,7 @@ fn test_eip2780_call_empty_with_value() {
 fn test_eip2780_create_no_value() {
     let mut evm = evm();
     let gas = run(&mut evm, TxKind::Create, U256::ZERO);
-    // Intrinsic regular: TX_BASE_COST + CREATE_ACCESS = 21_600.
+    // Intrinsic regular: TX_BASE_COST + CREATE_ACCESS = 24_000.
     // Intrinsic state gas: STATE_BYTES_PER_NEW_ACCOUNT × CPSB = 183_600.
     let expected_regular = eip2780::TX_BASE_COST + eip8038::CREATE_ACCESS;
     assert_eq!(regular_spent(&gas), expected_regular);
@@ -134,10 +132,10 @@ fn test_eip2780_create_no_value() {
 fn test_eip2780_create_with_value() {
     let mut evm = evm();
     let gas = run(&mut evm, TxKind::Create, U256::from(1u64));
-    // Intrinsic regular: TX_BASE_COST + CREATE_ACCESS + TRANSFER_LOG_COST.
+    // Intrinsic regular: TX_BASE_COST + CREATE_ACCESS. Since glamsterdam
+    // devnet-8 a create transaction pays no value-based charge.
     // Intrinsic state gas: STATE_BYTES_PER_NEW_ACCOUNT × CPSB.
-    let expected_regular =
-        eip2780::TX_BASE_COST + eip8038::CREATE_ACCESS + eip2780::TRANSFER_LOG_COST;
+    let expected_regular = eip2780::TX_BASE_COST + eip8038::CREATE_ACCESS;
     assert_eq!(regular_spent(&gas), expected_regular);
     assert_eq!(gas.state_gas_spent_final(), STATE_BYTES_PER_NEW_ACCOUNT);
 }
@@ -215,7 +213,7 @@ fn test_eip2780_create_to_existing_target_no_state_gas() {
 
 #[test]
 fn test_eip2780_create_runtime_state_gas_oog_is_included() {
-    // Gas covers the intrinsic cost (TX_BASE + CREATE_ACCESS = 23,000) but not
+    // Gas covers the intrinsic cost (TX_BASE + CREATE_ACCESS = 24,000) but not
     // the runtime new-account state gas: the transaction stays valid and is
     // included as an out-of-gas halt consuming all supplied gas.
     let gas_limit = eip2780::TX_BASE_COST + eip8038::CREATE_ACCESS;
@@ -237,10 +235,7 @@ fn test_eip2780_call_runtime_state_gas_oog_is_included() {
     // Value transfer to a non-existent recipient funded only for the intrinsic
     // 21,000: valid, included, halts out-of-gas in the runtime phase.
     let to = address!("0x00000000000000000000000000000000000000ab");
-    let gas_limit = eip2780::TX_BASE_COST
-        + eip8038::COLD_ACCOUNT_ACCESS
-        + eip2780::TRANSFER_LOG_COST
-        + eip2780::TX_VALUE_COST;
+    let gas_limit = eip2780::TX_BASE_COST + eip8038::COLD_ACCOUNT_ACCESS + eip2780::TX_VALUE_COST;
     let mut evm = evm();
 
     let tx = TxEnv::builder_for_bench()
@@ -499,7 +494,7 @@ fn test_eip2780_create_spilled_charge_reverted_initcode() {
     assert_eq!(gas.state_gas_spent_final(), 0);
     // TX_BASE_COST + CREATE_ACCESS + initcode words + REVERT-path costs; the
     // rolled-back spilled charge is returned as unused regular gas.
-    assert_eq!(gas.total_gas_spent(), 23_064);
+    assert_eq!(gas.total_gas_spent(), 24_064);
 }
 
 #[test]
@@ -526,7 +521,7 @@ fn test_eip2780_create_spilled_charge_laundering_success() {
     // Only the create charge remains as state gas: all three storage slots
     // were restored to zero, so their 0->x charges were refilled.
     assert_eq!(gas.state_gas_spent_final(), STATE_BYTES_PER_NEW_ACCOUNT);
-    assert_eq!(gas.total_gas_spent(), 249_563);
+    assert_eq!(gas.total_gas_spent(), 247_863);
 }
 
 #[test]
@@ -541,7 +536,7 @@ fn test_eip2780_create_spilled_charge_laundering_revert() {
     assert!(!result.is_halt());
     let gas = result.gas();
     assert_eq!(gas.state_gas_spent_final(), 0);
-    assert_eq!(gas.total_gas_spent(), 66_021);
+    assert_eq!(gas.total_gas_spent(), 64_321);
 }
 
 #[test]

--- a/crates/ee-tests/src/revm_tests.rs
+++ b/crates/ee-tests/src/revm_tests.rs
@@ -279,8 +279,8 @@ fn test_eip7708_transfer_log_tx_value() {
 
     let tx_value = U256::from(1_000_000_000_000_000u128); // 0.001 ETH (within balance)
 
-    // ETH transfer creating new account costs ~207k gas under EIP-2780
-    // (TX_BASE_COST + COLD_ACCOUNT_ACCESS + ACCOUNT_WRITE + TRANSFER_LOG_COST
+    // ETH transfer creating new account costs ~205k gas under EIP-2780
+    // (TX_BASE_COST + COLD_ACCOUNT_ACCESS + TX_VALUE_COST
     //  + STATE_BYTES_PER_NEW_ACCOUNT × CPSB at top-level execution).
     let result = evm
         .transact_one(

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_block_gas_limit_enforced_with_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_block_gas_limit_enforced_with_state_gas.snap
@@ -6,7 +6,7 @@ expression: "&result_fits"
   "Success": {
     "reason": "Stop",
     "gas": {
-      "gas_spent": 234006,
+      "gas_spent": 233106,
       "state_gas_spent": 200000,
       "gas_refunded": 0,
       "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_propagates.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_propagates.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 45525,
+        "gas_spent": 45625,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 581531,
+        "gas_spent": 581631,
         "state_gas_spent": 536000,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_reverts.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_child_sstore_reverts.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 45747,
+        "gas_spent": 45847,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 385753,
+        "gas_spent": 385853,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_existing_account.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_existing_account.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 29122,
+        "gas_spent": 30122,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -32,7 +32,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 29122,
+        "gas_spent": 30122,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_call_new_account.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 32022,
+        "gas_spent": 33022,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -32,7 +32,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 282022,
+        "gas_spent": 283022,
         "state_gas_spent": 250000,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create2_with_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create2_with_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 32079,
+        "gas_spent": 33079,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 372085,
+        "gas_spent": 373085,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -37,7 +37,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 372076,
+        "gas_spent": 373076,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_child_propagates.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_child_propagates.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 45121,
+        "gas_spent": 45221,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 576127,
+        "gas_spent": 576227,
         "state_gas_spent": 531000,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_code_deposit_state_gas_oog.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_code_deposit_state_gas_oog.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, baseline_tight_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 32079,
+        "gas_spent": 33079,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, baseline_tight_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 32079,
+        "gas_spent": 33079,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -39,7 +39,7 @@ expression: "&(baseline_result, baseline_tight_result, result)"
         "OutOfGas": "Basic"
       },
       "gas": {
-        "gas_spent": 32080,
+        "gas_spent": 33080,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_empty_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_empty_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 32067,
+        "gas_spent": 33067,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 362067,
+        "gas_spent": 363067,
         "state_gas_spent": 330000,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_large_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_large_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 32088,
+        "gas_spent": 33088,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 562130,
+        "gas_spent": 563130,
         "state_gas_spent": 530000,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_code.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_code.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 32070,
+        "gas_spent": 33070,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 372076,
+        "gas_spent": 373076,
         "state_gas_spent": 340000,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_create_with_sstore.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 45121,
+        "gas_spent": 45221,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 576127,
+        "gas_spent": 576227,
         "state_gas_spent": 531000,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_nested_call_create_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_nested_call_create_sstore.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 45525,
+        "gas_spent": 45625,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 581531,
+        "gas_spent": 581631,
         "state_gas_spent": 536000,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -37,7 +37,7 @@ expression: "&(baseline_result, result, create_result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 368076,
+        "gas_spent": 369076,
         "state_gas_spent": 336000,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_parent_sstore_after_child_revert.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_parent_sstore_after_child_revert.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 58753,
+        "gas_spent": 57953,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 598759,
+        "gas_spent": 597959,
         "state_gas_spent": 540000,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_causes_oog.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_causes_oog.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 34006,
+        "gas_spent": 33106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_sufficient.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_regular_gas_cap_sufficient.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 34006,
+        "gas_spent": 33106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 234006,
+        "gas_spent": 233106,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_state_gas_less.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_state_gas_less.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 34006,
+        "gas_spent": 33106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_vs_revert_difference.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_halt_vs_revert_difference.snap
@@ -20,7 +20,7 @@ expression: "&(result_halt, result_revert)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 34012,
+        "gas_spent": 33112,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_less.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_less.snap
@@ -6,7 +6,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 34012,
+        "gas_spent": 33112,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -18,7 +18,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 34012,
+        "gas_spent": 33112,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_more.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reservoir_refill_revert_state_gas_more.snap
@@ -6,7 +6,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 47018,
+        "gas_spent": 45218,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -18,7 +18,7 @@ expression: "&(baseline_result, result)"
   {
     "Revert": {
       "gas": {
-        "gas_spent": 47018,
+        "gas_spent": 45218,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reverted_create_child.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_reverted_create_child.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 45118,
+        "gas_spent": 45218,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 45118,
+        "gas_spent": 45218,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_selfdestruct_new_account.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_selfdestruct_new_account.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "SelfDestruct",
       "gas": {
-        "gas_spent": 37003,
+        "gas_spent": 38003,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -32,7 +32,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "SelfDestruct",
       "gas": {
-        "gas_spent": 287003,
+        "gas_spent": 288003,
         "state_gas_spent": 250000,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_multiple_new_slots.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_multiple_new_slots.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 60018,
+        "gas_spent": 57318,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 660018,
+        "gas_spent": 657318,
         "state_gas_spent": 600000,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_new_slot.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_new_slot.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 34006,
+        "gas_spent": 33106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 234006,
+        "gas_spent": 233106,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_overwrite_no_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_overwrite_no_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 34112,
+        "gas_spent": 33212,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 234112,
+        "gas_spent": 233212,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_set_then_clear_refund.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_set_then_clear_refund.snap
@@ -7,9 +7,9 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 34112,
+        "gas_spent": 33212,
         "state_gas_spent": 0,
-        "gas_refunded": 6822,
+        "gas_refunded": 6642,
         "floor_gas": 12000
       },
       "logs": [],
@@ -22,9 +22,9 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 34112,
+        "gas_spent": 33212,
         "state_gas_spent": 0,
-        "gas_refunded": 6822,
+        "gas_refunded": 6642,
         "floor_gas": 12000
       },
       "logs": [],

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_zero_to_zero_no_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_sstore_zero_to_zero_no_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 24006,
+        "gas_spent": 23106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 24006,
+        "gas_spent": 23106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_does_not_reduce_regular_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_does_not_reduce_regular_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 34006,
+        "gas_spent": 33106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 234006,
+        "gas_spent": 233106,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_oog_remaining.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_oog_remaining.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 34006,
+        "gas_spent": 33106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_spent_final_in_result.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_state_gas_spent_final_in_result.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 34006,
+        "gas_spent": 33106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 234006,
+        "gas_spent": 233106,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_collision.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_collision.snap
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 16777216,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 23384
+        "floor_gas": 24384
       },
       "logs": []
     }

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_halts.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_halts.snap
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
         "gas_spent": 1000000000,
         "state_gas_spent": 0,
         "gas_refunded": 0,
-        "floor_gas": 23384
+        "floor_gas": 24384
       },
       "logs": []
     }

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_selfdestruct_after_sstore.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_create_initcode_selfdestruct_after_sstore.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Return",
       "gas": {
-        "gas_spent": 50431,
+        "gas_spent": 50531,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 13728
@@ -25,10 +25,10 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Return",
       "gas": {
-        "gas_spent": 571431,
+        "gas_spent": 571531,
         "state_gas_spent": 530000,
         "gas_refunded": 0,
-        "floor_gas": 24728
+        "floor_gas": 25728
       },
       "logs": [],
       "output": {

--- a/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_limit_cap_not_enforced_with_state_gas.snap
+++ b/crates/ee-tests/src/snapshots/revm_ee_tests__eip8037__eip8037_tx_limit_cap_not_enforced_with_state_gas.snap
@@ -7,7 +7,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 34006,
+        "gas_spent": 33106,
         "state_gas_spent": 0,
         "gas_refunded": 0,
         "floor_gas": 12000
@@ -22,7 +22,7 @@ expression: "&(baseline_result, result)"
     "Success": {
       "reason": "Stop",
       "gas": {
-        "gas_spent": 234006,
+        "gas_spent": 233106,
         "state_gas_spent": 200000,
         "gas_refunded": 0,
         "floor_gas": 12000

--- a/crates/primitives/src/eip2780.rs
+++ b/crates/primitives/src/eip2780.rs
@@ -8,14 +8,10 @@
 /// Reduced intrinsic base cost charged to `tx.sender` (execution-specs `TX_BASE`).
 pub const TX_BASE_COST: u64 = 12_000;
 
-/// Regular gas cost of the EIP-7708 transfer log emitted for every nonzero-value
-/// transfer to a different account.
-///
-/// `TRANSFER_LOG_COST = GAS_LOG + 3 * GAS_LOG_TOPIC + 32 * GAS_LOG_DATA_PER_BYTE`
-/// = `375 + 1_125 + 256 = 1_756`.
-pub const TRANSFER_LOG_COST: u64 = 1_756;
-
 /// Additional intrinsic regular-gas charge for a value-bearing (non-create,
-/// non-self) transaction (execution-specs `TX_VALUE_COST`), on top of
-/// [`TRANSFER_LOG_COST`].
-pub const TX_VALUE_COST: u64 = 4_244;
+/// non-self) transaction (execution-specs `TX_VALUE_COST`).
+///
+/// Since glamsterdam devnet-8 the former separate `TRANSFER_LOG_COST` (1,756)
+/// is folded into this constant (`4,244 + 1,756 = 6,000`); contract-creation
+/// transactions no longer pay any value-based charge.
+pub const TX_VALUE_COST: u64 = 6_000;

--- a/crates/primitives/src/eip8038.rs
+++ b/crates/primitives/src/eip8038.rs
@@ -1,10 +1,8 @@
 //! EIP-8038: State-Access Gas Cost Update
 //!
 //! Increases the gas cost of state-access operations to reflect Ethereum's
-//! larger state. The values below are the parameters proposed in
-//! [ethereum/EIPs#11802](https://github.com/ethereum/EIPs/pull/11802) (still a
-//! draft — treat as preliminary), superseding the earlier `previous_value + 1`
-//! placeholders.
+//! larger state. The values below match the glamsterdam devnet-8 numbers in
+//! execution-specs `forks/amsterdam` (`vm/gas.py::GasCosts`).
 //!
 //! Active alongside EIP-7904 and EIP-8037 starting at the Amsterdam hardfork.
 
@@ -13,10 +11,11 @@ pub const COLD_ACCOUNT_ACCESS: u64 = 3_000;
 
 /// Surcharge for writing to an account that changes one account leaf value for
 /// the first time (was 6,700 pre-EIP-8038).
-pub const ACCOUNT_WRITE: u64 = 8_000;
+pub const ACCOUNT_WRITE: u64 = 9_000;
 
-/// Cold touch of a storage slot (was 2,100 pre-EIP-8038).
-pub const COLD_STORAGE_ACCESS: u64 = 3_000;
+/// Cold touch of a storage slot. Unchanged from the pre-EIP-8038 cost, but
+/// under EIP-8038 it is the *total* cold charge (the warm base is folded in).
+pub const COLD_STORAGE_ACCESS: u64 = 2_100;
 
 /// Surcharge for writing to a storage slot that changes its value for the
 /// first time (was 2,800 pre-EIP-8038).
@@ -32,18 +31,21 @@ pub const STORAGE_CLEAR_REFUND: u64 = (STORAGE_WRITE + COLD_STORAGE_ACCESS) * 4_
 
 /// State access cost for contract deployment (was 7,000 pre-EIP-8038).
 ///
-/// Per the spec, `CREATE_ACCESS = ACCOUNT_WRITE + COLD_STORAGE_ACCESS`. This does
+/// Per the spec, `CREATE_ACCESS = ACCOUNT_WRITE + COLD_ACCOUNT_ACCESS`. This does
 /// not match the legacy decomposition (`GAS_CREATE - GAS_NEW_ACCOUNT = 7,000`); the
 /// EIP keeps that discrepancy rather than reconciling it.
-pub const CREATE_ACCESS: u64 = ACCOUNT_WRITE + COLD_STORAGE_ACCESS;
+pub const CREATE_ACCESS: u64 = ACCOUNT_WRITE + COLD_ACCOUNT_ACCESS;
 
 /// Gas charged per storage key included in a transaction's access list
-/// (was 1,900 pre-EIP-8038). Derived per the spec as `COLD_STORAGE_ACCESS`.
-pub const ACCESS_LIST_STORAGE_KEY_COST: u64 = COLD_STORAGE_ACCESS;
+/// (was 1,900 pre-EIP-8038). Derived per the spec as
+/// `COLD_STORAGE_ACCESS - WARM_ACCESS`: the access list pre-pays only the cold
+/// premium, the warm base is still charged at first use.
+pub const ACCESS_LIST_STORAGE_KEY_COST: u64 = COLD_STORAGE_ACCESS - WARM_ACCESS;
 
 /// Gas charged per address included in a transaction's access list
-/// (was 2,400 pre-EIP-8038). Derived per the spec as `COLD_ACCOUNT_ACCESS`.
-pub const ACCESS_LIST_ADDRESS_COST: u64 = COLD_ACCOUNT_ACCESS;
+/// (was 2,400 pre-EIP-8038). Derived per the spec as
+/// `COLD_ACCOUNT_ACCESS - WARM_ACCESS`.
+pub const ACCESS_LIST_ADDRESS_COST: u64 = COLD_ACCOUNT_ACCESS - WARM_ACCESS;
 
 /// Cold premium on top of `WARM_ACCESS` for account access.
 pub const COLD_ACCOUNT_ACCESS_ADDITIONAL: u64 = COLD_ACCOUNT_ACCESS - WARM_ACCESS;
@@ -85,19 +87,19 @@ pub const EIP7702_PER_AUTH_BASE_REGULAR: u64 = EIP7702_AUTH_TUPLE_BYTES * TX_DAT
 mod tests {
     use super::*;
 
-    /// Values must match the parameters table in ethereum/EIPs#11802.
+    /// Values must match execution-specs `forks/amsterdam` (glamsterdam devnet-8).
     #[test]
     fn constants_match_spec() {
         assert_eq!(WARM_ACCESS, 100); // unchanged by EIP-8038
         assert_eq!(COLD_ACCOUNT_ACCESS, 3_000);
-        assert_eq!(ACCOUNT_WRITE, 8_000);
-        assert_eq!(COLD_STORAGE_ACCESS, 3_000);
+        assert_eq!(ACCOUNT_WRITE, 9_000);
+        assert_eq!(COLD_STORAGE_ACCESS, 2_100);
         assert_eq!(STORAGE_WRITE, 10_000);
-        assert_eq!(STORAGE_CLEAR_REFUND, 12_480);
-        assert_eq!(CREATE_ACCESS, 11_000);
-        assert_eq!(ACCESS_LIST_ADDRESS_COST, 3_000);
-        assert_eq!(ACCESS_LIST_STORAGE_KEY_COST, 3_000);
-        assert_eq!(CALL_VALUE, 10_300);
+        assert_eq!(STORAGE_CLEAR_REFUND, 11_616);
+        assert_eq!(CREATE_ACCESS, 12_000);
+        assert_eq!(ACCESS_LIST_ADDRESS_COST, 2_900);
+        assert_eq!(ACCESS_LIST_STORAGE_KEY_COST, 2_000);
+        assert_eq!(CALL_VALUE, 11_300);
         assert_eq!(EIP7702_PER_AUTH_BASE_REGULAR, 7_816);
     }
 
@@ -105,10 +107,13 @@ mod tests {
     /// renumber of one base value propagates correctly).
     #[test]
     fn derived_relations() {
-        assert_eq!(CREATE_ACCESS, ACCOUNT_WRITE + COLD_STORAGE_ACCESS);
+        assert_eq!(CREATE_ACCESS, ACCOUNT_WRITE + COLD_ACCOUNT_ACCESS);
         assert_eq!(CALL_VALUE, ACCOUNT_WRITE + 2_300);
-        assert_eq!(ACCESS_LIST_ADDRESS_COST, COLD_ACCOUNT_ACCESS);
-        assert_eq!(ACCESS_LIST_STORAGE_KEY_COST, COLD_STORAGE_ACCESS);
+        assert_eq!(ACCESS_LIST_ADDRESS_COST, COLD_ACCOUNT_ACCESS - WARM_ACCESS);
+        assert_eq!(
+            ACCESS_LIST_STORAGE_KEY_COST,
+            COLD_STORAGE_ACCESS - WARM_ACCESS
+        );
         assert_eq!(
             STORAGE_CLEAR_REFUND,
             (STORAGE_WRITE + COLD_STORAGE_ACCESS) * 4_800 / 5_000

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 
 # Version for the execution spec tests
 MAIN_VERSION="v5.4.0"
-DEVNET_VERSION="tests-glamsterdam-devnet%40v7.2.0"
+DEVNET_VERSION="tests-glamsterdam-devnet%40v8.1.0"
 
 ### Directories ###
 FIXTURES_DIR="test-fixtures"


### PR DESCRIPTION
## Summary

Aligns Amsterdam with execution-specs `forks/amsterdam` at glamsterdam devnet-8 ([spec overview](https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-8), fixtures `tests-glamsterdam-devnet@v8.1.0`).

Most devnet-8 mechanics (EIP-8037 source-based/LIFO spill refunds, EIP-7928 recipient exclusion on runtime-phase halt, EIP-7702 paid-writes gating) were already implemented on main; this PR carries the remaining constant repricing and the EIP-2780 value-charge fold.

### EIP-8038 repricing (`primitives::eip8038`)

| Constant | devnet-7 | devnet-8 |
|---|---:|---:|
| `ACCOUNT_WRITE` | 8,000 | 9,000 |
| `COLD_STORAGE_ACCESS` | 3,000 | 2,100 |
| `CREATE_ACCESS` | 11,000 (`AW + COLD_STORAGE`) | 12,000 (`AW + COLD_ACCOUNT`) |
| `ACCESS_LIST_ADDRESS_COST` | 3,000 (full cold) | 2,900 (cold − warm) |
| `ACCESS_LIST_STORAGE_KEY_COST` | 3,000 (full cold) | 2,000 (cold − warm) |
| `STORAGE_CLEAR_REFUND` (derived) | 12,480 | 11,616 |
| `CALL_VALUE` (derived) | 10,300 | 11,300 |

### EIP-2780 value-charge fold (`primitives::eip2780`)

- `TX_VALUE_COST` 4,244 → 6,000; `TRANSFER_LOG_COST` (1,756) deleted (folded per spec).
- Calls with value are unchanged at 21,000 intrinsic total; **create transactions no longer pay any value-based charge** (24,000 flat = `TX_BASE + CREATE_ACCESS`).
- The `tx_transfer_log_cost` GasId is removed (`tx_account_write_cost` → 48, `tx_create_access_cost` → 49). The EIP-7708 transfer-log emission itself is unchanged.

### Misc

- `scripts/run-tests.sh` devnet fixtures bumped to `tests-glamsterdam-devnet@v8.1.0`.
- ee-tests golden totals and eip8037 insta snapshots re-baselined (all deltas are exactly the repriced constants: +1,000 per create access / account write, −900 per cold storage access).

## Validation

- `tests-glamsterdam-devnet@v8.1.0`: all state tests and blockchain tests pass (17,758 Amsterdam-fork tests, ~81k total, 0 failures; skips are the usual system-contract/EIP-7610 categories).
- Main develop `v5.4.0` and legacy fixtures pass (no pre-Amsterdam regression).
- Workspace tests pass in default, `--all-features`, and `--no-default-features`; clippy, fmt, typos clean.

Note: v8.1.0 fixtures were cut pre-freeze; a follow-up release carrying the frozen repricing (ethereum/EIPs PR-12083) is expected. Since `CREATE_ACCESS`, `CALL_VALUE`, and the refunds are derived, a renumber should only touch the base constants in `eip8038.rs`.