### PR TITLE
fix(eip8037): place the system call state-gas margin in the reservoir

### DIFF
--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -4,6 +4,7 @@ use crate::{
     frame::handle_reservoir_remaining_gas,
     post_execution::{self, build_result_gas},
     pre_execution::{self, apply_eip7702_auth_list, PreExecutionOutput},
+    system_call::SYSTEM_CALL_REGULAR_GAS_LIMIT,
     validation, EvmTr, FrameResult, ItemOrResult,
 };
 use context::{
@@ -129,7 +130,7 @@ pub trait Handler {
     ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
         // dummy values that are not used.
         let init_and_floor_gas = InitialAndFloorGas::new(0, 0);
-        let mut gas = self.tx_gas(evm, &init_and_floor_gas);
+        let mut gas = self.system_call_gas(evm);
         // System calls skip pre-execution, so the checkpoint that
         // [`Handler::execution`] settles is opened here.
         let checkpoint = evm.ctx().journal_mut().checkpoint();
@@ -218,6 +219,29 @@ pub trait Handler {
         let (remaining, reservoir) = init_and_floor_gas
             .initial_gas_and_reservoir(tx_gas_limit, ctx.cfg().tx_gas_limit_cap());
         GasTracker::new(tx_gas_limit, remaining, reservoir)
+    }
+
+    /// Creates the transaction-level [`GasTracker`] for a system call.
+    ///
+    /// System calls have no intrinsic gas and are not subject to the EIP-7825
+    /// `TX_MAX_GAS_LIMIT` cap. Under EIP-8037 the base
+    /// [`SYSTEM_CALL_REGULAR_GAS_LIMIT`] is the regular budget (`gas_left`) and
+    /// everything above it, the margin sized for [`SYSTEM_MAX_SSTORES_PER_CALL`]
+    /// fresh storage writes, is placed in the state-gas reservoir, so `GAS`
+    /// inside a system contract reports the regular budget only. Without
+    /// EIP-8037 the whole gas limit is regular gas.
+    ///
+    /// [`SYSTEM_MAX_SSTORES_PER_CALL`]: crate::system_call::SYSTEM_MAX_SSTORES_PER_CALL
+    #[inline]
+    fn system_call_gas(&self, evm: &mut Self::Evm) -> GasTracker {
+        let ctx = evm.ctx_ref();
+        let gas_limit = ctx.tx().gas_limit();
+        let reservoir = if ctx.cfg().is_amsterdam_eip8037_enabled() {
+            gas_limit.saturating_sub(SYSTEM_CALL_REGULAR_GAS_LIMIT)
+        } else {
+            0
+        };
+        GasTracker::new(gas_limit, gas_limit - reservoir, reservoir)
     }
 
     /// Prepares the EVM state for execution.

--- a/crates/handler/src/lib.rs
+++ b/crates/handler/src/lib.rs
@@ -57,4 +57,7 @@ pub use precompile_provider::{
 };
 #[cfg(feature = "asyncdb")]
 pub use system_call::SystemCallEvmAsync;
-pub use system_call::{SystemCallCommitEvm, SystemCallEvm, SystemCallTx, SYSTEM_ADDRESS};
+pub use system_call::{
+    SystemCallCommitEvm, SystemCallEvm, SystemCallTx, SYSTEM_ADDRESS, SYSTEM_CALL_GAS_LIMIT,
+    SYSTEM_CALL_REGULAR_GAS_LIMIT, SYSTEM_CALL_STATE_GAS_RESERVOIR, SYSTEM_MAX_SSTORES_PER_CALL,
+};

--- a/crates/handler/src/system_call.rs
+++ b/crates/handler/src/system_call.rs
@@ -39,12 +39,26 @@ pub const SYSTEM_ADDRESS: Address = address!("0xffffffffffffffffffffffffffffffff
 /// Maximum number of SSTOREs a system call reserves state gas for under EIP-8037.
 pub const SYSTEM_MAX_SSTORES_PER_CALL: u64 = 16;
 
+/// Regular-gas budget of a system call: the `gas_left` a system contract runs on.
+///
+/// This is the pre-EIP-8037 system call gas limit. Under EIP-8037 it stays the
+/// regular budget while state gas is provided through the reservoir.
+pub const SYSTEM_CALL_REGULAR_GAS_LIMIT: u64 = 30_000_000;
+
+/// State-gas reservoir of a system call under EIP-8037, sized for
+/// `SYSTEM_MAX_SSTORES_PER_CALL` fresh storage writes.
+pub const SYSTEM_CALL_STATE_GAS_RESERVOIR: u64 =
+    eip8037::SSTORE_SET_BYTES * eip8037::CPSB_GLAMSTERDAM * SYSTEM_MAX_SSTORES_PER_CALL;
+
 /// Gas limit for system calls under EIP-8037.
 ///
 /// System calls get the base 30M regular-gas budget plus
 /// a state-gas reservoir sized for `SYSTEM_MAX_SSTORES_PER_CALL` storage writes.
-pub const SYSTEM_CALL_GAS_LIMIT: u64 = 30_000_000
-    + eip8037::SSTORE_SET_BYTES * eip8037::CPSB_GLAMSTERDAM * SYSTEM_MAX_SSTORES_PER_CALL;
+/// The split between the two is applied by [`Handler::system_call_gas`].
+///
+/// [`Handler::system_call_gas`]: crate::Handler::system_call_gas
+pub const SYSTEM_CALL_GAS_LIMIT: u64 =
+    SYSTEM_CALL_REGULAR_GAS_LIMIT + SYSTEM_CALL_STATE_GAS_RESERVOIR;
 
 /// Creates the system transaction with default values and set data and tx call target to system contract address
 /// that is going to be called.
@@ -433,5 +447,45 @@ mod tests {
             "State is not updated {:?}",
             output.state
         );
+    }
+
+    /// EIP-8037: the 30M base budget of a system call is its regular gas
+    /// (`gas_left`), and the state-gas margin sized for
+    /// `SYSTEM_MAX_SSTORES_PER_CALL` writes lives in the reservoir.
+    /// `GAS` inside a system contract therefore reports the regular budget
+    /// only, and a fresh-slot `SSTORE` is paid from the reservoir.
+    #[test]
+    fn test_system_call_eip8037_state_gas_reservoir() {
+        use primitives::{eip8037, hardfork::SpecId};
+
+        const SYSTEM_CONTRACT: Address = address!("0x000000000000000000000000000000000000c0de");
+        // GAS PUSH0 SSTORE STOP: store gasleft() into fresh slot 0.
+        static CODE: Bytes = bytes!("0x5a5f5500");
+
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            SYSTEM_CONTRACT,
+            AccountInfo::default().with_code(Bytecode::new_legacy(CODE.clone())),
+        );
+
+        let mut evm = Context::mainnet()
+            .with_db(db)
+            .modify_cfg_chained(|cfg| cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM))
+            .build_mainnet();
+        let output = evm.system_call(SYSTEM_CONTRACT, Bytes::default()).unwrap();
+        assert!(output.result.is_success(), "{:?}", output.result);
+
+        let gas_seen = output.state[&SYSTEM_CONTRACT]
+            .storage
+            .get(&StorageKey::from(0))
+            .map(|slot| slot.present_value)
+            .unwrap_or_default();
+        // `GAS` charges its own 2 gas before pushing the remaining regular gas.
+        assert_eq!(gas_seen, U256::from(SYSTEM_CALL_REGULAR_GAS_LIMIT - 2));
+
+        // The fresh-slot SSTORE is a state-gas charge drawn from the reservoir.
+        let sstore_state_gas = eip8037::SSTORE_SET_BYTES * eip8037::CPSB_GLAMSTERDAM;
+        assert_eq!(output.result.gas().block_state_gas_used(), sstore_state_gas);
+        assert!(sstore_state_gas <= SYSTEM_CALL_STATE_GAS_RESERVOIR);
     }
 }

