### PR TITLE
fix(state): align Account's manual Deserialize field order with derived Serialize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -625,7 +625,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1128,6 +1128,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,7 +1489,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2016,7 +2025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2824,7 +2833,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3087,7 +3096,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4072,6 +4081,7 @@ name = "revm-state"
 version = "42.0.0"
 dependencies = [
  "alloy-eip7928 0.4.0",
+ "bincode",
  "bitflags",
  "nonmax",
  "revm-bytecode",
@@ -4267,7 +4277,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4324,7 +4334,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4706,7 +4716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4863,7 +4873,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5486,7 +5496,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ serde_json = { version = "1.0", default-features = false }
 
 # misc
 auto_impl = "1.3.0"
+bincode = "1.3"
 bitflags = { version = "2.10", default-features = false }
 cfg-if = { version = "1.0", default-features = false }
 corosensei = { version = "0.3.4", default-features = false, features = [

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -33,6 +33,7 @@ nonmax = { version = "0.5.5", default-features = false }
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
 [dev-dependencies]
+bincode = { workspace = true }
 serde_json = { workspace = true, features = ["alloc"] }
 
 [features]

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -430,13 +430,16 @@ mod serde_impl {
     }
 
     #[derive(Deserialize)]
+    // Field order must match `Account`'s declaration order: the derived `Serialize` emits
+    // fields positionally, and non-self-describing formats (bincode, postcard) replay them in
+    // this struct's declared order — only self-describing formats match fields by name.
     struct AccountSerde {
         info: AccountInfo,
+        transaction_id: TransactionId,
+        storage: EvmStorage,
+        status: AccountStatus,
         #[serde(default)]
         original_info: MaybeOriginalInfo,
-        storage: EvmStorage,
-        transaction_id: TransactionId,
-        status: AccountStatus,
     }
 
     impl<'de> Deserialize<'de> for super::Account {
@@ -762,6 +765,36 @@ mod tests {
         let serialized = serde_json::to_string(&account).unwrap();
         let deserialized: Account = serde_json::from_str(&serialized).unwrap();
         assert_eq!(account, deserialized);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_account_bincode_round_trip() {
+        // Positional formats carry no field names, so a `Serialize`/`Deserialize` field-order
+        // mismatch is invisible to the JSON tests above and a default account round-trips by
+        // accident. Populate every field with a distinct non-default value, `original_info`
+        // differing from `info`, to pin each field's position.
+        let mut account = Account::from(AccountInfo {
+            nonce: 5,
+            ..AccountInfo::default()
+        });
+        account.info.nonce = 7;
+        account.transaction_id = TransactionId::new(3).unwrap();
+        account.storage.insert(
+            StorageKey::from(42u64),
+            EvmStorageSlot {
+                original_value: U256::from(1u64),
+                present_value: U256::from(2u64),
+                transaction_id: account.transaction_id,
+                is_cold: false,
+            },
+        );
+        account.status = AccountStatus::Touched;
+
+        let bytes = bincode::serialize(&account).unwrap();
+        let decoded: Account = bincode::deserialize(&bytes).unwrap();
+
+        assert_eq!(account, decoded);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #3869.

`Account` derives `Serialize` (fields emitted in declaration order: `info, transaction_id, storage, status, original_info`) but hand-writes `Deserialize` around the `AccountSerde` helper, which declared the fields as `info, original_info, storage, transaction_id, status`. Self-describing formats match fields by name and never notice; positional formats (bincode, postcard) mis-parse the bytes they just produced, so a populated `Account` cannot round-trip through bincode at all (`UnexpectedEof`).

## Changes

- Reorder `AccountSerde`'s fields to `Account`'s declaration order, with a comment stating the lockstep invariant. This only changes which bytes the deserializer expects at each position — JSON deserialization matches by name, so the old-format/`null`/present handling of `original_info` (`MaybeOriginalInfo`) behaves exactly as before. All existing JSON compatibility tests pass unchanged.
- Add a bincode round-trip regression test with every field set to a distinct non-default value (`original_info` differing from `info`). A default account round-trips by accident, which is why the existing `serde_json`-only tests never caught this. The test fails on `main` before the fix and passes after.
- `bincode` added as a workspace dev-dependency for the test.

## Scope notes

- The `Serialize` side is deliberately untouched: changing it would alter the output format for all existing writers, while fixing the `Deserialize` side is invisible to self-describing formats.
- This does not attempt to make pre-12 positional data decodable. Positional formats carry no field names, so the old 4-field layout cannot be distinguished from the new one regardless of ordering — an inherent limitation, unrelated to this fix.
