### PR TITLE
fix(bytecode): include kind in Bytecode PartialEq

### DIFF
--- a/crates/bytecode/src/bytecode/mod.rs
+++ b/crates/bytecode/src/bytecode/mod.rs
@@ -67,7 +67,7 @@ impl Default for Bytecode {
 impl PartialEq for Bytecode {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.original_byte_slice() == other.original_byte_slice()
+        self.kind() == other.kind() && self.original_byte_slice() == other.original_byte_slice()
     }
 }
 


### PR DESCRIPTION
## Summary
- Make `Bytecode`'s `PartialEq` compare both `kind` and the original byte slice.
- Previously two values with identical bytes but different kinds (legacy vs EIP-7702) were treated as equal.

## Test plan
- [ ] `cargo nextest run -p revm-bytecode`
- [ ] `cargo clippy -p revm-bytecode --all-targets`