### PR TITLE
feat(interpreter): add delegate scheme helper

### DIFF
--- a/crates/interpreter/src/interpreter_action/call_inputs.rs
+++ b/crates/interpreter/src/interpreter_action/call_inputs.rs
@@ -249,6 +249,11 @@ impl CallScheme {
         matches!(self, Self::CallCode)
     }
 
+    /// Returns true if the call executes code in the caller's context.
+    pub const fn is_delegate(&self) -> bool {
+        matches!(self, Self::CallCode | Self::DelegateCall)
+    }
+
     /// Returns true if it is `DELEGATECALL`.
     pub const fn is_delegate_call(&self) -> bool {
         matches!(self, Self::DelegateCall)
@@ -351,6 +356,14 @@ mod tests {
         fn take_precompile_error_context(&mut self) -> Option<String> {
             None
         }
+    }
+
+    #[test]
+    fn call_scheme_is_delegate() {
+        assert!(CallScheme::CallCode.is_delegate());
+        assert!(CallScheme::DelegateCall.is_delegate());
+        assert!(!CallScheme::Call.is_delegate());
+        assert!(!CallScheme::StaticCall.is_delegate());
     }
 
     #[test]


### PR DESCRIPTION
Adds `CallScheme::is_delegate()`, which returns true for both `CALLCODE` and `DELEGATECALL`. Both schemes execute target bytecode in the caller's context, so consumers can identify this shared behavior without duplicating matches or changing the existing exact-variant helpers.