### PR TITLE
Revert "fix(eip8037): place the system call state-gas margin (#3892)"

### DIFF
--- a/crates/handler/src/handler.rs
+++ b/crates/handler/src/handler.rs
@@ -4,7 +4,6 @@ use crate::{
     frame::handle_reservoir_remaining_gas,
     post_execution::{self, build_result_gas},
     pre_execution::{self, apply_eip7702_auth_list, PreExecutionOutput},
-    system_call::SYSTEM_CALL_REGULAR_GAS_LIMIT,
     validation, EvmTr, FrameResult, ItemOrResult,
 };
 use context::{
@@ -130,7 +129,7 @@ pub trait Handler {
     ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
         // dummy values that are not used.
         let init_and_floor_gas = InitialAndFloorGas::new(0, 0);
-        let mut gas = self.system_call_gas(evm);
+        let mut gas = self.tx_gas(evm, &init_and_floor_gas);
         // System calls skip pre-execution, so the checkpoint that
         // [`Handler::execution`] settles is opened here.
         let checkpoint = evm.ctx().journal_mut().checkpoint();
@@ -219,29 +218,6 @@ pub trait Handler {
         let (remaining, reservoir) = init_and_floor_gas
             .initial_gas_and_reservoir(tx_gas_limit, ctx.cfg().tx_gas_limit_cap());
         GasTracker::new(tx_gas_limit, remaining, reservoir)
-    }
-
-    /// Creates the transaction-level [`GasTracker`] for a system call.
-    ///
-    /// System calls have no intrinsic gas and are not subject to the EIP-7825
-    /// `TX_MAX_GAS_LIMIT` cap. Under EIP-8037 the base
-    /// [`SYSTEM_CALL_REGULAR_GAS_LIMIT`] is the regular budget (`gas_left`) and
-    /// everything above it, the margin sized for [`SYSTEM_MAX_SSTORES_PER_CALL`]
-    /// fresh storage writes, is placed in the state-gas reservoir, so `GAS`
-    /// inside a system contract reports the regular budget only. Without
-    /// EIP-8037 the whole gas limit is regular gas.
-    ///
-    /// [`SYSTEM_MAX_SSTORES_PER_CALL`]: crate::system_call::SYSTEM_MAX_SSTORES_PER_CALL
-    #[inline]
-    fn system_call_gas(&self, evm: &mut Self::Evm) -> GasTracker {
-        let ctx = evm.ctx_ref();
-        let gas_limit = ctx.tx().gas_limit();
-        let reservoir = if ctx.cfg().is_amsterdam_eip8037_enabled() {
-            gas_limit.saturating_sub(SYSTEM_CALL_REGULAR_GAS_LIMIT)
-        } else {
-            0
-        };
-        GasTracker::new(gas_limit, gas_limit - reservoir, reservoir)
     }
 
     /// Prepares the EVM state for execution.

--- a/crates/handler/src/lib.rs
+++ b/crates/handler/src/lib.rs
@@ -57,7 +57,4 @@ pub use precompile_provider::{
 };
 #[cfg(feature = "asyncdb")]
 pub use system_call::SystemCallEvmAsync;
-pub use system_call::{
-    SystemCallCommitEvm, SystemCallEvm, SystemCallTx, SYSTEM_ADDRESS, SYSTEM_CALL_GAS_LIMIT,
-    SYSTEM_CALL_REGULAR_GAS_LIMIT, SYSTEM_CALL_STATE_GAS_RESERVOIR, SYSTEM_MAX_SSTORES_PER_CALL,
-};
+pub use system_call::{SystemCallCommitEvm, SystemCallEvm, SystemCallTx, SYSTEM_ADDRESS};

--- a/crates/handler/src/system_call.rs
+++ b/crates/handler/src/system_call.rs
@@ -39,26 +39,12 @@ pub const SYSTEM_ADDRESS: Address = address!("0xffffffffffffffffffffffffffffffff
 /// Maximum number of SSTOREs a system call reserves state gas for under EIP-8037.
 pub const SYSTEM_MAX_SSTORES_PER_CALL: u64 = 16;
 
-/// Regular-gas budget of a system call: the `gas_left` a system contract runs on.
-///
-/// This is the pre-EIP-8037 system call gas limit. Under EIP-8037 it stays the
-/// regular budget while state gas is provided through the reservoir.
-pub const SYSTEM_CALL_REGULAR_GAS_LIMIT: u64 = 30_000_000;
-
-/// State-gas reservoir of a system call under EIP-8037, sized for
-/// `SYSTEM_MAX_SSTORES_PER_CALL` fresh storage writes.
-pub const SYSTEM_CALL_STATE_GAS_RESERVOIR: u64 =
-    eip8037::SSTORE_SET_BYTES * eip8037::CPSB_GLAMSTERDAM * SYSTEM_MAX_SSTORES_PER_CALL;
-
 /// Gas limit for system calls under EIP-8037.
 ///
 /// System calls get the base 30M regular-gas budget plus
 /// a state-gas reservoir sized for `SYSTEM_MAX_SSTORES_PER_CALL` storage writes.
-/// The split between the two is applied by [`Handler::system_call_gas`].
-///
-/// [`Handler::system_call_gas`]: crate::Handler::system_call_gas
-pub const SYSTEM_CALL_GAS_LIMIT: u64 =
-    SYSTEM_CALL_REGULAR_GAS_LIMIT + SYSTEM_CALL_STATE_GAS_RESERVOIR;
+pub const SYSTEM_CALL_GAS_LIMIT: u64 = 30_000_000
+    + eip8037::SSTORE_SET_BYTES * eip8037::CPSB_GLAMSTERDAM * SYSTEM_MAX_SSTORES_PER_CALL;
 
 /// Creates the system transaction with default values and set data and tx call target to system contract address
 /// that is going to be called.
@@ -447,45 +433,5 @@ mod tests {
             "State is not updated {:?}",
             output.state
         );
-    }
-
-    /// EIP-8037: the 30M base budget of a system call is its regular gas
-    /// (`gas_left`), and the state-gas margin sized for
-    /// `SYSTEM_MAX_SSTORES_PER_CALL` writes lives in the reservoir.
-    /// `GAS` inside a system contract therefore reports the regular budget
-    /// only, and a fresh-slot `SSTORE` is paid from the reservoir.
-    #[test]
-    fn test_system_call_eip8037_state_gas_reservoir() {
-        use primitives::{eip8037, hardfork::SpecId};
-
-        const SYSTEM_CONTRACT: Address = address!("0x000000000000000000000000000000000000c0de");
-        // GAS PUSH0 SSTORE STOP: store gasleft() into fresh slot 0.
-        static CODE: Bytes = bytes!("0x5a5f5500");
-
-        let mut db = InMemoryDB::default();
-        db.insert_account_info(
-            SYSTEM_CONTRACT,
-            AccountInfo::default().with_code(Bytecode::new_legacy(CODE.clone())),
-        );
-
-        let mut evm = Context::mainnet()
-            .with_db(db)
-            .modify_cfg_chained(|cfg| cfg.set_spec_and_mainnet_gas_params(SpecId::AMSTERDAM))
-            .build_mainnet();
-        let output = evm.system_call(SYSTEM_CONTRACT, Bytes::default()).unwrap();
-        assert!(output.result.is_success(), "{:?}", output.result);
-
-        let gas_seen = output.state[&SYSTEM_CONTRACT]
-            .storage
-            .get(&StorageKey::from(0))
-            .map(|slot| slot.present_value)
-            .unwrap_or_default();
-        // `GAS` charges its own 2 gas before pushing the remaining regular gas.
-        assert_eq!(gas_seen, U256::from(SYSTEM_CALL_REGULAR_GAS_LIMIT - 2));
-
-        // The fresh-slot SSTORE is a state-gas charge drawn from the reservoir.
-        let sstore_state_gas = eip8037::SSTORE_SET_BYTES * eip8037::CPSB_GLAMSTERDAM;
-        assert_eq!(output.result.gas().block_state_gas_used(), sstore_state_gas);
-        assert!(sstore_state_gas <= SYSTEM_CALL_STATE_GAS_RESERVOIR);
     }
 }

--- a/crates/inspector/src/handler.rs
+++ b/crates/inspector/src/handler.rs
@@ -163,7 +163,7 @@ where
     ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
         // dummy values that are not used.
         let init_and_floor_gas = InitialAndFloorGas::new(0, 0);
-        let mut gas = self.system_call_gas(evm);
+        let mut gas = self.tx_gas(evm, &init_and_floor_gas);
         // System calls skip pre-execution, so the checkpoint that
         // `inspect_execution` settles is opened here.
         let checkpoint = evm.ctx().journal_mut().checkpoint();


### PR DESCRIPTION
This reverts commit 1382fa0322d92af08aa323dcd6140ba48ff5b9ab.

Reverting allows us to do patch of revm. With this change tempo breaks.