--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -163,7 +163,7 @@ where
     ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
         // dummy values that are not used.
         let init_and_floor_gas = InitialAndFloorGas::new(0, 0);
-        let mut gas = self.tx_gas(evm, &init_and_floor_gas);
+        let mut gas = self.system_call_gas(evm);
         // System calls skip pre-execution, so the checkpoint that
         // `inspect_execution` settles is opened here.
         let checkpoint = evm.ctx().journal_mut().checkpoint();


### PR DESCRIPTION
### Summary

EIP-8037 sizes the system call gas limit as `30_000_000 + STATE_BYTES_PER_STORAGE_SET × CPSB × SYSTEM_MAX_SSTORES_PER_CALL` and specifies that "the additional `STATE_BYTES_PER_STORAGE_SET × CPSB × SYSTEM_MAX_SSTORES_PER_CALL` is placed in `state_gas_reservoir` while the rest of the system call's gas is placed in `gas_left`" ([EIP-8037, "System contracts and system transactions"](https://eips.ethereum.org/EIPS/eip-8037#system-contracts-and-system-transactions)). `execution-specs` does the same: the Amsterdam system transaction is built with `execution_gas_grant=SYSTEM_TRANSACTION_GAS` (30M) and `state_gas_reservoir=StateGasCosts.STORAGE_SET * SYSTEM_MAX_SSTORES_PER_CALL` (`src/ethereum/forks/amsterdam/fork.py`, `process_system_transaction`).

#3672 adopted the new limit but kept building the system call gas through `tx_gas` with an all-zero `InitialAndFloorGas`. That path lifts the EIP-7825 cap to `u64::MAX` for system calls, so the whole 31,566,720 lands in `gas_left` and the reservoir is 0. The `SYSTEM_CALL_GAS_LIMIT` doc comment ("the base 30M regular-gas budget plus a state-gas reservoir") already describes the intended split.

Observable differences against the spec today:
- `GAS` inside a system contract reports 31,566,718 instead of 29,999,998.
- Every state-gas charge in a system call spills into regular gas (`state_gas_spilled` grows), so a revert inside the system call credits it back to `gas_left` instead of the reservoir.

The four mainnet system contracts (EIP-2935/4788/7002/7251) do not branch on `gasleft()`, so this does not change their results; it changes what a system contract can observe and how state gas is settled on its failure paths.

### Changes

- `SYSTEM_CALL_GAS_LIMIT` is now expressed as `SYSTEM_CALL_REGULAR_GAS_LIMIT` (30M) + `SYSTEM_CALL_STATE_GAS_RESERVOIR`; both constants are public.
- New `Handler::system_call_gas` (default method) builds the system call `GasTracker`: with EIP-8037 enabled, everything above the regular budget goes to the reservoir; without it the whole limit stays regular gas. `run_system_call` and `inspect_run_system_call` use it instead of `tx_gas`.
- Test `test_system_call_eip8037_state_gas_reservoir`: a system contract running `GAS PUSH0 SSTORE STOP` under `SpecId::AMSTERDAM` stores `29_999_998` and the fresh-slot SSTORE is accounted as `SSTORE_SET_BYTES × CPSB` state gas.

No change for configurations without EIP-8037; `total_gas_spent` of a system call is unchanged (it already subtracts the reservoir).

### Verification

- `cargo nextest run -p revm-handler -p revm-inspector`: 48 passed
- `cargo nextest run -p revm-ee-tests -E 'test(eip8037) | test(system_call)'`: 43 passed
- `cargo clippy -p revm-handler -p revm-inspector --all-targets --all-features`: clean; `cargo fmt --all --check`: clean; `RUSTDOCFLAGS=-D warnings cargo doc -p revm-handler --no-deps`: clean
- The new test fails on `main` (6014612c) with `left: 31566718, right: 29999998` and passes with this change.
