### PR TITLE
fix(database): make with_bal_builder_if a true conditional setter

### DIFF
--- a/crates/database/src/states/state_builder.rs
+++ b/crates/database/src/states/state_builder.rs
@@ -154,9 +154,7 @@ impl<DB: Database> StateBuilder<DB> {
 
     /// Conditionally set BAL builder based on the flag.
     pub fn with_bal_builder_if(mut self, enable: bool) -> Self {
-        if enable {
-            self.bal_state.bal_builder = Some(Bal::new());
-        }
+        self.bal_state.bal_builder = enable.then(Bal::new);
         self
     }
 


### PR DESCRIPTION
## Summary
- `with_bal_builder_if(false)` previously left an existing `Some(Bal)` untouched (no-op), which is not how a conditional setter should behave
- Assign with `enable.then(Bal::new)` so `false` clears `bal_builder` to `None`

## Test plan
- [ ] Confirm `with_bal_builder_if(true)` still enables the BAL builder
- [ ] Confirm `with_bal_builder_if(false)` clears a previously set builder
- [ ] `cargo check -p revm-database`