### PR TITLE
fix(examples): halt custom precompile on static writes

### DIFF
--- a/examples/custom_precompile_journal/src/precompile_provider.rs
+++ b/examples/custom_precompile_journal/src/precompile_provider.rs
@@ -93,10 +93,13 @@ fn run_custom_precompile<CTX: ContextTr>(
         handle_read_storage(context, inputs.gas_limit)
     } else if input_bytes.len() == 32 {
         if inputs.is_static {
-            return Err("Cannot modify state in static context".to_string());
+            Err(PrecompileHalt::Other(
+                "Cannot modify state in static context".into(),
+            ))
+        } else {
+            // Write storage operation
+            handle_write_storage(context, &input_bytes, inputs.gas_limit)
         }
-        // Write storage operation
-        handle_write_storage(context, &input_bytes, inputs.gas_limit)
     } else {
         Err(PrecompileHalt::Other("Invalid input length".into()))
     };


### PR DESCRIPTION
## Summary
- In the custom precompile journal example, a static call that would write storage now returns a `PrecompileHalt` instead of a host `String` error.
- That keeps the failure on the precompile result path (`from_eth_result` / `InterpreterResult`) instead of bubbling out of `run_custom_precompile`.

## Test plan
- [ ] `cargo check -p custom_precompile_journal`
- [ ] `cargo clippy --workspace --all-targets --all-features`