### PR TITLE
chore(ci): add Socket Firewall to Linux host jobs

### DIFF
--- a/.github/actions/check-socket-shim/action.yml
+++ b/.github/actions/check-socket-shim/action.yml
@@ -1,0 +1,7 @@
+name: Verify Socket Cargo interception
+description: Fail if Cargo resolves to an unprotected binary.
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: test "$(command -v cargo)" = "${SFW_SHIM_DIR:?Socket shims are missing}/cargo"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -8,11 +8,17 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  NODE_OPTIONS: --no-network-family-autoselection
+  SFW_UNKNOWN_HOST_ACTION: ignore
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
 
 permissions: {}
 
 jobs:
   codspeed:
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -20,6 +26,12 @@ jobs:
           submodules: true
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
+      - name: Secure runner
+        uses: tempoxyz/gh-actions/actions/secure-runner@5338a3746a2ac2ddd88cbede733c79f907aca3a0
+        with:
+          egress-policy: audit
+      - name: Verify Socket Cargo interception
+        uses: ./.github/actions/check-socket-shim
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-on-failure: true

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -13,8 +13,16 @@ on:
 
 permissions: {}
 
+env:
+  NODE_OPTIONS: --no-network-family-autoselection
+  SFW_UNKNOWN_HOST_ACTION: ignore
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+
 jobs:
   test:
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     name: test
 
@@ -23,6 +31,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Secure runner
+        uses: tempoxyz/gh-actions/actions/secure-runner@5338a3746a2ac2ddd88cbede733c79f907aca3a0
+        with:
+          egress-policy: audit
+      - name: Verify Socket Cargo interception
+        uses: ./.github/actions/check-socket-shim
       - name: Install mdbook
         run: |
           mkdir mdbook
@@ -62,6 +76,9 @@ jobs:
         run: mdbook-linkcheck --standalone
 
   build:
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -71,6 +88,12 @@ jobs:
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@nightly
+      - name: Secure runner
+        uses: tempoxyz/gh-actions/actions/secure-runner@5338a3746a2ac2ddd88cbede733c79f907aca3a0
+        with:
+          egress-policy: audit
+      - name: Verify Socket Cargo interception
+        uses: ./.github/actions/check-socket-shim
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-on-failure: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,17 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  NODE_OPTIONS: --no-network-family-autoselection
+  SFW_UNKNOWN_HOST_ACTION: ignore
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
 
 permissions: {}
 
 jobs:
   test:
