### PR TITLE
fix(database): cache newly created contract code

### DIFF
--- a/crates/database/src/states/cache.rs
+++ b/crates/database/src/states/cache.rs
@@ -235,7 +235,13 @@ impl CacheState {
         // by just setting storage inside CRATE constructor. Overlap of those contracts
         // is not possible because CREATE2 is introduced later.
         if is_created {
-            return Some(this_account.newly_created(account));
+            let transition = this_account.newly_created(account);
+            if let Some(info) = transition.info.as_ref() {
+                if let Some(code) = info.code.as_ref() {
+                    self.contracts.insert(info.code_hash, code.clone());
+                }
+            }
+            return Some(transition);
         }
 
         // Account is touched, but not selfdestructed or newly created.

--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -566,7 +566,7 @@ mod tests {
         states::{reverts::AccountInfoRevert, StorageSlot},
         AccountRevert, AccountStatus, BundleAccount, RevertToSlot,
     };
-    use primitives::{keccak256, BLOCK_HASH_HISTORY, U256};
+    use primitives::{keccak256, Bytes, BLOCK_HASH_HISTORY, U256};
     use state::{EvmStorageSlot, TransactionId};
 
     fn evm_storage<const N: usize>(
@@ -631,6 +631,22 @@ mod tests {
         // Block 0 should now be in cache with correct value
         assert_eq!(state.block_hashes.get(0), Some(expected_hash));
     }
+
+    #[test]
+    fn created_contract_code_is_available_before_transition_merge() {
+        let bytecode = Bytecode::new_raw(Bytes::from_static(&[0x00]));
+        let code_hash = bytecode.hash_slow();
+        let account = Account::default()
+            .with_info(AccountInfo::default().with_code(bytecode.clone()))
+            .with_touched_mark()
+            .with_created_mark();
+        let mut state = State::builder().with_bundle_update().build();
+
+        state.commit(HashMap::from_iter([(Address::ZERO, account)]));
+
+        assert_eq!(state.code_by_hash(code_hash).unwrap(), bytecode);
+    }
+
     /// Checks that if accounts is touched multiple times in the same block,
     /// then the old values from the first change are preserved and not overwritten.
     ///


### PR DESCRIPTION
## Summary

Cache bytecode from newly created accounts as soon as their transaction changes are committed to `CacheState`.

A later transaction can load a different account with the same code hash before block transitions are merged into `BundleState`. Previously, `State::code_by_hash` missed the newly created code and fell through to the backing database. This breaks stateless execution when the witness correctly omits a code preimage that was created earlier in the block, as exercised by [`test_witness_codes_create_same_hash_then_read`](https://github.com/ethereum/execution-specs/blob/tests-zkevm%40v0.6.2/tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_contract_creation.py).

The regression test commits a contract containing `0x00`, then resolves its hash before transition merging. Without the cache insertion, `EmptyDB` returns empty bytecode and the assertion fails.

## Validation

- `cargo fmt --all --check`
- `cargo test -p revm-database --all-features`
- `cargo clippy -p revm-database --all-targets --all-features -- -D warnings`
- `cargo check -p revm-database --no-default-features`
- `cargo check --target riscv64imac-unknown-none-elf -p revm-database --no-default-features`
- The referenced EEST fixture passes through the Reth stateless validator with this patch applied.
