### PR TITLE
chore: fix clippy for Rust 1.98

### DIFF
--- a/crates/precompile/bench/modexp.rs
+++ b/crates/precompile/bench/modexp.rs
@@ -28,7 +28,9 @@ fn repeated(byte: u8, len: usize) -> Vec<u8> {
 fn hex_bytes(hex: &str) -> Vec<u8> {
     assert!(hex.len().is_multiple_of(2), "hex input length must be even");
     hex.as_bytes()
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|chunk| {
             let high = hex_value(chunk[0]);
             let low = hex_value(chunk[1]);

--- a/crates/precompile/src/blake2/mod.rs
+++ b/crates/precompile/src/blake2/mod.rs
@@ -127,19 +127,23 @@ pub fn run(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
     // Parse state vector h (8 × u64)
     let mut h = [0u64; 8];
     input[4..68]
-        .chunks_exact(8)
+        .as_chunks::<8>()
+        .0
+        .iter()
         .enumerate()
         .for_each(|(i, chunk)| {
-            h[i] = u64::from_le_bytes(chunk.try_into().unwrap());
+            h[i] = u64::from_le_bytes(*chunk);
         });
 
     // Parse message block m (16 × u64)
     let mut m = [0u64; 16];
     input[68..196]
-        .chunks_exact(8)
+        .as_chunks::<8>()
+        .0
+        .iter()
         .enumerate()
         .for_each(|(i, chunk)| {
-            m[i] = u64::from_le_bytes(chunk.try_into().unwrap());
+            m[i] = u64::from_le_bytes(*chunk);
         });
 
     // Parse offset counters

--- a/crates/precompile/src/bls12_381/g1_msm.rs
+++ b/crates/precompile/src/bls12_381/g1_msm.rs
@@ -33,14 +33,14 @@ pub fn g1_msm(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
         return Err(PrecompileHalt::Bls12381G1MsmInputLength);
     }
 
-    let input_chunks = input.chunks_exact(G1_MSM_INPUT_LENGTH);
+    let input_chunks = input.as_chunks::<G1_MSM_INPUT_LENGTH>().0;
     let k = input_chunks.len();
     let required_gas = msm_required_gas(k, &DISCOUNT_TABLE_G1_MSM, G1_MSM_BASE_GAS_FEE);
     if required_gas > gas_limit {
         return Err(PrecompileHalt::OutOfGas);
     }
 
-    let mut valid_pairs_iter = input_chunks.map(|pair| {
+    let mut valid_pairs_iter = input_chunks.iter().map(|pair| {
         let (padded_g1, scalar_bytes) = pair.split_at(PADDED_G1_LENGTH);
 
         // Remove padding from G1 point - this validates padding format

--- a/crates/precompile/src/bls12_381/g2_msm.rs
+++ b/crates/precompile/src/bls12_381/g2_msm.rs
@@ -30,14 +30,14 @@ pub fn g2_msm(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
         return Err(PrecompileHalt::Bls12381G2MsmInputLength);
     }
 
-    let input_chunks = input.chunks_exact(G2_MSM_INPUT_LENGTH);
+    let input_chunks = input.as_chunks::<G2_MSM_INPUT_LENGTH>().0;
     let k = input_chunks.len();
     let required_gas = msm_required_gas(k, &DISCOUNT_TABLE_G2_MSM, G2_MSM_BASE_GAS_FEE);
     if required_gas > gas_limit {
         return Err(PrecompileHalt::OutOfGas);
     }
 
-    let mut valid_pairs_iter = input_chunks.map(|pair| {
+    let mut valid_pairs_iter = input_chunks.iter().map(|pair| {
         let (padded_g2, scalar_bytes) = pair.split_at(PADDED_G2_LENGTH);
 
         // Remove padding from G2 point - this validates padding format

--- a/crates/precompile/src/bls12_381/pairing.rs
+++ b/crates/precompile/src/bls12_381/pairing.rs
@@ -49,7 +49,7 @@ pub fn pairing(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
 
     // Collect pairs of points for the pairing check
     let mut pairs: Vec<PairingPair> = Vec::with_capacity(k);
-    for pair in input.chunks_exact(PAIRING_INPUT_LENGTH) {
+    for pair in input.as_chunks::<PAIRING_INPUT_LENGTH>().0 {
         let (encoded_g1_element, encoded_g2_element) = pair.split_at(PADDED_G1_LENGTH);
 
         let [a_x, a_y] = remove_g1_padding(encoded_g1_element)?;

--- a/crates/precompile/src/bn254.rs
+++ b/crates/precompile/src/bn254.rs
@@ -196,7 +196,7 @@ pub fn run_pair(
 
     let mut points = Vec::with_capacity(elements);
 
-    for pair in input.chunks_exact(PAIR_ELEMENT_LEN) {
+    for pair in input.as_chunks::<PAIR_ELEMENT_LEN>().0 {
         let (encoded_g1_element, encoded_g2_element) = pair.split_at(G1_LEN);
         points.push((encoded_g1_element, encoded_g2_element));
     }


### PR DESCRIPTION
## Summary

- replace constant-size `chunks_exact` calls with `as_chunks`
- use fixed-size arrays directly when decoding Blake2 words
- resolve the new Rust 1.98 `chunks_exact_to_as_chunks` lint

## Testing

- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `cargo test -p revm-precompile --all-features`