### PR TITLE
chore: release v119

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 Because this is workspace with multi libraries, tags will be simplified, and with this document you can match version of project with git tag.
 
+# v119
+date: 09.09.2026
+
+Patch release reverting the EIP-8037 system-call gas-reservoir change from v118.
+
+Highlights:
+* Restore the pre-v118 system-call gas-tracking behavior ([#3903](https://github.com/bluealloy/revm/pull/3903))
+
+See [MIGRATION_GUIDE.md](./MIGRATION_GUIDE.md) for the reverted handler API and gas-accounting behavior.
+
+* `revm-handler`: 43.0.1 -> 43.0.2 (⚠ API breaking changes)
+* `revm-inspector`: 43.0.1 -> 43.0.2 (✓ API compatible changes)
+* `revm`: 43.0.1 -> 43.0.2 (✓ dependency bump)
+* `revme`: 43.0.1 -> 43.0.2 (✓ dependency bump)
+
 # v118
 date: 08.09.2026
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "43.0.1"
+version = "43.0.2"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "43.0.1"
+version = "43.0.2"
 dependencies = [
  "alloy-signer",
  "alloy-signer-local",
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "43.0.1"
+version = "43.0.2"
 dependencies = [
  "auto_impl",
  "either",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "revme"
-version = "43.0.1"
+version = "43.0.2"
 dependencies = [
  "alloy-consensus",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,19 +41,19 @@ default-members = ["crates/revm"]
 
 [workspace.dependencies]
 # revm
-revm = { path = "crates/revm", version = "43.0.1", default-features = false }
+revm = { path = "crates/revm", version = "43.0.2", default-features = false }
 primitives = { path = "crates/primitives", package = "revm-primitives", version = "43.0.0", default-features = false }
 bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "43.0.0", default-features = false }
 database = { path = "crates/database", package = "revm-database", version = "43.0.0", default-features = false }
 database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "43.0.0", default-features = false }
 state = { path = "crates/state", package = "revm-state", version = "43.0.0", default-features = false }
 interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "43.0.1", default-features = false }
-inspector = { path = "crates/inspector", package = "revm-inspector", version = "43.0.1", default-features = false }
+inspector = { path = "crates/inspector", package = "revm-inspector", version = "43.0.2", default-features = false }
 precompile = { path = "crates/precompile", package = "revm-precompile", version = "43.0.2", default-features = false }
 statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "43.0.1", default-features = false }
 context = { path = "crates/context", package = "revm-context", version = "43.0.2", default-features = false }
 context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "43.0.1", default-features = false }
-handler = { path = "crates/handler", package = "revm-handler", version = "43.0.1", default-features = false }
+handler = { path = "crates/handler", package = "revm-handler", version = "43.0.2", default-features = false }
 ee-tests = { path = "crates/ee-tests", package = "revm-ee-tests", version = "43.0.0", default-features = false }
 
 # alloy

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,6 +1,10 @@
 
 # Unreleased
 
+# v119 tag (revm v43.0.2)
+
+This release reverts the EIP-8037 system-call gas change from [#3892](https://github.com/bluealloy/revm/pull/3892) in [#3903](https://github.com/bluealloy/revm/pull/3903).
+
 # v118 tag (revm v43.0.1)
 
 No API migration is required for this patch release. Consumers that assert exact Glamsterdam gas results may need to update their expectations for corrected EIP-8037 system-call and sibling-frame state-gas accounting. The `revme evmrunner` default gas limit is now `2^24`; pass `--gas-limit` explicitly to retain a different limit.

--- a/bins/revme/CHANGELOG.md
+++ b/bins/revme/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [43.0.1](https://github.com/bluealloy/revm/compare/revme-v43.0.0...revme-v43.0.1) - 2026-09-08
+## [43.0.2](https://github.com/bluealloy/revm/compare/revme-v43.0.0...revme-v43.0.2) - 2026-09-08
 
 ### Fixed
 

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revme"
 description = "Rust Ethereum Virtual Machine Executable"
-version = "43.0.1"
+version = "43.0.2"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/handler/CHANGELOG.md
+++ b/crates/handler/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [43.0.1](https://github.com/bluealloy/revm/compare/revm-handler-v43.0.0...revm-handler-v43.0.1) - 2026-09-08
+## [43.0.2](https://github.com/bluealloy/revm/compare/revm-handler-v43.0.0...revm-handler-v43.0.2) - 2026-09-08
 
 ### Fixed
 

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-handler"
 description = "Revm handler crates"
-version = "43.0.1"
+version = "43.0.2"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/inspector/CHANGELOG.md
+++ b/crates/inspector/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [43.0.1](https://github.com/bluealloy/revm/compare/revm-inspector-v43.0.0...revm-inspector-v43.0.1) - 2026-09-08
+## [43.0.2](https://github.com/bluealloy/revm/compare/revm-inspector-v43.0.0...revm-inspector-v43.0.2) - 2026-09-08
 
 ### Fixed
 

--- a/crates/inspector/Cargo.toml
+++ b/crates/inspector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-inspector"
 description = "Revm inspector interface"
-version = "43.0.1"
+version = "43.0.2"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/crates/revm/CHANGELOG.md
+++ b/crates/revm/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [43.0.1](https://github.com/bluealloy/revm/compare/revm-v43.0.0...revm-v43.0.1) - 2026-09-08
+## [43.0.2](https://github.com/bluealloy/revm/compare/revm-v43.0.0...revm-v43.0.2) - 2026-09-08
 
 ### Other
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm"
 description = "Revm - Rust Ethereum Virtual Machine"
-version = "43.0.1"
+version = "43.0.2"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
## Summary

- prepare v119 following the EIP-8037 system-call gas revert in #3903
- bump `revm-handler`, `revm-inspector`, `revm`, and `revme` to 43.0.2
- update the workspace changelog and migration guide

## Validation

- `cargo fmt --all`
- `git diff --check`