### PR TITLE
fix: enforce EIP-7610 creation collisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3943,10 +3943,10 @@ dependencies = [
 name = "revm-database"
 version = "42.0.0"
 dependencies = [
- "alloy-consensus",
  "alloy-eips",
  "alloy-provider",
  "alloy-transport",
+ "alloy-trie",
  "derive_more",
  "either",
  "revm-bytecode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3943,6 +3943,7 @@ dependencies = [
 name = "revm-database"
 version = "42.0.0"
 dependencies = [
+ "alloy-consensus",
  "alloy-eips",
  "alloy-provider",
  "alloy-transport",

--- a/bins/revme/src/cmd/blockchaintest.rs
+++ b/bins/revme/src/cmd/blockchaintest.rs
@@ -1148,8 +1148,7 @@ fn fork_to_spec_id(fork: ForkSpec) -> SpecId {
 fn skip_test(path: &Path) -> bool {
     let path_str = path.to_str().unwrap_or_default();
     // blobs excess gas calculation is not supported or osaka BPO configuration
-    if path_str.contains("paris/eip7610_create_collision")
-        || path_str.contains("cancun/eip4844_blobs")
+    if path_str.contains("cancun/eip4844_blobs")
         || path_str.contains("prague/eip7251_consolidations")
         || path_str.contains("prague/eip7685_general_purpose_el_requests")
         || path_str.contains("prague/eip7002_el_triggerable_withdrawals")
@@ -1162,20 +1161,8 @@ fn skip_test(path: &Path) -> bool {
     // Add any problematic tests here that should be skipped
     matches!(
         name,
-        // Test with some storage check.
-        "RevertInCreateInInit_Paris.json"
-        | "RevertInCreateInInit.json"
-        | "dynamicAccountOverwriteEmpty.json"
-        | "dynamicAccountOverwriteEmpty_Paris.json"
-        | "RevertInCreateInInitCreate2Paris.json"
-        | "create2collisionStorage.json"
-        | "RevertInCreateInInitCreate2.json"
-        | "create2collisionStorageParis.json"
-        | "InitCollision.json"
-        | "InitCollisionParis.json"
-
         // Malformed value.
-        | "ValueOverflow.json"
+        "ValueOverflow.json"
         | "ValueOverflowParis.json"
 
         // These tests are passing, but they take a lot of time to execute so we are going to skip them.

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -65,32 +65,12 @@ pub enum TestErrorKind {
 /// Check if a test should be skipped based on its filename
 /// Some tests are known to be problematic or take too long
 fn skip_test(path: &Path) -> bool {
-    let path_str = path.to_str().unwrap_or_default();
-
-    // Skip tets that have storage for newly created account.
-    if path_str.contains("paris/eip7610_create_collision") {
-        return true;
-    }
-
     let name = path.file_name().unwrap().to_str().unwrap_or_default();
 
     matches!(
         name,
-        // Test with some storage check.
-        "RevertInCreateInInit_Paris.json"
-        | "RevertInCreateInInit.json"
-        | "dynamicAccountOverwriteEmpty.json"
-        | "dynamicAccountOverwriteEmpty_Paris.json"
-        | "RevertInCreateInInitCreate2Paris.json"
-        | "create2collisionStorage.json"
-        | "RevertInCreateInInitCreate2.json"
-        | "create2collisionStorageParis.json"
-        | "InitCollision.json"
-        | "InitCollisionParis.json"
-        | "test_init_collision_create_opcode.json"
-
         // Malformed value.
-        | "ValueOverflow.json"
+        "ValueOverflow.json"
         | "ValueOverflowParis.json"
 
         // These tests are passing, but they take a lot of time to execute so we are going to skip them.

--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -196,6 +196,12 @@ pub trait JournalTr {
         address: Address,
     ) -> Result<StateLoad<&Account>, <Self::Database as Database>::Error>;
 
+    /// Returns whether the account's current state has any non-zero storage slots.
+    fn account_has_storage(
+        &mut self,
+        address: Address,
+    ) -> Result<bool, <Self::Database as Database>::Error>;
+
     /// Loads the account code, use `load_account_with_code` instead.
     #[inline]
     #[deprecated(note = "Use `load_account_with_code` instead")]

--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -197,10 +197,15 @@ pub trait JournalTr {
     ) -> Result<StateLoad<&Account>, <Self::Database as Database>::Error>;
 
     /// Returns whether the account's current state has any non-zero storage slots.
+    ///
+    /// Custom journals that can contain pending storage changes should override this method.
+    #[inline]
     fn account_has_storage(
         &mut self,
         address: Address,
-    ) -> Result<bool, <Self::Database as Database>::Error>;
+    ) -> Result<bool, <Self::Database as Database>::Error> {
+        self.db_mut().account_has_storage(address)
+    }
 
     /// Loads the account code, use `load_account_with_code` instead.
     #[inline]

--- a/crates/context/src/journal.rs
+++ b/crates/context/src/journal.rs
@@ -269,6 +269,11 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
     }
 
     #[inline]
+    fn account_has_storage(&mut self, address: Address) -> Result<bool, DB::Error> {
+        self.inner.account_has_storage(&mut self.database, address)
+    }
+
+    #[inline]
     fn load_account_mut_skip_cold_load(
         &mut self,
         address: Address,

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -768,18 +768,15 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
             .map_err(JournalLoadError::unwrap_db_error)
     }
 
-    /// Returns whether the loaded account's current state has any non-zero storage slots.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the account has not been loaded into the journal.
+    /// Returns whether the account's current state has any non-zero storage slots.
     #[inline]
     pub fn account_has_storage<DB: Database>(
         &mut self,
         db: &mut DB,
         address: Address,
     ) -> Result<bool, DB::Error> {
-        let account = self.state.get(&address).expect("account must be loaded");
+        self.load_account(db, address)?;
+        let account = self.state.get(&address).expect("account was just loaded");
         if account
             .storage
             .values()
@@ -1177,9 +1174,53 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
 mod tests {
     use super::*;
     use context_interface::journaled_state::entry::JournalEntry;
-    use database_interface::EmptyDB;
+    use core::convert::Infallible;
+    use database_interface::{Database, EmptyDB};
     use primitives::{address, HashSet, U256};
     use state::AccountInfo;
+
+    struct StorageDb;
+
+    impl Database for StorageDb {
+        type Error = Infallible;
+
+        fn basic(&mut self, _address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+            Ok(Some(AccountInfo::default()))
+        }
+
+        fn account_has_storage(&mut self, _address: Address) -> Result<bool, Self::Error> {
+            Ok(true)
+        }
+
+        fn code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            Ok(Bytecode::default())
+        }
+
+        fn storage(
+            &mut self,
+            _address: Address,
+            _index: StorageKey,
+        ) -> Result<StorageValue, Self::Error> {
+            Ok(StorageValue::ZERO)
+        }
+
+        fn block_hash(&mut self, _number: u64) -> Result<B256, Self::Error> {
+            Ok(B256::ZERO)
+        }
+    }
+
+    #[test]
+    fn account_storage_check_loads_account() {
+        let mut journal = JournalInner::<JournalEntry>::new();
+        let address = Address::with_last_byte(1);
+
+        assert!(!journal.state.contains_key(&address));
+        assert_eq!(
+            journal.account_has_storage(&mut StorageDb, address),
+            Ok(true)
+        );
+        assert!(journal.state.contains_key(&address));
+    }
 
     #[test]
     fn test_sload_skip_cold_load() {

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -768,6 +768,34 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
             .map_err(JournalLoadError::unwrap_db_error)
     }
 
+    /// Returns whether the loaded account's current state has any non-zero storage slots.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the account has not been loaded into the journal.
+    #[inline]
+    pub fn account_has_storage<DB: Database>(
+        &mut self,
+        db: &mut DB,
+        address: Address,
+    ) -> Result<bool, DB::Error> {
+        let account = self.state.get(&address).expect("account must be loaded");
+        if account
+            .storage
+            .values()
+            .any(|slot| !slot.present_value.is_zero())
+        {
+            return Ok(true);
+        }
+        if account.is_created()
+            || account.is_selfdestructed()
+            || account.is_loaded_as_not_existing()
+        {
+            return Ok(false);
+        }
+        db.account_has_storage(address)
+    }
+
     /// Loads account into memory. If account is EIP-7702 type it will additionally
     /// load delegated account.
     ///

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -34,8 +34,8 @@ tokio = { workspace = true, features = [
 	"macros",
 ], optional = true }
 alloy-provider = { workspace = true, optional = true }
-alloy-consensus = { workspace = true, optional = true }
 alloy-eips = { workspace = true, optional = true }
+alloy-trie = { workspace = true, optional = true }
 alloy-transport = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -45,8 +45,8 @@ serde_json = { workspace = true, features = ["alloc"] }
 default = ["std"]
 std = [
 	"serde?/std",
-	"alloy-consensus?/std",
 	"alloy-eips?/std",
+	"alloy-trie?/std",
 	"bytecode/std",
 	"database-interface/std",
 	"derive_more/std",
@@ -57,8 +57,8 @@ std = [
 ]
 serde = [
 	"dep:serde",
-	"alloy-consensus?/serde",
 	"alloy-eips?/serde",
+	"alloy-trie?/serde",
 	"bytecode/serde",
 	"database-interface/serde",
 	"primitives/serde",
@@ -70,8 +70,8 @@ alloydb = [
 	"database-interface/asyncdb",
 	"dep:tokio",
 	"dep:alloy-provider",
-	"dep:alloy-consensus",
 	"dep:alloy-eips",
+	"dep:alloy-trie",
 	"dep:alloy-transport",
 ]
 map-foldhash = ["primitives/map-foldhash", "state/map-foldhash"]

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -34,6 +34,7 @@ tokio = { workspace = true, features = [
 	"macros",
 ], optional = true }
 alloy-provider = { workspace = true, optional = true }
+alloy-consensus = { workspace = true, optional = true }
 alloy-eips = { workspace = true, optional = true }
 alloy-transport = { workspace = true, optional = true }
 
@@ -44,6 +45,7 @@ serde_json = { workspace = true, features = ["alloc"] }
 default = ["std"]
 std = [
 	"serde?/std",
+	"alloy-consensus?/std",
 	"alloy-eips?/std",
 	"bytecode/std",
 	"database-interface/std",
@@ -55,6 +57,7 @@ std = [
 ]
 serde = [
 	"dep:serde",
+	"alloy-consensus?/serde",
 	"alloy-eips?/serde",
 	"bytecode/serde",
 	"database-interface/serde",
@@ -67,6 +70,7 @@ alloydb = [
 	"database-interface/asyncdb",
 	"dep:tokio",
 	"dep:alloy-provider",
+	"dep:alloy-consensus",
 	"dep:alloy-eips",
 	"dep:alloy-transport",
 ]

--- a/crates/database/interface/src/async_db.rs
+++ b/crates/database/interface/src/async_db.rs
@@ -477,6 +477,12 @@ pub trait DatabaseAsync {
         address: Address,
     ) -> impl Future<Output = Result<Option<AccountInfo>, Self::Error>> + Send;
 
+    /// Returns whether the account has any non-zero storage slots.
+    fn account_has_storage_async(
+        &mut self,
+        address: Address,
+    ) -> impl Future<Output = Result<bool, Self::Error>> + Send;
+
     /// Gets account code by its hash.
     fn code_by_hash_async(
         &mut self,
@@ -525,6 +531,12 @@ pub trait DatabaseAsyncRef {
         &self,
         address: Address,
     ) -> impl Future<Output = Result<Option<AccountInfo>, Self::Error>> + Send;
+
+    /// Returns whether the account has any non-zero storage slots.
+    fn account_has_storage_async_ref(
+        &self,
+        address: Address,
+    ) -> impl Future<Output = Result<bool, Self::Error>> + Send;
 
     /// Gets account code by its hash.
     fn code_by_hash_async_ref(
@@ -640,6 +652,15 @@ impl<T: DatabaseAsync> Database for AsyncDb<T> {
     }
 
     #[inline]
+    fn account_has_storage(&mut self, address: Address) -> Result<bool, Self::Error> {
+        let Self { db, rt } = self;
+        block_on_runtime_result(
+            rt.as_ref().map(HandleOrRuntime::handle),
+            db.account_has_storage_async(address),
+        )
+    }
+
+    #[inline]
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
         let Self { db, rt } = self;
         block_on_runtime_result(
@@ -693,6 +714,14 @@ impl<T: DatabaseAsyncRef> DatabaseRef for AsyncDb<T> {
         block_on_runtime_result(
             self.rt.as_ref().map(HandleOrRuntime::handle),
             self.db.basic_async_ref(address),
+        )
+    }
+
+    #[inline]
+    fn account_has_storage_ref(&self, address: Address) -> Result<bool, Self::Error> {
+        block_on_runtime_result(
+            self.rt.as_ref().map(HandleOrRuntime::handle),
+            self.db.account_has_storage_async_ref(address),
         )
     }
 
@@ -813,6 +842,11 @@ impl<T: DatabaseAsync> Database for WrapDatabaseAsync<T> {
     }
 
     #[inline]
+    fn account_has_storage(&mut self, address: Address) -> Result<bool, Self::Error> {
+        self.0.account_has_storage(address)
+    }
+
+    #[inline]
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
         self.0.code_by_hash(code_hash)
     }
@@ -849,6 +883,11 @@ impl<T: DatabaseAsyncRef> DatabaseRef for WrapDatabaseAsync<T> {
     #[inline]
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         self.0.basic_ref(address)
+    }
+
+    #[inline]
+    fn account_has_storage_ref(&self, address: Address) -> Result<bool, Self::Error> {
+        self.0.account_has_storage_ref(address)
     }
 
     #[inline]
@@ -1102,6 +1141,13 @@ mod tests {
             Ok(None)
         }
 
+        async fn account_has_storage_async(
+            &mut self,
+            _address: Address,
+        ) -> Result<bool, Self::Error> {
+            Ok(false)
+        }
+
         async fn code_by_hash_async(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
             Ok(Bytecode::default())
         }
@@ -1131,6 +1177,13 @@ mod tests {
             _address: Address,
         ) -> Result<Option<AccountInfo>, Self::Error> {
             Ok(None)
+        }
+
+        async fn account_has_storage_async(
+            &mut self,
+            _address: Address,
+        ) -> Result<bool, Self::Error> {
+            Ok(false)
         }
 
         async fn code_by_hash_async(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
@@ -1183,6 +1236,13 @@ mod tests {
             Ok(None)
         }
 
+        async fn account_has_storage_async(
+            &mut self,
+            _address: Address,
+        ) -> Result<bool, Self::Error> {
+            Ok(false)
+        }
+
         async fn code_by_hash_async(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
             Ok(Bytecode::default())
         }
@@ -1211,6 +1271,14 @@ mod tests {
         ) -> Result<Option<AccountInfo>, Self::Error> {
             tokio::task::yield_now().await;
             Ok(None)
+        }
+
+        async fn account_has_storage_async(
+            &mut self,
+            _address: Address,
+        ) -> Result<bool, Self::Error> {
+            tokio::task::yield_now().await;
+            Ok(false)
         }
 
         async fn code_by_hash_async(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {

--- a/crates/database/interface/src/async_db.rs
+++ b/crates/database/interface/src/async_db.rs
@@ -478,10 +478,15 @@ pub trait DatabaseAsync {
     ) -> impl Future<Output = Result<Option<AccountInfo>, Self::Error>> + Send;
 
     /// Returns whether the account has any non-zero storage slots.
+    ///
+    /// The default preserves the behavior from before EIP-7610 storage collisions were enforced.
+    /// Databases that can contain persisted account storage should override this method.
     fn account_has_storage_async(
         &mut self,
-        address: Address,
-    ) -> impl Future<Output = Result<bool, Self::Error>> + Send;
+        _address: Address,
+    ) -> impl Future<Output = Result<bool, Self::Error>> + Send {
+        async { Ok(false) }
+    }
 
     /// Gets account code by its hash.
     fn code_by_hash_async(
@@ -533,10 +538,15 @@ pub trait DatabaseAsyncRef {
     ) -> impl Future<Output = Result<Option<AccountInfo>, Self::Error>> + Send;
 
     /// Returns whether the account has any non-zero storage slots.
+    ///
+    /// The default preserves the behavior from before EIP-7610 storage collisions were enforced.
+    /// Databases that can contain persisted account storage should override this method.
     fn account_has_storage_async_ref(
         &self,
-        address: Address,
-    ) -> impl Future<Output = Result<bool, Self::Error>> + Send;
+        _address: Address,
+    ) -> impl Future<Output = Result<bool, Self::Error>> + Send {
+        async { Ok(false) }
+    }
 
     /// Gets account code by its hash.
     fn code_by_hash_async_ref(

--- a/crates/database/interface/src/bal.rs
+++ b/crates/database/interface/src/bal.rs
@@ -398,6 +398,13 @@ impl<DB: Database> Database for BalDatabase<DB> {
     }
 
     #[inline]
+    fn account_has_storage(&mut self, address: Address) -> Result<bool, Self::Error> {
+        self.db
+            .account_has_storage(address)
+            .map_err(EvmDatabaseError::Database)
+    }
+
+    #[inline]
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
         self.db
             .code_by_hash(code_hash)

--- a/crates/database/interface/src/bal.rs
+++ b/crates/database/interface/src/bal.rs
@@ -399,6 +399,7 @@ impl<DB: Database> Database for BalDatabase<DB> {
 
     #[inline]
     fn account_has_storage(&mut self, address: Address) -> Result<bool, Self::Error> {
+        self.bal_state.get_account_id(&address)?;
         self.db
             .account_has_storage(address)
             .map_err(EvmDatabaseError::Database)
@@ -467,8 +468,43 @@ impl<DB: DatabaseCommit> DatabaseCommit for BalDatabase<DB> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::convert::Infallible;
     use primitives::U256;
-    use state::bal::{AccountBal, BalWrites};
+    use state::{
+        bal::{AccountBal, BalWrites},
+        AccountInfo, Bytecode,
+    };
+
+    #[derive(Debug)]
+    struct StorageDb(bool);
+
+    impl Database for StorageDb {
+        type Error = Infallible;
+
+        fn basic(&mut self, _address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+            Ok(None)
+        }
+
+        fn account_has_storage(&mut self, _address: Address) -> Result<bool, Self::Error> {
+            Ok(self.0)
+        }
+
+        fn code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            Ok(Bytecode::default())
+        }
+
+        fn storage(
+            &mut self,
+            _address: Address,
+            _index: StorageKey,
+        ) -> Result<StorageValue, Self::Error> {
+            Ok(StorageValue::ZERO)
+        }
+
+        fn block_hash(&mut self, _number: u64) -> Result<B256, Self::Error> {
+            Ok(B256::ZERO)
+        }
+    }
 
     fn bal_with_account(address: Address, slot: StorageKey) -> Arc<Bal> {
         let mut account = AccountBal::default();
@@ -526,5 +562,26 @@ mod tests {
             bal_state.storage(&address, slot),
             Ok(Some(StorageValue::from(42u64)))
         );
+    }
+
+    #[test]
+    fn account_storage_check_honors_bal_coverage() {
+        let address = Address::with_last_byte(1);
+        let missing = Address::with_last_byte(2);
+        let bal = bal_with_account(address, U256::ZERO);
+        let mut db = BalDatabase::new(StorageDb(true)).with_bal_option(Some(bal.clone()));
+
+        assert_eq!(db.account_has_storage(address), Ok(true));
+        assert_eq!(
+            db.account_has_storage(missing),
+            Err(EvmDatabaseError::Bal(BalError::AccountNotFound {
+                address: missing
+            }))
+        );
+
+        let mut db = BalDatabase::new(StorageDb(true))
+            .with_bal_option(Some(bal))
+            .with_allow_bal_db_fallback(true);
+        assert_eq!(db.account_has_storage(missing), Ok(true));
     }
 }

--- a/crates/database/interface/src/either.rs
+++ b/crates/database/interface/src/either.rs
@@ -19,6 +19,13 @@ where
         }
     }
 
+    fn account_has_storage(&mut self, address: Address) -> Result<bool, Self::Error> {
+        match self {
+            Self::Left(db) => db.account_has_storage(address),
+            Self::Right(db) => db.account_has_storage(address),
+        }
+    }
+
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
         match self {
             Self::Left(db) => db.code_by_hash(code_hash),
@@ -88,6 +95,13 @@ where
         match self {
             Self::Left(db) => db.basic_ref(address),
             Self::Right(db) => db.basic_ref(address),
+        }
+    }
+
+    fn account_has_storage_ref(&self, address: Address) -> Result<bool, Self::Error> {
+        match self {
+            Self::Left(db) => db.account_has_storage_ref(address),
+            Self::Right(db) => db.account_has_storage_ref(address),
         }
     }
 

--- a/crates/database/interface/src/empty_db.rs
+++ b/crates/database/interface/src/empty_db.rs
@@ -63,6 +63,11 @@ impl<E: DBErrorMarker + core::error::Error + Send + Sync + 'static> Database for
     }
 
     #[inline]
+    fn account_has_storage(&mut self, address: Address) -> Result<bool, Self::Error> {
+        <Self as DatabaseRef>::account_has_storage_ref(self, address)
+    }
+
+    #[inline]
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
         <Self as DatabaseRef>::code_by_hash_ref(self, code_hash)
     }
@@ -90,6 +95,11 @@ impl<E: DBErrorMarker + core::error::Error + Send + Sync + 'static> DatabaseRef
     #[inline]
     fn basic_ref(&self, _address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         Ok(None)
+    }
+
+    #[inline]
+    fn account_has_storage_ref(&self, _address: Address) -> Result<bool, Self::Error> {
+        Ok(false)
     }
 
     #[inline]

--- a/crates/database/interface/src/lib.rs
+++ b/crates/database/interface/src/lib.rs
@@ -69,6 +69,9 @@ pub trait Database {
     /// Gets basic account information.
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error>;
 
+    /// Returns whether the account has any non-zero storage slots.
+    fn account_has_storage(&mut self, address: Address) -> Result<bool, Self::Error>;
+
     /// Gets account code by its hash.
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error>;
 
@@ -152,6 +155,9 @@ pub trait DatabaseRef {
     /// Gets basic account information.
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error>;
 
+    /// Returns whether the account has any non-zero storage slots.
+    fn account_has_storage_ref(&self, address: Address) -> Result<bool, Self::Error>;
+
     /// Gets account code by its hash.
     fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error>;
 
@@ -194,6 +200,11 @@ impl<T: DatabaseRef> Database for WrapDatabaseRef<T> {
     #[inline]
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         self.0.basic_ref(address)
+    }
+
+    #[inline]
+    fn account_has_storage(&mut self, address: Address) -> Result<bool, Self::Error> {
+        self.0.account_has_storage_ref(address)
     }
 
     #[inline]
@@ -245,6 +256,11 @@ impl<T: DatabaseRef> DatabaseRef for WrapDatabaseRef<T> {
     #[inline]
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         self.0.basic_ref(address)
+    }
+
+    #[inline]
+    fn account_has_storage_ref(&self, address: Address) -> Result<bool, Self::Error> {
+        self.0.account_has_storage_ref(address)
     }
 
     #[inline]
@@ -422,6 +438,10 @@ mod tests {
 
             fn basic_ref(&self, _address: Address) -> Result<Option<AccountInfo>, Self::Error> {
                 Ok(None)
+            }
+
+            fn account_has_storage_ref(&self, _address: Address) -> Result<bool, Self::Error> {
+                Ok(false)
             }
 
             fn code_by_hash_ref(&self, _code_hash: B256) -> Result<Bytecode, Self::Error> {

--- a/crates/database/interface/src/lib.rs
+++ b/crates/database/interface/src/lib.rs
@@ -70,7 +70,13 @@ pub trait Database {
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error>;
 
     /// Returns whether the account has any non-zero storage slots.
-    fn account_has_storage(&mut self, address: Address) -> Result<bool, Self::Error>;
+    ///
+    /// The default preserves the behavior from before EIP-7610 storage collisions were enforced.
+    /// Databases that can contain persisted account storage should override this method.
+    #[inline]
+    fn account_has_storage(&mut self, _address: Address) -> Result<bool, Self::Error> {
+        Ok(false)
+    }
 
     /// Gets account code by its hash.
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error>;
@@ -156,7 +162,13 @@ pub trait DatabaseRef {
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error>;
 
     /// Returns whether the account has any non-zero storage slots.
-    fn account_has_storage_ref(&self, address: Address) -> Result<bool, Self::Error>;
+    ///
+    /// The default preserves the behavior from before EIP-7610 storage collisions were enforced.
+    /// Databases that can contain persisted account storage should override this method.
+    #[inline]
+    fn account_has_storage_ref(&self, _address: Address) -> Result<bool, Self::Error> {
+        Ok(false)
+    }
 
     /// Gets account code by its hash.
     fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error>;

--- a/crates/database/src/alloydb.rs
+++ b/crates/database/src/alloydb.rs
@@ -1,12 +1,12 @@
 //! Alloy provider database implementation.
 
-use alloy_consensus::constants::EMPTY_ROOT_HASH;
 pub use alloy_eips::BlockId;
 use alloy_provider::{
     network::{primitives::HeaderResponse, BlockResponse},
     Network, Provider,
 };
 use alloy_transport::TransportError;
+use alloy_trie::EMPTY_ROOT_HASH;
 use core::error::Error;
 use database_interface::{async_db::DatabaseAsyncRef, DBErrorMarker};
 use primitives::{Address, StorageKey, StorageValue, B256};

--- a/crates/database/src/alloydb.rs
+++ b/crates/database/src/alloydb.rs
@@ -1,5 +1,6 @@
 //! Alloy provider database implementation.
 
+use alloy_consensus::constants::EMPTY_ROOT_HASH;
 pub use alloy_eips::BlockId;
 use alloy_provider::{
     network::{primitives::HeaderResponse, BlockResponse},
@@ -104,6 +105,15 @@ impl<N: Network, P: Provider<N>> DatabaseAsyncRef for AlloyDB<N, P> {
         let nonce = nonce?;
 
         Ok(Some(AccountInfo::new(balance, nonce, code_hash, code)))
+    }
+
+    async fn account_has_storage_async_ref(&self, address: Address) -> Result<bool, Self::Error> {
+        let proof = self
+            .provider
+            .get_proof(address, Vec::new())
+            .block_id(self.block_number)
+            .await?;
+        Ok(proof.storage_hash != EMPTY_ROOT_HASH)
     }
 
     async fn block_hash_async_ref(&self, number: u64) -> Result<B256, Self::Error> {

--- a/crates/database/src/in_memory_db.rs
+++ b/crates/database/src/in_memory_db.rs
@@ -334,6 +334,21 @@ impl<ExtDB: DatabaseRef> Database for CacheDB<ExtDB> {
         Ok(self.load_account(address)?.info())
     }
 
+    fn account_has_storage(&mut self, address: Address) -> Result<bool, Self::Error> {
+        if let Some(account) = self.cache.accounts.get(&address) {
+            if account.storage.values().any(|value| !value.is_zero()) {
+                return Ok(true);
+            }
+            if matches!(
+                account.account_state,
+                AccountState::StorageCleared | AccountState::NotExisting
+            ) {
+                return Ok(false);
+            }
+        }
+        self.db.account_has_storage_ref(address)
+    }
+
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
         match self.cache.contracts.entry(code_hash) {
             Entry::Occupied(entry) => Ok(entry.get().clone()),
@@ -408,6 +423,21 @@ impl<ExtDB: DatabaseRef> DatabaseRef for CacheDB<ExtDB> {
             Some(acc) => Ok(acc.info()),
             None => self.db.basic_ref(address),
         }
+    }
+
+    fn account_has_storage_ref(&self, address: Address) -> Result<bool, Self::Error> {
+        if let Some(account) = self.cache.accounts.get(&address) {
+            if account.storage.values().any(|value| !value.is_zero()) {
+                return Ok(true);
+            }
+            if matches!(
+                account.account_state,
+                AccountState::StorageCleared | AccountState::NotExisting
+            ) {
+                return Ok(false);
+            }
+        }
+        self.db.account_has_storage_ref(address)
     }
 
     fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error> {
@@ -570,6 +600,10 @@ impl Database for BenchmarkDB {
         Ok(None)
     }
 
+    fn account_has_storage(&mut self, _address: Address) -> Result<bool, Self::Error> {
+        Ok(false)
+    }
+
     /// Get account code by its hash
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
         if code_hash == self.1 {
@@ -622,6 +656,7 @@ mod tests {
 
         assert_eq!(new_state.basic(account).unwrap().unwrap().nonce, nonce);
         assert_eq!(new_state.storage(account, key), Ok(value));
+        assert_eq!(new_state.account_has_storage(account), Ok(true));
     }
 
     #[test]
@@ -651,6 +686,12 @@ mod tests {
         assert_eq!(new_state.basic(account).unwrap().unwrap().nonce, nonce);
         assert_eq!(new_state.storage(account, key0), Ok(StorageValue::ZERO));
         assert_eq!(new_state.storage(account, key1), Ok(value1));
+        assert_eq!(new_state.account_has_storage(account), Ok(true));
+
+        new_state
+            .replace_account_storage(account, HashMap::default())
+            .unwrap();
+        assert_eq!(new_state.account_has_storage(account), Ok(false));
     }
 
     #[test]

--- a/crates/database/src/states/account_status.rs
+++ b/crates/database/src/states/account_status.rs
@@ -110,25 +110,16 @@ impl AccountStatus {
     }
 
     /// Returns the next account status on change.
-    pub const fn on_changed(&self, had_no_nonce_and_code: bool) -> Self {
+    pub const fn on_changed(&self, _had_no_nonce_and_code: bool) -> Self {
         match self {
             // If the account was loaded as not existing, promote it to changed.
             // This account was likely created by a balance transfer.
             Self::LoadedNotExisting => Self::InMemoryChange,
-            // Change on empty account, should transfer storage if there is any.
-            // There is possibility that there are storage entries inside db.
-            // That storage is used in merkle tree calculation before state clear EIP.
-            Self::LoadedEmptyEIP161 => Self::InMemoryChange,
+            // Empty account info does not imply empty storage. EIP-7610 requires preserving the
+            // backing database until storage emptiness has been established explicitly.
+            Self::LoadedEmptyEIP161 => Self::Changed,
             // The account was loaded as existing.
-            Self::Loaded => {
-                if had_no_nonce_and_code {
-                    // Account is fully in memory
-                    Self::InMemoryChange
-                } else {
-                    // Can be contract and some of storage slots can be present inside db.
-                    Self::Changed
-                }
-            }
+            Self::Loaded => Self::Changed,
 
             // On change, the "changed" type account statuses are preserved.
             // Any checks for empty accounts are done outside of this fn.
@@ -312,16 +303,16 @@ mod test {
 
         assert_eq!(
             AccountStatus::LoadedEmptyEIP161.on_changed(true),
-            AccountStatus::InMemoryChange
+            AccountStatus::Changed
         );
         assert_eq!(
             AccountStatus::LoadedEmptyEIP161.on_changed(false),
-            AccountStatus::InMemoryChange
+            AccountStatus::Changed
         );
 
         assert_eq!(
             AccountStatus::Loaded.on_changed(true),
-            AccountStatus::InMemoryChange
+            AccountStatus::Changed
         );
         assert_eq!(
             AccountStatus::Loaded.on_changed(false),

--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -325,6 +325,25 @@ impl<DB: Database> Database for State<DB> {
         Ok(basic)
     }
 
+    fn account_has_storage(&mut self, address: Address) -> Result<bool, Self::Error> {
+        let account = self
+            .load_cache_account(address)
+            .map_err(EvmDatabaseError::Database)?;
+        if account
+            .account
+            .as_ref()
+            .is_some_and(|account| account.storage.values().any(|value| !value.is_zero()))
+        {
+            return Ok(true);
+        }
+        if account.status.is_storage_known() {
+            return Ok(false);
+        }
+        self.database
+            .account_has_storage(address)
+            .map_err(EvmDatabaseError::Database)
+    }
+
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
         let res = match self.cache.contracts.entry(code_hash) {
             hash_map::Entry::Occupied(entry) => Ok(entry.get().clone()),
@@ -500,6 +519,38 @@ impl<DB: DatabaseRef> DatabaseRef for State<DB> {
         Ok(account)
     }
 
+    fn account_has_storage_ref(&self, address: Address) -> Result<bool, Self::Error> {
+        if let Some(account) = self.cache.accounts.get(&address) {
+            if account
+                .account
+                .as_ref()
+                .is_some_and(|account| account.storage.values().any(|value| !value.is_zero()))
+            {
+                return Ok(true);
+            }
+            if account.status.is_storage_known() {
+                return Ok(false);
+            }
+        }
+        if self.use_preloaded_bundle {
+            if let Some(account) = self.bundle_state.account(&address) {
+                if account
+                    .storage
+                    .values()
+                    .any(|slot| !slot.present_value.is_zero())
+                {
+                    return Ok(true);
+                }
+                if account.status.is_storage_known() {
+                    return Ok(false);
+                }
+            }
+        }
+        self.database
+            .account_has_storage_ref(address)
+            .map_err(EvmDatabaseError::Database)
+    }
+
     fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error> {
         // Check if code is in cache
         if let Some(code) = self.cache.contracts.get(&code_hash) {
@@ -564,7 +615,7 @@ mod tests {
     use super::*;
     use crate::{
         states::{reverts::AccountInfoRevert, StorageSlot},
-        AccountRevert, AccountStatus, BundleAccount, RevertToSlot,
+        AccountRevert, AccountStatus, BundleAccount, CacheDB, RevertToSlot,
     };
     use primitives::{keccak256, Bytes, BLOCK_HASH_HISTORY, U256};
     use state::{EvmStorageSlot, TransactionId};
@@ -582,6 +633,23 @@ mod tests {
 
         let state = State::builder().with_bal(Arc::new(Bal::new())).build();
         assert!(state.has_bal());
+    }
+
+    #[test]
+    fn balance_change_preserves_unknown_backing_storage() {
+        let address = Address::with_last_byte(42);
+        let mut database = CacheDB::<EmptyDB>::default();
+        database.insert_account_info(address, AccountInfo::default());
+        database
+            .insert_account_storage(address, U256::ZERO, U256::from(1))
+            .unwrap();
+
+        let mut state = State::builder().with_database(database).build();
+        let account = state.load_cache_account(address).unwrap();
+        account.increment_balance(1);
+
+        assert_eq!(account.status, AccountStatus::Changed);
+        assert!(state.account_has_storage(address).unwrap());
     }
 
     #[test]

--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -326,6 +326,9 @@ impl<DB: Database> Database for State<DB> {
     }
 
     fn account_has_storage(&mut self, address: Address) -> Result<bool, Self::Error> {
+        self.bal_state
+            .get_account_id(&address)
+            .map_err(EvmDatabaseError::Bal)?;
         let account = self
             .load_cache_account(address)
             .map_err(EvmDatabaseError::Database)?;
@@ -520,6 +523,9 @@ impl<DB: DatabaseRef> DatabaseRef for State<DB> {
     }
 
     fn account_has_storage_ref(&self, address: Address) -> Result<bool, Self::Error> {
+        self.bal_state
+            .get_account_id(&address)
+            .map_err(EvmDatabaseError::Bal)?;
         if let Some(account) = self.cache.accounts.get(&address) {
             if account
                 .account
@@ -618,7 +624,7 @@ mod tests {
         AccountRevert, AccountStatus, BundleAccount, CacheDB, RevertToSlot,
     };
     use primitives::{keccak256, Bytes, BLOCK_HASH_HISTORY, U256};
-    use state::{EvmStorageSlot, TransactionId};
+    use state::{bal::BalError, EvmStorageSlot, TransactionId};
 
     fn evm_storage<const N: usize>(
         slots: [(StorageKey, EvmStorageSlot); N],
@@ -650,6 +656,29 @@ mod tests {
 
         assert_eq!(account.status, AccountStatus::Changed);
         assert!(state.account_has_storage(address).unwrap());
+    }
+
+    #[test]
+    fn account_storage_check_honors_bal_coverage() {
+        let address = Address::with_last_byte(42);
+        let missing = Address::with_last_byte(43);
+        let mut database = CacheDB::<EmptyDB>::default();
+        database.insert_account_info(address, AccountInfo::default());
+        database
+            .insert_account_storage(address, U256::ZERO, U256::from(1))
+            .unwrap();
+        let bal = Arc::new(Bal::from_iter([(address, Default::default())]));
+        let mut state = State::builder()
+            .with_database(database)
+            .with_bal(bal)
+            .build();
+
+        assert!(state.account_has_storage(address).unwrap());
+        assert!(matches!(
+            state.account_has_storage(missing),
+            Err(EvmDatabaseError::Bal(BalError::AccountNotFound { address: error_address }))
+                if error_address == missing
+        ));
     }
 
     #[test]

--- a/crates/ee-tests/src/eip2780.rs
+++ b/crates/ee-tests/src/eip2780.rs
@@ -616,6 +616,10 @@ impl revm::Database for NoCodeInBasicDB {
         )
     }
 
+    fn account_has_storage(&mut self, address: Address) -> Result<bool, Self::Error> {
+        revm::Database::account_has_storage(&mut self.0, address)
+    }
+
     fn code_by_hash(&mut self, code_hash: revm::primitives::B256) -> Result<Bytecode, Self::Error> {
         revm::Database::code_by_hash(&mut self.0, code_hash)
     }

--- a/crates/ee-tests/src/eip7610.rs
+++ b/crates/ee-tests/src/eip7610.rs
@@ -94,7 +94,10 @@ fn tx_create_collides_with_storage_only_account() {
     funded_caller(&mut db, 0);
     storage_only_target(&mut db, target);
 
-    let mut evm = Context::mainnet().with_db(db).build_mainnet();
+    let mut evm = Context::mainnet()
+        .modify_cfg_chained(|cfg| cfg.set_spec_and_mainnet_gas_params(SpecId::FRONTIER))
+        .with_db(db)
+        .build_mainnet();
     let result = evm
         .transact_one(
             TxEnv::builder_for_bench()

--- a/crates/ee-tests/src/eip7610.rs
+++ b/crates/ee-tests/src/eip7610.rs
@@ -1,0 +1,199 @@
+//! EIP-7610 contract-creation collision tests.
+
+use revm::{
+    bytecode::opcode,
+    context::TxEnv,
+    context_interface::result::{ExecutionResult, HaltReason},
+    database::{CacheDB, EmptyDB, BENCH_CALLER},
+    primitives::{address, hardfork::SpecId, Address, Bytes, TxKind, B256, U256},
+    state::{AccountInfo, Bytecode},
+    Context, ExecuteEvm, MainBuilder, MainContext,
+};
+
+const CREATOR: Address = address!("0x000000000000000000000000000000000000c0de");
+
+fn storage_only_target(db: &mut CacheDB<EmptyDB>, target: Address) {
+    db.insert_account_info(target, AccountInfo::default());
+    db.insert_account_storage(target, U256::ZERO, U256::from(1))
+        .unwrap();
+}
+
+fn funded_caller(db: &mut CacheDB<EmptyDB>, nonce: u64) {
+    db.insert_account_info(
+        BENCH_CALLER,
+        AccountInfo {
+            balance: U256::from(u64::MAX),
+            nonce,
+            ..Default::default()
+        },
+    );
+}
+
+fn create_and_return(opcode: u8) -> Bytecode {
+    let mut code = vec![opcode::PUSH1, 0, opcode::PUSH1, 0, opcode::PUSH1, 0];
+    if opcode == opcode::CREATE2 {
+        code.extend([opcode::PUSH1, 0]);
+    }
+    code.extend([
+        opcode,
+        opcode::PUSH1,
+        0,
+        opcode::MSTORE,
+        opcode::PUSH1,
+        32,
+        opcode::PUSH1,
+        0,
+        opcode::RETURN,
+    ]);
+    Bytecode::new_raw(code.into())
+}
+
+fn run_opcode_create(spec: SpecId, opcode: u8, target_has_storage: bool) -> Bytes {
+    let mut db = CacheDB::<EmptyDB>::default();
+    funded_caller(&mut db, 0);
+    db.insert_account_info(
+        CREATOR,
+        AccountInfo::default()
+            .with_nonce(1)
+            .with_code(create_and_return(opcode)),
+    );
+
+    let target = if opcode == opcode::CREATE {
+        CREATOR.create(1)
+    } else {
+        CREATOR.create2_from_code(B256::ZERO, Bytes::new())
+    };
+    db.insert_account_info(target, AccountInfo::default().with_balance(U256::from(1)));
+    if target_has_storage {
+        storage_only_target(&mut db, target);
+    }
+
+    let mut evm = Context::mainnet()
+        .modify_cfg_chained(|cfg| cfg.set_spec_and_mainnet_gas_params(spec))
+        .with_db(db)
+        .build_mainnet();
+    let result = evm
+        .transact_one(
+            TxEnv::builder_for_bench()
+                .kind(TxKind::Call(CREATOR))
+                .gas_limit(1_000_000)
+                .gas_price(0)
+                .build_fill(),
+        )
+        .unwrap();
+    result
+        .output()
+        .unwrap_or_else(|| panic!("unexpected create result: {result:?}"))
+        .clone()
+}
+
+#[test]
+fn tx_create_collides_with_storage_only_account() {
+    let target = BENCH_CALLER.create(0);
+    let mut db = CacheDB::<EmptyDB>::default();
+    funded_caller(&mut db, 0);
+    storage_only_target(&mut db, target);
+
+    let mut evm = Context::mainnet().with_db(db).build_mainnet();
+    let result = evm
+        .transact_one(
+            TxEnv::builder_for_bench()
+                .kind(TxKind::Create)
+                .gas_limit(1_000_000)
+                .gas_price(0)
+                .build_fill(),
+        )
+        .unwrap();
+
+    assert!(matches!(
+        result,
+        ExecutionResult::Halt {
+            reason: HaltReason::CreateCollision,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn tx_create_allows_balance_only_account() {
+    let target = BENCH_CALLER.create(0);
+    let mut db = CacheDB::<EmptyDB>::default();
+    funded_caller(&mut db, 0);
+    db.insert_account_info(target, AccountInfo::default().with_balance(U256::from(1)));
+
+    let mut evm = Context::mainnet().with_db(db).build_mainnet();
+    let result = evm
+        .transact_one(
+            TxEnv::builder_for_bench()
+                .kind(TxKind::Create)
+                .gas_limit(1_000_000)
+                .gas_price(0)
+                .build_fill(),
+        )
+        .unwrap();
+
+    assert!(result.is_success());
+}
+
+#[test]
+fn create_collision_rule_is_retroactive() {
+    assert_eq!(
+        run_opcode_create(SpecId::BYZANTIUM, opcode::CREATE, true),
+        Bytes::from(vec![0; 32])
+    );
+    assert_ne!(
+        run_opcode_create(SpecId::BYZANTIUM, opcode::CREATE, false),
+        Bytes::from(vec![0; 32])
+    );
+}
+
+#[test]
+fn create2_collides_with_storage_only_account() {
+    assert_eq!(
+        run_opcode_create(SpecId::PETERSBURG, opcode::CREATE2, true),
+        Bytes::from(vec![0; 32])
+    );
+    assert_ne!(
+        run_opcode_create(SpecId::PETERSBURG, opcode::CREATE2, false),
+        Bytes::from(vec![0; 32])
+    );
+}
+
+#[test]
+fn balance_change_preserves_persisted_storage_collision() {
+    let target = BENCH_CALLER.create(1);
+    let mut db = CacheDB::<EmptyDB>::default();
+    funded_caller(&mut db, 0);
+    storage_only_target(&mut db, target);
+
+    let mut evm = Context::mainnet().with_db(db).build_mainnet();
+    let transfer = evm
+        .transact_one(
+            TxEnv::builder_for_bench()
+                .kind(TxKind::Call(target))
+                .gas_limit(1_000_000)
+                .value(U256::from(1))
+                .gas_price(0)
+                .build_fill(),
+        )
+        .unwrap();
+    assert!(transfer.is_success());
+
+    let result = evm
+        .transact_one(
+            TxEnv::builder_for_bench()
+                .nonce(1)
+                .kind(TxKind::Create)
+                .gas_limit(1_000_000)
+                .gas_price(0)
+                .build_fill(),
+        )
+        .unwrap();
+    assert!(matches!(
+        result,
+        ExecutionResult::Halt {
+            reason: HaltReason::CreateCollision,
+            ..
+        }
+    ));
+}

--- a/crates/ee-tests/src/lib.rs
+++ b/crates/ee-tests/src/lib.rs
@@ -22,4 +22,7 @@ mod revm_tests;
 mod eip2780;
 
 #[cfg(test)]
+mod eip7610;
+
+#[cfg(test)]
 mod eip8037;

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -22,7 +22,7 @@ use interpreter::{
 use primitives::{
     constants::CALL_STACK_LIMIT,
     hardfork::SpecId::{self, HOMESTEAD, LONDON, SPURIOUS_DRAGON},
-    Address, Bytes, U256,
+    Address, Bytes, KECCAK_EMPTY, U256,
 };
 use state::Bytecode;
 use std::{borrow::ToOwned, boxed::Box, vec::Vec};
@@ -316,8 +316,14 @@ impl EthFrame<EthInterpreter> {
 
         drop(caller_info); // Drop caller info to avoid borrow checker issues.
 
-        // warm load account.
-        journal.load_account(created_address)?;
+        // Warm load account and apply EIP-7610's storage collision check.
+        let target_has_code_or_nonce = {
+            let target = journal.load_account(created_address)?;
+            target.info.code_hash != KECCAK_EMPTY || target.info.nonce != 0
+        };
+        if !target_has_code_or_nonce && journal.account_has_storage(created_address)? {
+            return return_error(InstructionResult::CreateCollision);
+        }
 
         // Create account, transfer funds and make the journal checkpoint.
         let checkpoint = match context.journal_mut().create_account_checkpoint(

--- a/examples/cheatcode_inspector/src/main.rs
+++ b/examples/cheatcode_inspector/src/main.rs
@@ -168,6 +168,10 @@ impl JournalTr for Backend {
         self.journaled_state.load_account(address)
     }
 
+    fn account_has_storage(&mut self, address: Address) -> Result<bool, Infallible> {
+        self.journaled_state.account_has_storage(address)
+    }
+
     fn load_account_with_code(
         &mut self,
         address: Address,

--- a/examples/database_components/src/lib.rs
+++ b/examples/database_components/src/lib.rs
@@ -61,6 +61,12 @@ impl<S: State, BH: BlockHash> Database for DatabaseComponents<S, BH> {
         self.state.basic(address).map_err(Self::Error::State)
     }
 
+    fn account_has_storage(&mut self, address: Address) -> Result<bool, Self::Error> {
+        self.state
+            .account_has_storage(address)
+            .map_err(Self::Error::State)
+    }
+
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
         self.state
             .code_by_hash(code_hash)
@@ -89,6 +95,12 @@ impl<S: StateRef, BH: BlockHashRef> DatabaseRef for DatabaseComponents<S, BH> {
 
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         self.state.basic(address).map_err(Self::Error::State)
+    }
+
+    fn account_has_storage_ref(&self, address: Address) -> Result<bool, Self::Error> {
+        self.state
+            .account_has_storage(address)
+            .map_err(Self::Error::State)
     }
 
     fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error> {

--- a/examples/database_components/src/state.rs
+++ b/examples/database_components/src/state.rs
@@ -19,6 +19,9 @@ pub trait State {
     /// Gets basic account information.
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error>;
 
+    /// Returns whether the account has any non-zero storage slots.
+    fn account_has_storage(&mut self, address: Address) -> Result<bool, Self::Error>;
+
     /// Gets account code by its hash.
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error>;
 
@@ -38,6 +41,9 @@ pub trait StateRef {
     /// Gets basic account information.
     fn basic(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error>;
 
+    /// Returns whether the account has any non-zero storage slots.
+    fn account_has_storage(&self, address: Address) -> Result<bool, Self::Error>;
+
     /// Gets account code by its hash.
     fn code_by_hash(&self, code_hash: B256) -> Result<Bytecode, Self::Error>;
 
@@ -53,6 +59,10 @@ where
 
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         StateRef::basic(*self, address)
+    }
+
+    fn account_has_storage(&mut self, address: Address) -> Result<bool, Self::Error> {
+        StateRef::account_has_storage(*self, address)
     }
 
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
@@ -76,6 +86,10 @@ where
 
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         self.deref().basic(address)
+    }
+
+    fn account_has_storage(&mut self, address: Address) -> Result<bool, Self::Error> {
+        self.deref().account_has_storage(address)
     }
 
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {


### PR DESCRIPTION
## Motivation

The Reth stateless-validator corpus exposed 12 EIP-7610 output-root mismatches. This change addresses the underlying consensus behavior by treating non-empty storage as a contract-creation collision for transaction creation, `CREATE`, and `CREATE2`.

The collision check runs before initcode execution and covers current journal state as well as persisted database storage. Existing nonce and code collision checks remain unchanged.

[EIP-8253](https://eips.ethereum.org/EIPS/eip-8253) may remove the lookup after a future irregular state transition, but it does not replace historical EIP-7610 execution. See also #1803.


