### PR TITLE
chore: release v118

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
 
+# v118
+date: 08.09.2026
+
+Small patch release fixing EIP-8037 state-gas accounting and aligning the `revme` gas-limit default with EIP-7825.
+
+Highlights:
+* Reconcile state-gas refills across sibling frames ([#3893](https://github.com/bluealloy/revm/pull/3893))
+* Place the EIP-8037 system-call state-gas margin in the reservoir ([#3892](https://github.com/bluealloy/revm/pull/3892))
+* Lower the `revme evmrunner` default gas limit to `2^24` ([#3886](https://github.com/bluealloy/revm/pull/3886))
+
+* `revm-context-interface`: 43.0.0 -> 43.0.1 (✓ API compatible changes)
+* `revm-handler`: 43.0.0 -> 43.0.1 (✓ API compatible changes)
+* `revm-inspector`: 43.0.0 -> 43.0.1 (✓ API compatible changes)
+* `revme`: 43.0.0 -> 43.0.1 (✓ API compatible changes)
+* `revm-context`: 43.0.1 -> 43.0.2 (✓ dependency bump)
+* `revm-interpreter`: 43.0.0 -> 43.0.1 (✓ dependency bump)
+* `revm-precompile`: 43.0.1 -> 43.0.2 (✓ dependency bump)
+* `revm-statetest-types`: 43.0.0 -> 43.0.1 (✓ dependency bump)
+* `revm`: 43.0.0 -> 43.0.1 (✓ dependency bump)
+
 # v117
 date: 28.08.2026
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "43.0.0"
+version = "43.0.1"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "43.0.1"
+version = "43.0.2"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "43.0.0"
+version = "43.0.1"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "43.0.0"
+version = "43.0.1"
 dependencies = [
  "alloy-signer",
  "alloy-signer-local",
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "43.0.0"
+version = "43.0.1"
 dependencies = [
  "auto_impl",
  "either",
@@ -4051,7 +4051,7 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "43.0.0"
+version = "43.0.1"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -4063,7 +4063,7 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "43.0.1"
+version = "43.0.2"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -4116,7 +4116,7 @@ dependencies = [
 
 [[package]]
 name = "revm-statetest-types"
-version = "43.0.0"
+version = "43.0.1"
 dependencies = [
  "alloy-eip7928 0.4.0",
  "k256",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "revme"
-version = "43.0.0"
+version = "43.0.1"
 dependencies = [
  "alloy-consensus",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,19 +41,19 @@ default-members = ["crates/revm"]
 
 [workspace.dependencies]
 # revm
-revm = { path = "crates/revm", version = "43.0.0", default-features = false }
+revm = { path = "crates/revm", version = "43.0.1", default-features = false }
 primitives = { path = "crates/primitives", package = "revm-primitives", version = "43.0.0", default-features = false }
 bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "43.0.0", default-features = false }
 database = { path = "crates/database", package = "revm-database", version = "43.0.0", default-features = false }
 database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "43.0.0", default-features = false }
 state = { path = "crates/state", package = "revm-state", version = "43.0.0", default-features = false }
-interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "43.0.0", default-features = false }
-inspector = { path = "crates/inspector", package = "revm-inspector", version = "43.0.0", default-features = false }
-precompile = { path = "crates/precompile", package = "revm-precompile", version = "43.0.1", default-features = false }
-statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "43.0.0", default-features = false }
-context = { path = "crates/context", package = "revm-context", version = "43.0.1", default-features = false }
-context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "43.0.0", default-features = false }
-handler = { path = "crates/handler", package = "revm-handler", version = "43.0.0", default-features = false }
+interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "43.0.1", default-features = false }
+inspector = { path = "crates/inspector", package = "revm-inspector", version = "43.0.1", default-features = false }
+precompile = { path = "crates/precompile", package = "revm-precompile", version = "43.0.2", default-features = false }
+statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "43.0.1", default-features = false }
+context = { path = "crates/context", package = "revm-context", version = "43.0.2", default-features = false }
+context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "43.0.1", default-features = false }
+handler = { path = "crates/handler", package = "revm-handler", version = "43.0.1", default-features = false }
 ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "43.0.0", default-features = false }
 
 # alloy

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,6 +1,10 @@
 
 # Unreleased
 
+# v118 tag (revm v43.0.1)
+
+No API migration is required for this patch release. Consumers that assert exact Glamsterdam gas results may need to update their expectations for corrected EIP-8037 system-call and sibling-frame state-gas accounting. The `revme evmrunner` default gas limit is now `2^24`; pass `--gas-limit` explicitly to retain a different limit.
+
 # v116 tag (all crates v43.0.0)
 
 ## Custom interpreter inputs (`revm-interpreter`)

--- a/bins/revme/CHANGELOG.md
+++ b/bins/revme/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [43.0.1](https://github.com/bluealloy/revm/compare/revme-v43.0.0...revme-v43.0.1) - 2026-09-08
+
+### Fixed
+
+- *(revme)* lower evmrunner default gas_limit to 2^24 ([#3886](https://github.com/bluealloy/revm/pull/3886))
+
 ## [43.0.0](https://github.com/bluealloy/revm/compare/revme-v42.0.1...revme-v43.0.0) - 2026-08-20
 
 ### Added

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revme"
 description = "Rust Ethereum Virtual Machine Executable"
-version = "43.0.0"
+version = "43.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/context/CHANGELOG.md
+++ b/crates/context/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [43.0.2](https://github.com/bluealloy/revm/compare/revm-context-v43.0.1...revm-context-v43.0.2) - 2026-09-08
+
+### Other
+
+- updated the following local packages: revm-context-interface
+
 ## [43.0.1](https://github.com/bluealloy/revm/compare/revm-context-v43.0.0...revm-context-v43.0.1) - 2026-08-28
 
 ### Fixed

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-context"
 description = "Revm context crates"
-version = "43.0.1"
+version = "43.0.2"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/context/interface/CHANGELOG.md
+++ b/crates/context/interface/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [43.0.1](https://github.com/bluealloy/revm/compare/revm-context-interface-v43.0.0...revm-context-interface-v43.0.1) - 2026-09-08
+
+### Fixed
+
+- reconcile sibling state gas refills ([#3893](https://github.com/bluealloy/revm/pull/3893))
+
 ## [43.0.0](https://github.com/bluealloy/revm/compare/revm-context-interface-v42.0.0...revm-context-interface-v43.0.0) - 2026-08-20
 
 ### Added

--- a/crates/context/interface/Cargo.toml
+++ b/crates/context/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-context-interface"
 description = "Revm context interface crates"
-version = "43.0.0"
+version = "43.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/handler/CHANGELOG.md
+++ b/crates/handler/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [43.0.1](https://github.com/bluealloy/revm/compare/revm-handler-v43.0.0...revm-handler-v43.0.1) - 2026-09-08
+
+### Fixed
+
+- reconcile sibling state gas refills ([#3893](https://github.com/bluealloy/revm/pull/3893))
+- *(eip8037)* place the system call state-gas margin in the reservoir ([#3892](https://github.com/bluealloy/revm/pull/3892))
+
 ## [43.0.0](https://github.com/bluealloy/revm/compare/revm-handler-v42.0.1...revm-handler-v43.0.0) - 2026-08-20
 
 ### Added

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-handler"
 description = "Revm handler crates"
-version = "43.0.0"
+version = "43.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/inspector/CHANGELOG.md
+++ b/crates/inspector/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [43.0.1](https://github.com/bluealloy/revm/compare/revm-inspector-v43.0.0...revm-inspector-v43.0.1) - 2026-09-08
+
+### Fixed
+
+- *(eip8037)* place the system call state-gas margin in the reservoir ([#3892](https://github.com/bluealloy/revm/pull/3892))
+
 ## [43.0.0](https://github.com/bluealloy/revm/compare/revm-inspector-v42.0.1...revm-inspector-v43.0.0) - 2026-08-20
 
 ### Other

--- a/crates/inspector/Cargo.toml
+++ b/crates/inspector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-inspector"
 description = "Revm inspector interface"
-version = "43.0.0"
+version = "43.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [43.0.1](https://github.com/bluealloy/revm/compare/revm-interpreter-v43.0.0...revm-interpreter-v43.0.1) - 2026-09-08
+
+### Other
+
+- updated the following local packages: revm-context-interface
+
 ## [43.0.0](https://github.com/bluealloy/revm/compare/revm-interpreter-v42.0.0...revm-interpreter-v43.0.0) - 2026-08-20
 
 ### Fixed

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-interpreter"
 description = "Revm Interpreter that executes bytecode."
-version = "43.0.0"
+version = "43.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/precompile/CHANGELOG.md
+++ b/crates/precompile/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [43.0.2](https://github.com/bluealloy/revm/compare/revm-precompile-v43.0.1...revm-precompile-v43.0.2) - 2026-09-08
+
+### Other
+
+- updated the following local packages: revm-context-interface
+
 ## [43.0.1](https://github.com/bluealloy/revm/compare/revm-precompile-v43.0.0...revm-precompile-v43.0.1) - 2026-08-28
 
 ### Other

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-precompile"
 description = "Revm Precompiles - Ethereum compatible precompiled contracts"
-version = "43.0.1"
+version = "43.0.2"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/revm/CHANGELOG.md
+++ b/crates/revm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [43.0.1](https://github.com/bluealloy/revm/compare/revm-v43.0.0...revm-v43.0.1) - 2026-09-08
+
+### Other
+
+- updated the following local packages: revm-context-interface, revm-handler, revm-inspector, revm-context, revm-interpreter, revm-precompile, revm-statetest-types
+
 ## [43.0.0](https://github.com/bluealloy/revm/compare/revm-v42.0.1...revm-v43.0.0) - 2026-08-20
 
 ### Added

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm"
 description = "Revm - Rust Ethereum Virtual Machine"
-version = "43.0.0"
+version = "43.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/statetest-types/CHANGELOG.md
+++ b/crates/statetest-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [43.0.1](https://github.com/bluealloy/revm/compare/revm-statetest-types-v43.0.0...revm-statetest-types-v43.0.1) - 2026-09-08
+
+### Other
+
+- updated the following local packages: revm-context-interface, revm-context
+
 ## [43.0.0](https://github.com/bluealloy/revm/compare/revm-statetest-types-v42.0.0...revm-statetest-types-v43.0.0) - 2026-08-20
 
 ### Other

--- a/crates/statetest-types/Cargo.toml
+++ b/crates/statetest-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-statetest-types"
 description = "Statetest types for revme"
-version = "43.0.0"
+version = "43.0.1"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
## Summary

- bump the nine affected workspace packages with release-plz
- add the concise v118 root changelog entry
- document that no API migration is required for this patch release

## Checks

- `cargo fmt --all --check`
- `cargo check --workspace --locked`
- `cargo metadata --no-deps --format-version 1`
- `git diff --check`