### PR TITLE
feat(database): support state overrides with BAL reads

### DIFF
--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -26,5 +26,6 @@ pub use in_memory_db::*;
 pub use states::{
     AccountRevert, AccountStatus, BundleAccount, BundleState, CacheState, DBBox,
     OriginalValuesKnown, PlainAccount, RevertToSlot, State, StateBuilder, StateDBBox,
-    StorageWithOriginalValues, TransitionAccount, TransitionState,
+    StateOverrides, StorageOverrideMode, StorageWithOriginalValues, TransitionAccount,
+    TransitionState,
 };

--- a/crates/database/src/states.rs
+++ b/crates/database/src/states.rs
@@ -22,6 +22,8 @@ pub mod reverts;
 pub mod state;
 /// State builder utilities.
 pub mod state_builder;
+/// State overrides applied above block access list reads.
+pub mod state_overrides;
 /// Transition account representation.
 pub mod transition_account;
 /// Transition state management.
@@ -38,5 +40,6 @@ pub use plain_account::{PlainAccount, StorageSlot, StorageWithOriginalValues};
 pub use reverts::{AccountRevert, RevertToSlot};
 pub use state::{DBBox, State, StateDBBox};
 pub use state_builder::StateBuilder;
+pub use state_overrides::{StateOverrides, StorageOverrideMode};
 pub use transition_account::TransitionAccount;
 pub use transition_state::TransitionState;