+    permissions:
+      contents: read
+      id-token: write
     name: test ${{ matrix.rust }} ${{ matrix.flags }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -32,6 +38,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+      - name: Secure runner
+        uses: tempoxyz/gh-actions/actions/secure-runner@5338a3746a2ac2ddd88cbede733c79f907aca3a0
+        with:
+          egress-policy: audit
+      - name: Verify Socket Cargo interception
+        uses: ./.github/actions/check-socket-shim
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - uses: taiki-e/install-action@nextest
       - name: Install GMP (all-features)
@@ -42,6 +54,9 @@ jobs:
       - run: cargo nextest run --workspace ${{ matrix.flags }}
 
   ethereum-tests:
+    permissions:
+      contents: read
+      id-token: write
     name: eth ${{ matrix.profile }} ${{ matrix.target }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -55,6 +70,12 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
+      - name: Secure runner
+        uses: tempoxyz/gh-actions/actions/secure-runner@5338a3746a2ac2ddd88cbede733c79f907aca3a0
+        with:
+          egress-policy: audit
+      - name: Verify Socket Cargo interception
+        uses: ./.github/actions/check-socket-shim
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-on-failure: true
@@ -64,6 +85,9 @@ jobs:
         run: ./scripts/run-tests.sh clean cross ${{ matrix.profile }} ${{ matrix.target }}
 
   check-no-std:
+    permissions:
+      contents: read
+      id-token: write
     name: check no_std ${{ matrix.target }} ${{ matrix.features }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -79,11 +103,20 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      - name: Secure runner
+        uses: tempoxyz/gh-actions/actions/secure-runner@5338a3746a2ac2ddd88cbede733c79f907aca3a0
+        with:
+          egress-policy: audit
+      - name: Verify Socket Cargo interception
+        uses: ./.github/actions/check-socket-shim
       - run: |
           cargo check --target ${{ matrix.target }} --no-default-features --features=${{ matrix.features }}
           cargo check --target ${{ matrix.target }} -p revm-database --no-default-features
 
   check:
+    permissions:
+      contents: read
+      id-token: write
     name: check ${{ matrix.features }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -96,9 +129,18 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
+      - name: Secure runner
+        uses: tempoxyz/gh-actions/actions/secure-runner@5338a3746a2ac2ddd88cbede733c79f907aca3a0
+        with:
+          egress-policy: audit
+      - name: Verify Socket Cargo interception
+        uses: ./.github/actions/check-socket-shim
       - run: cargo check --no-default-features -p revm --features=${{ matrix.features }}
 
   feature-checks:
+    permissions:
+      contents: read
+      id-token: write
     name: features
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -107,6 +149,12 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
+      - name: Secure runner
+        uses: tempoxyz/gh-actions/actions/secure-runner@5338a3746a2ac2ddd88cbede733c79f907aca3a0
+        with:
+          egress-policy: audit
+      - name: Verify Socket Cargo interception
+        uses: ./.github/actions/check-socket-shim
       - uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
@@ -119,6 +167,9 @@ jobs:
         run: cargo hack check --feature-powerset --depth 1
 
   clippy:
+    permissions:
+      contents: read
+      id-token: write
     name: clippy
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -126,18 +177,27 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy
+      - name: Secure runner
+        uses: tempoxyz/gh-actions/actions/secure-runner@5338a3746a2ac2ddd88cbede733c79f907aca3a0
+        with:
+          egress-policy: audit
+      - name: Verify Socket Cargo interception
+        uses: ./.github/actions/check-socket-shim
       - name: Install GMP
         run: |
           sudo apt-get update
           sudo apt-get install -y libgmp-dev
-      - run: cargo clippy --workspace --all-targets --all-features
+      - run: cargo +nightly clippy --workspace --all-targets --all-features
         env:
           RUSTFLAGS: -Dwarnings
 
   docs:
+    permissions:
+      contents: read
+      id-token: write
     name: docs
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -148,6 +208,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rust-docs
+      - name: Secure runner
+        uses: tempoxyz/gh-actions/actions/secure-runner@5338a3746a2ac2ddd88cbede733c79f907aca3a0
+        with:
+          egress-policy: audit
+      - name: Verify Socket Cargo interception
+        uses: ./.github/actions/check-socket-shim
       - name: Install GMP
         run: |
           sudo apt-get update
@@ -157,6 +223,9 @@ jobs:
           RUSTDOCFLAGS: "--cfg docsrs -D warnings"
 
   doctest:
+    permissions:
+      contents: read
+      id-token: write
     name: doctest
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -165,12 +234,21 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
+      - name: Secure runner
+        uses: tempoxyz/gh-actions/actions/secure-runner@5338a3746a2ac2ddd88cbede733c79f907aca3a0
+        with:
+          egress-policy: audit
+      - name: Verify Socket Cargo interception
+        uses: ./.github/actions/check-socket-shim
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-on-failure: true
       - run: cargo test --workspace --doc
 
   fmt:
+    permissions:
+      contents: read
+      id-token: write
     name: fmt
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -178,12 +256,21 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-      - run: cargo fmt --all --check
+      - name: Secure runner
+        uses: tempoxyz/gh-actions/actions/secure-runner@5338a3746a2ac2ddd88cbede733c79f907aca3a0
+        with:
+          egress-policy: audit
+      - name: Verify Socket Cargo interception
+        uses: ./.github/actions/check-socket-shim
+      - run: cargo +nightly fmt --all --check
 
   feature-propagation:
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -191,8 +278,15 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
+      - name: Secure runner
+        uses: tempoxyz/gh-actions/actions/secure-runner@5338a3746a2ac2ddd88cbede733c79f907aca3a0
+        with:
+          egress-policy: audit
+      - name: Verify Socket Cargo interception
+        uses: ./.github/actions/check-socket-shim
       - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
+      - run: sccache --start-server
       - uses: taiki-e/cache-cargo-install-action@9ee83daaa7b96a6fab930949ecf1122bba04a389 # v3.0.8
         with:
           tool: zepter

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -10,8 +10,17 @@ on:
     branches:
       - main
 
+env:
+  NODE_OPTIONS: --no-network-family-autoselection
+  SFW_UNKNOWN_HOST_ACTION: ignore
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+
 jobs:
   release-plz:
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
     name: Release-plz
     runs-on: ubuntu-latest
     steps:
@@ -21,7 +30,13 @@ jobs:
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-        # Commits the cargo lock (generally a good practice for upstream libraries)
+      - name: Secure runner
+        uses: tempoxyz/gh-actions/actions/secure-runner@5338a3746a2ac2ddd88cbede733c79f907aca3a0
+        with:
+          egress-policy: audit
+      - name: Verify Socket Cargo interception
+        uses: ./.github/actions/check-socket-shim
+      # Commits the cargo lock (generally a good practice for upstream libraries)
       - name: Commit Cargo.lock
         run: |
           git config --local user.email "action@github.com"


### PR DESCRIPTION
## Summary

- Install pinned `secure-runner` in 14 Linux jobs across tests, benchmarks, book tests/builds, and release-PR preparation, with scoped OIDC and a Cargo-shim check.
- Ignore unknown Socket hosts, use Git CLI certificate support, and disable Node network-family autoselection. Start sccache before wrapped Cargo installs; use nightly for formatting and Clippy.

Scope: host package-manager traffic only. Cross-test containers, cargo-deny, cached dependencies, and direct tool downloads remain outside coverage. Fork PRs use Socket Free without organization policies; no macOS/Windows runners are added.

Validation: workflow syntax/expressions, shim-check success/failure cases, and nightly formatting pass locally. CI policy validation is pending; the release-PR workflow is push-to-main only and is not exercised by PR CI.

Prompted by: @grandizzy
