### PR TITLE
perf(state): size BAL storage vectors by partition

### DIFF
--- a/crates/state/src/bal/account.rs
+++ b/crates/state/src/bal/account.rs
@@ -155,8 +155,14 @@ impl AccountBal {
     #[inline]
     pub fn into_alloy_account(self, address: Address) -> AlloyAccountChanges {
         let storage_len = self.storage.storage.len();
-        let mut storage_reads = Vec::with_capacity(storage_len);
-        let mut storage_changes = Vec::with_capacity(storage_len);
+        let read_len = self
+            .storage
+            .storage
+            .values()
+            .filter(|value| value.writes.is_empty())
+            .count();
+        let mut storage_reads = Vec::with_capacity(read_len);
+        let mut storage_changes = Vec::with_capacity(storage_len - read_len);
         for (key, value) in self.storage.storage {
             if value.writes.is_empty() {
                 storage_reads.push(key);


### PR DESCRIPTION
Reserve BAL storage read/write vectors for their actual partition sizes instead of reserving the full slot count for both. Across 30 validated Reth 300M fixtures, this removes about 640KB of unused vector capacity and 558 allocation calls per block; lazy growth adds reallocations and requests more bytes overall. A six-pair [Reth 300M BAL benchmark](https://github.com/paradigmxyz/reth/actions/runs/34218825670) is neutral on server latency (102.53 → 102.68ms, +0.15% ±0.58%); this is an allocation reduction, with no demonstrated e2e speedup.
