### PR TITLE
chore(deps): replace unmaintained bincode with postcard in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,15 +1128,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +1408,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1985,6 +1985,18 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -3453,6 +3465,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4081,9 +4105,9 @@ name = "revm-state"
 version = "42.0.0"
 dependencies = [
  "alloy-eip7928 0.4.0",
- "bincode",
  "bitflags",
  "nonmax",
+ "postcard",
  "revm-bytecode",
  "revm-primitives",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,9 @@ serde_json = { version = "1.0", default-features = false }
 
 # misc
 auto_impl = "1.3.0"
-bincode = "1.3"
+postcard = { version = "1.1", default-features = false, features = [
+    "use-std",
+] }
 bitflags = { version = "2.10", default-features = false }
 cfg-if = { version = "1.0", default-features = false }
 corosensei = { version = "0.3.4", default-features = false, features = [

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -33,7 +33,7 @@ nonmax = { version = "0.5.5", default-features = false }
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
 [dev-dependencies]
-bincode = { workspace = true }
+postcard = { workspace = true }
 serde_json = { workspace = true, features = ["alloc"] }
 
 [features]

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -769,7 +769,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "serde")]
-    fn test_account_bincode_round_trip() {
+    fn test_account_postcard_round_trip() {
         // Positional formats carry no field names, so a `Serialize`/`Deserialize` field-order
         // mismatch is invisible to the JSON tests above and a default account round-trips by
         // accident. Populate every field with a distinct non-default value, `original_info`
@@ -791,8 +791,8 @@ mod tests {
         );
         account.status = AccountStatus::Touched;
 
-        let bytes = bincode::serialize(&account).unwrap();
-        let decoded: Account = bincode::deserialize(&bytes).unwrap();
+        let bytes = postcard::to_allocvec(&account).unwrap();
+        let decoded: Account = postcard::from_bytes(&bytes).unwrap();
 
         assert_eq!(account, decoded);
     }

--- a/examples/custom_precompile_journal/Cargo.toml
+++ b/examples/custom_precompile_journal/Cargo.toml
@@ -11,7 +11,7 @@ readme.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-revm = { path = "../../crates/revm", features = ["optional_eip3607"] }
+revm = { workspace = true, features = ["std", "optional_eip3607"] }
 anyhow = "1.0"
 
 [features]


### PR DESCRIPTION
## Summary
Fixes the failing `cargo deny` CI on main (`RUSTSEC-2025-0141`).

bincode 1.3.3 is permanently unmaintained (no safe upgrade available) and was only a dev-dependency of `revm-state`, used by a single test that round-trips `Account` through a non-self-describing serde format to pin the `Serialize`/`Deserialize` field order (#3870).

Replaced with `postcard`. wincode (the advisory's first suggestion) was tried first, but it serializes via its own `SchemaWrite`/`SchemaRead` derives rather than serde, so it cannot exercise `Account`'s serde impls — the entire point of the test. postcard is serde-based and positional, matching the test's intent exactly.

Also switches the `custom_precompile_journal` example to the workspace `revm` dependency (with `std` retained), fixing the deny wildcard-dependency warning.

## Test plan
- `cargo deny check advisories` — ok
- `cargo nextest run -p revm-state --features serde` — 30/30 pass
- `cargo check -p example-custom-precompile-journal` — clean