### PR TITLE
fix(context): preserve error state in with_db

### DIFF
--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -207,7 +207,7 @@ where
             journaled_state,
             local: self.local,
             chain: self.chain,
-            error: Ok(()),
+            error: self.error,
         }
     }
 


### PR DESCRIPTION
## Summary
- Preserve the existing `error` field when calling `Context::with_db`.
- Previously `with_db` reset `error` to `Ok(())`, which could silently drop a prior database error after swapping the database.

## Test plan
- [ ] `cargo nextest run -p revm-context`
- [ ] `cargo clippy --workspace --all-targets --all-features`