### PR TITLE
chore: batch Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,17 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      cargo-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- group all Cargo version updates into one weekly PR
- group all GitHub Actions version updates into one weekly PR
- preserve the existing seven-day cooldown

## Validation

- parsed .github/dependabot.yml successfully
- git diff --check