### PR TITLE
fix(interpreter): return MemoryOOG when memory resize fails

### DIFF
--- a/crates/interpreter/src/interpreter/shared_memory.rs
+++ b/crates/interpreter/src/interpreter/shared_memory.rs
@@ -600,7 +600,9 @@ fn resize_memory_cold<Memory: MemoryTr>(
     if !gas.record_regular_cost(cost) {
         return Err(InstructionResult::MemoryOOG);
     }
-    memory.resize(new_num_words * 32);
+    if !memory.resize(new_num_words * 32) {
+        return Err(InstructionResult::MemoryOOG);
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Honor `MemoryTr::resize`'s `bool` result in `resize_memory_cold`.
- If resize fails (custom memory that cannot grow), halt with `MemoryOOG` instead of ignoring the failure and risking later out-of-bounds access.

## Test plan
- [ ] `cargo nextest run -p revm-interpreter`
- [ ] `cargo clippy --workspace --all-targets --all-features`