### PR TITLE
fix(revme): lower evmrunner default gas_limit to 2^24

### DIFF
--- a/bins/revme/src/cmd/evmrunner.rs
+++ b/bins/revme/src/cmd/evmrunner.rs
@@ -47,7 +47,7 @@ pub struct Cmd {
     #[arg(long, default_value = "")]
     input: String,
     /// Gas limit
-    #[arg(long, default_value = "1000000000")]
+    #[arg(long, default_value = "16777216")]
     gas_limit: u64,
 
     /// Whether to print the state


### PR DESCRIPTION
## Summary
- Change `revme evm` default `--gas-limit` from `1_000_000_000` to `16_777_216` (`2^24`).
- Aligns the CLI default with the EIP-7825 transaction gas limit cap.

## Test plan
- [ ] `cargo run -p revme -- evm --help` shows default gas limit `16777216`
- [ ] `cargo clippy -p revme --all-targets`