### PR TITLE
fix(inspector): clamp negative EIP-3155 refund to zero

### DIFF
--- a/crates/inspector/src/eip3155.rs
+++ b/crates/inspector/src/eip3155.rs
@@ -275,7 +275,7 @@ where
             stack: &self.stack,
             depth: context.journal_mut().depth() as u64,
             return_data: "0x",
-            refund: self.refunded as u64,
+            refund: self.refunded.max(0) as u64,
             mem_size: self.mem_size as u64,
 
             op_name: OpCode::new(self.opcode).map(|i| i.as_str()),


### PR DESCRIPTION
## Summary
- Clamp `refunded` with `.max(0)` before casting to `u64` in the EIP-3155 tracer.
- A negative `i64` refund previously wrapped to a huge unsigned value in the JSON output; this matches the existing `state_gas` clamp.

## Test plan
- [ ] `cargo nextest run -p revm-inspector`
- [ ] `cargo clippy --workspace --all-targets --all-features`