### PR TITLE
fix: reconcile sibling state gas refills

### DIFF
--- a/crates/context/interface/src/cfg/gas.rs
+++ b/crates/context/interface/src/cfg/gas.rs
@@ -92,6 +92,31 @@ impl GasTracker {
         self.reservoir = val;
     }
 
+    /// Adopts a reservoir returned by a child frame and reconciles it with any
+    /// outstanding state gas spilled into regular gas.
+    ///
+    /// A successful child can refill state gas charged by an ancestor (for
+    /// example, by clearing a slot created by a sibling). Since the child does
+    /// not inherit the ancestor's [`Self::state_gas_spilled`] counter, that
+    /// refill initially lands in the child's reservoir. On return it must first
+    /// restore the parent's regular gas in last-in-first-out order; only the
+    /// excess remains in the reservoir.
+    ///
+    /// This only reconciles the funding pools. The child's signed
+    /// `state_gas_spent` has already accounted for the refill and is merged
+    /// separately by the frame handler.
+    #[inline]
+    pub const fn absorb_returned_reservoir(&mut self, reservoir: u64) {
+        let to_remaining = if reservoir < self.state_gas_spilled {
+            reservoir
+        } else {
+            self.state_gas_spilled
+        };
+        self.remaining = self.remaining.saturating_add(to_remaining);
+        self.state_gas_spilled -= to_remaining;
+        self.reservoir = reservoir - to_remaining;
+    }
+
     /// Returns the state gas spent.
     #[inline]
     pub const fn state_gas_spent(&self) -> i64 {
@@ -269,6 +294,26 @@ mod tests {
             GasTracker::new_used_gas(10, 11, 3),
             GasTracker::new(10, 0, 3)
         );
+    }
+
+    #[test]
+    fn returned_reservoir_restores_spilled_state_gas_first() {
+        let mut gas = GasTracker::new(1_000, 600, 0);
+        assert!(gas.record_state_cost(400));
+
+        gas.absorb_returned_reservoir(250);
+
+        assert_eq!(gas.remaining(), 450);
+        assert_eq!(gas.reservoir(), 0);
+        assert_eq!(gas.state_gas_spilled(), 150);
+        assert_eq!(gas.state_gas_spent(), 400);
+
+        gas.absorb_returned_reservoir(200);
+
+        assert_eq!(gas.remaining(), 600);
+        assert_eq!(gas.reservoir(), 50);
+        assert_eq!(gas.state_gas_spilled(), 0);
+        assert_eq!(gas.state_gas_spent(), 400);
     }
 }
 

--- a/crates/ee-tests/src/eip8037.rs
+++ b/crates/ee-tests/src/eip8037.rs
@@ -2051,6 +2051,37 @@ fn sstore_parent_then_delegatecall_clear_bytecode() -> Bytecode {
     Bytecode::new_legacy(bytecode.into())
 }
 
+/// Parent DELEGATECALLs sibling A to set slot 0, then sibling B to clear it,
+/// and returns the value observed by GAS after both children complete.
+fn sibling_set_then_clear_gas_bytecode(setter: [u8; 20], clearer: [u8; 20]) -> Bytecode {
+    let mut bytecode = Vec::new();
+    for target in [setter, clearer] {
+        // DELEGATECALL(gas, target, 0, 0, 0, 0).
+        for _ in 0..4 {
+            bytecode.extend_from_slice(&[opcode::PUSH1, 0]);
+        }
+        bytecode.push(opcode::PUSH20);
+        bytecode.extend_from_slice(&target);
+        bytecode.push(opcode::GAS);
+        bytecode.push(opcode::DELEGATECALL);
+        bytecode.push(opcode::POP);
+    }
+
+    // Return GAS as a 32-byte word.
+    bytecode.extend_from_slice(&[
+        opcode::GAS,
+        opcode::PUSH1,
+        0,
+        opcode::MSTORE,
+        opcode::PUSH1,
+        32,
+        opcode::PUSH1,
+        0,
+        opcode::RETURN,
+    ]);
+    Bytecode::new_legacy(bytecode.into())
+}
+
 /// EIP-8037 issue #2 — cross frame: parent charges state gas on SSTORE(0,1),
 /// then DELEGATECALLs a child that does SSTORE(0,0). Because DELEGATECALL
 /// shares the caller's storage, the child performs the 0→1→0 restoration