--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -2,7 +2,8 @@ use crate::states::block_hash_cache::BlockHashCache;
 
 use super::{
     bundle_state::BundleRetention, cache::CacheState, plain_account::PlainStorage, BundleState,
-    CacheAccount, StateBuilder, TransitionAccount, TransitionState,
+    CacheAccount, StateBuilder, StateOverrides, StorageOverrideMode, TransitionAccount,
+    TransitionState,
 };
 use bytecode::Bytecode;
 use database_interface::{
@@ -70,6 +71,8 @@ pub struct State<DB> {
     ///
     /// Can contain both the BAL for reads and BAL builder that is used to build BAL.
     pub bal_state: BalState,
+    /// State overrides that take precedence over BAL and database reads.
+    pub state_overrides: Option<StateOverrides>,
     /// Hook invoked whenever state changes are committed.
     #[debug(skip)]
     pub state_hook: Option<Box<dyn OnStateHook>>,
@@ -265,6 +268,32 @@ impl<DB: Database> State<DB> {
         self.bal_state.bal.is_some()
     }
 
+    /// Applies account and nested per-account storage overrides above BAL reads.
+    ///
+    /// Once overrides are installed, subsequently committed execution state is kept above the BAL
+    /// as well. A [`StorageOverrideMode::Replace`] entry makes unspecified slots read as zero;
+    /// [`StorageOverrideMode::Diff`] falls through to the BAL and underlying database.
+    pub fn apply_state_overrides(
+        &mut self,
+        accounts: impl IntoIterator<Item = (Address, Option<AccountInfo>)>,
+        storage: impl IntoIterator<
+            Item = (
+                Address,
+                StorageOverrideMode,
+                impl IntoIterator<Item = (StorageKey, StorageValue)>,
+            ),
+        >,
+    ) {
+        self.state_overrides
+            .get_or_insert_default()
+            .extend(accounts, storage);
+    }
+
+    /// Clears all state overrides and restores normal BAL/database precedence.
+    pub fn clear_state_overrides(&mut self) {
+        self.state_overrides = None;
+    }
+
     /// Gets storage value of address at index.
     #[inline]
     fn storage(&mut self, address: Address, index: StorageKey) -> Result<StorageValue, DB::Error> {
@@ -305,6 +334,14 @@ impl<DB: Database> Database for State<DB> {
     type Error = EvmDatabaseError<DB::Error>;
 
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        if let Some(account) = self
+            .state_overrides
+            .as_ref()
+            .and_then(|overrides| overrides.account(&address))
+        {
+            return Ok(account.clone());
+        }
+
         // if bal is existing but account is not found, error will be returned.
         let account_id = self
             .bal_state
@@ -326,6 +363,14 @@ impl<DB: Database> Database for State<DB> {
     }
 
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        if let Some(code) = self
+            .state_overrides
+            .as_ref()
+            .and_then(|overrides| overrides.code_by_hash(&code_hash))
+        {
+            return Ok(code.clone());
+        }
+
         let res = match self.cache.contracts.entry(code_hash) {
             hash_map::Entry::Occupied(entry) => Ok(entry.get().clone()),
             hash_map::Entry::Vacant(entry) => {
@@ -352,6 +397,14 @@ impl<DB: Database> Database for State<DB> {
         address: Address,
         index: StorageKey,
     ) -> Result<StorageValue, Self::Error> {
+        if let Some(value) = self
+            .state_overrides
+            .as_ref()
+            .and_then(|overrides| overrides.storage(&address, index))
+        {
+            return Ok(value);
+        }
+
         if let Some(storage) = self
             .bal_state
             .storage(&address, index)
@@ -370,6 +423,14 @@ impl<DB: Database> Database for State<DB> {
         account_id: AccountId,
         key: StorageKey,
     ) -> Result<StorageValue, Self::Error> {
+        if let Some(value) = self
+            .state_overrides
+            .as_ref()
+            .and_then(|overrides| overrides.storage(&address, key))
+        {
+            return Ok(value);
+        }
+
         if let Some(storage) = self.bal_state.storage_by_account_id(account_id, key)? {
             return Ok(storage);
         }
@@ -400,6 +461,9 @@ impl<DB: Database> Database for State<DB> {
 impl<DB: Database> DatabaseCommit for State<DB> {
     fn commit(&mut self, changes: AddressMap<Account>) {
         self.bal_state.commit(&changes);
+        if let Some(overrides) = self.state_overrides.as_mut() {
+            overrides.commit(&changes);
+        }
 
         if let Some(hook) = self.state_hook.as_mut() {
             let transitions = self.cache.apply_evm_state_iter(
@@ -435,7 +499,7 @@ impl<DB: Database> DatabaseCommit for State<DB> {
     }
 
     fn commit_iter(&mut self, changes: &mut dyn Iterator<Item = (Address, Account)>) {
-        if self.state_hook.is_some() {
+        if self.state_hook.is_some() || self.state_overrides.is_some() {
             let changes = changes.collect::<AddressMap<_>>();
             self.commit(changes);
             return;
@@ -463,6 +527,14 @@ impl<DB: DatabaseRef> DatabaseRef for State<DB> {
     type Error = EvmDatabaseError<DB::Error>;
 
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        if let Some(account) = self
+            .state_overrides
+            .as_ref()
+            .and_then(|overrides| overrides.account(&address))
+        {
+            return Ok(account.clone());
+        }
+
         // if bal is present and account is not found, error will be returned.
         let account_id = self.bal_state.get_account_id(&address)?;
 
@@ -501,6 +573,14 @@ impl<DB: DatabaseRef> DatabaseRef for State<DB> {
     }
 
     fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        if let Some(code) = self
+            .state_overrides
+            .as_ref()
+            .and_then(|overrides| overrides.code_by_hash(&code_hash))
+        {
+            return Ok(code.clone());
+        }
+
         // Check if code is in cache
         if let Some(code) = self.cache.contracts.get(&code_hash) {
             return Ok(code.clone());
@@ -522,6 +602,14 @@ impl<DB: DatabaseRef> DatabaseRef for State<DB> {
         address: Address,
         index: StorageKey,
     ) -> Result<StorageValue, Self::Error> {
+        if let Some(value) = self
+            .state_overrides
+            .as_ref()
+            .and_then(|overrides| overrides.storage(&address, index))
+        {
+            return Ok(value);
+        }
+
         // if bal has storage value, return it
         if let Some(storage) = self.bal_state.storage(&address, index)? {
             return Ok(storage);
@@ -567,7 +655,10 @@ mod tests {
         AccountRevert, AccountStatus, BundleAccount, RevertToSlot,
     };
     use primitives::{keccak256, Bytes, BLOCK_HASH_HISTORY, U256};
-    use state::{EvmStorageSlot, TransactionId};
+    use state::{
+        bal::{AccountBal, BalWrites},
+        EvmStorageSlot, TransactionId,
+    };
 
     fn evm_storage<const N: usize>(
         slots: [(StorageKey, EvmStorageSlot); N],
@@ -582,6 +673,136 @@ mod tests {
 
         let state = State::builder().with_bal(Arc::new(Bal::new())).build();
         assert!(state.has_bal());
+    }
+
+    #[test]
+    fn state_overrides_take_precedence_over_bal() {
+        let address = Address::with_last_byte(1);
+        let (overridden_slot, bal_slot, fallback_slot) = (
+            StorageKey::from(1),
+            StorageKey::from(2),
+            StorageKey::from(3),
+        );
+
+        let mut db = crate::CacheDB::new(EmptyDB::default());
+        db.insert_account_info(
+            address,
+            AccountInfo::default()
+                .with_balance(U256::from(100))
+                .with_nonce(3),
+        );
+        db.insert_account_storage(address, overridden_slot, U256::from(10))
+            .unwrap();
+        db.insert_account_storage(address, bal_slot, U256::from(11))
+            .unwrap();
+        db.insert_account_storage(address, fallback_slot, U256::from(12))
+            .unwrap();
+
+        let mut bal_account = AccountBal::default();
+        bal_account.account_info.balance =
+            BalWrites::new(vec![(BlockAccessIndex::new(1), U256::from(500))]);
+        bal_account.storage.storage.insert(
+            overridden_slot,
+            BalWrites::new(vec![(BlockAccessIndex::new(1), U256::from(42))]),
+        );
+        bal_account.storage.storage.insert(
+            bal_slot,
+            BalWrites::new(vec![(BlockAccessIndex::new(1), U256::from(43))]),
+        );
+
+        let mut state = State::builder()
+            .with_database(db)
+            .with_bal(Arc::new(Bal::from_iter([(address, bal_account)])))
+            .build();
+        state.set_allow_bal_db_fallback(true);
+        state.set_bal_index(BlockAccessIndex::new(2));
+
+        let positioned = state.basic(address).unwrap().unwrap();
+        assert_eq!(positioned.balance, U256::from(500));
+        let override_code = Bytecode::new_raw(Bytes::from_static(&[0x00]));
+        let override_code_hash = override_code.hash_slow();
+
+        state.apply_state_overrides(
+            [(
+                address,
+                Some(
+                    AccountInfo {
+                        balance: U256::from(700),
+                        ..positioned.clone()
+                    }
+                    .with_code(override_code.clone()),
+                ),
+            )],
+            [(
+                address,
+                StorageOverrideMode::Diff,
+                [(overridden_slot, U256::from(99))],
+            )],
+        );
+
+        let overridden = state.basic(address).unwrap().unwrap();
+        assert_eq!(overridden.balance, U256::from(700));
+        assert_eq!(overridden.nonce, 3);
+        assert_eq!(
+            state.code_by_hash(override_code_hash).unwrap(),
+            override_code
+        );
+        assert_eq!(
+            Database::storage(&mut state, address, overridden_slot).unwrap(),
+            U256::from(99)
+        );
+        assert_eq!(
+            Database::storage(&mut state, address, bal_slot).unwrap(),
+            U256::from(43)
+        );
+        assert_eq!(
+            Database::storage(&mut state, address, fallback_slot).unwrap(),
+            U256::from(12)
+        );
+
+        state.apply_state_overrides(
+            core::iter::empty(),
+            [(
+                address,
+                StorageOverrideMode::Replace,
+                [(overridden_slot, U256::from(101))],
+            )],
+        );
+        assert_eq!(
+            Database::storage(&mut state, address, overridden_slot).unwrap(),
+            U256::from(101)
+        );
+        assert_eq!(
+            Database::storage(&mut state, address, bal_slot).unwrap(),
+            U256::ZERO
+        );
+
+        let mut committed = Account::from(overridden);
+        committed.info.balance = U256::from(800);
+        committed.mark_touch();
+        committed.storage.insert(
+            overridden_slot,
+            EvmStorageSlot::new_changed(U256::from(101), U256::from(102), TransactionId::ZERO),
+        );
+        state.commit(HashMap::from_iter([(address, committed)]));
+        assert_eq!(
+            state.basic(address).unwrap().unwrap().balance,
+            U256::from(800)
+        );
+        assert_eq!(
+            Database::storage(&mut state, address, overridden_slot).unwrap(),
+            U256::from(102)
+        );
+
+        state.clear_state_overrides();
+        assert_eq!(
+            state.basic(address).unwrap().unwrap().balance,
+            U256::from(500)
+        );
+        assert_eq!(
+            Database::storage(&mut state, address, overridden_slot).unwrap(),
+            U256::from(42)
+        );
     }
 
     #[test]

--- a/crates/database/src/states/state_builder.rs
+++ b/crates/database/src/states/state_builder.rs
@@ -176,6 +176,7 @@ impl<DB: Database> StateBuilder<DB> {
             use_preloaded_bundle,
             block_hashes: self.with_block_hashes,
             bal_state: self.bal_state,
+            state_overrides: None,
             state_hook: None,
         }
     }

--- a/crates/database/src/states/state_overrides.rs
+++ b/crates/database/src/states/state_overrides.rs
@@ -1,0 +1,134 @@
+use bytecode::Bytecode;
+use primitives::{
+    Address, AddressMap, B256Map, StorageKey, StorageKeyMap, StorageValue, KECCAK_EMPTY,
+};
+use state::{Account, AccountInfo};
+
+/// Controls how an account's storage overrides are applied.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum StorageOverrideMode {
+    /// Override only the supplied slots and fall through for all other slots.
+    #[default]
+    Diff,
+    /// Replace the account's storage, making every unspecified slot zero.
+    Replace,
+}
+
+/// State values that take precedence over an attached block access list.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct StateOverrides {
+    accounts: AddressMap<Option<AccountInfo>>,
+    storage: AddressMap<StorageOverrides>,
+    contracts: B256Map<Bytecode>,
+}
+
+impl StateOverrides {
+    /// Extends the overrides with account and nested per-account storage values.
+    pub fn extend(
+        &mut self,
+        accounts: impl IntoIterator<Item = (Address, Option<AccountInfo>)>,
+        storage: impl IntoIterator<
+            Item = (
+                Address,
+                StorageOverrideMode,
+                impl IntoIterator<Item = (StorageKey, StorageValue)>,
+            ),
+        >,
+    ) {
+        for (address, account) in accounts {
+            self.insert_account(address, account);
+        }
+        for (address, mode, slots) in storage {
+            let storage = self.storage.entry(address).or_default();
+            if mode == StorageOverrideMode::Replace {
+                storage.slots.clear();
+                storage.wiped = true;
+            }
+            storage.slots.extend(slots);
+        }
+    }
+
+    /// Returns an account override, including an explicit absent account.
+    #[inline]
+    pub fn account(&self, address: &Address) -> Option<&Option<AccountInfo>> {
+        self.accounts.get(address)
+    }
+
+    /// Returns an overridden bytecode by hash.
+    #[inline]
+    pub fn code_by_hash(&self, code_hash: &primitives::B256) -> Option<&Bytecode> {
+        self.contracts.get(code_hash)
+    }
+
+    /// Returns a storage override, including zero for an unspecified slot after replacement.
+    #[inline]
+    pub fn storage(&self, address: &Address, key: StorageKey) -> Option<StorageValue> {
+        let storage = self.storage.get(address)?;
+        storage
+            .slots
+            .get(&key)
+            .copied()
+            .or(storage.wiped.then_some(StorageValue::ZERO))
+    }
+
+    /// Applies committed execution state above the current overrides.
+    pub(crate) fn commit(&mut self, changes: &AddressMap<Account>) {
+        for (address, account) in changes {
+            if !account.is_touched() {
+                continue;
+            }
+
+            if account.is_selfdestructed() || (!account.is_created() && account.is_empty()) {
+                self.insert_account(*address, None);
+                self.storage.entry(*address).or_default().wipe();
+                continue;
+            }
+
+            self.insert_account(*address, Some(account.info.clone()));
+            let storage = self.storage.entry(*address).or_default();
+            if account.is_created() {
+                storage.wipe();
+            }
+            storage.slots.extend(
+                account
+                    .changed_storage_slots()
+                    .map(|(key, slot)| (*key, slot.present_value)),
+            );
+        }
+    }
+
+    fn insert_account(&mut self, address: Address, mut account: Option<AccountInfo>) {
+        if let Some(info) = account.as_mut() {
+            if let Some(code) = info.code.as_ref() {
+                if !code.is_empty() {
+                    if info.code_hash == KECCAK_EMPTY {
+                        info.code_hash = code.hash_slow();
+                    }
+                    self.contracts
+                        .entry(info.code_hash)
+                        .or_insert_with(|| code.clone());
+                }
+            }
+            if info.code_hash.is_zero() {
+                info.code_hash = KECCAK_EMPTY;
+            }
+        }
+        if account.is_none() {
+            self.storage.entry(address).or_default().wipe();
+        }
+        self.accounts.insert(address, account);
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct StorageOverrides {
+    slots: StorageKeyMap<StorageValue>,
+    wiped: bool,
+}
+
+impl StorageOverrides {
+    fn wipe(&mut self) {
+        self.slots.clear();
+        self.wiped = true;
+    }
+}


### PR DESCRIPTION
Adds a dedicated state-override layer to `State` so account, code, and nested storage overrides read before an attached BAL and the backing database. Diff and replacement storage modes accept nested iterators, and later committed execution state remains above the BAL.

This lets Reth position RPC execution with a BAL even when state overrides are present (paradigmxyz/reth#23734).