### PR TITLE
chore: release v116

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
 
+# v116
+date: 26.08.2026
+
+All publishable workspace crates are now versioned in lockstep at **43.0.0**.
+
+Highlights:
+* Glamsterdam devnet-8 gas repricing ([#3850](https://github.com/bluealloy/revm/pull/3850))
+* Async database fiber support, including async transaction and system-call APIs ([#3709](https://github.com/bluealloy/revm/pull/3709))
+* Finalize Cancun self-destructed accounts in place; Amsterdam EIP-8246 preserves a remaining balance ([#3863](https://github.com/bluealloy/revm/pull/3863))
+* Correctly return `MemoryOOG` when memory growth fails ([#3864](https://github.com/bluealloy/revm/pull/3864))
+* Prevent failed CREATE pre-access checks from warming or adding the destination to the BAL ([#3829](https://github.com/bluealloy/revm/pull/3829))
+* Cache newly created contract code in `State` ([#3855](https://github.com/bluealloy/revm/pull/3855))
+* Validate receipt-trie roots in `revme` blockchain tests ([#3841](https://github.com/bluealloy/revm/pull/3841))
+* Faster BLS12-381 pairing through fused multi-Miller loops ([#3823](https://github.com/bluealloy/revm/pull/3823))
+
+See [MIGRATION_GUIDE.md](./MIGRATION_GUIDE.md) for the full list of breaking changes.
+
+* `revm-bytecode`: 42.0.1 -> 43.0.0 (✓ dependency bump)
+* `revm-state`: 42.0.1 -> 43.0.0 (⚠ API breaking changes)
+* `revm-database-interface`: 42.1.0 -> 43.0.0 (⚠ API breaking changes)
+* `revm-database`: 42.0.1 -> 43.0.0 (✓ API compatible changes)
+* `revm-precompile`: 42.0.2 -> 43.0.0 (✓ API compatible changes)
+* `revm-handler`: 42.1.0 -> 43.0.0 (⚠ API breaking changes)
+* `revm-inspector`: 42.0.2 -> 43.0.0 (⚠ dependency bump)
+* `revm-statetest-types`: 42.0.1 -> 43.0.0 (⚠ dependency bump)
+* `revm`: 42.1.0 -> 43.0.0 (⚠ dependency bump)
+* `revm-ee-tests`: 42.0.0 -> 43.0.0 (✓ dependency bump)
+* `revme`: 42.1.0 -> 43.0.0 (⚠ dependency bump)
+
+`revm-primitives`, `revm-context`, `revm-context-interface`, and `revm-interpreter` were already at 43.0.0.
+
+# v115
+date: 23.07.2026
+
+Patch release for precompile state-gas accounting.
+
+Highlights:
+* Preserve spilled state gas when converting `PrecompileOutput` to frame gas, so rollback credits it back to regular gas correctly ([#3821](https://github.com/bluealloy/revm/pull/3821))
+* Add `PrecompileOutput::{from_gas_tracker, set_gas, to_gas_tracker}` helpers ([#3821](https://github.com/bluealloy/revm/pull/3821))
+* Treat a precompile reporting gas above its frame limit as precompile out-of-gas ([#3821](https://github.com/bluealloy/revm/pull/3821))
+
+See [MIGRATION_GUIDE.md](./MIGRATION_GUIDE.md) for the breaking `PrecompileOutput` struct-literal change.
+
+* `revm-precompile`: 42.0.0 -> 42.0.1 (⚠ API breaking changes)
+* `revm-handler`: 42.0.0 -> 42.0.1 (✓ dependency bump)
+* `revm-inspector`: 42.0.0 -> 42.0.1 (✓ dependency bump)
+* `revm`: 42.0.0 -> 42.0.1 (✓ dependency bump)
+* `revme`: 42.0.0 -> 42.0.1 (✓ dependency bump)
+
 # v114
 date: 23.07.2026
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "42.1.0"
+version = "43.0.0"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "42.0.1"
+version = "43.0.0"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -3974,7 +3974,7 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "42.0.1"
+version = "43.0.0"
 dependencies = [
  "alloy-eips",
  "alloy-provider",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "42.1.0"
+version = "43.0.0"
 dependencies = [
  "auto_impl",
  "corosensei",
@@ -4006,7 +4006,7 @@ dependencies = [
 
 [[package]]
 name = "revm-ee-tests"
-version = "42.0.0"
+version = "43.0.0"
 dependencies = [
  "insta",
  "revm",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "42.1.0"
+version = "43.0.0"
 dependencies = [
  "alloy-signer",
  "alloy-signer-local",
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "42.0.2"
+version = "43.0.0"
 dependencies = [
  "auto_impl",
  "either",
@@ -4063,7 +4063,7 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "42.0.2"
+version = "43.0.0"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "42.0.1"
+version = "43.0.0"
 dependencies = [
  "alloy-eip7928 0.4.0",
  "bitflags",
@@ -4116,7 +4116,7 @@ dependencies = [
 
 [[package]]
 name = "revm-statetest-types"
-version = "42.0.1"
+version = "43.0.0"
 dependencies = [
  "alloy-eip7928 0.4.0",
  "k256",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "revme"
-version = "42.1.0"
+version = "43.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,20 +41,20 @@ default-members = ["crates/revm"]
 
 [workspace.dependencies]
 # revm
-revm = { path = "crates/revm", version = "42.1.0", default-features = false }
+revm = { path = "crates/revm", version = "43.0.0", default-features = false }
 primitives = { path = "crates/primitives", package = "revm-primitives", version = "43.0.0", default-features = false }
-bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "42.0.1", default-features = false }
-database = { path = "crates/database", package = "revm-database", version = "42.0.1", default-features = false }
-database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "42.1.0", default-features = false }
-state = { path = "crates/state", package = "revm-state", version = "42.0.1", default-features = false }
+bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "43.0.0", default-features = false }
+database = { path = "crates/database", package = "revm-database", version = "43.0.0", default-features = false }
+database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "43.0.0", default-features = false }
+state = { path = "crates/state", package = "revm-state", version = "43.0.0", default-features = false }
 interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "43.0.0", default-features = false }
-inspector = { path = "crates/inspector", package = "revm-inspector", version = "42.0.2", default-features = false }
-precompile = { path = "crates/precompile", package = "revm-precompile", version = "42.0.2", default-features = false }
-statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "42.0.1", default-features = false }
+inspector = { path = "crates/inspector", package = "revm-inspector", version = "43.0.0", default-features = false }
+precompile = { path = "crates/precompile", package = "revm-precompile", version = "43.0.0", default-features = false }
+statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "43.0.0", default-features = false }
 context = { path = "crates/context", package = "revm-context", version = "43.0.0", default-features = false }
 context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "43.0.0", default-features = false }
-handler = { path = "crates/handler", package = "revm-handler", version = "42.1.0", default-features = false }
-ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "42.0.0", default-features = false }
+handler = { path = "crates/handler", package = "revm-handler", version = "43.0.0", default-features = false }
+ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "43.0.0", default-features = false }
 
 # alloy
 alloy-eip2930 = { version = "0.2.3", default-features = false }

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,6 +1,34 @@
 
 # Unreleased
 
+# v116 tag (all crates v43.0.0)
+
+## Custom interpreter inputs (`revm-interpreter`)
+
+`InputsTr` gained a required `depth(&self) -> usize` method. Implement it on custom input types, returning the depth of the frame being executed (`0` for the initial frame). `InputsImpl` also gained a public `depth: usize` field, so update direct struct literals.
+
+## Glamsterdam devnet-8 gas API and behavior (`revm-primitives`, `revm-context-interface`)
+
+* Removed `eip2780::TRANSFER_LOG_COST`, `GasId::tx_transfer_log_cost`, and `GasParams::tx_transfer_log_cost`. For non-create, non-self value transfers, use `eip2780::TX_VALUE_COST`, which now includes the former transfer-log charge. Contract-creation transactions no longer receive a value-based intrinsic charge.
+* Removed unused EIP-8037 CPSB formula constants: `BLOCKS_PER_YEAR`, `TARGET_STATE_GROWTH_PER_YEAR`, `CPSB_OFFSET`, and `CPSB_SIGNIFICANT_BITS`.
+* Amsterdam now uses the Glamsterdam devnet-8 EIP-8038 prices. This changes transaction, account, storage, CREATE, access-list, refund, and state-gas accounting; integrations relying on exact gas results must update their expected values.
+
+## Async database feature (`revm-context`, `revm-database-interface`, `revm-handler`)
+
+With the `asyncdb` feature enabled, `Evm` gained the public `async_stack` field; direct `Evm { ... }` construction must initialize it with `FiberStack::default()` or move to the provided constructors/builders. `AsyncDb` is the new async-database adapter. `WrapDatabaseAsync` remains available, but both adapters now report `AsyncError<DB::Error>` rather than the database error directly; update error matching and propagation accordingly.
+
+## Cancun self-destruct finalization (`revm-context`, `revm-database`)
+
+At Cancun and later, journal finalization destroys self-destructed accounts in place: storage, nonce, code, and (unless EIP-8246 preserves it) balance are cleared and the self-destruct flags are removed. Consumers that inspected self-destruct flags after finalization must instead use the finalized account state. Pre-Cancun behavior remains flag-based.
+
+## Account serialization (`revm-state`)
+
+`Account` deserialization now matches its serialized field order for non-self-describing formats such as bincode and postcard. Re-encode any persisted binary `Account` values written by earlier releases before reading them with v43.
+
+# v115 tag (revm v42.0.1)
+
+`PrecompileOutput` gained the public `state_gas_spilled: u64` field. Add `state_gas_spilled: 0` to direct struct literals (or use the constructors), and preserve the value when implementing custom precompile providers. The field tracks state gas charged from regular gas after the reservoir is exhausted.
+
 # v114 tag (all crates v42.0.0)
 
 Released by [#3814](https://github.com/bluealloy/revm/pull/3814). Breaking changes below, grouped by crate; `revm-bytecode`, `revm-state`, `revm-database` and `revme` are API compatible with v41.

--- a/bins/revme/CHANGELOG.md
+++ b/bins/revme/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [42.1.0](https://github.com/bluealloy/revm/compare/revme-v42.0.1...revme-v42.1.0) - 2026-08-20
+## [43.0.0](https://github.com/bluealloy/revm/compare/revme-v42.0.1...revme-v43.0.0) - 2026-08-20
 
 ### Added
 

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revme"
 description = "Rust Ethereum Virtual Machine Executable"
-version = "42.1.0"
+version = "43.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/bytecode/CHANGELOG.md
+++ b/crates/bytecode/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [42.0.1](https://github.com/bluealloy/revm/compare/revm-bytecode-v42.0.0...revm-bytecode-v42.0.1) - 2026-08-20
+## [43.0.0](https://github.com/bluealloy/revm/compare/revm-bytecode-v42.0.0...revm-bytecode-v43.0.0) - 2026-08-20
 
 ### Other
 

--- a/crates/bytecode/Cargo.toml
+++ b/crates/bytecode/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-bytecode"
 description = "EVM Bytecodes"
-version = "42.0.1"
+version = "43.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/database/CHANGELOG.md
+++ b/crates/database/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [42.0.1](https://github.com/bluealloy/revm/compare/revm-database-v42.0.0...revm-database-v42.0.1) - 2026-08-20
+## [43.0.0](https://github.com/bluealloy/revm/compare/revm-database-v42.0.0...revm-database-v43.0.0) - 2026-08-20
 
 ### Fixed
 

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-database"
 description = "Revm Database implementations"
-version = "42.0.1"
+version = "43.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/database/interface/CHANGELOG.md
+++ b/crates/database/interface/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [42.1.0](https://github.com/bluealloy/revm/compare/revm-database-interface-v42.0.0...revm-database-interface-v42.1.0) - 2026-08-20
+## [43.0.0](https://github.com/bluealloy/revm/compare/revm-database-interface-v42.0.0...revm-database-interface-v43.0.0) - 2026-08-20
 
 ### Added
 

--- a/crates/database/interface/Cargo.toml
+++ b/crates/database/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-database-interface"
 description = "Revm Database interface"
-version = "42.1.0"
+version = "43.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/ee-tests/Cargo.toml
+++ b/crates/ee-tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-ee-tests"
 description = "Common test utilities for REVM crates"
-version = "42.0.0"
+version = "43.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/handler/CHANGELOG.md
+++ b/crates/handler/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [42.1.0](https://github.com/bluealloy/revm/compare/revm-handler-v42.0.1...revm-handler-v42.1.0) - 2026-08-20
+## [43.0.0](https://github.com/bluealloy/revm/compare/revm-handler-v42.0.1...revm-handler-v43.0.0) - 2026-08-20
 
 ### Added
 

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-handler"
 description = "Revm handler crates"
-version = "42.1.0"
+version = "43.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/inspector/CHANGELOG.md
+++ b/crates/inspector/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [42.0.2](https://github.com/bluealloy/revm/compare/revm-inspector-v42.0.1...revm-inspector-v42.0.2) - 2026-08-20
+## [43.0.0](https://github.com/bluealloy/revm/compare/revm-inspector-v42.0.1...revm-inspector-v43.0.0) - 2026-08-20
 
 ### Other
 

--- a/crates/inspector/Cargo.toml
+++ b/crates/inspector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-inspector"
 description = "Revm inspector interface"
-version = "42.0.2"
+version = "43.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/interpreter/src/interpreter/stack.rs
+++ b/crates/interpreter/src/interpreter/stack.rs
@@ -359,8 +359,7 @@ impl Stack {
             let mut i = 0;
 
             // Write full words
-            let words = slice.chunks_exact(32);
-            let partial_last_word = words.remainder();
+            let (words, partial_last_word) = slice.as_chunks::<32>();
             for word in words {
                 // Note: We unroll `U256::from_be_bytes` here to write directly into the buffer,
                 // instead of creating a 32 byte array on the stack and then copying it over.

--- a/crates/precompile/CHANGELOG.md
+++ b/crates/precompile/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [42.0.2](https://github.com/bluealloy/revm/compare/revm-precompile-v42.0.1...revm-precompile-v42.0.2) - 2026-08-20
+## [43.0.0](https://github.com/bluealloy/revm/compare/revm-precompile-v42.0.1...revm-precompile-v43.0.0) - 2026-08-20
 
 ### Other
 

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-precompile"
 description = "Revm Precompiles - Ethereum compatible precompiled contracts"
-version = "42.0.2"
+version = "43.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/revm/CHANGELOG.md
+++ b/crates/revm/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [42.1.0](https://github.com/bluealloy/revm/compare/revm-v42.0.1...revm-v42.1.0) - 2026-08-20
+## [43.0.0](https://github.com/bluealloy/revm/compare/revm-v42.0.1...revm-v43.0.0) - 2026-08-20
 
 ### Added
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm"
 description = "Revm - Rust Ethereum Virtual Machine"
-version = "42.1.0"
+version = "43.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/state/CHANGELOG.md
+++ b/crates/state/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [42.0.1](https://github.com/bluealloy/revm/compare/revm-state-v42.0.0...revm-state-v42.0.1) - 2026-08-20
+## [43.0.0](https://github.com/bluealloy/revm/compare/revm-state-v42.0.0...revm-state-v43.0.0) - 2026-08-20
 
 ### Fixed
 

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-state"
 description = "Revm state types"
-version = "42.0.1"
+version = "43.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/statetest-types/CHANGELOG.md
+++ b/crates/statetest-types/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [42.0.1](https://github.com/bluealloy/revm/compare/revm-statetest-types-v42.0.0...revm-statetest-types-v42.0.1) - 2026-08-20
+## [43.0.0](https://github.com/bluealloy/revm/compare/revm-statetest-types-v42.0.0...revm-statetest-types-v43.0.0) - 2026-08-20
 
 ### Other
 

--- a/crates/statetest-types/Cargo.toml
+++ b/crates/statetest-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-statetest-types"
 description = "Statetest types for revme"
-version = "42.0.1"
+version = "43.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
## Summary
- bump all publishable workspace crates to 43.0.0
- add the missing v115 changelog and migration-guide entries
- add v116 release notes and migration guidance

## Validation
- cargo fmt --all --check
- cargo metadata --no-deps --format-version 1