@@ -2078,6 +2109,81 @@ fn test_eip8037_sstore_refill_cross_frame() {
     // refills it on 1→0. Only the CREATE + code-deposit state gas remains.
     let expected_state_gas = STATE_GAS_CREATE + STATE_GAS_CODE_DEPOSIT * CHILD_RUNTIME_LEN;
     assert_eq!(result.gas().state_gas_spent_final(), expected_state_gas);
+}
+
+/// EIP-8037 issue #2 — sibling frames: A creates a slot using regular gas,
+/// then B clears it. B's refill initially lands in its reservoir because its
+/// local spill counter is zero. When B returns, P must absorb that reservoir
+/// against the spill inherited from A, making the gas available to GAS again.
+#[test]
+fn test_eip8037_sibling_refill_restores_parent_gas_left() {
+    use revm::{
+        database::{CacheDB, EmptyDB, BENCH_TARGET},
+        state::AccountInfo,
+    };
+
+    const SETTER: [u8; 20] = [0xa1; 20];
+    const CLEARER: [u8; 20] = [0xb2; 20];
+    const GAS_LIMIT: u64 = 1_000_000;
+
+    let parent_code = sibling_set_then_clear_gas_bytecode(SETTER, CLEARER);
+    let setter_code = sstore_bytecode(0, 1);
+    let clearer_code = sstore_bytecode(0, 0);
+    let build_db = || {
+        let mut db = CacheDB::<EmptyDB>::default();
+        for (address, code) in [
+            (BENCH_TARGET, parent_code.clone()),
+            (SETTER.into(), setter_code.clone()),
+            (CLEARER.into(), clearer_code.clone()),
+        ] {
+            db.insert_account_info(
+                address,
+                AccountInfo::new(U256::ZERO, 1, code.hash_slow(), code),
+            );
+        }
+        db.insert_account_info(
+            BENCH_CALLER,
+            AccountInfo {
+                balance: U256::from(u64::MAX),
+                ..Default::default()
+            },
+        );
+        db
+    };
+    let build_tx = || {
+        TxEnv::builder_for_bench()
+            .gas_limit(GAS_LIMIT)
+            .gas_price(0)
+            .build_fill()
+    };
+
+    let mut baseline = Context::mainnet()
+        .modify_cfg_chained(|cfg| {
+            cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
+            cfg.enable_amsterdam_eip8037 = false;
+            cfg.enable_amsterdam_eip2780 = false;
+            cfg.tx_gas_limit_cap = Some(u64::MAX);
+        })
+        .with_db(build_db())
+        .build_mainnet();
+    let baseline_result = baseline.transact_one(build_tx()).unwrap();
+
+    let mut evm = Context::mainnet()
+        .modify_cfg_chained(|cfg| {
+            cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM);
+            cfg.enable_amsterdam_eip2780 = false;
+            cfg.tx_gas_limit_cap = Some(u64::MAX);
+            cfg.gas_params
+                .override_gas([(GasId::sstore_set_state_gas(), STATE_GAS_SSTORE_SET)]);
+        })
+        .with_db(build_db())
+        .build_mainnet();
+    let result = evm.transact_one(build_tx()).unwrap();
+
+    assert!(baseline_result.is_success());
+    assert!(result.is_success());
+    assert_eq!(result.gas().state_gas_spent_final(), 0);
+    assert_eq!(result.output(), baseline_result.output());
 }
 
 // ---- Tx-kind Create with initcode that halts / self-destructs ----

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -586,7 +586,8 @@ impl EthFrame<EthInterpreter> {
 ///   flows back to the parent on success or revert; a halt consumes it.
 /// - the reservoir, a shared state-gas pool the child inherited at call time, is
 ///   always adopted from the child (restored to the inherited value on
-///   revert/halt).
+///   revert/halt). Any returned reservoir first unwinds the parent's outstanding
+///   spilled state gas in LIFO order.
 /// - net state gas, its spilled portion, and the refund counter persist only on
 ///   success; on revert/halt the child's state changes roll back and contribute
 ///   nothing.
@@ -612,7 +613,6 @@ pub const fn handle_reservoir_remaining_gas(
     if instruction_result.is_ok_or_revert() {
         parent_gas.erase_cost(child_gas.remaining());
     }
-    parent_gas.set_reservoir(child_gas.reservoir());
     if instruction_result.is_ok() {
         // Parent may have already charged state gas (e.g. new_account + create)
         // before creating the child frame, so add rather than overwrite. The
@@ -627,6 +627,7 @@ pub const fn handle_reservoir_remaining_gas(
         parent_gas.add_state_gas_spilled(child_gas.state_gas_spilled());
         parent_gas.record_refund(child_gas.refunded());
     }
+    parent_gas.absorb_returned_reservoir(child_gas.reservoir());
 }
 
 /// Handles the result of a CREATE operation, including validation and state updates.
@@ -731,4 +732,44 @@ pub fn return_create<CTX: ContextTr>(
     journal.set_code(address, bytecode);
 
     interpreter_result.result = InstructionResult::Return;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sibling_refill_restores_parent_regular_gas() {
+        const STATE_GAS: u64 = 200;
+        const CHILD_GAS: u64 = 500;
+
+        let mut parent = GasTracker::new(1_000, 1_000, 0);
+
+        // P calls A. A creates a slot after the reservoir is exhausted, so the
+        // charge spills into regular gas and is absorbed by P on success.
+        assert!(parent.record_regular_cost(CHILD_GAS));
+        let mut child_a = GasTracker::new(CHILD_GAS, CHILD_GAS, 0);
+        assert!(child_a.record_state_cost(STATE_GAS));
+        handle_reservoir_remaining_gas(InstructionResult::Stop, &mut parent, &mut child_a);
+        assert_eq!(parent.remaining(), 800);
+        assert_eq!(parent.reservoir(), 0);
+        assert_eq!(parent.state_gas_spent(), STATE_GAS as i64);
+        assert_eq!(parent.state_gas_spilled(), STATE_GAS);
+
+        // P then calls B. B clears A's slot, but has no local spill counter, so
+        // its refill initially lands in its reservoir.
+        assert!(parent.record_regular_cost(CHILD_GAS));
+        let mut child_b = GasTracker::new(CHILD_GAS, CHILD_GAS, parent.reservoir());
+        child_b.refill_reservoir(STATE_GAS);
+        assert_eq!(child_b.reservoir(), STATE_GAS);
+        assert_eq!(child_b.state_gas_spilled(), 0);
+
+        // On success, P absorbs B's refill in global LIFO order: the reservoir
+        // is moved back to regular gas to unwind A's spilled charge.
+        handle_reservoir_remaining_gas(InstructionResult::Stop, &mut parent, &mut child_b);
+        assert_eq!(parent.remaining(), 1_000);
+        assert_eq!(parent.reservoir(), 0);
+        assert_eq!(parent.state_gas_spent(), 0);
+        assert_eq!(parent.state_gas_spilled(), 0);
+    }
 }


### PR DESCRIPTION
## Summary

- reconcile a returned child reservoir against outstanding parent state-gas spills in LIFO order
- restore gas-left-funded state gas to regular gas without double-adjusting signed state-gas spend
- cover partial/excess reservoir absorption and the sibling A-set/B-clear frame flow
- add an end-to-end sibling DELEGATECALL regression that checks the parent GAS value

## Tests

- cargo test -p revm-context-interface returned_reservoir_restores_spilled_state_gas_first
- cargo test -p revm-handler sibling_refill_restores_parent_regular_gas
- cargo test -p revm-ee-tests eip8037
- cargo test -p revm-ee-tests eip2780
- cargo clippy -p revm-context-interface -p revm-handler --all-targets --all-features
- cargo fmt --all --check