### PR TITLE
chore: release v117

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
 
+# v117
+date: 28.08.2026
+
+Patch release restoring flag-based selfdestruct finalization and Rust 1.98 clippy compatibility.
+
+Highlights:
+* Restore flag-based selfdestruct finalization while preserving EIP-8246 balance handling ([#3887](https://github.com/bluealloy/revm/pull/3887))
+* Fix clippy lints for Rust 1.98 ([#3884](https://github.com/bluealloy/revm/pull/3884))
+
+* `revm-context`: 43.0.0 -> 43.0.1 (✓ API compatible changes)
+* `revm-precompile`: 43.0.0 -> 43.0.1 (✓ API compatible changes)
+
 # v116
 date: 26.08.2026
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "43.0.0"
+version = "43.0.1"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -4063,7 +4063,7 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "43.0.0"
+version = "43.0.1"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,9 @@ database-interface = { path = "crates/database/interface", package = "revm-datab
 state = { path = "crates/state", package = "revm-state", version = "43.0.0", default-features = false }
 interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "43.0.0", default-features = false }
 inspector = { path = "crates/inspector", package = "revm-inspector", version = "43.0.0", default-features = false }
-precompile = { path = "crates/precompile", package = "revm-precompile", version = "43.0.0", default-features = false }
+precompile = { path = "crates/precompile", package = "revm-precompile", version = "43.0.1", default-features = false }
 statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "43.0.0", default-features = false }
-context = { path = "crates/context", package = "revm-context", version = "43.0.0", default-features = false }
+context = { path = "crates/context", package = "revm-context", version = "43.0.1", default-features = false }
 context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "43.0.0", default-features = false }
 handler = { path = "crates/handler", package = "revm-handler", version = "43.0.0", default-features = false }
 ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "43.0.0", default-features = false }

--- a/crates/context/CHANGELOG.md
+++ b/crates/context/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [43.0.1](https://github.com/bluealloy/revm/compare/revm-context-v43.0.0...revm-context-v43.0.1) - 2026-08-28
+
+### Fixed
+
+- *(journal)* restore flag-based selfdestruct finalization ([#3887](https://github.com/bluealloy/revm/pull/3887))
+
 ## [43.0.0](https://github.com/bluealloy/revm/compare/revm-context-v42.0.0...revm-context-v43.0.0) - 2026-08-20
 
 ### Added

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-context"
 description = "Revm context crates"
-version = "43.0.0"
+version = "43.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/precompile/CHANGELOG.md
+++ b/crates/precompile/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [43.0.1](https://github.com/bluealloy/revm/compare/revm-precompile-v43.0.0...revm-precompile-v43.0.1) - 2026-08-28
+
+### Other
+
+- fix clippy for Rust 1.98 ([#3884](https://github.com/bluealloy/revm/pull/3884))
+
 ## [43.0.0](https://github.com/bluealloy/revm/compare/revm-precompile-v42.0.1...revm-precompile-v43.0.0) - 2026-08-20
 
 ### Other

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-precompile"
 description = "Revm Precompiles - Ethereum compatible precompiled contracts"
-version = "43.0.0"
+version = "43.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
## Summary
- bump revm-context from 43.0.0 to 43.0.1
- bump revm-precompile from 43.0.0 to 43.0.1
- populate the v117 workspace and crate changelogs

## Validation
- cargo fmt --all --check
- cargo metadata --locked --no-deps --format-version 1
- cargo check -p revm-context -p revm-precompile --all-features
- git diff --check