### PR TITLE
chore: add Bogota to SpecId

### DIFF
--- a/crates/context/interface/src/cfg/gas_params.rs
+++ b/crates/context/interface/src/cfg/gas_params.rs
@@ -177,7 +177,7 @@ impl GasParams {
                 TABLE.get_or_init(|| Self::new_spec_inner(spec))
             }
             // New fork.
-            SpecId::AMSTERDAM => {
+            AMSTERDAM | BOGOTA => {
                 static TABLE: OnceLock<GasParams> = OnceLock::new();
                 TABLE.get_or_init(|| Self::new_spec_inner(spec))
             }

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -457,7 +457,7 @@ impl PrecompileSpecId {
             BERLIN | LONDON | MERGE | SHANGHAI => Self::BERLIN,
             CANCUN => Self::CANCUN,
             PRAGUE => Self::PRAGUE,
-            OSAKA | AMSTERDAM => Self::OSAKA,
+            OSAKA | AMSTERDAM | BOGOTA => Self::OSAKA,
         }
     }
 }

--- a/crates/primitives/src/hardfork.rs
+++ b/crates/primitives/src/hardfork.rs
@@ -74,6 +74,10 @@ pub enum SpecId {
     ///
     /// Activated at block TBD
     AMSTERDAM,
+    /// Bogota
+    ///
+    /// Activated at block TBD
+    BOGOTA,
 }
 
 impl SpecId {
@@ -83,7 +87,7 @@ impl SpecId {
     /// **Warning**: This value will change between minor versions as new hard forks are added.
     /// Do not rely on it for stable behavior.
     #[doc(alias = "MAX")]
-    pub const NEXT: Self = Self::AMSTERDAM;
+    pub const NEXT: Self = Self::BOGOTA;
 
     /// Returns the [`SpecId`] for the given [`u8`].
     #[inline]
@@ -151,6 +155,8 @@ pub mod name {
     pub const OSAKA: &str = "Osaka";
     /// String identifier for the Amsterdam hardfork
     pub const AMSTERDAM: &str = "Amsterdam";
+    /// String identifier for the Bogota hardfork
+    pub const BOGOTA: &str = "Bogota";
     /// String identifier for the latest hardfork
     pub const LATEST: &str = "Latest";
 }
@@ -179,6 +185,7 @@ impl FromStr for SpecId {
             name::PRAGUE => Ok(Self::PRAGUE),
             name::OSAKA => Ok(Self::OSAKA),
             name::AMSTERDAM => Ok(Self::AMSTERDAM),
+            name::BOGOTA => Ok(Self::BOGOTA),
             _ => Err(UnknownHardfork),
         }
     }
@@ -202,6 +209,7 @@ impl From<SpecId> for &'static str {
             SpecId::PRAGUE => name::PRAGUE,
             SpecId::OSAKA => name::OSAKA,
             SpecId::AMSTERDAM => name::AMSTERDAM,
+            SpecId::BOGOTA => name::BOGOTA,
         }
     }
 }


### PR DESCRIPTION
adds Bogota as the next `SpecId`
